### PR TITLE
fix(mllm): type client-safe stream errors (#1849)

### DIFF
--- a/tests/test_api_validation_bundle.py
+++ b/tests/test_api_validation_bundle.py
@@ -743,25 +743,25 @@ class TestMLLMBatchGeneratorFailsLoud:
 
         return Path(mod.__file__).read_text()
 
-    def test_image_branch_raises_value_error(self):
+    def test_image_branch_raises_explicit_client_error(self):
         src = self._source()
         assert "Failed to process image" in src
         # Window straddles the marker so we see the raise above it.
         idx = src.find("Failed to process image")
         window = src[max(0, idx - 200) : idx + 200]
-        assert "raise ValueError" in window
+        assert "raise ClientRequestError" in window
         # The old silent-drop pattern must not return.
         assert 'logger.warning(f"Failed to process image' not in src
         # And we must NOT use HTTPException here — the scheduler's
-        # narrow except catches ValueError/RuntimeError only.
+        # narrow except catches its ValueError base class.
         assert "HTTPException" not in window
 
-    def test_video_branch_raises_value_error(self):
+    def test_video_branch_raises_explicit_client_error(self):
         src = self._source()
         assert "Failed to process video" in src
         idx = src.find("Failed to process video")
         window = src[max(0, idx - 200) : idx + 200]
-        assert "raise ValueError" in window
+        assert "raise ClientRequestError" in window
         assert 'logger.warning(f"Failed to process video' not in src
         assert "HTTPException" not in window
 

--- a/tests/test_image_aspect_ratio.py
+++ b/tests/test_image_aspect_ratio.py
@@ -234,4 +234,5 @@ def test_unreadable_image_does_not_short_circuit_guard(monkeypatch, tmp_path):
     # prefix — confirms the dim guard didn't preempt the wrapper.
     msg = str(exc_info.value)
     assert msg.startswith("Failed to process image"), msg
-    assert "broken data stream" in msg
+    assert "valid PNG, JPEG, GIF, or WebP" in msg
+    assert "broken data stream" not in msg

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -2097,6 +2097,34 @@ class TestMLLMSchedulerErrorPropagation:
                 pass
 
     @pytest.mark.asyncio
+    async def test_stream_outputs_preserves_explicit_client_error_type(self):
+        """Only scheduler-vetted public errors cross the route trust boundary."""
+        import asyncio
+
+        from vllm_mlx.mllm_scheduler import MLLMScheduler
+        from vllm_mlx.request import ClientRequestError, RequestOutput
+
+        sched = MLLMScheduler.__new__(MLLMScheduler)
+        sched.output_queues = {}
+        req_id = "req-explicit-client-error"
+        queue: asyncio.Queue = asyncio.Queue()
+        sched.output_queues[req_id] = queue
+        await queue.put(
+            RequestOutput(
+                request_id=req_id,
+                output_text="",
+                finished=True,
+                error="Failed to process image: image too small",
+                error_kind="invalid_request",
+                finish_reason="error",
+            )
+        )
+
+        with pytest.raises(ClientRequestError, match="image too small"):
+            async for _ in sched.stream_outputs(req_id):
+                pass
+
+    @pytest.mark.asyncio
     async def test_stream_outputs_yields_normally_when_no_error(self):
         """Non-error outputs MUST continue to flow through stream_outputs
         unchanged — the error check is additive, not a behavior swap."""

--- a/tests/test_mllm_corrupt_image.py
+++ b/tests/test_mllm_corrupt_image.py
@@ -34,11 +34,9 @@ The bug had two faces:
   (``finish_reason="length"``, ``error=None``) → silent ``200 OK`` with
   ``content=null`` and ``prompt_tokens=0`` (F-062).
 
-The fix wraps the ``prepare_inputs`` call in
-``MLLMBatchGenerator._preprocess_request`` so every non-canonical
-exception is re-raised as ``ValueError("Failed to process image: <orig>")``.
-That makes ``_step_no_queue`` clean-abort the request *and* the route
-layer return ``HTTP 400`` with the underlying PIL message.
+The fix maps expected decoder failures to a typed ``ClientRequestError``
+with a bounded public message. That makes ``_step_no_queue`` clean-abort
+the request without exposing temporary paths from the underlying decoder.
 """
 
 from __future__ import annotations
@@ -130,9 +128,8 @@ def test_preprocess_wraps_pil_oserror_as_failed_to_process_image(monkeypatch):
     with pytest.raises(ValueError) as exc_info:
         gen._preprocess_request(req)
     assert str(exc_info.value).startswith("Failed to process image")
-    # Original PIL message must still be embedded for the route layer
-    # to surface to the client.
-    assert "broken data stream" in str(exc_info.value)
+    assert "valid PNG, JPEG, GIF, or WebP" in str(exc_info.value)
+    assert "broken data stream" not in str(exc_info.value)
 
 
 def test_preprocess_wraps_pil_unidentified_image_as_failed_to_process_image(
@@ -156,7 +153,7 @@ def test_preprocess_wraps_pil_unidentified_image_as_failed_to_process_image(
     with pytest.raises(ValueError) as exc_info:
         gen._preprocess_request(req)
     assert str(exc_info.value).startswith("Failed to process image")
-    assert "cannot identify image file" in str(exc_info.value)
+    assert "cannot identify image file" not in str(exc_info.value)
 
 
 def test_preprocess_normalizes_failed_to_load_image_to_failed_to_process_image(
@@ -186,21 +183,17 @@ def test_preprocess_normalizes_failed_to_load_image_to_failed_to_process_image(
     assert msg.startswith("Failed to process image"), (
         f"matcher would miss this message: {msg!r}"
     )
-    # Underlying mlx_vlm message is still embedded — clients see why.
-    assert "cannot identify image file" in msg
+    # Underlying mlx_vlm message can contain private temporary paths and must
+    # stay in the exception cause rather than crossing the public boundary.
+    assert "/tmp/xyz.png" not in msg
 
 
-def test_preprocess_preserves_canonical_message_unchanged(monkeypatch):
-    """A pre-canonical ``ValueError("Failed to process image: …")`` (the
-    ``process_image_input`` branch already raises this shape for
-    download / base64-decode failures) must pass through *without* being
-    double-wrapped — otherwise the route-layer 400 message becomes
-    ``"Failed to process image: Failed to process image: …"``.
-    """
+def test_preprocess_does_not_reflect_canonical_looking_decoder_message(monkeypatch):
+    """Message shape must not grant permission to cross the boundary."""
     _bypass_process_image(monkeypatch)
 
     def _raise_canonical(*args, **kwargs):
-        raise ValueError("Failed to process image: 404 Client Error")
+        raise ValueError("Failed to process image: /Users/private/secret.png")
 
     _install_prepare_inputs_stub(monkeypatch, _raise_canonical)
 
@@ -210,9 +203,24 @@ def test_preprocess_preserves_canonical_message_unchanged(monkeypatch):
     with pytest.raises(ValueError) as exc_info:
         gen._preprocess_request(req)
     msg = str(exc_info.value)
-    assert msg == "Failed to process image: 404 Client Error", (
-        f"canonical message must pass through unchanged, got {msg!r}"
-    )
+    assert "/Users/private/secret.png" not in msg
+
+
+def test_process_image_internal_runtime_error_is_not_made_public(monkeypatch):
+    """Unexpected loader bugs remain server errors even if their text looks safe."""
+    from vllm_mlx.models import mllm as mllm_models
+
+    sentinel = RuntimeError("Failed to process image: /Users/private/secret.png")
+
+    def _raise_runtime_error(_image):
+        raise sentinel
+
+    monkeypatch.setattr(mllm_models, "process_image_input", _raise_runtime_error)
+    gen = _make_generator()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        gen._preprocess_request(_make_request(images=["https://example.test/a.png"]))
+    assert exc_info.value is sentinel
 
 
 def test_preprocess_propagates_internal_bugs_unchanged(monkeypatch):

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -613,8 +613,10 @@ def test_disconnect_guard_surfaces_client_actionable_error_message():
     """
 
     async def _generator():
+        from vllm_mlx.request import ClientRequestError
+
         yield 'data: {"role":"assistant"}\n\n'
-        raise ValueError(
+        raise ClientRequestError(
             "Vision-request prompt tokens (20000) exceeds the per-batch cap "
             "(8192 = prefill_step_size 8192 × 1 vision request(s)). "
             "For image inputs, downscale the image."
@@ -657,3 +659,23 @@ def test_disconnect_guard_still_masks_genuine_engine_fault():
     assert "TextEncodeInput" not in err["message"], (
         f"raw Python exception detail must not leak; got {err['message']!r}"
     )
+
+
+@pytest.mark.parametrize("error_type", [RuntimeError, ValueError])
+def test_disconnect_guard_does_not_trust_actionable_substrings(error_type):
+    """F-131: marker text cannot promote an arbitrary exception to public."""
+
+    async def _generator():
+        yield 'data: {"role":"assistant"}\n\n'
+        raise error_type(
+            "Failed to process image: /Users/private/internal-secret-token"
+        )
+
+    chunks = _collect_disconnect_guard_chunks(_generator())
+    error_frame = [c for c in chunks if '"error"' in c][-1]
+    payload = json.loads(error_frame.replace("data: ", "", 1).strip())
+    assert payload["error"] == {
+        "message": "Internal error during streaming",
+        "type": "internal_error",
+    }
+    assert "internal-secret-token" not in str(chunks)

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -39,6 +39,7 @@ from mlx_lm.sample_utils import make_logits_processors, make_sampler  # noqa: E4
 
 from .mllm_cache_compat import first_incompatible_mllm_cache_type  # noqa: E402
 from .multimodal_processor import MultimodalProcessor  # noqa: E402
+from .request import ClientRequestError  # noqa: E402
 from .vision_embedding_cache import (  # noqa: E402
     VisionEmbeddingCache,
     compute_images_hash,
@@ -786,14 +787,14 @@ class MLLMBatchGenerator:
         all_images = []
 
         if request.images:
-            from .models.mllm import process_image_input
+            from .models.mllm import FileSizeExceededError, process_image_input
 
             # Pre-PR: undecodable / unreachable image was logged at WARN
             # and silently dropped from ``all_images``, so the model
             # would caption a non-existent image and confidently
             # hallucinate ("a vibrant red jellyfish" for a 404'd URL).
-            # Fail loud with ValueError so MLLMScheduler._step's narrow
-            # ``except (ValueError, RuntimeError)`` cleans up the
+            # Fail loud with a typed, bounded public diagnostic so the
+            # scheduler cleans up the
             # request (finish_reason="error") instead of the generic
             # ``except Exception`` in _process_loop swallowing the
             # error and hanging the client.
@@ -801,13 +802,19 @@ class MLLMBatchGenerator:
                 try:
                     path = process_image_input(img)
                     all_images.append(path)
-                except Exception as e:
-                    raise ValueError(f"Failed to process image: {e}") from e
+                except FileSizeExceededError as e:
+                    raise ClientRequestError(f"Failed to process image: {e}") from e
+                except (OSError, ValueError) as e:
+                    raise ClientRequestError(
+                        "Failed to process image: could not load the image; "
+                        "check that its URL or encoded data is valid"
+                    ) from e
 
         if request.videos:
             from .models.mllm import (
                 DEFAULT_FPS,
                 MAX_FRAMES,
+                FileSizeExceededError,
                 extract_video_frames_smart,
                 process_video_input,
                 save_frames_to_temp,
@@ -830,11 +837,16 @@ class MLLMBatchGenerator:
                     )
                     frame_paths = save_frames_to_temp(frames)
                     all_images.extend(frame_paths)
-                except Exception as e:
+                except FileSizeExceededError as e:
+                    raise ClientRequestError(f"Failed to process video: {e}") from e
+                except (OSError, ValueError) as e:
                     # Same rationale as the image branch above: silent
-                    # drop hallucinates; ValueError so the scheduler
-                    # cleans up the request properly.
-                    raise ValueError(f"Failed to process video: {e}") from e
+                    # drop hallucinates; the typed error lets the scheduler
+                    # clean up the request without exposing decoder internals.
+                    raise ClientRequestError(
+                        "Failed to process video: could not load or decode the video; "
+                        "check that its URL or encoded data is valid"
+                    ) from e
 
         # Key this request's images into the vision-feature cache by content
         # hash (robust to the per-request temp-file paths ``all_images`` holds).
@@ -884,9 +896,8 @@ class MLLMBatchGenerator:
         #
         # Pre-filter with PIL here so the request fails fast with a
         # canonical ``Failed to process image: image too small …``
-        # ``ValueError`` — the same marker the
-        # ``except (OSError, ValueError)`` block below uses, so
-        # ``is_client_error`` fires and routes map it to HTTP 400.
+        # ``ClientRequestError``. Its explicit type tells the scheduler and
+        # route that this bounded diagnostic may cross the F-131 boundary.
         if all_images:
             from PIL import Image as _PILImage
 
@@ -900,7 +911,7 @@ class MLLMBatchGenerator:
                     # try/except below; don't double-report here.
                     continue
                 if min(_w, _h) < _MIN_DIM:
-                    raise ValueError(
+                    raise ClientRequestError(
                         f"Failed to process image: image too small "
                         f"(min dimension must be >= {_MIN_DIM}, "
                         f"got {_w}x{_h})"
@@ -931,11 +942,10 @@ class MLLMBatchGenerator:
         #     ``content=null`` and ``prompt_tokens=0`` (F-062).
         #
         # Normalize every image-decode failure to the canonical
-        # ``Failed to process image: …`` ``ValueError`` so:
+        # ``Failed to process image: …`` ``ClientRequestError`` so:
         #   * ``_step_no_queue``'s ``except (ValueError, RuntimeError)``
         #     catches it (no infinite retry),
-        #   * ``is_client_error`` fires on the ``"Failed to process
-        #     image"`` substring (clean ``error`` field), and
+        #   * its explicit type produces a clean public ``error`` field, and
         #   * ``routes/chat.py`` / ``routes/anthropic.py`` /
         #     ``routes/responses.py`` map the marker to HTTP 400 with
         #     an actionable message.
@@ -956,14 +966,14 @@ class MLLMBatchGenerator:
                 image_token_index=image_token_index,
             )
         except (OSError, ValueError) as e:
-            # Already-canonical messages (the ``process_image_input``
-            # branch above raises ``ValueError("Failed to process image:
-            # …")``) pass through unchanged; everything else gets the
-            # canonical prefix so downstream matchers fire.
-            msg = str(e)
-            if msg.startswith("Failed to process image"):
-                raise
-            raise ValueError(f"Failed to process image: {msg}") from e
+            # Do not reflect decoder text: PIL / mlx-vlm messages can contain
+            # server-side temporary paths. Keep the public diagnostic useful
+            # and bounded while preserving the original exception as cause for
+            # logs and observability.
+            raise ClientRequestError(
+                "Failed to process image: image data could not be decoded; "
+                "use a valid PNG, JPEG, GIF, or WebP image"
+            ) from e
 
         request.input_ids = inputs.get("input_ids")
         request.pixel_values = inputs.get("pixel_values")
@@ -1233,7 +1243,7 @@ class MLLMBatchGenerator:
         # be rejected just because ``prefill_step_size`` defaults to 8192.
         _cap_help = _prefill_cap_violation(requests, self.prefill_step_size)
         if _cap_help is not None:
-            raise ValueError(_cap_help)
+            raise ClientRequestError(_cap_help)
 
         # Run vision encoding for each request with its own KVCache.
         # Vision encoding cannot be batched because each request may have

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -48,7 +48,12 @@ from .mllm_batch_generator import (  # noqa: E402
 )
 from .mllm_cache import MLLMCacheManager  # noqa: E402
 from .multimodal_processor import MultimodalProcessor  # noqa: E402
-from .request import RequestOutput, RequestStatus, SamplingParams  # noqa: E402
+from .request import (  # noqa: E402
+    ClientRequestError,
+    RequestOutput,
+    RequestStatus,
+    SamplingParams,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1152,19 +1157,10 @@ class MLLMScheduler:
                 # VLM saw an empty assistant message + "Reached max_tokens
                 # before any output" rendered by the client).
                 #
-                # The "per-batch cap" string is the marker raised by
-                # ``mllm_batch_generator._process_prompts`` when prompt
-                # tokens (vision + text) exceed the configured cap. For
-                # VLM the typical trigger is a high-resolution image; the
-                # error message already tells the user to downscale or
-                # raise --prefill-step-size, so surfacing the message
-                # is strictly more informative than the legacy soft
-                # truncation.
-                is_client_error = (
-                    "Failed to process image" in err_msg
-                    or "Failed to process video" in err_msg
-                    or "exceeds the per-batch cap" in err_msg
-                )
+                # An explicit type owns the public-message trust boundary.
+                # Arbitrary RuntimeError/ValueError text may include caller
+                # data or local paths that happen to match the old markers.
+                is_client_error = isinstance(e, ClientRequestError)
                 # Create error outputs (queue delivery deferred to caller).
                 for request_id in error_ids:
                     output.outputs.append(
@@ -1173,6 +1169,7 @@ class MLLMScheduler:
                             output_text="",
                             finished=True,
                             error=err_msg if is_client_error else None,
+                            error_kind=("invalid_request" if is_client_error else None),
                             finish_reason="error" if is_client_error else "length",
                         )
                     )
@@ -1781,6 +1778,8 @@ class MLLMScheduler:
                     # Mark finished BEFORE raising so the finally block
                     # doesn't double-abort what's already cleaned up.
                     finished_normally = True
+                    if output.error_kind == "invalid_request":
+                        raise ClientRequestError(output.error)
                     raise ValueError(output.error)
                 # Mark terminal output before yielding it. A consumer of an
                 # async generator may stop immediately after receiving the

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -279,6 +279,16 @@ class InferenceAbortedError(RuntimeError):
     """
 
 
+class ClientRequestError(ValueError):
+    """A request rejection whose message is explicitly safe for clients.
+
+    This is a trust-boundary type, not a generic validation alias. Only code
+    that constructs a bounded, actionable diagnostic may raise it. Streaming
+    guards use the type — never message substrings — to decide whether an
+    exception may cross the F-131 sanitisation boundary.
+    """
+
+
 @dataclass
 class RequestOutput:
     """
@@ -327,7 +337,11 @@ class RequestOutput:
     # so positional constructor args for the pre-existing fields keep
     # their indices.
     matched_stop: str | None = None
-    # Distinguishes WHY the request aborted, when ``error`` is set. The engine
+    # Distinguishes WHY the request aborted, when ``error`` is set.
+    # ``invalid_request`` means the scheduler caught an explicit
+    # ``ClientRequestError`` whose bounded message is safe to expose through
+    # the route; it must never be inferred from arbitrary exception text.
+    # The engine
     # raises InferenceAbortedError (→ HTTP 503) for genuine mid-flight failures
     # (Metal runtime errors, engine-loop crashes) where the partial output may
     # be corrupt. A repetition-guard hard-stop is different: the scheduler

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3769,32 +3769,6 @@ def _force_abort_request(engine, request_id_holder) -> bool:
     return False
 
 
-_CLIENT_ACTIONABLE_STREAM_MARKERS = (
-    "exceeds the per-batch cap",
-    "Failed to process image",
-    "Failed to process video",
-    "Chat template error",
-)
-
-
-def _stream_error_is_client_actionable(message: str) -> bool:
-    """Whether a mid-stream generator exception carries a client-correctable
-    request error whose real message should be surfaced instead of masked.
-
-    Mirrors the markers the non-streaming chat route maps to HTTP 400
-    (#457 image/video fetch, #682 per-batch prefill cap, chat-template
-    errors). On the streaming path the SSE response has already started by
-    the time these surface mid-stream, so they cannot be turned into a 400
-    status; instead ``_disconnect_guard`` emits the real message with the
-    OpenAI ``invalid_request_error`` type so the caller sees the actionable
-    guidance rather than a generic "Internal error during streaming" (#1849).
-    Returns ``False`` for any other (genuine engine) fault, which keeps the
-    F-131 sanitisation intact for raw Python exception messages / class
-    names.
-    """
-    return any(marker in message for marker in _CLIENT_ACTIONABLE_STREAM_MARKERS)
-
-
 async def _disconnect_guard(
     generator: AsyncIterator[str],
     raw_request: Request,
@@ -4023,10 +3997,9 @@ async def _disconnect_guard(
                 # surface from this entry point. The full exception is
                 # logged above with ``exc_info`` so operators retain
                 # the diagnostic detail server-side.
-                # #1849: some exceptions are *client-actionable* request
-                # rejections whose real message must reach the caller —
-                # e.g. the MLLM per-batch-prefill cap ("exceeds the
-                # per-batch cap") or a failed image/video fetch. The
+                # #1849: explicit ``ClientRequestError`` exceptions are
+                # client-actionable rejections whose bounded message must
+                # reach the caller (MLLM prefill cap, bad image/video). The
                 # non-streaming route already maps these to HTTP 400 with
                 # the real message; but on the streaming path the SSE
                 # response has already started (headers + role chunk were
@@ -4034,12 +4007,13 @@ async def _disconnect_guard(
                 # generic masking would otherwise swallow the actionable
                 # message and hand the client a misleading 200 with
                 # "Internal error during streaming" — exactly the shape
-                # #1849 reports. Surface the real message for those
-                # known client-error markers (OpenAI ``invalid_request_error``
-                # type) while keeping F-131's sanitisation for every other
-                # (genuine engine) fault so a raw Python class name /
-                # traceback can never leak through the SSE payload.
-                if _stream_error_is_client_actionable(str(exc)):
+                # #1849 reports. Trust the explicit carrier type, never a
+                # message substring: arbitrary internal exceptions may contain
+                # caller text or local paths. Every other fault remains under
+                # F-131's generic sanitisation.
+                from ..request import ClientRequestError
+
+                if isinstance(exc, ClientRequestError):
                     _sse_type = "invalid_request_error"
                     _sse_message = str(exc)
                 else:


### PR DESCRIPTION
## Summary

Hardens the #1849 streaming-error fix from #1855 without changing its intended client behavior:

- replaces substring-based trust decisions with an explicit `ClientRequestError` carrier type;
- preserves actionable `invalid_request_error` SSE events for known MLLM input failures;
- keeps arbitrary `ValueError` / `RuntimeError` messages behind F-131's generic stream error, even when their text contains an old allowlisted marker;
- bounds image/video diagnostics so decoder temporary paths and other internals cannot cross the public boundary;
- propagates the vetted error kind through `RequestOutput` and restores the carrier type at the stream boundary.

This is the security/correctness follow-up for layer 2 of #1849. The issue intentionally stays open for layer 1: returning a true HTTP 4xx before headers are committed requires a separate first-result/preflight design with TTFT, keepalive, and disconnect tradeoffs.

## Verification

- `ruff check` and `ruff format --check`: clean on all 9 changed files.
- Focused MLLM/SSE/API regression suite: **159 passed, 9 deselected**.
- Full suite on the parent implementation: **17,158 passed, 235 skipped, 42 deselected, 6 xfailed, 1 xpassed**; the only two failures require a live server on `127.0.0.1:8000` (`test_event_loop_responsiveness`, `test_disconnect_recovery`).

Regression coverage explicitly proves that `RuntimeError("Failed to process image: /private/path")` and the equivalent `ValueError` are still sanitized, while typed bad-image errors retain actionable client guidance.
