### PR TITLE
feat(agents): add safe setup for Claude and Continue

### DIFF
--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -33,11 +33,15 @@ npm install -g @anthropic-ai/claude-code
 # 2. Start rapid-mlx
 rapid-mlx serve qwen3.6-35b-4bit --port 8000
 
-# 3. Point Claude Code at the local server (note: bare host, no /v1)
-ANTHROPIC_BASE_URL=http://localhost:8000 \
-ANTHROPIC_API_KEY=not-needed \
-  claude
+# 3. Preview, then safely persist Claude Code's connection settings
+rapid-mlx agents claude-code --setup --dry-run
+rapid-mlx agents claude-code --setup
 ```
+
+Setup shows the exact JSON diff before asking, preserves unrelated settings,
+backs up an existing file, writes atomically, and checks the running server.
+For automation use `--yes`; use `--no-check` only when intentionally preparing
+the config before starting the server.
 
 To make it permanent, export the two env vars in your shell profile:
 

--- a/docs/guides/ai-clients.md
+++ b/docs/guides/ai-clients.md
@@ -79,14 +79,14 @@ config, plus an honest test-backed [support matrix](../agents/matrix.md):
 |--------|------|-------|--------|-------|
 | [Aider](https://aider.chat) | CLI | `OPENAI_API_BASE=http://localhost:8000/v1 aider --model openai/default` | Verified | Architect mode, edit-and-commit |
 | [OpenCode](https://github.com/sst/opencode) | TUI | `rapid-mlx agents opencode --setup` | Compatible | Claude Code-like terminal UX |
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | CLI | `ANTHROPIC_BASE_URL=http://localhost:8000 claude` | Compatible | Uses Anthropic `/v1/messages` |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | CLI | `rapid-mlx agents claude-code --setup` | Compatible | Safe diff/confirm/backup flow; uses Anthropic `/v1/messages` |
 | [Cursor](https://cursor.com) | IDE | `RAPID_MLX_API_KEY=your-secret rapid-mlx launch cursor --server-url https://your-public-host` | Not compatible locally | BYOK requests pass through Cursor's servers; public HTTPS and server auth are required |
 
 Rapid-MLX rejects explicit local/private Cursor addresses, but it does not use
 your Mac's DNS result as proof that Cursor's backend can reach a hostname.
 Split-horizon DNS may look different from Cursor's network, so verify the
 authenticated HTTPS endpoint from an external network before configuring it.
-| [Continue.dev](https://continue.dev) | IDE Extension | `~/.continue/config.yaml` `apiBase: http://localhost:8000/v1` | Compatible | VS Code / JetBrains |
+| [Continue.dev](https://continue.dev) | IDE Extension | `rapid-mlx agents continue --setup` | Compatible | Safe diff/confirm/backup flow; VS Code / JetBrains |
 | [pi](https://shittycodingagent.ai) | TUI | `OPENAI_BASE_URL=http://localhost:8000/v1` | Community-reported | Works with Qwen3.5/Qwen3.6 models |
 
 ### Web UIs

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,22 @@
 | `rapid-mlx doctor` | Run self-diagnostic / regression harness |
 | `rapid-mlx telemetry` | Manage anonymous usage telemetry (opt-in) |
 | `rapid-mlx upgrade` | Upgrade rapid-mlx (brew / pip / install.sh) |
+
+Agent integrations can be configured without hand-editing dotfiles:
+
+```bash
+# Preview the exact change (never writes)
+rapid-mlx agents claude-code --setup --dry-run
+rapid-mlx agents continue --setup --dry-run
+
+# Confirm interactively, back up existing config, write atomically, and verify
+rapid-mlx agents claude-code --setup
+rapid-mlx agents continue --setup
+```
+
+Use `--yes` for an explicitly non-interactive apply. `--no-check` skips only
+the post-write server health/model check; preview, merge, backup, and atomic
+write behavior are unchanged.
 | `rapid-mlx version` | Show version number |
 | `rapid-mlx help <cmd>` | Show help for a subcommand |
 

--- a/tests/test_agent_first_class_setup.py
+++ b/tests/test_agent_first_class_setup.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_mlx.agents.setup import (
+    apply_setup_plan,
+    build_setup_plan,
+    verify_server,
+)
+from vllm_mlx.launch import claude_code, continue_dev
+
+
+@pytest.fixture
+def setup_paths(tmp_path, monkeypatch):
+    claude_path = tmp_path / "claude" / "settings.json"
+    continue_path = tmp_path / "continue" / "config.json"
+    monkeypatch.setattr(claude_code, "current_config_path", lambda: claude_path)
+    monkeypatch.setattr(continue_dev, "current_config_path", lambda: continue_path)
+    return claude_path, continue_path
+
+
+def test_claude_plan_is_side_effect_free_and_uses_bare_base(setup_paths):
+    claude_path, _ = setup_paths
+    claude_path.parent.mkdir(parents=True)
+    claude_path.write_text('{"permissions":{"allow":["Read"]}}')
+
+    plan = build_setup_plan(
+        "claude-code", "http://localhost:8000/v1", "qwen3.6-35b-4bit"
+    )
+
+    assert json.loads(claude_path.read_text()) == {"permissions": {"allow": ["Read"]}}
+    assert plan.after["permissions"] == {"allow": ["Read"]}
+    assert plan.after["env"]["ANTHROPIC_BASE_URL"] == "http://localhost:8000"
+    assert "ANTHROPIC_API_KEY" in plan.diff()
+
+
+def test_continue_apply_preserves_models_and_creates_backup(setup_paths):
+    _, continue_path = setup_paths
+    continue_path.parent.mkdir(parents=True)
+    continue_path.write_text(
+        json.dumps({"models": [{"title": "Existing", "provider": "ollama"}]})
+    )
+    plan = build_setup_plan("continue", "http://localhost:8000", "qwen3.5-9b-4bit")
+
+    apply_setup_plan(plan)
+
+    data = json.loads(continue_path.read_text())
+    assert any(model["title"] == "Existing" for model in data["models"])
+    rapid = next(model for model in data["models"] if model["title"] == "rapid-mlx")
+    assert rapid["apiBase"] == "http://localhost:8000/v1"
+    assert rapid["model"] == "qwen3.5-9b-4bit"
+    assert len(list(continue_path.parent.glob("config.json.bak.*"))) == 1
+
+
+def test_apply_refuses_file_changed_after_preview(setup_paths):
+    claude_path, _ = setup_paths
+    claude_path.parent.mkdir(parents=True)
+    claude_path.write_text("{}")
+    plan = build_setup_plan("claude-code", "http://localhost:8000", "model")
+    claude_path.write_text('{"new":"concurrent edit"}')
+
+    with pytest.raises(RuntimeError, match="changed after preview"):
+        apply_setup_plan(plan)
+    assert json.loads(claude_path.read_text()) == {"new": "concurrent edit"}
+
+
+def test_verify_server_checks_health_and_models(monkeypatch):
+    class Response:
+        status = 200
+
+        def __init__(self, body=b""):
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return self.body
+
+    urls: list[str] = []
+
+    def fake_open(url, timeout):
+        urls.append(url)
+        if url.endswith("/health"):
+            return Response()
+        return Response(json.dumps({"data": [{"id": "served-model"}]}).encode())
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_open)
+    assert verify_server("http://localhost:8000/v1", "default") == "served-model"
+    assert urls == [
+        "http://localhost:8000/health",
+        "http://localhost:8000/v1/models",
+    ]
+
+
+def test_cli_parser_exposes_setup_safety_flags(monkeypatch):
+    import vllm_mlx.cli as cli
+
+    captured = {}
+    monkeypatch.setattr(cli, "agents_command", lambda args: captured.update(vars(args)))
+    monkeypatch.setattr(
+        "sys.argv", ["rapid-mlx", "agents", "continue", "--setup", "--dry-run"]
+    )
+    cli.main()
+    assert captured["agent_name"] == "continue"
+    assert captured["setup"] is True
+    assert captured["dry_run"] is True
+    assert captured["yes"] is False

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -182,6 +182,9 @@ NON_ROUTING_FLAGS_ALLOWLIST: frozenset[str] = frozenset(
         # `serve` (and the canonical name on `chat`). Same dest, same
         # semantics — pure UX symmetry between the two subcommands.
         "--no-think",
+        # Agent setup UX knob: skips a post-write HTTP connectivity probe.
+        # It does not change model/runtime routing or any auto-detection.
+        "--no-check",
         # CORS toggle.
         "--enable-cors",
         # Perf / UX toggles, not routing decisions.

--- a/vllm_mlx/agents/profiles/continue.yaml
+++ b/vllm_mlx/agents/profiles/continue.yaml
@@ -1,0 +1,19 @@
+name: continue
+display_name: "Continue.dev"
+repo: "continuedev/continue"
+stars: 30000
+
+# Setup is handled by agents.setup because Continue's model list needs an
+# update-in-place operation rather than a generic dict deep merge.
+config:
+  type: json
+  path: "~/.continue/config.json"
+
+models:
+  recommended:
+    - "qwen3.6-35b-4bit"
+    - "qwen3.5-9b-4bit"
+
+capabilities:
+  function_calling: true
+  streaming: true

--- a/vllm_mlx/agents/setup.py
+++ b/vllm_mlx/agents/setup.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Safe plan/apply flow for first-class agent integrations."""
+
+from __future__ import annotations
+
+import difflib
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from vllm_mlx.launch import _common as launch_common
+from vllm_mlx.launch import claude_code, continue_dev
+
+
+@dataclass(frozen=True)
+class SetupPlan:
+    agent: str
+    display_name: str
+    path: Path
+    before: dict[str, Any]
+    after: dict[str, Any]
+    base_url: str
+    model: str
+
+    @property
+    def changed(self) -> bool:
+        return self.before != self.after
+
+    def diff(self) -> str:
+        before = json.dumps(self.before, indent=2, ensure_ascii=False, sort_keys=True)
+        after = json.dumps(self.after, indent=2, ensure_ascii=False, sort_keys=True)
+        return "\n".join(
+            difflib.unified_diff(
+                before.splitlines(),
+                after.splitlines(),
+                fromfile=str(self.path),
+                tofile=str(self.path) + " (proposed)",
+                lineterm="",
+            )
+        )
+
+
+def build_setup_plan(agent: str, base_url: str, model: str) -> SetupPlan:
+    """Build a side-effect-free setup plan for a supported client."""
+    if agent in {"claude", "claude-code"}:
+        path = claude_code.current_config_path()
+        assert path is not None
+        before = launch_common.load_json_lenient(path)
+        after = claude_code.patched_config(before, base_url, model)
+        return SetupPlan(
+            "claude-code", "Claude Code", path, before, after, base_url, model
+        )
+    if agent in {"continue", "continue-dev"}:
+        path = continue_dev.current_config_path()
+        assert path is not None
+        before = launch_common.load_json_lenient(path)
+        after = continue_dev.patched_config(before, base_url, model)
+        return SetupPlan(
+            "continue", "Continue.dev", path, before, after, base_url, model
+        )
+    raise ValueError(f"{agent} does not have a first-class safe setup flow")
+
+
+def apply_setup_plan(plan: SetupPlan) -> Path:
+    """Back up the existing config and atomically apply an unchanged plan."""
+    # Re-read to prevent overwriting an edit made between preview and consent.
+    current = launch_common.load_json_lenient(plan.path)
+    if current != plan.before:
+        raise RuntimeError(f"{plan.path} changed after preview; re-run --setup")
+    launch_common.backup_existing(plan.path)
+    launch_common.atomic_write_json(plan.path, plan.after)
+    return plan.path
+
+
+def verify_server(base_url: str, expected_model: str, timeout: float = 2.0) -> str:
+    """Verify health and model discovery without performing inference."""
+    root = base_url.rstrip("/").removesuffix("/v1")
+    try:
+        with urllib.request.urlopen(f"{root}/health", timeout=timeout) as response:
+            if response.status != 200:
+                raise RuntimeError(f"health returned HTTP {response.status}")
+        with urllib.request.urlopen(f"{root}/v1/models", timeout=timeout) as response:
+            payload = json.loads(response.read())
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"server is not ready at {root}: {exc}") from exc
+    models = payload.get("data", []) if isinstance(payload, dict) else []
+    ids = [item.get("id") for item in models if isinstance(item, dict)]
+    if not ids:
+        raise RuntimeError(f"server at {root} reported no models")
+    if expected_model != "default" and expected_model not in ids and len(ids) != 1:
+        raise RuntimeError(
+            f"server does not advertise model {expected_model!r} (found: {', '.join(ids)})"
+        )
+    return ids[0]
+
+
+def confirm_plan(plan: SetupPlan) -> bool:
+    """Ask before writing; non-interactive callers must use --yes."""
+    if not sys.stdin.isatty():
+        return False
+    try:
+        return input("Apply this configuration? [y/N] ").strip().lower() in {"y", "yes"}
+    except (EOFError, KeyboardInterrupt):
+        return False

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7673,6 +7673,50 @@ def agents_command(args):
             # User specified model — look up *that* model's context window
             context_length = fetch_context_window(base_url, model_id)
 
+        # Claude Code and Continue are the first first-class setup flows. They
+        # preview an exact diff, require consent, back up existing config,
+        # write atomically, and verify the server afterwards. Keep the generic
+        # profile writer below for the remaining integrations until each one
+        # receives an equally precise adapter.
+        if profile.name in {"claude-code", "continue"}:
+            from vllm_mlx.agents.setup import (
+                apply_setup_plan,
+                build_setup_plan,
+                confirm_plan,
+                verify_server,
+            )
+
+            try:
+                plan = build_setup_plan(profile.name, base_url, model_id)
+            except (OSError, ValueError) as exc:
+                print(f"\n  {profile.display_name} setup failed: {exc}\n")
+                sys.exit(1)
+
+            print(f"\n  {profile.display_name} configuration: {plan.path}")
+            if plan.changed:
+                print(plan.diff())
+            else:
+                print("  Already configured; no file changes needed.")
+
+            if args.dry_run:
+                print("\n  Dry run only; nothing was written.\n")
+                return
+            if plan.changed and not args.yes and not confirm_plan(plan):
+                print("\n  Setup cancelled; nothing was written.\n")
+                return
+            try:
+                if plan.changed:
+                    apply_setup_plan(plan)
+                    print(f"\n  Configured {profile.display_name} at {plan.path}.")
+                if not args.no_check:
+                    advertised = verify_server(base_url, model_id)
+                    print(f"  Connection check passed (model: {advertised}).")
+            except RuntimeError as exc:
+                print(f"\n  Setup incomplete: {exc}\n")
+                sys.exit(1)
+            print()
+            return
+
         summary = setup_agent_config(
             profile,
             base_url,
@@ -9583,6 +9627,22 @@ Examples:
         "--setup",
         action="store_true",
         help="Auto-configure the agent to point at this server",
+    )
+    agents_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview setup changes without writing configuration",
+    )
+    agents_parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Apply setup without an interactive confirmation",
+    )
+    agents_parser.add_argument(
+        "--no-check",
+        action="store_true",
+        help="Skip the post-write server health and model check",
     )
     agents_parser.add_argument(
         "--test",

--- a/vllm_mlx/launch/claude_code.py
+++ b/vllm_mlx/launch/claude_code.py
@@ -25,6 +25,7 @@ the standard ``~/.config`` tree before the first run.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from . import _common
 
@@ -112,6 +113,21 @@ def write_or_patch_config(
     existing = _common.load_json_lenient(path)
     _common.backup_existing(path)
 
+    existing = patched_config(existing, server_url, model, api_key)
+
+    _common.atomic_write_json(path, existing)
+    return path
+
+
+def patched_config(
+    existing: dict[str, Any],
+    server_url: str,
+    model: str,
+    api_key: str = "sk-noop",
+) -> dict[str, Any]:
+    """Return the Claude settings we would write, without touching disk."""
+    existing = dict(existing)
+
     # Strip a trailing ``/v1`` if the user pasted one — the Anthropic
     # SDK appends ``/v1/messages`` itself, and ``/v1/v1/messages`` is a
     # 404. This is the inverse of Cline's behaviour (which *requires*
@@ -127,5 +143,4 @@ def write_or_patch_config(
     env["ANTHROPIC_MODEL"] = model
     existing["env"] = env
 
-    _common.atomic_write_json(path, existing)
-    return path
+    return existing

--- a/vllm_mlx/launch/continue_dev.py
+++ b/vllm_mlx/launch/continue_dev.py
@@ -17,6 +17,7 @@ so we don't keep stacking copies.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from . import _common
 
@@ -91,6 +92,21 @@ def write_or_patch_config(
     existing = _common.load_json_lenient(path)
     _common.backup_existing(path)
 
+    existing = patched_config(existing, server_url, model, api_key)
+
+    _common.atomic_write_json(path, existing)
+    return path
+
+
+def patched_config(
+    existing: dict[str, Any],
+    server_url: str,
+    model: str,
+    api_key: str = "sk-noop",
+) -> dict[str, Any]:
+    """Return the Continue config we would write, without touching disk."""
+    existing = dict(existing)
+
     base_url = server_url.rstrip("/")
     if not base_url.endswith("/v1"):
         base_url = base_url + "/v1"
@@ -117,5 +133,4 @@ def write_or_patch_config(
         models.append(new_entry)
     existing["models"] = models
 
-    _common.atomic_write_json(path, existing)
-    return path
+    return existing


### PR DESCRIPTION
## Summary

Adds first-class safe setup flows for the two highest-value integrations:

```bash
rapid-mlx agents claude-code --setup
rapid-mlx agents continue --setup
```

Both flows now:

- resolve the running model when one is available;
- render and show an exact unified config diff before writing;
- require interactive confirmation by default (`--yes` for automation);
- support a side-effect-free `--dry-run`;
- preserve unrelated existing config;
- create a timestamped backup before replacement;
- write atomically;
- refuse to overwrite a config changed after preview;
- verify `/health` and `/v1/models` after setup (`--no-check` for intentional offline preparation).

Claude Code persists the documented Anthropic environment under its settings file and strips `/v1`. Continue gets a deduplicated `rapid-mlx` OpenAI model entry while retaining all other models and settings.

## Verification

- `ruff check` and `ruff format --check`: clean.
- Agent/launch regression selection: **163 passed**.
- Real subprocess dry-runs for Claude Code and Continue against an empty temporary HOME produced the expected diffs and created no files.

No GUI changes are included in this PR.
