### PR TITLE
ci(release): add PF-2 gate — release secrets present, and usable

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -14,6 +14,7 @@ name: Release pre-flight
 #   G11  auto-routing escape-hatch registry    macOS-14 (needs MLX)
 #   PF-1 squash subject regex pre-check        ubuntu-latest
 #   PF-2 release secret + var presence         ubuntu-latest
+#        + Cloudflare credential probe (expiry blocks; scope gaps advise)
 #
 # What this workflow does NOT cover (M3-only, runs locally — see
 # releasing.md):
@@ -116,6 +117,17 @@ jobs:
         run: |
           python scripts/check_release_secrets.py \
             .github/workflows/rapid-mac-release.yml
+
+      - name: PF-2 — release credentials are usable, not just present
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          # Read into the environment rather than interpolated into the shell,
+          # so a repository-variable value can never be parsed as script.
+          R2_BUCKET: ${{ vars.RAPID_MAC_DIST_R2_BUCKET }}
+        run: |
+          python scripts/probe_release_credentials.py --bucket "$R2_BUCKET"
 
   g1-release-smoke:
     # G1 — clean-room install + import smoke on macOS-14. Catches the

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -13,6 +13,7 @@ name: Release pre-flight
 #   G10  MLX upstream cross-chip-family scan   advisory
 #   G11  auto-routing escape-hatch registry    macOS-14 (needs MLX)
 #   PF-1 squash subject regex pre-check        ubuntu-latest
+#   PF-2 release secret + var presence         ubuntu-latest
 #
 # What this workflow does NOT cover (M3-only, runs locally — see
 # releasing.md):
@@ -83,6 +84,38 @@ jobs:
             echo "::error::PR title says v$TITLE_VER but pyproject.toml is $PYPROJECT_VER. Bump pyproject.toml or rename the PR."
             exit 1
           fi
+
+  pf2-release-secrets:
+    # PF-2 — every secret and var that rapid-mac-release.yml references must
+    # already be configured. Actions evaluates a missing secret to the empty
+    # string rather than erroring, so the gap surfaces only on the tag, after
+    # the notarised build, with the GitHub Release already published (#1851).
+    # Checking on the bump PR moves that discovery before the tag exists.
+    #
+    # Skipped on fork PRs: Actions withholds secrets from them by design, so
+    # an empty context there would fail every name without proving anything.
+    needs: detect-bump-pr
+    if: >-
+      needs.detect-bump-pr.outputs.is_bump == 'true' &&
+      github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML
+        run: python -m pip install --upgrade pip pyyaml
+      - name: PF-2 — release workflow secrets and vars are configured
+        env:
+          # Actions exposes no way to enumerate configured names, so the whole
+          # context is passed as JSON. The script reads KEYS only and never
+          # prints a value.
+          AVAILABLE_SECRETS_JSON: ${{ toJSON(secrets) }}
+          AVAILABLE_VARS_JSON: ${{ toJSON(vars) }}
+        run: |
+          python scripts/check_release_secrets.py \
+            .github/workflows/rapid-mac-release.yml
 
   g1-release-smoke:
     # G1 — clean-room install + import smoke on macOS-14. Catches the
@@ -159,6 +192,7 @@ jobs:
     needs:
       - detect-bump-pr
       - pf1-subject-regex
+      - pf2-release-secrets
       - g1-release-smoke
       - g10-upstream-mlx-scan
       - g11-escape-hatch
@@ -168,15 +202,23 @@ jobs:
       - name: Aggregate gate results
         env:
           PF1: ${{ needs.pf1-subject-regex.result }}
+          PF2: ${{ needs.pf2-release-secrets.result }}
           G1: ${{ needs.g1-release-smoke.result }}
           G10: ${{ needs.g10-upstream-mlx-scan.result }}
           G11: ${{ needs.g11-escape-hatch.result }}
         run: |
           echo "PF-1 subject regex:   $PF1"
+          echo "PF-2 release secrets: $PF2  (skipped on fork PRs)"
           echo "G1   release-smoke:   $G1"
           echo "G10  upstream MLX:    $G10  (advisory — never fails)"
           echo "G11  escape-hatch:    $G11"
-          # G10 is advisory — never blocks. Others must pass.
+          # G10 is advisory — never blocks. Others must pass. PF-2 is allowed
+          # to be "skipped" because a fork PR cannot see secrets at all; every
+          # other skip path is already excluded by the is_bump guard above.
+          if [ "$PF2" != "success" ] && [ "$PF2" != "skipped" ]; then
+            echo "::error::PF-2 failed: the release workflow references a secret or var that is not configured. A release cut now would fail on the tag with the release already published (#1851)."
+            exit 1
+          fi
           if [ "$PF1" != "success" ] || [ "$G1" != "success" ] || [ "$G11" != "success" ]; then
             echo "::error::One or more release pre-flight gates failed. See docs/development/releasing.md for the gate definitions."
             exit 1

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -182,7 +182,9 @@ This is the rule. No exceptions. CI doesn't fake-inference with a tiny model on 
 
 **Every bump PR** (title matches `chore: bump version to X.Y.Z`) → `release-preflight.yml` adds PF-1, PF-2, G1, G10 (advisory), G11. The `preflight-summary` job aggregates them so the bump PR has a single required check.
 
-PF-2 derives its required set from `rapid-mac-release.yml` itself rather than a list maintained here, so a step that starts needing a new secret extends the gate without anyone remembering to. It checks presence only — an expired or under-scoped token is a non-empty string and passes. It is skipped on fork PRs, where Actions withholds secrets by design.
+PF-2 derives its required set from `rapid-mac-release.yml` itself rather than a list maintained here, so a step that starts needing a new secret extends the gate without anyone remembering to. It is skipped on fork PRs, where Actions withholds secrets by design.
+
+PF-2 then probes the Cloudflare credentials, because presence is not validity — an expired or revoked token is a non-empty string and passes every presence check. Only an authoritative "this token is not active" blocks: every valid token can call `/user/tokens/verify` regardless of its permissions, so that answer cannot false-block. The R2 bucket and zone lookups are advisory, because the release needs R2 *write* and *cache purge* and neither implies the read permission those lookups use — a token scoped to exactly what the release needs can legitimately be denied them. Cache-purge permission itself is left unproven: there is no dry run, and exercising it on every bump PR to prove it works is a worse trade than not knowing. Transport errors and 5xx are advisory everywhere, so a Cloudflare blip cannot block a release.
 
 **Every PR + push to main** → `ci.yml` runs lint (ruff + audit + mandatory
 GHA SHA-pin check + parser microbench) + test-matrix (linux curated) +

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -174,12 +174,15 @@ This is the rule. No exceptions. CI doesn't fake-inference with a tiny model on 
 | G10 | MLX upstream cross-chip-family audit | CI | `release-preflight.yml` advisory (macOS-14) | M5-style #404 landmines |
 | G11 | Auto-routing escape-hatch registry | CI | `release-preflight.yml` (macOS-14) + ci.yml test-apple-silicon | silent auto-detection failures (#393/#400/#404) |
 | PF-1 | Auto-release subject regex pre-check | CI | `release-preflight.yml` (ubuntu) | `(#NN)` squash suffix trap |
+| PF-2 | Release workflow secret + var presence | CI | `release-preflight.yml` (ubuntu) | a credential the tag run needs but nobody configured (#1851) |
 
 ### CI coverage — what runs without you lifting a finger
 
 **Every PR** → `pr-validate.yml` runs the `pr_validate` pipeline (7 of 9 steps; `stress_e2e_bench` and `full_unit` skipped because both need MLX/a live server which ubuntu-latest can't provide). The scorecard is posted as a PR comment so contributor + maintainer see the verdict without leaving the PR page. The skipped pair is covered on M3 by `make release-check-m3` at release time.
 
-**Every bump PR** (title matches `chore: bump version to X.Y.Z`) → `release-preflight.yml` adds PF-1, G1, G10 (advisory), G11. The `preflight-summary` job aggregates them so the bump PR has a single required check.
+**Every bump PR** (title matches `chore: bump version to X.Y.Z`) → `release-preflight.yml` adds PF-1, PF-2, G1, G10 (advisory), G11. The `preflight-summary` job aggregates them so the bump PR has a single required check.
+
+PF-2 derives its required set from `rapid-mac-release.yml` itself rather than a list maintained here, so a step that starts needing a new secret extends the gate without anyone remembering to. It checks presence only — an expired or under-scoped token is a non-empty string and passes. It is skipped on fork PRs, where Actions withholds secrets by design.
 
 **Every PR + push to main** → `ci.yml` runs lint (ruff + audit + mandatory
 GHA SHA-pin check + parser microbench) + test-matrix (linux curated) +

--- a/scripts/check_release_secrets.py
+++ b/scripts/check_release_secrets.py
@@ -50,12 +50,27 @@ import yaml
 # inside these, so prose in a ``run:`` block that happens to say "secrets.FOO"
 # is not mistaken for a requirement.
 EXPR = re.compile(r"\$\{\{(.*?)\}\}", re.S)
-SECRET_REF = re.compile(r"\bsecrets\.([A-Za-z_][A-Za-z0-9_]*)")
-VARS_REF = re.compile(r"\bvars\.([A-Za-z_][A-Za-z0-9_]*)")
+# A ``secrets.NAME`` / ``vars.NAME`` reference in either GitHub Actions form:
+# dot notation (``secrets.FOO``) or the equivalent index form
+# (``secrets['FOO']`` / ``secrets["FOO"]``). Both resolve identically, so a
+# workflow edit that switches to brackets must not silently drop out of the
+# derived required set — that would reopen the exact drift this gate closes.
+_NAME = r"[A-Za-z_][A-Za-z0-9_]*"
+SECRET_REF = re.compile(rf"""\bsecrets(?:\.({_NAME})|\[\s*['"]({_NAME})['"]\s*\])""")
+VARS_REF = re.compile(rf"""\bvars(?:\.({_NAME})|\[\s*['"]({_NAME})['"]\s*\])""")
 
 # Injected by Actions into every workflow; never a configured repo secret, so
 # its absence from the secrets context proves nothing.
 ALWAYS_PROVIDED = frozenset({"GITHUB_TOKEN"})
+
+
+def _names(pattern: re.Pattern, expr: str) -> set[str]:
+    """Names captured by *pattern* in *expr*.
+
+    Each match carries the name in exactly one group — group 1 for the dot
+    form, group 2 for the bracket form — so pick whichever is non-empty.
+    """
+    return {m.group(1) or m.group(2) for m in pattern.finditer(expr)}
 
 
 def walk(node):
@@ -84,8 +99,8 @@ def referenced_names(text: str) -> tuple[set[str], set[str]]:
     variables: set[str] = set()
     for scalar in walk(doc):
         for expr in EXPR.findall(scalar):
-            secrets.update(SECRET_REF.findall(expr))
-            variables.update(VARS_REF.findall(expr))
+            secrets.update(_names(SECRET_REF, expr))
+            variables.update(_names(VARS_REF, expr))
     return secrets - ALWAYS_PROVIDED, variables
 
 

--- a/scripts/check_release_secrets.py
+++ b/scripts/check_release_secrets.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Fail a release bump PR when a release workflow needs a secret that is absent.
+
+A workflow can reference ``secrets.FOO`` that was never configured. Actions
+does not warn: the expression simply evaluates to the empty string, and the
+failure surfaces wherever that value is finally used — which, for a release
+pipeline, is on a tag, after the notarised build, once the GitHub Release is
+already published.
+
+That is how #1851 happened. #1747 added two new credential requirements
+(``CLOUDFLARE_API_TOKEN``, ``CLOUDFLARE_ZONE_ID``); neither was ever added to
+the repo. The guard inside ``rapid-mac-release.yml`` caught it correctly, but
+only at tag time, three releases in a row, each time leaving a shipped release
+whose updater fallback pointer had to be published by hand.
+
+This check moves that discovery to the ``chore: bump version to X.Y.Z`` PR,
+before the tag exists. The required set is derived from the workflow file
+rather than hand-maintained here, so a future step that needs a new secret
+extends the gate on its own — a hand-written list would have drifted exactly
+the way the credential did.
+
+Scope: presence only. An expired or under-scoped token is a non-empty string
+and passes this check just as it passes the ``[[ -n ... ]]`` guard in the
+release workflow. Catching that needs an authenticated probe, which needs a
+working token to write against first (see #1852).
+
+Available names arrive through the environment as the JSON of the ``secrets``
+and ``vars`` contexts, because Actions offers no way to enumerate them
+otherwise. Only the KEYS are ever read, and no value is printed or returned.
+
+Usage::
+
+    AVAILABLE_SECRETS_JSON='{"FOO":"..."}' AVAILABLE_VARS_JSON='{"BAR":"..."}' \\
+        scripts/check_release_secrets.py .github/workflows/rapid-mac-release.yml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+# Contents of every ``${{ ... }}`` expression. References are only read from
+# inside these, so prose in a ``run:`` block that happens to say "secrets.FOO"
+# is not mistaken for a requirement.
+EXPR = re.compile(r"\$\{\{(.*?)\}\}", re.S)
+SECRET_REF = re.compile(r"\bsecrets\.([A-Za-z_][A-Za-z0-9_]*)")
+VARS_REF = re.compile(r"\bvars\.([A-Za-z_][A-Za-z0-9_]*)")
+
+# Injected by Actions into every workflow; never a configured repo secret, so
+# its absence from the secrets context proves nothing.
+ALWAYS_PROVIDED = frozenset({"GITHUB_TOKEN"})
+
+
+def walk(node):
+    """Yield every string scalar in a parsed YAML document."""
+    if isinstance(node, str):
+        yield node
+    elif isinstance(node, dict):
+        for k, v in node.items():
+            yield from walk(k)
+            yield from walk(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from walk(v)
+
+
+def referenced_names(text: str) -> tuple[set[str], set[str]]:
+    """Return ``(secrets, vars)`` referenced by a workflow's expressions.
+
+    Parses YAML and walks values, so names appearing in genuine YAML comments
+    are ignored — the parser drops those before Actions ever sees them, and a
+    header comment documenting "requires CLOUDFLARE_API_TOKEN" must not count
+    as a reference.
+    """
+    doc = yaml.safe_load(text)
+    secrets: set[str] = set()
+    variables: set[str] = set()
+    for scalar in walk(doc):
+        for expr in EXPR.findall(scalar):
+            secrets.update(SECRET_REF.findall(expr))
+            variables.update(VARS_REF.findall(expr))
+    return secrets - ALWAYS_PROVIDED, variables
+
+
+def load_available(env_var: str) -> set[str]:
+    """Read the KEYS of a JSON context passed through the environment.
+
+    Values are never returned, printed, or logged.
+    """
+    raw = os.environ.get(env_var)
+    if raw is None:
+        raise SystemExit(
+            f"::error::{env_var} is not set. Pass the context as JSON, e.g. "
+            f"`{env_var}: ${{{{ toJSON(secrets) }}}}`."
+        )
+    try:
+        parsed = json.loads(raw or "{}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"::error::{env_var} is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise SystemExit(f"::error::{env_var} must be a JSON object")
+    return set(parsed)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "workflows",
+        nargs="+",
+        type=Path,
+        help="workflow files whose secret/var references must all exist",
+    )
+    args = parser.parse_args()
+
+    available_secrets = load_available("AVAILABLE_SECRETS_JSON")
+    available_vars = load_available("AVAILABLE_VARS_JSON")
+
+    # file -> missing names, so the error names the workflow to fix.
+    missing_secrets: dict[Path, set[str]] = {}
+    missing_vars: dict[Path, set[str]] = {}
+    total_refs = 0
+
+    for path in args.workflows:
+        if not path.is_file():
+            print(f"::error::no such workflow: {path}", file=sys.stderr)
+            return 1
+        secrets, variables = referenced_names(path.read_text(encoding="utf-8"))
+        total_refs += len(secrets) + len(variables)
+        if gap := secrets - available_secrets:
+            missing_secrets[path] = gap
+        if gap := variables - available_vars:
+            missing_vars[path] = gap
+
+    if not missing_secrets and not missing_vars:
+        print(
+            f"release secrets OK — {total_refs} reference(s) across "
+            f"{len(args.workflows)} workflow(s), all configured"
+        )
+        return 0
+
+    for path, names in sorted(missing_secrets.items()):
+        for name in sorted(names):
+            print(
+                f"::error::{path} references secrets.{name}, which is not "
+                f"configured. Add it with `gh secret set {name}`.",
+                file=sys.stderr,
+            )
+    for path, names in sorted(missing_vars.items()):
+        for name in sorted(names):
+            print(
+                f"::error::{path} references vars.{name}, which is not "
+                f"configured. Add it with `gh variable set {name}`.",
+                file=sys.stderr,
+            )
+    print(
+        "\nA release cut now would fail after the notarised build, on the tag, "
+        "with the GitHub Release already published — see #1851. Configure the "
+        "names above before merging the bump.",
+        file=sys.stderr,
+    )
+    if not available_secrets:
+        print(
+            "Note: the secrets context is empty. Besides genuinely having no "
+            "secrets, that is what a fork PR looks like — Actions withholds "
+            "them by design, and this gate should skip rather than fail there.",
+            file=sys.stderr,
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_release_credentials.py
+++ b/scripts/probe_release_credentials.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Probe the Cloudflare credentials the mac release needs, before the tag.
+
+``check_release_secrets.py`` proves a secret is *configured*. It cannot prove
+the value still works: an expired or revoked token is a non-empty string and
+passes every presence check, including the ``[[ -n ... ]]`` guard inside
+``rapid-mac-release.yml``. Expiry is the realistic way #1851 comes back —
+Cloudflare tokens can carry an expiry date, and nothing in the pipeline would
+notice until a tag run failed with the release already published.
+
+What is and is not blocking here matters, so it is spelled out:
+
+  * ``/user/tokens/verify`` is BLOCKING. Every valid token can call it
+    regardless of its permissions, so an authoritative "this token is not
+    active" is unambiguous and cannot false-block a correctly-scoped token.
+
+  * The R2 bucket and zone lookups are ADVISORY. The release needs R2 *write*
+    and *cache purge*; neither implies the read permission these lookups use.
+    A token scoped exactly to what the release needs — and nothing more — can
+    legitimately 403 here. Blocking on that would stop releases to punish a
+    correctly-scoped token, so a failure is surfaced and nothing more.
+
+  * Cache-purge permission specifically cannot be verified without purging.
+    There is no dry run. It is left unproven rather than exercised on every
+    bump PR.
+
+  * Transport errors, timeouts, and 5xx are ADVISORY everywhere. "We could not
+    check" is not "we checked and it is bad", and a Cloudflare blip must not
+    block a release.
+
+The token is read from the environment and is never printed, returned, or
+included in a message.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://api.cloudflare.com/client/v4"
+TIMEOUT = 15
+
+BLOCKING = "blocking"
+ADVISORY = "advisory"
+
+
+class UnreachableError(Exception):
+    """Transport-level failure — never blocking, only advisory."""
+
+
+def http_get(url: str, token: str) -> tuple[int, dict]:
+    """GET a Cloudflare API endpoint. Raises ``UnreachableError`` on transport error.
+
+    An HTTP error response still carries a JSON body worth reading (Cloudflare
+    puts the reason in ``errors``), so 4xx is returned rather than raised; only
+    a genuine transport failure raises.
+    """
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            # Explicit UA: some Cloudflare-fronted endpoints reject the urllib
+            # default outright, which would read as an auth failure.
+            "User-Agent": "rapid-mlx-release-preflight",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+            return response.status, json.loads(response.read() or b"{}")
+    except urllib.error.HTTPError as exc:
+        try:
+            return exc.code, json.loads(exc.read() or b"{}")
+        except (ValueError, OSError):
+            return exc.code, {}
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        raise UnreachableError(str(exc)) from exc
+
+
+def _reason(body: dict) -> str:
+    errors = body.get("errors") or []
+    parts = [str(e.get("message", e)) for e in errors if isinstance(e, dict)]
+    return "; ".join(parts) or "no reason given"
+
+
+def check_token_active(fetch, token: str) -> list[tuple[str, str]]:
+    """BLOCKING — the token exists, is not expired, and is not revoked."""
+    try:
+        status, body = fetch(f"{API}/user/tokens/verify", token)
+    except UnreachableError as exc:
+        return [(ADVISORY, f"could not reach Cloudflare to verify the token: {exc}")]
+    if status >= 500:
+        return [(ADVISORY, f"Cloudflare returned HTTP {status} verifying the token")]
+    if status in (401, 403) or not body.get("success"):
+        return [
+            (
+                BLOCKING,
+                f"CLOUDFLARE_API_TOKEN is not usable (HTTP {status}): {_reason(body)}. "
+                "An expired or revoked token passes every presence check and then "
+                "fails on the tag, with the release already published (#1851).",
+            )
+        ]
+    state = (body.get("result") or {}).get("status")
+    if state != "active":
+        return [
+            (BLOCKING, f"CLOUDFLARE_API_TOKEN status is '{state}', expected 'active'")
+        ]
+    return []
+
+
+def check_bucket_visible(fetch, token: str, account: str, bucket: str):
+    """ADVISORY — the expected R2 bucket is visible to this token."""
+    try:
+        status, body = fetch(f"{API}/accounts/{account}/r2/buckets", token)
+    except UnreachableError as exc:
+        return [(ADVISORY, f"could not reach Cloudflare to list R2 buckets: {exc}")]
+    if not body.get("success"):
+        return [
+            (
+                ADVISORY,
+                f"could not list R2 buckets (HTTP {status}): {_reason(body)}. "
+                "Expected if the token is scoped to write only — not proof of a problem.",
+            )
+        ]
+    names = {b.get("name") for b in (body.get("result") or {}).get("buckets", [])}
+    if bucket not in names:
+        return [
+            (
+                ADVISORY,
+                f"R2 bucket '{bucket}' was not in the listing this token can see",
+            )
+        ]
+    return []
+
+
+def check_zone_visible(fetch, token: str, zone: str):
+    """ADVISORY — the zone id resolves for this token."""
+    try:
+        status, body = fetch(f"{API}/zones/{zone}", token)
+    except UnreachableError as exc:
+        return [(ADVISORY, f"could not reach Cloudflare to resolve the zone: {exc}")]
+    if not body.get("success"):
+        return [
+            (
+                ADVISORY,
+                f"could not resolve CLOUDFLARE_ZONE_ID (HTTP {status}): {_reason(body)}. "
+                "Expected if the token holds Cache Purge without Zone Read — cache-purge "
+                "permission cannot be verified without purging, so it is left unproven.",
+            )
+        ]
+    return []
+
+
+def run(fetch, token: str, account: str, zone: str, bucket: str):
+    findings = check_token_active(fetch, token)
+    # Stop on ANY token-level finding. A dead token makes every later call fail
+    # for the same reason, and an unreachable Cloudflare makes them fail for the
+    # same reason too — reporting those as separate findings would bury the one
+    # that matters behind two restatements of it.
+    if not findings:
+        findings += check_bucket_visible(fetch, token, account, bucket)
+        findings += check_zone_visible(fetch, token, zone)
+    # Defence in depth: a transport error carries a message we did not compose,
+    # and these findings are printed straight into a public CI log. Actions
+    # masks registered secrets, but that is the last line of defence, not the
+    # only one.
+    if token:
+        findings = [(sev, msg.replace(token, "<redacted>")) for sev, msg in findings]
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bucket", required=True, help="expected R2 bucket name")
+    args = parser.parse_args()
+
+    token = os.environ.get("CLOUDFLARE_API_TOKEN", "")
+    account = os.environ.get("CLOUDFLARE_ACCOUNT_ID", "")
+    zone = os.environ.get("CLOUDFLARE_ZONE_ID", "")
+    if not (token and account and zone):
+        # Presence is PF-2's other half; this probe has nothing to say.
+        print(
+            "::notice::credentials absent — presence check reports that, skipping probe"
+        )
+        return 0
+
+    findings = run(http_get, token, account, zone, args.bucket)
+    blocking = [m for sev, m in findings if sev == BLOCKING]
+    for severity, message in findings:
+        stream = sys.stderr if severity == BLOCKING else sys.stdout
+        print(
+            f"::{'error' if severity == BLOCKING else 'warning'}::{message}",
+            file=stream,
+        )
+    if blocking:
+        return 1
+    if not findings:
+        print("release credentials OK — token active, R2 bucket and zone both visible")
+    else:
+        print("release credentials usable — token active; see warnings above")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_release_credentials.py
+++ b/scripts/probe_release_credentials.py
@@ -96,6 +96,20 @@ def check_token_active(fetch, token: str) -> list[tuple[str, str]]:
         return [(ADVISORY, f"could not reach Cloudflare to verify the token: {exc}")]
     if status >= 500:
         return [(ADVISORY, f"Cloudflare returned HTTP {status} verifying the token")]
+    # Only an authoritative rejection blocks. 401/403 mean the token is
+    # invalid, revoked, or expired — the #1851 failure mode. A 429 (rate
+    # limit) or any other non-2xx also carries ``success: false``, but that
+    # is "could not check", not "checked and it is dead"; blocking on it
+    # would false-block a release on a transient Cloudflare blip, which the
+    # design keeps advisory (same rule as the 5xx and transport paths above).
+    if status not in (200, 401, 403):
+        return [
+            (
+                ADVISORY,
+                f"could not verify CLOUDFLARE_API_TOKEN (HTTP {status}): {_reason(body)}. "
+                "A transient response is not proof the token is bad.",
+            )
+        ]
     if status in (401, 403) or not body.get("success"):
         return [
             (

--- a/tests/test_check_release_secrets.py
+++ b/tests/test_check_release_secrets.py
@@ -59,6 +59,31 @@ def test_collects_secret_and_var_references(crs, tmp_path):
     assert variables == {"RAPID_MAC_DIST_R2_BUCKET"}
 
 
+def test_collects_bracket_notation_references(crs, tmp_path):
+    """``secrets['FOO']`` / ``vars["BAR"]`` resolve exactly like the dot form.
+
+    A future edit to the release workflow that uses index syntax must not
+    silently drop out of the derived required set — that would reopen the
+    #1851 drift the gate exists to close.
+    """
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - env:
+                  TOKEN: ${{ secrets['CLOUDFLARE_API_TOKEN'] }}
+                  ZONE: ${{ secrets["CLOUDFLARE_ZONE_ID"] }}
+                  BUCKET: ${{ vars['RAPID_MAC_DIST_R2_BUCKET'] }}
+                run: echo hi
+        """,
+    )
+    secrets, variables = crs.referenced_names(wf.read_text())
+    assert secrets == {"CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ZONE_ID"}
+    assert variables == {"RAPID_MAC_DIST_R2_BUCKET"}
+
+
 def test_github_token_is_not_a_requirement(crs, tmp_path):
     """Actions injects it; its absence from the context proves nothing."""
     wf = _make_workflow(

--- a/tests/test_check_release_secrets.py
+++ b/tests/test_check_release_secrets.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``scripts/check_release_secrets.py``.
+
+Pure stdlib + PyYAML — runs on Linux CI without MLX. Tests synthesize tiny
+workflow YAMLs in tmp dirs so the production workflow files don't affect the
+assertions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import textwrap
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check_release_secrets.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_release_secrets", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def crs():
+    return _load_module()
+
+
+def _make_workflow(tmp_path: pathlib.Path, body: str) -> pathlib.Path:
+    wf = tmp_path / "test.yml"
+    wf.write_text(textwrap.dedent(body))
+    return wf
+
+
+# ---------- reference extraction --------------------------------------
+
+
+def test_collects_secret_and_var_references(crs, tmp_path):
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - env:
+                  TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  ZONE: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+                  BUCKET: ${{ vars.RAPID_MAC_DIST_R2_BUCKET }}
+                run: echo hi
+        """,
+    )
+    secrets, variables = crs.referenced_names(wf.read_text())
+    assert secrets == {"CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ZONE_ID"}
+    assert variables == {"RAPID_MAC_DIST_R2_BUCKET"}
+
+
+def test_github_token_is_not_a_requirement(crs, tmp_path):
+    """Actions injects it; its absence from the context proves nothing."""
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                run: echo hi
+        """,
+    )
+    secrets, _ = crs.referenced_names(wf.read_text())
+    assert secrets == set()
+
+
+def test_yaml_comment_is_not_a_reference(crs, tmp_path):
+    """A header documenting a credential must not count as using it.
+
+    ``rapid-mac-release.yml`` has exactly this shape — a comment block naming
+    the secrets the release needs. Counting those would make the gate assert
+    on documentation rather than on wiring.
+    """
+    wf = _make_workflow(
+        tmp_path,
+        """
+        # Required for tagged releases: secrets.LEGACY_DOCUMENTED_ONLY
+        jobs:
+          x:
+            steps:
+              - env:
+                  TOKEN: ${{ secrets.REAL_ONE }}
+                run: echo hi
+        """,
+    )
+    secrets, _ = crs.referenced_names(wf.read_text())
+    assert secrets == {"REAL_ONE"}
+
+
+def test_prose_outside_an_expression_is_not_a_reference(crs, tmp_path):
+    """Only ``${{ }}`` contents count — a run script may mention a name."""
+    wf = _make_workflow(
+        tmp_path,
+        """
+        jobs:
+          x:
+            steps:
+              - run: echo "set secrets.NOT_A_REF to enable mirroring"
+        """,
+    )
+    secrets, _ = crs.referenced_names(wf.read_text())
+    assert secrets == set()
+
+
+# ---------- available-context parsing ---------------------------------
+
+
+def test_load_available_reads_keys_only(crs, monkeypatch):
+    monkeypatch.setenv("AVAILABLE_SECRETS_JSON", '{"A":"supersecret","B":"x"}')
+    assert crs.load_available("AVAILABLE_SECRETS_JSON") == {"A", "B"}
+
+
+def test_load_available_rejects_unset(crs, monkeypatch):
+    monkeypatch.delenv("AVAILABLE_SECRETS_JSON", raising=False)
+    with pytest.raises(SystemExit):
+        crs.load_available("AVAILABLE_SECRETS_JSON")
+
+
+def test_load_available_rejects_non_json(crs, monkeypatch):
+    monkeypatch.setenv("AVAILABLE_SECRETS_JSON", "not json")
+    with pytest.raises(SystemExit):
+        crs.load_available("AVAILABLE_SECRETS_JSON")
+
+
+# ---------- end to end -------------------------------------------------
+
+
+def _run_main(crs, monkeypatch, wf, secrets_json, vars_json) -> int:
+    monkeypatch.setenv("AVAILABLE_SECRETS_JSON", secrets_json)
+    monkeypatch.setenv("AVAILABLE_VARS_JSON", vars_json)
+    monkeypatch.setattr("sys.argv", ["check_release_secrets.py", str(wf)])
+    return crs.main()
+
+
+_WORKFLOW = """
+jobs:
+  x:
+    steps:
+      - env:
+          TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          BUCKET: ${{ vars.R2_BUCKET }}
+        run: echo hi
+"""
+
+
+def test_main_passes_when_everything_is_configured(crs, tmp_path, monkeypatch):
+    wf = _make_workflow(tmp_path, _WORKFLOW)
+    rc = _run_main(
+        crs, monkeypatch, wf, '{"CLOUDFLARE_API_TOKEN":"v"}', '{"R2_BUCKET":"v"}'
+    )
+    assert rc == 0
+
+
+def test_main_fails_on_the_missing_secret_that_caused_1851(
+    crs, tmp_path, monkeypatch, capsys
+):
+    wf = _make_workflow(tmp_path, _WORKFLOW)
+    rc = _run_main(
+        crs, monkeypatch, wf, '{"CLOUDFLARE_ACCOUNT_ID":"v"}', '{"R2_BUCKET":"v"}'
+    )
+    assert rc == 1
+    assert "CLOUDFLARE_API_TOKEN" in capsys.readouterr().err
+
+
+def test_main_fails_on_a_missing_var(crs, tmp_path, monkeypatch, capsys):
+    wf = _make_workflow(tmp_path, _WORKFLOW)
+    rc = _run_main(crs, monkeypatch, wf, '{"CLOUDFLARE_API_TOKEN":"v"}', "{}")
+    assert rc == 1
+    assert "vars.R2_BUCKET" in capsys.readouterr().err
+
+
+def test_main_never_prints_a_secret_value(crs, tmp_path, monkeypatch, capsys):
+    wf = _make_workflow(tmp_path, _WORKFLOW)
+    _run_main(crs, monkeypatch, wf, '{"UNUSED":"supersecret"}', '{"R2_BUCKET":"v"}')
+    captured = capsys.readouterr()
+    assert "supersecret" not in captured.out + captured.err
+
+
+def test_main_reports_a_missing_workflow_file(crs, tmp_path, monkeypatch, capsys):
+    rc = _run_main(crs, monkeypatch, tmp_path / "nope.yml", "{}", "{}")
+    assert rc == 1
+    assert "no such workflow" in capsys.readouterr().err

--- a/tests/test_probe_release_credentials.py
+++ b/tests/test_probe_release_credentials.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``scripts/probe_release_credentials.py``.
+
+Pure stdlib — no network. The probe takes its HTTP primitive as an argument
+precisely so the blocking/advisory split can be pinned here, since that split
+is the whole design: a false block stops releases to punish a token that is
+scoped correctly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "probe_release_credentials.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("probe_release_credentials", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def prc():
+    return _load_module()
+
+
+def _fetch_map(responses):
+    """Build a fetch callable from a {url-substring: (status, body)} map.
+
+    A value that is an Exception is raised instead of returned.
+    """
+
+    def fetch(url, token):
+        for key, value in responses.items():
+            if key in url:
+                if isinstance(value, Exception):
+                    raise value
+                return value
+        raise AssertionError(f"unexpected URL: {url}")
+
+    return fetch
+
+
+_OK_TOKEN = (200, {"success": True, "result": {"status": "active"}})
+_OK_BUCKETS = (
+    200,
+    {"success": True, "result": {"buckets": [{"name": "rapid-desktop-dist"}]}},
+)
+_OK_ZONE = (200, {"success": True, "result": {"id": "z"}})
+
+
+def _run(prc, prcfetch):
+    return prc.run(prcfetch, "tok", "acct", "zone", "rapid-desktop-dist")
+
+
+def _severities(findings):
+    return {sev for sev, _ in findings}
+
+
+# ---------- the happy path ---------------------------------------------
+
+
+def test_all_green_reports_nothing(prc):
+    findings = _run(
+        prc,
+        _fetch_map(
+            {"tokens/verify": _OK_TOKEN, "r2/buckets": _OK_BUCKETS, "/zones/": _OK_ZONE}
+        ),
+    )
+    assert findings == []
+
+
+# ---------- blocking: the token itself is dead -------------------------
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        (401, {"success": False, "errors": [{"message": "Invalid API Token"}]}),
+        (403, {"success": False, "errors": [{"message": "Forbidden"}]}),
+        (200, {"success": False, "errors": [{"message": "expired"}]}),
+    ],
+)
+def test_unusable_token_blocks(prc, response):
+    findings = _run(prc, _fetch_map({"tokens/verify": response}))
+    assert prc.BLOCKING in _severities(findings)
+
+
+def test_non_active_status_blocks(prc):
+    findings = _run(
+        prc,
+        _fetch_map(
+            {"tokens/verify": (200, {"success": True, "result": {"status": "expired"}})}
+        ),
+    )
+    assert prc.BLOCKING in _severities(findings)
+
+
+def test_dead_token_does_not_also_report_downstream_noise(prc):
+    """One finding, not three — the later calls fail for the same reason."""
+    findings = _run(prc, _fetch_map({"tokens/verify": (401, {"success": False})}))
+    assert len(findings) == 1
+
+
+def test_unreachable_cloudflare_reports_once_not_three_times(prc):
+    """Same reasoning for a transport failure: one root cause, one finding."""
+    findings = _run(prc, _fetch_map({"tokens/verify": prc.UnreachableError("dns")}))
+    assert len(findings) == 1
+
+
+# ---------- advisory: scope gaps must never block ----------------------
+
+
+def test_r2_list_denied_is_advisory_not_blocking(prc):
+    """A write-only R2 token legitimately cannot list buckets."""
+    findings = _run(
+        prc,
+        _fetch_map(
+            {
+                "tokens/verify": _OK_TOKEN,
+                "r2/buckets": (
+                    403,
+                    {"success": False, "errors": [{"message": "denied"}]},
+                ),
+                "/zones/": _OK_ZONE,
+            }
+        ),
+    )
+    assert _severities(findings) == {prc.ADVISORY}
+
+
+def test_zone_read_denied_is_advisory_not_blocking(prc):
+    """Cache Purge without Zone Read is a correctly-scoped token."""
+    findings = _run(
+        prc,
+        _fetch_map(
+            {
+                "tokens/verify": _OK_TOKEN,
+                "r2/buckets": _OK_BUCKETS,
+                "/zones/": (403, {"success": False, "errors": [{"message": "denied"}]}),
+            }
+        ),
+    )
+    assert _severities(findings) == {prc.ADVISORY}
+
+
+def test_missing_bucket_is_advisory(prc):
+    findings = _run(
+        prc,
+        _fetch_map(
+            {
+                "tokens/verify": _OK_TOKEN,
+                "r2/buckets": (
+                    200,
+                    {"success": True, "result": {"buckets": [{"name": "other"}]}},
+                ),
+                "/zones/": _OK_ZONE,
+            }
+        ),
+    )
+    assert _severities(findings) == {prc.ADVISORY}
+
+
+# ---------- advisory: "could not check" is not "it is bad" -------------
+
+
+def test_transport_failure_on_token_verify_is_advisory(prc):
+    findings = _run(prc, _fetch_map({"tokens/verify": prc.UnreachableError("dns")}))
+    assert _severities(findings) == {prc.ADVISORY}
+
+
+def test_cloudflare_5xx_is_advisory(prc):
+    findings = _run(prc, _fetch_map({"tokens/verify": (503, {})}))
+    assert _severities(findings) == {prc.ADVISORY}
+
+
+# ---------- the token must never leak ----------------------------------
+
+
+def test_no_finding_message_contains_the_token(prc):
+    def fetch(url, token):
+        raise prc.UnreachableError(f"connection to host failed while sending {token}")
+
+    findings = prc.run(fetch, "SUPERSECRET", "acct", "zone", "bucket")
+    assert findings
+    assert all("SUPERSECRET" not in message for _, message in findings)

--- a/tests/test_probe_release_credentials.py
+++ b/tests/test_probe_release_credentials.py
@@ -181,6 +181,26 @@ def test_cloudflare_5xx_is_advisory(prc):
     assert _severities(findings) == {prc.ADVISORY}
 
 
+def test_rate_limit_on_token_verify_is_advisory_not_blocking(prc):
+    """A 429 carries ``success: false`` but is transient, not authoritative.
+
+    Blocking on it would false-block a legitimate bump PR on a Cloudflare
+    rate-limit blip, which the design keeps advisory alongside 5xx/transport.
+    """
+    findings = _run(
+        prc,
+        _fetch_map(
+            {
+                "tokens/verify": (
+                    429,
+                    {"success": False, "errors": [{"message": "rate limited"}]},
+                )
+            }
+        ),
+    )
+    assert _severities(findings) == {prc.ADVISORY}
+
+
 # ---------- the token must never leak ----------------------------------
 
 


### PR DESCRIPTION
Closes the first and last acceptance criteria of #1852. Context: #1851.

## Why

A workflow can reference a secret that was never configured. Actions does not warn — the expression evaluates to the empty string, and the failure surfaces wherever that value is finally used. For the mac release pipeline that is *on a tag, after the notarised build, once the GitHub Release is already published*.

That is #1851. #1747 introduced two credential requirements (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`); neither was ever added. `mirror-dist` hard-failed on three consecutive tags — 0.12.8, 0.12.9, 0.12.10 — and each release shipped anyway, with `dl.rapidmlx.com/latest.json` published by hand afterwards. The manual fix-up is what let it survive three cycles: it removed the symptom and left the defect.

The guard inside `rapid-mac-release.yml` was working correctly. It was just placed where nothing can act on it.

## What

A new **PF-2** gate on `release-preflight.yml`, which runs on the `chore: bump version to X.Y.Z` PR — before the tag exists. Two halves.

### 1. Presence — `scripts/check_release_secrets.py`

Parses `rapid-mac-release.yml`, collects every `secrets.*` / `vars.*` reference, fails if any is absent.

- **Derived, not listed.** The required set comes from the workflow file, so a step that starts needing a new secret extends the gate on its own. A hand-maintained list would drift exactly the way the credential did — that is the bug, not a variation of it.
- **References only come from inside `${{ }}`.** Parsed YAML values are walked, so the header comment in `rapid-mac-release.yml` that *documents* the required secrets is not mistaken for wiring, and prose in a `run:` block cannot register a requirement.
- **`GITHUB_TOKEN` is exempt** — injected by Actions, so its absence proves nothing.
- **Keys only.** Actions exposes no way to enumerate configured names, so `toJSON(secrets)` is passed in. The script reads keys and never prints, returns, or logs a value; a test asserts that.

### 2. Validity — `scripts/probe_release_credentials.py`

Presence is not validity: an expired or revoked token is a non-empty string and passes every presence check, including the `[[ -n ... ]]` guard in the release workflow. Cloudflare tokens can carry an expiry date, which makes silent expiry the realistic way #1851 returns.

The blocking/advisory split is the design, because a false block stops releases to punish a token that is scoped *correctly*:

| check | severity | why |
|---|---|---|
| `/user/tokens/verify` reports not-active | **blocking** | every valid token can call this regardless of permissions, so the answer is unambiguous and cannot false-block |
| R2 bucket listing, zone lookup | advisory | the release needs R2 *write* and *cache purge*; neither implies the read permission these use, so a minimally-scoped token can legitimately 403 |
| transport error, timeout, 5xx — anywhere | advisory | "could not check" is not "checked and it is bad"; a Cloudflare blip must not block a release |

Cache-purge permission is deliberately left unproven — there is no dry run, and exercising it on every bump PR to prove it works is the worse trade.

A token-level finding short-circuits the rest, so a dead token or an unreachable Cloudflare yields one finding rather than three restatements of it. Findings are scrubbed of the token before printing: Actions masks registered secrets, but a transport error carries a message we did not compose into a public log, so that mask is the last line of defence rather than the only one.

### Skipped on fork PRs

Actions withholds secrets from forks by design, so an empty context there would fail every name without proving anything. `preflight-summary` accepts `skipped` for PF-2 for that reason only — every other skip path is already excluded by the `is_bump` guard.

## Still out of scope

**Atomic publish.** `build` still attaches the GitHub Release before `mirror-dist` runs, so a downstream failure still leaves a shipped release. Making the release a draft until `publish-updater-fallback` succeeds changes when a release becomes visible and deserves its own review — remains in #1852.

## Verification

The presence half was run against the live repo state at both ends of the #1851 fix:

- **Before** the secrets were added: named exactly `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ZONE_ID`, and did not flag the seven configured secrets or two vars.
- **After**: `release secrets OK — 11 reference(s) across 1 workflow(s), all configured`, exit 0.

25 unit tests total (pure stdlib; the probe takes its HTTP primitive as an argument so the severity split is pinned without network). `ruff check` and `ruff format --check` clean, and the repo's own `check_workflow_expressions.py` and `check_gha_pinning.py` both pass on the modified workflow.

## Note for the reviewer

**PF-2 has not yet executed in CI.** The whole preflight only runs on bump PRs, so on this PR every gate reports `skipping` — a green check here does not exercise the new job. The `toJSON(secrets)` wiring and the probe's live call path first run on the next `chore: bump version to X.Y.Z` PR. Given the subject matter, that caveat seemed worth stating rather than leaving a green tick to imply more than it does.

The gate is blocking. It would have failed every bump PR while the secrets were missing, which is the intent. Those secrets now exist and the token verifies, so it is green today; merging does not block the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)