### PR TITLE
feat(cli): nudge on any newer release, not only same-minor ≥2-patch

### DIFF
--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -315,14 +315,19 @@ def test_warns_when_2_or_more_patch_behind(isolated_cache, monkeypatch):
     assert "rapid-mlx upgrade" in msg
 
 
-def test_silent_when_only_1_patch_behind(isolated_cache, monkeypatch):
-    """1 patch behind is normal noise — minor bug-fix releases happen.
-    We only want to nag when feature releases are missed (≥2 lag).
+def test_warns_when_1_patch_behind(isolated_cache, monkeypatch):
+    """Any newer release warns — including a single patch. There is no
+    ≥2-lag threshold anymore: we nudge on every update so no straggler is
+    silently left behind.
     """
     monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.15")
     _seed_cache(isolated_cache, "0.6.16")
 
-    assert vc.staleness_warning() is None
+    msg = vc.staleness_warning()
+    assert msg is not None
+    assert "0.6.15" in msg
+    assert "0.6.16" in msg
+    assert "rapid-mlx upgrade" in msg
 
 
 def test_silent_when_current(isolated_cache, monkeypatch):
@@ -341,14 +346,42 @@ def test_silent_when_dev_ahead(isolated_cache, monkeypatch):
     assert vc.staleness_warning() is None
 
 
-def test_silent_across_minor_boundary(isolated_cache, monkeypatch):
-    """If user is on 0.6.x and 0.7.x is out, that's a minor bump — they
-    might be intentionally pinning the 0.6 line. Don't auto-suggest a
-    cross-minor upgrade."""
+def test_warns_across_minor_boundary(isolated_cache, monkeypatch):
+    """Cross-minor lag now warns. Users pinned on an old minor are exactly
+    the fragmentation we want to nudge; the passive one-liner is opt-out
+    (``RAPID_MLX_DISABLE_VERSION_CHECK``) for anyone deliberately staying."""
     monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.10")
     _seed_cache(isolated_cache, "0.7.0")
 
-    assert vc.staleness_warning() is None
+    msg = vc.staleness_warning()
+    assert msg is not None
+    assert "0.6.10" in msg
+    assert "0.7.0" in msg
+
+
+@pytest.mark.parametrize(
+    "installed,latest",
+    [
+        ("0.10.8", "0.12.10"),  # the real straggler cohort (0.10.x panel bucket)
+        ("0.11.0", "0.12.10"),  # the real straggler cohort (0.11.x panel bucket)
+        ("0.9.9", "1.0.0"),  # behind by a whole major — still warns
+    ],
+)
+def test_warns_for_cross_line_stragglers(
+    isolated_cache, monkeypatch, installed, latest
+):
+    """Regression for the fragmentation goal: an install several minors
+    (or a major) behind the latest release MUST get the banner. The old
+    same-major.minor gate returned None for exactly these users, leaving
+    the fragmented base un-nudged on every non-``serve`` command."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: installed)
+    _seed_cache(isolated_cache, latest)
+
+    msg = vc.staleness_warning()
+    assert msg is not None
+    assert installed in msg
+    assert latest in msg
+    assert "rapid-mlx upgrade" in msg
 
 
 def test_silent_when_offline(tmp_path, monkeypatch):
@@ -705,8 +738,8 @@ def test_prompt_returns_true_and_runs_upgrade_on_accept(monkeypatch, interactive
 
 
 def test_prompt_crosses_minor_boundary(monkeypatch, interactive):
-    """``staleness_warning`` stays silent across minor bumps, but the
-    interactive prompt opts in — user can still say no."""
+    """The interactive prompt fires across minor bumps (as does the passive
+    banner now) — user can still say no."""
     monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.62")
     monkeypatch.setattr(vc, "get_latest_version", lambda force_refresh=False: "0.7.0")
     monkeypatch.setattr(

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -2,10 +2,14 @@
 """Background check for newer ``rapid-mlx`` releases on GitHub.
 
 Surfaces a one-line warning at the top of ``rapid-mlx models``,
-``rapid-mlx serve`` and ``rapid-mlx chat`` when the installed version
-is at least 2 patch versions behind the latest GitHub release. Designed
-to fail completely silently on network / parse / sandbox errors —
-staleness warnings should never break the CLI.
+``rapid-mlx serve`` and ``rapid-mlx chat`` whenever the installed
+version is behind the latest GitHub release — ANY newer release,
+regardless of how far behind (patch, minor, or major). There is no
+version-distance threshold: the whole point is that stragglers stuck on
+an old line (the version fragmentation we care about) actually see the
+nudge on every command, not only the ones a patch or two behind inside
+the same minor. Designed to fail completely silently on network / parse
+/ sandbox errors — staleness warnings should never break the CLI.
 
 Cache: ``~/.cache/rapid-mlx/version_check.json`` with 24h TTL. Network
 fetch is opt-out via ``RAPID_MLX_DISABLE_VERSION_CHECK=1`` or any
@@ -13,8 +17,14 @@ non-interactive context (``CI=1``, missing TTY).
 
 Behaviour matrix:
 
-  installed = 0.6.14, latest = 0.6.16 (2 patch behind)
+  installed = 0.6.15, latest = 0.6.16 (1 patch behind)
     → warns, suggests ``rapid-mlx upgrade``
+
+  installed = 0.10.8, latest = 0.12.10 (behind by minors)
+    → warns (cross-minor stragglers are exactly who we want to reach)
+
+  installed = 0.9.9, latest = 1.0.0 (behind by a major)
+    → warns
 
   installed = 0.6.16, latest = 0.6.16 (current)
     → silent
@@ -64,10 +74,6 @@ GITHUB_RELEASES_ENDPOINT = (
 USER_AGENT = "rapid-mlx-cli"
 CACHE_TTL_SECONDS = 24 * 3600  # 24h
 NETWORK_TIMEOUT_SECONDS = 2  # tight — staleness check is best-effort
-# Minimum patch lag before warning. Bumping by 1 patch happens often
-# enough that a one-version lag is normal noise; 2+ means a feature
-# release was missed.
-MIN_LAG_PATCH = 2
 _REMOTE_ENGINE_TAG_RE = re.compile(r"^v(\d{1,6})\.(\d{1,6})\.(\d{1,6})$")
 _CACHED_VERSION_RE = re.compile(r"^\d{1,6}\.\d{1,6}\.\d{1,6}$")
 
@@ -243,9 +249,9 @@ def get_latest_version(force_refresh: bool = False) -> str | None:
 
 
 def staleness_warning() -> str | None:
-    """Return a one-line warning string if the installed version is
-    ``MIN_LAG_PATCH`` or more patch versions behind the latest release.
-    Returns None when no warning is warranted (or check is disabled).
+    """Return a one-line warning string if the installed version is behind
+    the latest release by ANY amount (patch, minor, or major). Returns
+    None when no warning is warranted (current/ahead, or check disabled).
     """
     if _disabled():
         return None
@@ -263,12 +269,17 @@ def staleness_warning() -> str | None:
     if latest is None:
         return None
 
-    # Only warn for patch-level lag inside the same major.minor — across
-    # minors there might be intentional API changes the user is staying
-    # on for stability. Across majors, definitely silent.
-    if (installed[0], installed[1]) != (latest[0], latest[1]):
-        return None
-    if latest[2] - installed[2] < MIN_LAG_PATCH:
+    # Warn on ANY newer release — no version-distance gate. One patch, a
+    # whole minor, or a major behind all get the banner: cross-line
+    # stragglers (e.g. 0.10.x while 0.12.x ships) are precisely who we
+    # want to reach, and they'd never see a same-minor-only warning.
+    # This is a passive one-liner (it only *suggests* ``rapid-mlx
+    # upgrade``), so unlike the interactive ``prompt_upgrade_if_available``
+    # — which auto-runs an upgrade and therefore conservatively skips
+    # dev / pre-release builds — it can safely fire for anyone behind.
+    # Developers on builds AHEAD of latest still stay silent via the
+    # comparison below.
+    if latest <= installed:
         return None
 
     return (


### PR DESCRIPTION
## Why

The CLI already has a version-staleness nudge (`vllm_mlx/_version_check.py`, wired into the top of `serve` / `models` / `chat`), but the **passive banner** deliberately stayed silent across minor/major boundaries and required a **≥2-patch** lag:

```python
if (installed[0], installed[1]) != (latest[0], latest[1]):
    return None
if latest[2] - installed[2] < MIN_LAG_PATCH:  # MIN_LAG_PATCH = 2
    return None
```

That left the exact users we most want to reach — the fragmented base stuck on old lines (e.g. `0.10.x` / `0.11.x` while `0.12.x` ships) — with **no update nudge on any command except `serve`** (whose interactive prompt already crosses minors). A user who only runs `rapid-mlx chat` / `models` on an old minor saw nothing.

## What

`staleness_warning()` now warns on **any** newer release, regardless of distance (patch, minor, or major) — a single `if latest <= installed: return None`. Removed the now-dead `MIN_LAG_PATCH` constant and refreshed the module docstring / behaviour matrix.

Deliberately **unchanged** (kept conservative):
- opt-out via `RAPID_MLX_DISABLE_VERSION_CHECK`, plus `CI=1` / non-TTY gating
- 24h cache, 2s network timeout, fail-open on any error
- developers on builds **ahead** of latest stay silent (`latest <= installed`)
- the interactive `prompt_upgrade_if_available()` (serve) is untouched — it already fired on any newer release

The banner is passive (it only *suggests* `rapid-mlx upgrade`), so — unlike the interactive prompt that auto-runs an upgrade and therefore skips dev/pre-release builds — it can safely fire for anyone behind.

## Tests

`tests/test_version_check.py` — **60 passed**, ruff clean.
- Flipped the two tests that encoded the old contract: 1-patch-behind and cross-minor now assert the banner **fires**.
- Added a parametrized regression for the real straggler cohorts: `0.10.8→0.12.10`, `0.11.0→0.12.10`, and a cross-major `0.9.9→1.0.0`.
- Regression-first verified: all new/flipped assertions fail on the pre-change implementation (return `None`) and pass after.

Dogfooded the new code in a real pty as a simulated `0.10.8` user — both the banner and the `[Y/n]` prompt render and behave as expected.

## Notes

One-line change in scope; no version bump. Out of scope (candidates for follow-ups discussed separately): CLI→desktop-app migration nudge, tagging app-spawned sidecar telemetry.

🤖 This change was authored with the assistance of Claude Code (Opus 4.8).