### PR TITLE
perf(kv-cache): fused quantized-KV attention read path — opt-in quant cost drops from −27% to −9% at 16k

### DIFF
--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -1057,3 +1057,27 @@ def test_mask_patch_is_superset_for_stock_shapes():
         mask[None, None] * mx.ones((1, 1, 1, S), dtype=mx.bool_),
     )
     assert _max_abs(out, ref) < 5e-2
+
+
+def test_install_wires_the_mask_patch(monkeypatch):
+    """install_quantized_batch_cache() must itself install the mask-rank
+    patch — the equivalence tests above invoke the patch function
+    directly, so without this check the install hook could silently stop
+    wiring it and production would regress while tests stay green
+    (codex r4 blocking #2)."""
+    import mlx_lm.models.base as mlx_base
+
+    from vllm_mlx.quantized_batch_cache import install_quantized_batch_cache
+
+    # Reset the idempotence marker so this test observes the wiring
+    # regardless of which test ran first.
+    monkeypatch.setattr(
+        mlx_base, "_rapid_batched_mask_safe_qsdpa", False, raising=False
+    )
+
+    class _FakeBG:
+        def _make_new_cache(self):
+            return []
+
+    assert install_quantized_batch_cache(_FakeBG()) is True
+    assert getattr(mlx_base, "_rapid_batched_mask_safe_qsdpa", False) is True

--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -48,6 +48,31 @@ def _max_abs(a, b):
     return float(mx.max(mx.abs(a.astype(mx.float32) - b.astype(mx.float32))))
 
 
+def _deq(cache, triple):
+    """Dequantize an update_and_fetch return (quantized triples, #1751)."""
+    return _dequantize(list(triple), cache._q_group_size, cache._q_bits)
+
+
+def _ref_attention_fp32(queries, k, v, mask):
+    """Hand-composed fp32 GQA attention with an explicitly aligned mask.
+
+    ``mask`` is the rank-4 batched mask ``[B, 1, L, S]``; alignment against
+    the GQA-expanded scores is done here the *correct* way so the fused
+    path can be compared against unambiguous semantics."""
+    q32 = queries.astype(mx.float32)
+    k32 = k.astype(mx.float32)
+    v32 = v.astype(mx.float32)
+    B, n_q, L, Dh = q32.shape
+    n_kv = k32.shape[1]
+    rep_ = n_q // n_kv
+    q32 = q32.reshape(B, n_kv, rep_, L, Dh)
+    scores = q32 @ mx.expand_dims(k32, 2).swapaxes(-1, -2)
+    scores = mx.where(mask[:, None], scores, mx.finfo(mx.float32).min)
+    probs = mx.softmax(scores, axis=-1, precise=True)
+    out = probs @ mx.expand_dims(v32, 2)
+    return out.reshape(B, n_q, L, Dh)
+
+
 # --- update_and_fetch --------------------------------------------------------
 
 
@@ -55,7 +80,10 @@ def test_single_update_matches_quant_roundtrip():
     B, n = 3, 40
     k, v = _kv(B, n, 0)
     q = QuantizedBatchKVCache([0, 0, 0], GS, BITS)
-    ok, ov = q.update_and_fetch(k, v)
+    qk, qv = q.update_and_fetch(k, v)
+    # Fused read (#1751): returns are the quantized triples.
+    assert isinstance(qk, tuple) and len(qk) == 3
+    ok, ov = _deq(q, qk), _deq(q, qv)
     assert ok.shape == (B, H, n, D)
     assert _max_abs(ok, _qrt(k)) == 0.0
     assert _max_abs(ov, _qrt(v)) == 0.0
@@ -69,7 +97,8 @@ def test_multi_chunk_crosses_capacity_growth():
     total = 0
     for i, n in enumerate([100, 200, 50, 300]):  # crosses 256 boundary
         k, v = _kv(B, n, 10 + i)
-        ok, ov = q.update_and_fetch(k, v)
+        qk, qv = q.update_and_fetch(k, v)
+        ok, ov = _deq(q, qk), _deq(q, qv)
         ref_k_chunks.append(_qrt(k))
         ref_v_chunks.append(_qrt(v))
         total += n
@@ -377,7 +406,8 @@ def test_state_roundtrip_preserves_content():
     B = 2
     q = QuantizedBatchKVCache([0, 0], GS, BITS)
     k, v = _kv(B, 20, 6)
-    out_k, _ = q.update_and_fetch(k, v)
+    qk, _qv = q.update_and_fetch(k, v)
+    out_k = _deq(q, qk)
     st = q.state
 
     q2 = QuantizedBatchKVCache([0, 0], GS, BITS)
@@ -558,7 +588,8 @@ def test_update_adjusts_group_size_for_head_dim_96():
     # head_dim=96 is not divisible by 64 but is by 32 — must auto-adjust, not crash
     q = QuantizedBatchKVCache([0], group_size=64, bits=8)
     k = mx.random.normal((1, H, 10, 96)).astype(mx.bfloat16)
-    ok, ov = q.update_and_fetch(k, k)
+    qk, _qv = q.update_and_fetch(k, k)
+    ok = _deq(q, qk)
     assert q._q_group_size == 32
     assert ok.shape == (1, H, 10, 96)
     assert _max_abs(ok, _dequantize(_quantize(k, 32, 8), 32, 8)) == 0.0
@@ -925,3 +956,102 @@ def test_extend_mismatched_params_raises():
     b.update_and_fetch(*_kv(1, 10, 2))
     with pytest.raises(ValueError, match="mismatched quantization"):
         a.extend(b)
+
+
+# --- fused read path (#1751) --------------------------------------------------
+
+
+def test_cache_exposes_quantized_dispatch_attrs():
+    """``hasattr(cache, "bits")`` is mlx-lm's fused-SDPA dispatch predicate;
+    the attrs must mirror the effective quantization params."""
+    q = QuantizedBatchKVCache([0], group_size=64, bits=4)
+    assert q.bits == 4
+    assert q.group_size == 64
+    k = mx.random.normal((1, H, 10, 96)).astype(mx.bfloat16)
+    q.update_and_fetch(k, k)
+    # group size auto-adjusted for head_dim=96 must show through the attr
+    assert q.group_size == 32
+
+
+def test_fused_qsdpa_matches_dequant_reference_batched_gqa():
+    """Patched quantized SDPA on the triples must match full-precision
+    attention on the dequantized KV for B>1 + GQA + left-padded mask.
+
+    This is the mask-rank regression test: without the ``mask[:, None]``
+    fix the rank-4 batched mask broadcasts against the GQA repeat axis
+    and the outputs diverge by O(1), not O(quant-error).
+    """
+    from vllm_mlx.quantized_batch_cache import (
+        _install_batched_mask_safe_quantized_sdpa,
+    )
+
+    _install_batched_mask_safe_quantized_sdpa()
+    import mlx_lm.models.base as mlx_base
+
+    B, n_kv, n_q, S, Dh = 2, 2, 4, 24, 64
+    lp = [3, 0]
+    q = QuantizedBatchKVCache(lp, group_size=32, bits=8)
+    k = mx.random.normal((B, n_kv, S, Dh)).astype(mx.bfloat16)
+    v = mx.random.normal((B, n_kv, S, Dh)).astype(mx.bfloat16)
+    q.update_and_fetch(k, v)
+
+    # Real decode-step ordering: the mask is built BEFORE the step's
+    # update (covers S+1 keys), attention runs on the post-update cache.
+    mask = q.make_mask(1)
+    assert mask.ndim == 4  # the shape class the patch exists for
+    k1 = mx.random.normal((B, n_kv, 1, Dh)).astype(mx.bfloat16)
+    v1 = mx.random.normal((B, n_kv, 1, Dh)).astype(mx.bfloat16)
+    qk, qv = q.update_and_fetch(k1, v1)
+
+    queries = mx.random.normal((B, n_q, 1, Dh)).astype(mx.bfloat16)
+
+    out = mlx_base.quantized_scaled_dot_product_attention(
+        queries,
+        qk,
+        qv,
+        scale=1.0,
+        mask=mask,
+        group_size=q.group_size,
+        bits=q.bits,
+    )
+    ref = _ref_attention_fp32(queries, _deq(q, qk), _deq(q, qv), mask)
+    err = _max_abs(out, ref)
+    assert err < 5e-2, f"fused vs fp32 reference diverged: {err}"
+
+    # Negative control — the misalignment the patch exists to prevent
+    # (mask batch axis pairing with the GQA repeat axis) must move the
+    # output by far more than numeric noise, or this test could not
+    # catch a regression to the stock broadcast.
+    bad = _ref_attention_fp32(queries, _deq(q, qk), _deq(q, qv), mask[:, 0][None])
+    assert _max_abs(bad, ref) > 0.2
+
+
+def test_mask_patch_is_superset_for_stock_shapes():
+    """The mask-rank patch must be a no-op for the shapes mlx-lm's own
+    QuantizedKVCache path produces (rank-2 causal slice, B=1)."""
+    from vllm_mlx.quantized_batch_cache import (
+        _install_batched_mask_safe_quantized_sdpa,
+    )
+
+    _install_batched_mask_safe_quantized_sdpa()
+    import mlx_lm.models.base as mlx_base
+
+    n_kv, n_q, S, Dh = 2, 4, 16, 64
+    k = mx.random.normal((1, n_kv, S, Dh)).astype(mx.bfloat16)
+    v = mx.random.normal((1, n_kv, S, Dh)).astype(mx.bfloat16)
+    qk = tuple(_quantize(k, 32, 8))
+    qv = tuple(_quantize(v, 32, 8))
+    queries = mx.random.normal((1, n_q, 1, Dh)).astype(mx.bfloat16)
+    # rank-2 mask: one query row attending everywhere (stock shape class)
+    mask = mx.ones((1, S), dtype=mx.bool_)
+    assert mask.shape[-1] == qk[0].shape[-2]
+    out = mlx_base.quantized_scaled_dot_product_attention(
+        queries, qk, qv, scale=1.0, mask=mask, group_size=32, bits=8
+    )
+    ref = _ref_attention_fp32(
+        queries,
+        _dequantize(list(qk), 32, 8),
+        _dequantize(list(qv), 32, 8),
+        mask[None, None] * mx.ones((1, 1, 1, S), dtype=mx.bool_),
+    )
+    assert _max_abs(out, ref) < 5e-2

--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -988,6 +988,7 @@ def test_fused_qsdpa_matches_dequant_reference_batched_gqa():
     _install_batched_mask_safe_quantized_sdpa()
     import mlx_lm.models.base as mlx_base
 
+    mx.random.seed(1751)  # deterministic thresholds (codex r1 BLOCKING #2)
     B, n_kv, n_q, S, Dh = 2, 2, 4, 24, 64
     lp = [3, 0]
     q = QuantizedBatchKVCache(lp, group_size=32, bits=8)
@@ -1036,6 +1037,7 @@ def test_mask_patch_is_superset_for_stock_shapes():
     _install_batched_mask_safe_quantized_sdpa()
     import mlx_lm.models.base as mlx_base
 
+    mx.random.seed(1751)
     n_kv, n_q, S, Dh = 2, 4, 16, 64
     k = mx.random.normal((1, n_kv, S, Dh)).astype(mx.bfloat16)
     v = mx.random.normal((1, n_kv, S, Dh)).astype(mx.bfloat16)

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -107,7 +107,17 @@ def supported_group_size(head_dim: int, requested: int) -> int | None:
 
 
 class QuantizedBatchKVCache(_BaseCache):
-    """Batch-aware KV cache that stores quantized KV and returns bf16.
+    """Batch-aware KV cache that stores quantized KV and returns the triples.
+
+    Read contract (#1751): ``update_and_fetch`` returns the quantized
+    ``(packed, scales, biases)`` triples, NOT bf16 arrays — consumers must
+    route them through ``mlx_lm.models.base.scaled_dot_product_attention``
+    (which dispatches on the ``bits`` attribute), exactly like mlx-lm's own
+    ``QuantizedKVCache``. Every in-repo caller does: the stock mlx-lm model
+    files and the vendored models (muse_glimmer, bailing_hybrid) all pass
+    ``cache=cache`` into that dispatcher immediately after
+    ``update_and_fetch``; MLA families (deepseek_v4 etc.) never receive this
+    cache because ``resolve_kv_cache_dtype`` downgrades them to bf16.
 
     Storage layout mirrors :class:`~mlx_lm.models.cache.QuantizedKVCache` — each
     of ``self.keys`` / ``self.values`` is a 3-element list
@@ -569,6 +579,14 @@ def _install_batched_mask_safe_quantized_sdpa() -> None:
         # already laid out for the expanded scores (e.g.
         # ``[n_kv_heads, n_repeats, L, S]``) has shape[1] == n_repeats > 1
         # here and passes through untouched (codex r1 BLOCKING #1).
+        #
+        # The ``n_repeats > 1`` gate is deliberately co-extensive with the
+        # stock kernel's own expansion: quantized_scaled_dot_product_
+        # attention reshapes scores to rank 5 ONLY under ``n_repeats > 1``
+        # (mlx_lm/models/base.py:79 ``if n_repeats > 1``). For MHA
+        # (n_repeats == 1) scores stay rank 4 and a ``[B, 1, L, S]`` mask
+        # already broadcasts correctly — inserting an axis there would
+        # CREATE the misalignment this wrapper prevents.
         if (
             n_q_heads // n_kv_heads > 1
             and isinstance(mask, mx.array)

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -564,10 +564,17 @@ def _install_batched_mask_safe_quantized_sdpa() -> None:
     ):
         n_q_heads = queries.shape[1]
         n_kv_heads = q_keys[0].shape[-3]
+        # Only rewrite the exact shape this cache's make_mask produces:
+        # ``[B, 1, L, S]`` with B matching the query batch. A rank-4 mask
+        # already laid out for the expanded scores (e.g.
+        # ``[n_kv_heads, n_repeats, L, S]``) has shape[1] == n_repeats > 1
+        # here and passes through untouched (codex r1 BLOCKING #1).
         if (
             n_q_heads // n_kv_heads > 1
             and isinstance(mask, mx.array)
             and mask.ndim == 4
+            and mask.shape[0] == queries.shape[0]
+            and mask.shape[1] == 1
         ):
             mask = mask[:, None]
         return _orig(

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -8,8 +8,9 @@ used by continuous batching is mlx-lm's :class:`~mlx_lm.models.cache.BatchKVCach
 which is always bf16 — so a fresh server with ``--disable-prefix-cache`` got no
 memory reduction from the requested dtype at all.
 
-``QuantizedBatchKVCache`` is a drop-in replacement for ``BatchKVCache`` that
-stores keys/values **quantized** (``mx.quantize`` along the head dimension). The
+``QuantizedBatchKVCache`` is the batch-cache counterpart of mlx-lm's own
+``QuantizedKVCache`` — same read contract, batched bookkeeping. It stores
+keys/values **quantized** (``mx.quantize`` along the head dimension). The
 model reads KV through ``update_and_fetch``, which returns the **quantized
 triples**, and the cache exposes ``bits`` / ``group_size`` — so
 ``mlx_lm.models.base.scaled_dot_product_attention`` dispatches to the fused

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -569,8 +569,11 @@ def _install_batched_mask_safe_quantized_sdpa() -> None:
 
     _orig = _mlx_base.quantized_scaled_dot_product_attention
 
+    # ``mask=None`` default: upstream 0.31.3 declares mask as positional
+    # (no default), but a defaulted parameter is a strict superset — any
+    # caller relying on either shape keeps working (codex r5).
     def _batched_mask_safe(
-        queries, q_keys, q_values, scale, mask, group_size=64, bits=8
+        queries, q_keys, q_values, scale, mask=None, group_size=64, bits=8
     ):
         n_q_heads = queries.shape[1]
         n_kv_heads = q_keys[0].shape[-3]

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -10,11 +10,20 @@ memory reduction from the requested dtype at all.
 
 ``QuantizedBatchKVCache`` is a drop-in replacement for ``BatchKVCache`` that
 stores keys/values **quantized** (``mx.quantize`` along the head dimension). The
-paths the *model* reads through — ``update_and_fetch`` and ``extract`` —
-dequantize on the way out, so attention/SDPA see bf16 and nothing in the model
-changes. This is the "dequant-on-read" design that vLLM and SGLang both fall
-back to on backends without a fused quantized-attention kernel — it wins back
-the resident-memory footprint (the point of the flag) without a custom kernel.
+model reads KV through ``update_and_fetch``, which returns the **quantized
+triples**, and the cache exposes ``bits`` / ``group_size`` — so
+``mlx_lm.models.base.scaled_dot_product_attention`` dispatches to the fused
+``quantized_scaled_dot_product_attention`` and attention reads the packed KV
+directly through ``mx.quantized_matmul`` with no per-step full-precision
+materialization (#1751). The original dequant-on-read design rebuilt the
+layer's full bf16 history every decode step — an O(context) tax measured at
+-27% (int4) / -36% (int8) decode throughput at 16k on qwen3.5-4b
+(#1853/#1857); the fused read costs ~-8% vs bf16 while keeping the 4x/2x
+resident-KV saving. ``extract`` still dequantizes — it feeds the bf16
+single-sequence ``KVCache`` reuse path, not attention. mlx-lm's stock
+quantized SDPA mishandles this cache's rank-4 batched mask once GQA expands
+scores to rank 5, so ``install_quantized_batch_cache`` also installs a
+mask-rank-safe wrapper (a strict superset of the stock behavior).
 
 ``state`` / ``meta_state`` are the *serialization* interface (save / restore /
 mid-prefill snapshot), not a model-read path. Like mlx-lm's own
@@ -125,6 +134,19 @@ class QuantizedBatchKVCache(_BaseCache):
         self._q_group_size = group_size
         self._q_bits = bits
 
+    # ``hasattr(cache, "bits")`` is mlx-lm's dispatch predicate for the
+    # fused quantized attention path (models/base.py::
+    # scaled_dot_product_attention). Exposing these MUST stay paired with
+    # ``update_and_fetch`` returning quantized triples — bf16 returns plus
+    # these attributes would feed float tensors into quantized_matmul.
+    @property
+    def bits(self) -> int:
+        return self._q_bits
+
+    @property
+    def group_size(self) -> int:
+        return self._q_group_size
+
     # -- internal helpers -------------------------------------------------
 
     def _capacity(self) -> int:
@@ -219,24 +241,17 @@ class QuantizedBatchKVCache(_BaseCache):
             self.keys[i][..., prev : self._idx, :] = qk[i]
             self.values[i][..., prev : self._idx, :] = qv[i]
 
-        # dequant-on-read: return bf16 K/V so attention/SDPA stays unchanged.
-        # This materializes the current layer's full history in bf16, but only
-        # transiently — MLX frees it before the next layer's dequant runs, while
-        # the resident cache stays quantized. Net decode PEAK memory is therefore
-        # LOWER than a bf16 cache (all layers resident bf16), not higher:
-        # measured int8 0.65x / int4 0.43x of bf16 peak at L=32,B=4,T=4k. Because
-        # decode is memory-bandwidth-bound, the smaller cache also makes each
-        # step FASTER (int8 ~2.3x) despite the dequant. A fused quantized SDPA
-        # (route B) would drop the transient entirely but needs a custom kernel.
+        # Fused read (#1751): return the quantized triples. The model's
+        # attention dispatches on ``hasattr(cache, "bits")`` and reads the
+        # packed KV directly via ``mx.quantized_matmul`` — no per-step
+        # full-precision materialization. The previous dequant-on-read
+        # design rebuilt the layer's full bf16 history every decode step,
+        # an O(context) tax measured at -27% (int4) / -36% (int8) decode
+        # throughput at 16k context (#1853/#1857); the fused read costs
+        # ~-8% vs bf16 while keeping the 4x/2x resident-KV saving.
         return (
-            _dequantize(
-                self._slice_seq(self.keys, self._idx), self._q_group_size, self._q_bits
-            ),
-            _dequantize(
-                self._slice_seq(self.values, self._idx),
-                self._q_group_size,
-                self._q_bits,
-            ),
+            tuple(self._slice_seq(self.keys, self._idx)),
+            tuple(self._slice_seq(self.values, self._idx)),
         )
 
     def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
@@ -518,6 +533,57 @@ class _QuantizableKVCache(KVCache):
         )
 
 
+def _install_batched_mask_safe_quantized_sdpa() -> None:
+    """Make mlx-lm's fused quantized SDPA safe for batched rank-4 masks.
+
+    ``QuantizedBatchKVCache.make_mask`` produces a rank-4 boolean mask
+    ``[B, 1, L, S]`` (``create_causal_mask`` with per-row
+    ``left_padding``). mlx-lm's ``quantized_scaled_dot_product_attention``
+    expands scores to rank 5 ``[B, n_kv_heads, n_repeats, L, S]`` for GQA;
+    broadcasting a rank-4 mask against that aligns trailing dims, pairing
+    the mask's batch axis with ``n_repeats`` — silently wrong attention
+    for B > 1. Inserting an axis (``mask[:, None]`` ->
+    ``[B, 1, 1, L, S]``) restores correct alignment and is a no-op for
+    every shape the stock path already handles (rank-2 causal slices and
+    B=1 rank-4 masks become ``[1, 1, 1, L, S]``, which broadcast the
+    same).
+
+    Idempotent module-level patch on ``mlx_lm.models.base`` — the model
+    files call ``base.scaled_dot_product_attention``, which resolves the
+    quantized path through this module global.
+    """
+    import mlx_lm.models.base as _mlx_base
+
+    if getattr(_mlx_base, "_rapid_batched_mask_safe_qsdpa", False):
+        return
+
+    _orig = _mlx_base.quantized_scaled_dot_product_attention
+
+    def _batched_mask_safe(
+        queries, q_keys, q_values, scale, mask, group_size=64, bits=8
+    ):
+        n_q_heads = queries.shape[1]
+        n_kv_heads = q_keys[0].shape[-3]
+        if (
+            n_q_heads // n_kv_heads > 1
+            and isinstance(mask, mx.array)
+            and mask.ndim == 4
+        ):
+            mask = mask[:, None]
+        return _orig(
+            queries,
+            q_keys,
+            q_values,
+            scale=scale,
+            mask=mask,
+            group_size=group_size,
+            bits=bits,
+        )
+
+    _mlx_base.quantized_scaled_dot_product_attention = _batched_mask_safe
+    _mlx_base._rapid_batched_mask_safe_qsdpa = True
+
+
 def install_quantized_batch_cache(
     batch_gen: Any, group_size: int = 64, bits: int = 8
 ) -> bool:
@@ -569,6 +635,9 @@ def install_quantized_batch_cache(
         ]
 
     batch_gen._make_new_cache = _quantized_make_new_cache
+    # The fused read path (#1751) routes attention through mlx-lm's
+    # quantized SDPA; make it safe for this cache's batched masks first.
+    _install_batched_mask_safe_quantized_sdpa()
     return True
 
 


### PR DESCRIPTION
## Why

#1857 made quantized live KV opt-in because the dequant-on-read implementation materialized the layer's full bf16 KV history on every decode step — an O(context) tax measured at −27% (int4) / −36% (int8) at 16k vs bf16. That left `--kv-cache-dtype int4` (4× smaller KV — the memory-constrained-host feature) with a punitive speed cost exactly where it matters most, at long context.

mlx-lm already ships a fused read path (`quantized_scaled_dot_product_attention`, `mx.quantized_matmul` directly on the packed triples) dispatched on `hasattr(cache, "bits")`. This PR routes our batched cache through it.

## What changed

- `QuantizedBatchKVCache.update_and_fetch` returns the quantized triples (was: dequantized bf16), and the cache exposes `bits` / `group_size` — the model's attention dispatches to the fused path with zero model changes.
- mlx-lm's stock quantized SDPA silently misaligns our rank-4 batched mask once GQA expands scores to rank 5 (the mask's batch axis pairs with the repeat axis for B>1). `install_quantized_batch_cache` now also installs a mask-rank-safe wrapper (`mask[:, None]` when rank-4) — a strict superset of stock behavior, verified no-op for stock shapes.
- Prefill untouched: single-sequence prompt caches stay bf16; quantization still happens at the merge into the generation batch, so the quantization boundary remains the prefill→decode transition.
- `extract` / `state` / snapshot round-trip semantics unchanged (already triple-based).

## Measurements (qwen3.5-4b, parity server, live)

| int4 path | 128 ctx | 16k ctx |
|---|---|---|
| dequant-on-read (before) | 161 | 98 (−27% vs bf16) |
| **fused read (this PR)** | 151.5 | **123 (−8.6%)** |
| bf16 reference | 167 | 134.6 |

16k decode **+25%** for quantized-KV users; the residual −9% matches the mlx-lm B=1 fused path (kv_bits probe: int4 134.8 vs bf16 146.6), i.e. we now sit at the library's own ceiling for this composition. Short-context is ~6% below dequant-on-read (composed-op launch overhead vs a trivial dequant) — the trade favors the long contexts quantized KV exists for. bf16 remains fastest overall and stays the default (#1857); a genuinely faster-than-bf16 quantized path needs a fused quantized *flash* kernel upstream (`mx.fast` has none today).

Quality spot-check on the live int4 server produced fully coherent output; the fused-vs-fp32-reference equivalence test carries a negative control proving the mask misalignment it guards against moves outputs by >0.2 (vs <0.05 tolerance).

Closes #1751-tracked follow-up from #1853 discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)