### PR TITLE
feat(telemetry): define + implement activation/engagement semantics

### DIFF
--- a/docs/telemetry-activation.md
+++ b/docs/telemetry-activation.md
@@ -1,0 +1,181 @@
+# Telemetry activation / engagement semantics
+
+**Spec version: `1`** (`vllm_mlx.telemetry.activation_spec.ACTIVATION_SPEC_VERSION`)
+· Status: **active** · Owner: growth
+
+This document is the single, versioned source of truth for what counts as
+an **engaged** / **activated** install. The growth dashboard and the
+repository's regression tests both encode these rules; when the rules
+change, bump `ACTIVATION_SPEC_VERSION` and update both sides in lockstep.
+
+## Why this exists
+
+DAU / WK1-retention / announcement-recall experiments are only trustworthy
+if "an active user" means *someone who did real work*, not *a process that
+started and phoned home*. Without a fixed definition, a rise in DAU could be
+nothing but more `serve` boots, update polls, or health checks. This spec
+pins the behavioral definition so the baseline can't drift.
+
+## Definitions
+
+**Engaged** — the install completed at least one *successful inference*.
+This is the load-bearing signal for engaged-DAU and retention cohorts.
+
+**Activation** — the install crossed a funnel milestone for the *first time
+ever*. Each milestone represents one install reaching that step, keyed on the
+persistent `client_id`. Activation is a superset of "engaged": the
+`first_inference` milestone is the moment an install first becomes engaged.
+
+Emission is **at-least-once**, not exactly-once (see "Delivery semantics"
+below): the client suppresses repeats locally on a best-effort basis, and the
+**collector is the authoritative de-duplicator** — it counts *distinct*
+`client_id`, so a rare duplicate for the same install collapses to one.
+
+## What counts
+
+| Trigger | Activation? | `activation_kind` | Notes |
+|---|---|---|---|
+| First successful inference request (HTTP API) | ✅ engaged | `first_inference` | `surface = api`. Emitted after the response is built (non-streaming) or the stream completes normally (streaming). **Implemented.** |
+| CLI `chat` stream completes normally with ≥1 completion token | ✅ engaged | `first_inference` | `surface = cli`. Emitted after the stream drains normally, not at the first token — a partially consumed / client-cancelled stream is conservatively not counted. **Implemented.** |
+| `rapid-mlx pull <alias>` completes successfully | ✅ activation | `model_pull` | `surface = cli`; NOT inference-engaged. **Implemented.** |
+| Agent integration setup completes AND its connection check passes | ✅ activation | `agent_setup` | `surface = cli`; integration activation. **Spec'd; wiring deferred** — `rapid-mlx launch` has no engine connection check today; that check must land first (see below). |
+
+## What does NOT count
+
+- **Server startup** (`serve` boot / `session_start`) — a running process is
+  not engagement.
+- **`/health`, `/models`, and the update/version ping** — liveness and
+  metadata probes, never engagement.
+- **Error responses** — any non-`2xx` inference request.
+- **Empty generation** — a `2xx` request that produced **zero** completion
+  tokens (`completion_tokens == 0`). "It ran" is not "it worked."
+- **Model load / warmup** by itself — loading weights is not inference.
+
+Degenerate-but-non-empty output (repetitive / low-quality) **does** count as
+engaged: the user got tokens. Quality is tracked separately via the
+`request` event's `output_degenerate` canary, not here.
+
+## Success criteria, precisely
+
+A request is a **successful inference** iff **both**:
+
+1. HTTP status is `2xx`, and
+2. `completion_tokens > 0` (non-empty generation).
+
+Only generative endpoints are inference for this purpose. Today the
+**active, instrumented** endpoint is `/v1/chat/completions` (streaming and
+non-streaming). `/v1/completions` and `/v1/messages` are generative too but
+are **not wired yet** — they are excluded from `INFERENCE_ENDPOINTS` until
+their `request`/activation instrumentation lands, so the spec never claims
+coverage the code doesn't deliver.
+
+## The `activation` event
+
+A dedicated low-frequency telemetry event (opt-in, consent-gated, **never
+sampled** — unlike `request`). Envelope is the standard telemetry envelope
+(`client_id`, `session_id`, `rapid_mlx_version`, `platform`, `timestamp`);
+the event-specific payload is:
+
+```json
+{ "activation_kind": "first_inference" | "model_pull" | "agent_setup",
+  "surface":         "cli" | "api" }
+```
+
+No prompt, no completion, no content of any kind — two enums only. This is
+the same privacy class as the `first_session` / `auto_selected` booleans.
+
+### Why a dedicated event and not derivation from `request`
+
+The spec's preference is to **derive** engagement in the collector from
+existing `session` / `request` events and avoid new high-frequency events.
+That is not possible for `first_inference`: `request` events are sampled at
+10% (`RAPID_MLX_TELEMETRY_REQUEST_SAMPLE`), so ~90% of installs' *first*
+successful inference is never emitted — a first-touch milestone cannot be
+reconstructed from a 1-in-10 sample. `activation` is therefore emitted
+**unsampled** at the success chokepoint. It stays low-frequency by
+construction: the local marker suppresses it to ~one emission per install per
+`activation_kind` (see "Delivery semantics" for the at-least-once caveat), so
+it can never become a high-volume stream.
+
+### Delivery semantics — at-least-once, deduped by `client_id`
+
+Each `activation_kind` is guarded by a local marker file
+`~/.rapid-mlx/activation_seen_<kind>`, created with exclusive
+(`O_CREAT | O_EXCL`) semantics — the same primitive as `mark_first_session`.
+In the common case the first emission claims the marker and every later call
+(this process, via an in-memory latch; other processes, via the marker) is a
+silent no-op.
+
+The client deliberately does **not** attempt exactly-once across processes.
+It **enqueues first, then claims the marker**, so a transient envelope/enqueue
+failure leaves the marker unclaimed and the next successful inference simply
+retries — an install is never permanently dropped from the funnel by one
+queue hiccup. The tradeoff is that two processes racing the marker check can
+both enqueue; this is acceptable because the **collector de-duplicates by
+`client_id`** (it counts distinct installs, and — per the worker's
+aggregation — `activation` events are excluded from the per-session
+engaged-ratio accumulation, so a duplicate cannot inflate any metric). Losing
+an install (at-most-once) is a strictly worse error for a growth signal than a
+harmless, dedup-able duplicate (at-least-once). The marker is a local empty
+file; only the derived enum pair ever leaves the machine, and only when
+telemetry is enabled.
+
+`kind` is validated against the allowlist before it is ever interpolated into
+the marker filename, so no caller-controlled string can escape `~/.rapid-mlx`.
+
+### `surface` resolution
+
+`surface` distinguishes the CLI REPL from the HTTP API. Because
+`rapid-mlx chat` runs inference by spawning its own ephemeral `serve` and
+looping through `/v1/chat/completions`, the `first_inference` milestone is
+emitted at the **server-side** success chokepoint for both surfaces; the
+surface is derived from the marker `rapid-mlx chat` **already** sets on the
+server it spawns — `RAPID_MLX_CHAT_SPAWN=1`. A chat-spawned server is the
+`cli` surface; a standalone `serve` is `api`. Reusing the existing marker
+means no new env var, and a single emission site (no double-counting across
+the chat front-end and its spawned server).
+
+Edge: `rapid-mlx chat --base-url` / `--port` connects to a pre-existing
+server instead of spawning one, so that server attributes the inference to
+its own surface (`api` for a standalone `serve`). The auto-spawn path — the
+common case — attributes to `cli`.
+
+**Surface under the at-least-once duplicate.** Because emission is
+at-least-once (see "Delivery semantics"), one pathological interleaving can
+send two `first_inference` events for the *same* install with *different*
+`surface`: a chat-spawned server (`cli`) and a standalone `serve` (`api`) both
+running their very first successful inference for the same `client_id` before
+either claims the marker. This is deliberately treated as a best-effort
+*secondary* label: the load-bearing **engaged** metric counts distinct
+`client_id` and is unaffected (the install is engaged exactly once either way);
+only the cli-vs-api attribution of that one install may be order-dependent, and
+only in this rare same-install double-server race. Making the surface itself
+deterministic would require claiming before enqueue (reintroducing the
+permanent-suppression-on-failure hazard this design exists to avoid) or a
+collector-side tie-break; both are out of scope for a secondary dimension whose
+skew is bounded to at most one install per genuinely-concurrent double-serve.
+
+### `agent_setup` is deferred
+
+The spec defines `agent_setup` as "integration setup **and** a passing
+engine connection check." Today `rapid-mlx launch <agent>` writes the
+integration config but performs **no** connectivity probe against the local
+engine, so there is nothing to gate the milestone on. Wiring `agent_setup`
+is therefore blocked on first adding that connection check to `launch`;
+until then the enum value is reserved and never emitted.
+
+## Dashboard contract
+
+- **Engaged install**: a `client_id` with ≥1 `activation` event where
+  `activation_kind = first_inference`.
+- **Engaged-DAU / WK1**: build activation cohorts from the `activation`
+  event's `timestamp`, then measure return with the existing `session_start`
+  stream. Do **not** define "active" as "has a `session_start`" — that
+  counts boots and polls.
+- **Activation funnel**: `model_pull` → `first_inference`, and
+  `agent_setup` as the integration path, all keyed on the shared
+  `client_id`.
+
+Both this document and the repository tests (`tests/test_telemetry_activation.py`)
+reference `ACTIVATION_SPEC_VERSION`. Any change to the rules above bumps
+that constant.

--- a/tests/test_telemetry_activation.py
+++ b/tests/test_telemetry_activation.py
@@ -1,0 +1,752 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Activation / engagement semantics — the versioned caliber contract.
+
+Pins docs/telemetry-activation.md (``ACTIVATION_SPEC_VERSION``) in code so a
+silent drift in "what counts as engaged" fails CI. Covers, per the spec's
+required list:
+
+- the success predicate (2xx AND non-empty) for streaming + non-streaming,
+- failed requests and empty generations NOT counting,
+- health / models / server-startup NOT counting,
+- once-per-install dedup (marker, across processes) and unsampled emission,
+- ``surface`` resolution (cli when chat-spawned, else api).
+
+Every ``vllm_mlx`` import is lazy (inside helpers/tests) so this collects and
+runs on the no-mlx ``pr_validate`` gate, like the request-wiring mirrors.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+# --------------------------------------------------------------- spec pins
+
+
+def test_spec_version_is_int_and_doc_exists():
+    import re
+    from pathlib import Path
+
+    from vllm_mlx.telemetry import activation_spec as spec
+
+    assert isinstance(spec.ACTIVATION_SPEC_VERSION, int)
+    assert spec.ACTIVATION_SPEC_VERSION >= 1
+    # The human half of the contract ships alongside the code half.
+    doc = Path(__file__).resolve().parents[1] / "docs" / "telemetry-activation.md"
+    assert doc.exists(), "docs/telemetry-activation.md must ship with the spec"
+    text = doc.read_text()
+    # Version LOCK, not a substring probe: parse the number the doc actually
+    # states ("Spec version: `N`") and assert it equals the code constant, so
+    # bumping one without the other fails CI. A bare ``"ACTIVATION_SPEC_VERSION"
+    # in text`` check would still pass while the numbers silently disagree.
+    m = re.search(r"Spec version:\s*`(\d+)`", text)
+    assert m, "doc must state its version as 'Spec version: `N`'"
+    assert int(m.group(1)) == spec.ACTIVATION_SPEC_VERSION, (
+        f"doc says v{m.group(1)} but code is v{spec.ACTIVATION_SPEC_VERSION}"
+    )
+
+
+def test_kinds_and_surfaces_are_the_allowlist():
+    from vllm_mlx.telemetry import activation_spec as spec
+
+    assert {
+        "first_inference",
+        "model_pull",
+        "agent_setup",
+    } == spec.ACTIVATION_KINDS
+    assert {"cli", "api"} == spec.ACTIVATION_SURFACES
+
+
+def test_health_and_models_are_not_inference_endpoints():
+    """Liveness/metadata probes must never be classed as inference."""
+    from vllm_mlx.telemetry import activation_spec as spec
+
+    for probe in ("/health", "/healthz", "/v1/models", "/models"):
+        assert probe not in spec.INFERENCE_ENDPOINTS
+
+
+# ------------------------------------------------ success predicate (caliber)
+
+
+@pytest.mark.parametrize(
+    "status,tokens,expected",
+    [
+        (200, 8, True),  # non-streaming success
+        (200, 1, True),  # a single real token still counts
+        (201, 3, True),  # any 2xx
+        (299, 3, True),
+        (200, 0, False),  # EMPTY generation: "it ran" != "it worked"
+        (204, 0, False),  # 204 no-content: zero tokens fails the non-empty check
+        (400, 8, False),  # client error
+        (404, 8, False),
+        (500, 8, False),  # server error
+        (300, 8, False),  # redirect is not success
+        (200, -1, False),  # nonsense token count
+    ],
+)
+def test_is_successful_inference(status, tokens, expected):
+    from vllm_mlx.telemetry.activation_spec import is_successful_inference
+
+    assert is_successful_inference(status, tokens) is expected
+
+
+def test_is_successful_inference_tolerates_bad_types():
+    from vllm_mlx.telemetry.activation_spec import is_successful_inference
+
+    assert is_successful_inference("nope", 5) is False
+    assert is_successful_inference(200, None) is False
+
+
+# ------------------------------------------------------ marker (once/install)
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RAPID_MLX_TELEMETRY", raising=False)
+    monkeypatch.delenv("RAPID_MLX_CHAT_SPAWN", raising=False)
+
+    import vllm_mlx.telemetry.state as state
+
+    importlib.reload(state)
+    import vllm_mlx.telemetry.emit as emit
+
+    importlib.reload(emit)
+    emit._reset_for_tests()
+    return tmp_path
+
+
+def test_claim_activation_marker_is_once_per_kind(fake_home):
+    from vllm_mlx.telemetry import state
+
+    assert state.claim_activation_marker("first_inference") is True
+    # Second claim of the SAME kind loses — this is the once-per-install latch.
+    assert state.claim_activation_marker("first_inference") is False
+    # A different kind is independent.
+    assert state.claim_activation_marker("model_pull") is True
+    assert state.claim_activation_marker("model_pull") is False
+
+
+def test_marker_path_is_per_kind_under_rapid_mlx(fake_home):
+    from vllm_mlx.telemetry import state
+
+    p = state.activation_marker_path("first_inference")
+    assert p.name == "activation_seen_first_inference"
+    assert p.parent.name == ".rapid-mlx"
+
+
+def test_claim_activation_marker_is_atomic_across_processes(fake_home):
+    """PRIMITIVE test: ``claim_activation_marker`` itself elects exactly one
+    winner across REAL processes. ``fake_home`` set HOME in the environment;
+    spawned children inherit it and resolve the SAME marker dir, so N
+    interpreters race one O_CREAT|O_EXCL create and the kernel picks a single
+    winner. This is the best-effort suppressor ``activation()`` is built on — it
+    is NOT a claim that ``activation()`` *delivery* is exactly-once. Delivery is
+    at-least-once by design (enqueue-before-claim); that ordering is pinned in
+    ``test_activation_enqueues_before_claiming_marker``.
+
+    ``claim_activation_marker`` is a top-level function in the importable
+    ``vllm_mlx.telemetry.state`` package, so it pickles by reference and the
+    spawned children import only that light module (no mlx), keeping the test
+    fast and free of the tests-package import pitfalls of a custom worker.
+    """
+    import multiprocessing as mp
+
+    from vllm_mlx.telemetry.state import claim_activation_marker
+
+    n = 8
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(n) as pool:
+        results = pool.map(claim_activation_marker, ["first_inference"] * n)
+    assert sum(1 for r in results if r) == 1, results
+
+
+def test_activation_enqueues_before_claiming_marker(opted_in, monkeypatch):
+    """Pins the enqueue-BEFORE-claim ordering (design A) PRECISELY: the payload
+    must be durably enqueued before the once-ever marker is claimed. That
+    ordering is the whole point — it is what makes retry-after-failure work: if
+    the claim ran first, a failed enqueue would burn the marker and drop the
+    install from the funnel forever (see docs/telemetry-activation.md and
+    ``test_activation_retries_after_enqueue_failure``).
+
+    A spy on both operations distinguishes the two orderings unambiguously —
+    unlike a marker-delete-then-recall test, which enqueues twice under BOTH
+    orderings and so cannot pin which came first. In design B (claim-first) the
+    recorded order would be ``["claim", "enqueue"]``; design A must be the
+    reverse."""
+    from vllm_mlx.telemetry import emit, state
+
+    order: list[str] = []
+
+    class _SpyQueue:
+        def enqueue(self, payload):
+            order.append("enqueue")
+
+    real_claim = state.claim_activation_marker
+
+    def spy_claim(kind):
+        order.append("claim")
+        return real_claim(kind)
+
+    # emit.activation does a call-time ``from ...state import claim_activation_marker``,
+    # so patching the name on the state module is what it will resolve.
+    monkeypatch.setattr(emit, "get_queue", lambda: _SpyQueue())
+    monkeypatch.setattr(state, "claim_activation_marker", spy_claim)
+
+    emit.activation(activation_kind="first_inference", surface="api")
+
+    assert order == ["enqueue", "claim"]
+
+
+# ----------------------------------------------------------- surface resolve
+
+
+def test_server_surface_defaults_to_api(fake_home, monkeypatch):
+    from vllm_mlx.telemetry import emit
+
+    monkeypatch.delenv("RAPID_MLX_CHAT_SPAWN", raising=False)
+    assert emit.server_surface() == "api"
+
+
+def test_server_surface_is_cli_when_chat_spawned(fake_home, monkeypatch):
+    from vllm_mlx.telemetry import emit
+
+    monkeypatch.setenv("RAPID_MLX_CHAT_SPAWN", "1")
+    assert emit.server_surface() == "cli"
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on", " 1 "])
+def test_server_surface_truthy_values_are_cli(fake_home, monkeypatch, val):
+    from vllm_mlx.telemetry import emit
+
+    monkeypatch.setenv("RAPID_MLX_CHAT_SPAWN", val)
+    assert emit.server_surface() == "cli"
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "", "treu", "2", "cli"])
+def test_server_surface_non_allowlisted_values_default_to_api(
+    fake_home, monkeypatch, val
+):
+    """Only an explicit truthy allowlist is CLI; a typo like ``treu`` must
+    degrade to ``api``, not silently corrupt attribution toward ``cli``."""
+    from vllm_mlx.telemetry import emit
+
+    monkeypatch.setenv("RAPID_MLX_CHAT_SPAWN", val)
+    assert emit.server_surface() == "api"
+
+
+# ------------------------------------------------------ emit.activation gate
+
+
+@pytest.fixture
+def opted_in(fake_home):
+    from vllm_mlx.telemetry.state import record_consent
+
+    record_consent(True, rapid_mlx_version="0.0.0+test")
+    return fake_home
+
+
+@pytest.fixture
+def stub_queue(monkeypatch):
+    from vllm_mlx.telemetry import emit
+
+    captured: list[dict] = []
+
+    class _StubQueue:
+        def enqueue(self, payload):
+            captured.append(payload)
+
+    monkeypatch.setattr(emit, "get_queue", lambda: _StubQueue())
+    return captured
+
+
+def test_activation_no_op_when_disabled(fake_home, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert stub_queue == []
+    # A disabled install must NOT burn its once-ever marker, so enabling
+    # later still lets the first real inference emit.
+    from vllm_mlx.telemetry import state
+
+    assert not state.activation_marker_path("first_inference").exists()
+
+
+def test_activation_emits_expected_envelope(opted_in, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.activation(activation_kind="first_inference", surface="cli")
+    assert len(stub_queue) == 1
+    p = stub_queue[0]
+    assert p["event"] == "activation"
+    assert p["activation"] == {
+        "activation_kind": "first_inference",
+        "surface": "cli",
+    }
+    # Standard envelope present; no request/session/error payloads.
+    assert p["schema_version"] == 1
+    assert p["client_id"]
+    assert "session_id" in p and "timestamp" in p and "platform" in p
+    assert "request" not in p and "session" not in p and "error" not in p
+
+
+def test_activation_is_once_per_install_within_process(opted_in, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.activation(activation_kind="first_inference", surface="api")
+    emit.activation(activation_kind="first_inference", surface="api")
+    emit.activation(activation_kind="first_inference", surface="cli")
+    assert len(stub_queue) == 1  # only the first ever
+
+
+def test_activation_marker_dedup_survives_latch_reset(opted_in, stub_queue):
+    """Dedup is keyed on the persistent on-disk marker, not the in-process
+    latch: clearing the latch (as a fresh process would start) and re-calling
+    must NOT re-emit, because ``claim_activation_marker`` loses on the existing
+    marker. (The genuine cross-process *race* is covered by
+    ``test_claim_activation_marker_is_atomic_across_processes``; this asserts the
+    single-process restart path.)"""
+    from vllm_mlx.telemetry import emit
+
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert len(stub_queue) == 1
+    # Simulate a restarted process: clear the in-process latch, keep the marker.
+    emit._reset_for_tests()
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert len(stub_queue) == 1  # marker on disk suppresses the second claim
+
+
+def test_activation_retries_after_enqueue_failure(opted_in, monkeypatch):
+    """A transient enqueue failure must NOT permanently suppress the milestone.
+    Because emission enqueues BEFORE claiming the marker, a failing enqueue
+    leaves the marker unclaimed, so the next successful inference retries and
+    sends. (Claiming before enqueue would drop the install from the funnel
+    forever on one queue hiccup — the failure mode this ordering avoids.)"""
+    from vllm_mlx.telemetry import emit, state
+
+    class _BoomThenOK:
+        def __init__(self):
+            self.sent = []
+            self._armed = True
+
+        def enqueue(self, payload):
+            if self._armed:
+                self._armed = False
+                raise RuntimeError("queue down")
+            self.sent.append(payload)
+
+    q = _BoomThenOK()
+    monkeypatch.setattr(emit, "get_queue", lambda: q)
+
+    # First attempt: enqueue raises -> @_safe swallows; marker never claimed.
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert q.sent == []
+    assert not state.activation_marker_path("first_inference").exists()
+
+    # A restarted process retries; the queue is healthy now -> it sends once.
+    emit._reset_for_tests()
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert len(q.sent) == 1
+    assert state.activation_marker_path("first_inference").exists()
+
+
+def test_activation_latches_even_when_marker_persist_fails(
+    opted_in, stub_queue, monkeypatch
+):
+    """If the marker can't persist (e.g. ~/.rapid-mlx went read-only after
+    consent), the process must still latch after its single enqueue so it does
+    NOT re-emit on every later request. The cross-process duplicate this allows
+    is folded downstream by the stable client_id (guaranteed present whenever
+    activation can emit); the in-process latch bounds it to ONE per process."""
+    from vllm_mlx.telemetry import emit, state
+
+    # Simulate an unwritable state dir: claim always fails, marker never appears.
+    monkeypatch.setattr(state, "claim_activation_marker", lambda kind: False)
+
+    emit.activation(activation_kind="first_inference", surface="api")
+    emit.activation(activation_kind="first_inference", surface="api")
+    emit.activation(activation_kind="first_inference", surface="api")
+    # Exactly one enqueue this process despite the marker never persisting.
+    assert len(stub_queue) == 1
+
+
+def test_activation_marker_rejects_path_traversal_kinds(fake_home, tmp_path):
+    """`kind` is interpolated into a filename; an out-of-allowlist value with
+    ``../`` must never let ``claim_activation_marker`` create files outside
+    ~/.rapid-mlx. The path builder validates, so claim fail-safes to False and
+    touches nothing on disk.
+
+    The escape target is a UNIQUE path under this test's ``tmp_path`` (not a
+    shared global like ``/tmp/rapid_pwn``), so the "nothing was created"
+    assertion isolates THIS test's writes and can't be tripped by an unrelated
+    process or a prior run."""
+    import pytest as _pytest
+
+    from vllm_mlx.telemetry import state
+
+    # A kind that would escape ~/.rapid-mlx and land on a unique, guaranteed-
+    # absent target if validation were missing.
+    target = tmp_path / "rapid_pwn_target"
+    assert not target.exists()
+    evil = f"../../../../../../../..{target}"
+
+    with _pytest.raises(ValueError):
+        state.activation_marker_path(evil)
+    # Public claim swallows the rejection into a safe False — no fs write.
+    assert state.claim_activation_marker(evil) is False
+    assert not target.exists()  # nothing was created at the escape target
+
+
+def test_reset_state_clears_in_process_activation_latch(opted_in, stub_queue):
+    """`telemetry reset` in the SAME process must let a re-enabled install
+    re-earn milestones: reset_state wipes the markers AND the in-memory latch,
+    so the next call is not silently suppressed by stale process state."""
+    from vllm_mlx.telemetry import emit, state
+
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert len(stub_queue) == 1
+    assert "first_inference" in emit._activation_latched
+    state.reset_state()
+    assert "first_inference" not in emit._activation_latched
+    # reset_state also wiped consent; re-enable to model "reset then opt in
+    # again in the same process". Marker gone + latch cleared -> emits again.
+    state.record_consent(True, rapid_mlx_version="0.0.0+test")
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert len(stub_queue) == 2
+
+
+def test_reset_state_clears_activation_markers(opted_in, stub_queue):
+    """`telemetry reset` rotates the client_id; it must also drop the
+    activation markers so the fresh identity can re-earn its milestones —
+    otherwise dedup keyed on a stale marker permanently silences the funnel."""
+    from vllm_mlx.telemetry import emit, state
+
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert state.activation_marker_path("first_inference").exists()
+    state.reset_state()
+    assert not state.activation_marker_path("first_inference").exists()
+
+
+def test_activation_kinds_are_independent(opted_in, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.activation(activation_kind="first_inference", surface="api")
+    emit.activation(activation_kind="model_pull", surface="cli")
+    kinds = [p["activation"]["activation_kind"] for p in stub_queue]
+    assert kinds == ["first_inference", "model_pull"]
+
+
+def test_activation_drops_unknown_kind(opted_in, stub_queue):
+    from vllm_mlx.telemetry import emit
+
+    emit.activation(activation_kind="not_a_kind", surface="api")
+    assert stub_queue == []
+
+
+def test_activation_drops_unknown_surface(opted_in, stub_queue):
+    """An off-allowlist surface is an instrumentation bug: drop the event (like
+    an unknown kind) rather than silently mislabel it as ``api``."""
+    from vllm_mlx.telemetry import emit, state
+
+    emit.activation(activation_kind="first_inference", surface="carrier-pigeon")
+    assert stub_queue == []
+    # And it must not burn the once-ever marker — a later valid call still emits.
+    assert not state.activation_marker_path("first_inference").exists()
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert len(stub_queue) == 1
+    assert stub_queue[0]["activation"]["surface"] == "api"
+
+
+def test_activation_is_not_request_sampled(opted_in, stub_queue, monkeypatch):
+    """Setting the request sample rate to 0 silences ``request`` events but
+    MUST NOT silence activation — a first-touch milestone can't be sampled."""
+    monkeypatch.setenv("RAPID_MLX_TELEMETRY_REQUEST_SAMPLE", "0")
+    from vllm_mlx.telemetry import emit
+
+    emit.activation(activation_kind="first_inference", surface="api")
+    assert len(stub_queue) == 1
+
+
+def test_session_start_does_not_emit_activation(opted_in, stub_queue):
+    """Server startup / session_start is NOT engagement."""
+    from vllm_mlx.telemetry import emit
+
+    emit.session_start(subcommand="serve", first_session=True)
+    assert len(stub_queue) == 1
+    assert stub_queue[0]["event"] == "session_start"
+    # And no activation marker was created by merely starting.
+    from vllm_mlx.telemetry import state
+
+    assert not state.activation_marker_path("first_inference").exists()
+
+
+# ------------------------------------------ route caliber: non-streaming
+
+
+class _RawRequest:
+    def __init__(self, user_agent=None):
+        self.headers = {} if user_agent is None else {"user-agent": user_agent}
+
+    async def json(self):
+        return {}
+
+    async def is_disconnected(self):
+        return False
+
+
+class _FakeChatEngine:
+    supports_guided_generation = False
+    preserve_native_tool_format = False
+    is_mllm = False
+    model_name = "test-model"
+    tokenizer = SimpleNamespace(encode=lambda _text: [1])
+    _text = "hello there"
+    _completion_tokens = 8
+
+    async def chat(self, messages, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        return GenerationOutput(
+            text=self._text,
+            finish_reason="stop",
+            prompt_tokens=12,
+            completion_tokens=self._completion_tokens,
+        )
+
+
+class _EmptyChatEngine(_FakeChatEngine):
+    _text = ""
+    _completion_tokens = 0
+
+
+async def _await_direct(coro, *_a, **_k):
+    return await coro
+
+
+def _patch_route(monkeypatch, engine, activation_calls):
+    from vllm_mlx.routes import chat
+    from vllm_mlx.telemetry import emit
+
+    monkeypatch.setattr(emit, "is_enabled", lambda *a, **k: True)
+    monkeypatch.setattr(emit, "request", lambda **kw: None)  # silence the sampled event
+    monkeypatch.setattr(emit, "activation", lambda **kw: activation_calls.append(kw))
+    monkeypatch.setattr(chat, "_resolve_max_tokens", lambda *a, **k: 64)
+    monkeypatch.setattr(chat, "get_engine", lambda *a, **k: engine)
+    monkeypatch.setattr(chat, "_validate_model_name", lambda *a, **k: None)
+    monkeypatch.setattr(chat, "_check_admission_or_503", lambda *a, **k: None)
+    monkeypatch.setattr(
+        chat, "_release_admission_unless_committed", lambda *a, **k: None
+    )
+    monkeypatch.setattr(chat, "_wait_with_disconnect", _await_direct)
+    monkeypatch.setattr(
+        chat, "validate_content_blocks_for_capabilities", lambda *a, **k: None
+    )
+    monkeypatch.setattr(chat, "enforce_context_length_for_messages", lambda *a, **k: 1)
+
+
+def _request(model="test-model", stream=False):
+    from vllm_mlx.api.models import ChatCompletionRequest
+
+    return ChatCompletionRequest(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=None,
+        stream=stream,
+    )
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_success_emits_first_inference(monkeypatch):
+    from vllm_mlx.routes import chat
+
+    calls: list[dict] = []
+    _patch_route(monkeypatch, _FakeChatEngine(), calls)
+
+    await chat._create_chat_completion_impl(
+        _request(),
+        _RawRequest(user_agent="claude-cli/1.4.2"),
+        _FakeChatEngine(),
+        _commit_state=[False],
+        _admission_acquired=[False],
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["activation_kind"] == "first_inference"
+    assert calls[0]["surface"] == "api"  # not chat-spawned
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_success_surface_cli_when_chat_spawned(monkeypatch):
+    monkeypatch.setenv("RAPID_MLX_CHAT_SPAWN", "1")
+    from vllm_mlx.routes import chat
+
+    calls: list[dict] = []
+    _patch_route(monkeypatch, _FakeChatEngine(), calls)
+
+    await chat._create_chat_completion_impl(
+        _request(),
+        _RawRequest(),
+        _FakeChatEngine(),
+        _commit_state=[False],
+        _admission_acquired=[False],
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["surface"] == "cli"
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_empty_generation_does_not_engage(monkeypatch):
+    from vllm_mlx.routes import chat
+
+    calls: list[dict] = []
+    _patch_route(monkeypatch, _EmptyChatEngine(), calls)
+
+    await chat._create_chat_completion_impl(
+        _request(),
+        _RawRequest(),
+        _EmptyChatEngine(),
+        _commit_state=[False],
+        _admission_acquired=[False],
+    )
+
+    assert calls == []  # 200 + zero completion tokens is NOT engagement
+
+
+# ------------------------------------------ route caliber: streaming
+
+
+class _FakeStreamingOutput:
+    def __init__(self, new_text, finished, completion_tokens):
+        self.new_text = new_text
+        self.text = new_text
+        self.finished = finished
+        self.finish_reason = "stop" if finished else None
+        self.channel = None
+        self.prompt_tokens = 11
+        self.completion_tokens = completion_tokens
+        self.cached_tokens = 0
+        self.tokens = []
+        self.logprobs = None
+        self.tool_calls = None
+        self.matched_stop = None
+        self.raw_text = new_text
+
+
+class _FakeStreamEngine:
+    def __init__(self, deltas, completion_tokens):
+        self._deltas = deltas
+        self._completion_tokens = completion_tokens
+        self.tokenizer = None
+        self.is_mllm = False
+        self.supports_tool_calls = False
+        self.supports_guided_generation = False
+
+    async def stream_chat(self, **kwargs):
+        n = len(self._deltas)
+        for i, d in enumerate(self._deltas):
+            yield _FakeStreamingOutput(
+                d, finished=(i == n - 1), completion_tokens=self._completion_tokens
+            )
+
+    def build_prompt(self, *args, **kwargs):
+        return "prompt"
+
+
+@pytest.fixture
+def _stream_cfg(monkeypatch):
+    from vllm_mlx.config import server_config
+
+    cfg = server_config.get_config()
+    monkeypatch.setattr(cfg, "tool_call_parser", None, raising=False)
+    monkeypatch.setattr(cfg, "reasoning_parser_name", None, raising=False)
+    monkeypatch.setattr(cfg, "reasoning_parser", None, raising=False)
+    monkeypatch.setattr(cfg, "enable_auto_tool_choice", False, raising=False)
+    monkeypatch.setattr(cfg, "gc_control", False, raising=False)
+    yield
+
+
+def _drive_stream(monkeypatch, engine, activation_calls):
+    from vllm_mlx.routes import chat
+    from vllm_mlx.telemetry import emit
+
+    # monkeypatch (not direct assignment) so teardown restores emit's module
+    # state — otherwise these fakes leak into later tests in the same process.
+    monkeypatch.setattr(emit, "is_enabled", lambda *a, **k: True)
+    monkeypatch.setattr(emit, "request", lambda **kw: None)
+    monkeypatch.setattr(emit, "activation", lambda **kw: activation_calls.append(kw))
+
+    async def _run():
+        gen = chat.stream_chat_completion(
+            engine, [{"role": "user", "content": "hi"}], _request(stream=True)
+        )
+        async for _chunk in gen:
+            pass
+
+    asyncio.run(_run())
+
+
+def test_streaming_success_emits_first_inference(fake_home, _stream_cfg, monkeypatch):
+    calls: list[dict] = []
+    _drive_stream(
+        monkeypatch, _FakeStreamEngine(["hello", " there"], completion_tokens=7), calls
+    )
+    assert len(calls) == 1
+    assert calls[0]["activation_kind"] == "first_inference"
+
+
+def test_streaming_empty_does_not_engage(fake_home, _stream_cfg, monkeypatch):
+    calls: list[dict] = []
+    _drive_stream(monkeypatch, _FakeStreamEngine([""], completion_tokens=0), calls)
+    assert calls == []
+
+
+class _RaisingStreamEngine(_FakeStreamEngine):
+    async def stream_chat(self, **kwargs):
+        # Deliver a real token, then fail mid-stream (engine crash / server error).
+        yield _FakeStreamingOutput("par", finished=False, completion_tokens=3)
+        raise RuntimeError("engine exploded mid-stream")
+
+
+def test_streaming_failure_midway_does_not_engage(fake_home, _stream_cfg, monkeypatch):
+    """A stream that yields a token then RAISES must not record engagement: the
+    activation emit sits after a NORMAL drain of the generator, so a failed
+    generator never reaches it. Under-counting a broken stream is the intended
+    conservative behavior (never inflates the funnel)."""
+    calls: list[dict] = []
+    engine = _RaisingStreamEngine([], completion_tokens=3)
+    # Require the SPECIFIC engine failure to reach us — otherwise an unrelated
+    # setup/route error before the stream is consumed would also leave
+    # ``calls == []`` and the test would pass without exercising the path.
+    with pytest.raises(RuntimeError, match="engine exploded mid-stream"):
+        _drive_stream(monkeypatch, engine, calls)
+    assert calls == []
+
+
+def test_streaming_client_cancel_does_not_engage(fake_home, _stream_cfg, monkeypatch):
+    """Client disconnect mid-stream (break out of the async-for, then aclose ->
+    GeneratorExit at the paused yield) must not record engagement — emission is
+    reached only after a full normal drain."""
+    from vllm_mlx.routes import chat
+    from vllm_mlx.telemetry import emit
+
+    calls: list[dict] = []
+    monkeypatch.setattr(emit, "is_enabled", lambda *a, **k: True)
+    monkeypatch.setattr(emit, "request", lambda **kw: None)
+    monkeypatch.setattr(emit, "activation", lambda **kw: calls.append(kw))
+
+    engine = _FakeStreamEngine(["a", "b", "c", "d"], completion_tokens=9)
+
+    async def _run():
+        gen = chat.stream_chat_completion(
+            engine, [{"role": "user", "content": "hi"}], _request(stream=True)
+        )
+        async for _chunk in gen:
+            break  # simulate client disconnect after the first chunk
+        await gen.aclose()
+
+    asyncio.run(_run())
+    assert calls == []

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -140,6 +140,24 @@ def test_reset_removes_consent(fake_home):
     assert "never prompted" in status.stdout.lower()
 
 
+def test_reset_exits_nonzero_when_removal_fails(fake_home):
+    """A failed reset must NOT report success: automation running
+    ``rapid-mlx telemetry reset`` needs a non-zero exit when state survives on
+    disk (else it assumes telemetry is off when it may still be on)."""
+    import pathlib
+
+    _run_cli("telemetry", "enable", home=fake_home)
+    # Make one marker path unremovable: a NON-EMPTY directory where reset expects
+    # a file, so unlink() raises inside reset_state.
+    stuck = pathlib.Path(fake_home) / ".rapid-mlx" / "activation_seen_first_inference"
+    stuck.mkdir(parents=True, exist_ok=True)
+    (stuck / "child").write_text("x")
+
+    r = _run_cli("telemetry", "reset", home=fake_home)
+    assert r.returncode != 0
+    assert "reset incomplete" in (r.stdout + r.stderr).lower()
+
+
 def test_status_with_no_action_defaults_to_status(fake_home):
     """``rapid-mlx telemetry`` (no action) should be a friendly status,
     not an argparse error — users will type the bare command first."""

--- a/tests/test_telemetry_state.py
+++ b/tests/test_telemetry_state.py
@@ -53,9 +53,70 @@ def test_consent_round_trip(fake_home):
     assert state is not None
     assert state.consent is True
     assert state.prompted_version == "0.6.33"
-    assert state.schema_version == 1
+    from vllm_mlx.telemetry.state import CURRENT_CONSENT_SCHEMA_VERSION
+
+    assert state.schema_version == CURRENT_CONSENT_SCHEMA_VERSION
     assert state.prompted_at.endswith("Z")
     assert is_enabled() is True
+
+
+def test_prior_v1_consent_is_reprompted_after_activation_added(fake_home):
+    """v1 opt-ins predate the ``activation`` disclosure. Bumping the consent
+    schema to 2 must make a stored v1 record read as "never prompted" so the
+    user re-sees and re-accepts before any activation event can be emitted —
+    adding a new collected data type under stale consent would be a breach."""
+    import yaml
+
+    from vllm_mlx.telemetry.state import (
+        consent_path,
+        get_consent_state,
+        is_enabled,
+    )
+
+    # Hand-write a legacy v1 consent record (consent=yes under old copy).
+    p = consent_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "consent": True,
+                "prompted_at": "2026-01-01T00:00:00Z",
+                "prompted_version": "0.11.0",
+                "schema_version": 1,
+            }
+        )
+    )
+    # Treated as unprompted -> None -> telemetry stays OFF until re-accepted.
+    assert get_consent_state() is None
+    assert is_enabled() is False
+
+
+def test_reset_state_raises_when_a_path_cannot_be_removed(fake_home):
+    """`reset_state` must not silently claim success when state survives on disk
+    (that would leave telemetry enabled while the CLI prints "removed"). It
+    attempts every path, still clears the in-process latch, then raises an
+    aggregated OSError naming what it could not remove."""
+    import pytest
+
+    from vllm_mlx.telemetry import emit, state
+
+    # A normally-removable consent file...
+    state.record_consent(True, rapid_mlx_version="0.0.0+test")
+    assert state.consent_path().exists()
+    # ...and a marker path that is a NON-EMPTY DIRECTORY, so unlink() raises
+    # OSError (IsADirectoryError) — the glob picks it up like any marker.
+    stuck = state.activation_marker_path("first_inference")
+    stuck.mkdir(parents=True, exist_ok=True)
+    (stuck / "child").write_text("x")
+    # Latch a kind so we can assert the latch is cleared despite the failure.
+    emit._activation_latched.add("model_pull")
+
+    with pytest.raises(OSError):
+        state.reset_state()
+
+    # Removable state was still removed and the latch was still cleared.
+    assert not state.consent_path().exists()
+    assert "model_pull" not in emit._activation_latched
 
 
 def test_env_kill_switch_wins_over_consent(fake_home, monkeypatch):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5642,6 +5642,19 @@ def _print_pull_summary(repo_id: str, snapshot_dir, elapsed: float) -> None:
         f"{_format_pull_duration(elapsed)}"
     )
 
+    # Activation funnel (docs/telemetry-activation.md): a successful pull is
+    # the ``model_pull`` milestone (an activation, NOT inference-engaged).
+    # This helper is only reached on the two success exits of ``pull_command``,
+    # so it is the single "pull succeeded" chokepoint. Fired once per install,
+    # consent-gated + ``@_safe``, so it is a no-op when telemetry is off and
+    # can never affect the pull.
+    from vllm_mlx.telemetry import emit as _telemetry_emit
+    from vllm_mlx.telemetry.activation_spec import ACTIVATION_MODEL_PULL, SURFACE_CLI
+
+    _telemetry_emit.activation(
+        activation_kind=ACTIVATION_MODEL_PULL, surface=SURFACE_CLI
+    )
+
 
 def pull_command(args):
     """Download a model to the HuggingFace cache without serving."""
@@ -7880,7 +7893,17 @@ def telemetry_command(args) -> None:
         return
 
     if action == "reset":
-        reset_state()
+        try:
+            reset_state()
+        except OSError as exc:
+            print()
+            print(f"  Reset incomplete — some files could not be removed: {exc}")
+            print("  Telemetry state may still be present; check ~/.rapid-mlx/.")
+            print()
+            # Non-zero exit so automation (`rapid-mlx telemetry reset` in a
+            # script) sees the failure instead of a false success — state may
+            # still be on disk and telemetry may still be enabled.
+            sys.exit(1)
         print()
         print("  Removed consent + client-id files. Next interactive run re-prompts.")
         print()

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5952,11 +5952,31 @@ async def _create_chat_completion_impl(
         output_degenerate=_output_degenerate,
     )
 
-    return Response(
+    # Serialize the response FIRST so a serialization failure surfaces as an
+    # error the client sees — not as a "successful inference" we already
+    # counted. ``model_dump_json`` can raise; the activation emit below must be
+    # reached only when the 2xx body is actually built.
+    response = Response(
         content=chat_response.model_dump_json(exclude_none=True),
         media_type="application/json",
         headers=response_headers or None,
     )
+
+    # Activation funnel (docs/telemetry-activation.md): a successful, non-empty
+    # inference is the ``first_inference`` engagement milestone. Fired once per
+    # install and UNSAMPLED — distinct from the 10%-sampled ``request`` event
+    # above — so the engaged baseline can't be reconstructed-from-sample. A
+    # 2xx with zero completion tokens (empty generation) does NOT count. Emitted
+    # only after the response above is successfully constructed.
+    from vllm_mlx.telemetry.activation_spec import is_successful_inference
+
+    if is_successful_inference(200, output.completion_tokens):
+        _telemetry_emit.activation(
+            activation_kind="first_inference",
+            surface=_telemetry_emit.server_surface(),
+        )
+
+    return response
 
 
 async def stream_chat_completion(
@@ -7236,6 +7256,25 @@ async def stream_chat_completion(
             caller_agent=caller_agent,
             output_degenerate=_output_degenerate,
         )
+
+        # Activation funnel (docs/telemetry-activation.md): the streaming
+        # analogue of the non-streaming site above. A successful, non-empty
+        # stream is the ``first_inference`` milestone — once per install,
+        # unsampled. An empty stream (zero completion tokens) does NOT count.
+        #
+        # Placement is intentional: we emit only after the generator drains
+        # normally (all tokens flushed). A stream the client disconnects or
+        # cancels mid-generation raises out before here and is deliberately NOT
+        # counted — under-counting is conservative and never inflates the
+        # engaged funnel, whereas emitting at the first yielded token would
+        # over-count streams that then error out (contradicting "successful").
+        from vllm_mlx.telemetry.activation_spec import is_successful_inference
+
+        if is_successful_inference(200, completion_tokens):
+            _telemetry_emit.activation(
+                activation_kind="first_inference",
+                surface=_telemetry_emit.server_surface(),
+            )
     finally:
         if cfg.gc_control and gc_was_enabled:
             gc.enable()

--- a/vllm_mlx/telemetry/activation_spec.py
+++ b/vllm_mlx/telemetry/activation_spec.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Machine-readable half of the activation/engagement spec.
+
+The human spec lives in ``docs/telemetry-activation.md``; this module is
+the code contract it references. The growth dashboard and the repository
+tests both key off ``ACTIVATION_SPEC_VERSION`` — bump it (and update the
+doc) whenever the rules below change.
+
+Nothing here touches the network or reads consent; it is pure definition
+so both ``emit`` (producer) and the tests (verifier) import the same
+constants instead of re-declaring them.
+"""
+
+from __future__ import annotations
+
+# Bump in lockstep with docs/telemetry-activation.md whenever what counts
+# as engaged/activated changes (new kind, changed success predicate, ...).
+ACTIVATION_SPEC_VERSION = 1
+
+# The funnel milestones. Each fires at most once per install (client_id).
+ACTIVATION_FIRST_INFERENCE = "first_inference"
+ACTIVATION_MODEL_PULL = "model_pull"
+ACTIVATION_AGENT_SETUP = "agent_setup"
+ACTIVATION_KINDS: frozenset[str] = frozenset(
+    {
+        ACTIVATION_FIRST_INFERENCE,
+        ACTIVATION_MODEL_PULL,
+        ACTIVATION_AGENT_SETUP,
+    }
+)
+
+# Where the milestone happened. ``cli`` = the interactive REPL / a CLI
+# subcommand; ``api`` = the HTTP server serving an external caller.
+SURFACE_CLI = "cli"
+SURFACE_API = "api"
+ACTIVATION_SURFACES: frozenset[str] = frozenset({SURFACE_CLI, SURFACE_API})
+
+# ``rapid-mlx chat`` spawns its own ephemeral ``serve`` and drives it over
+# HTTP, so first_inference is emitted at the server-side success chokepoint
+# for BOTH surfaces. Rather than invent a new env var, we reuse the marker
+# the chat front-end ALREADY sets on the server it spawns
+# (``RAPID_MLX_CHAT_SPAWN=1``): a chat-spawned server is the ``cli`` surface,
+# a standalone ``serve`` is ``api``. One emission site, no double-counting.
+CHAT_SPAWN_ENV = "RAPID_MLX_CHAT_SPAWN"
+
+# Generative endpoints whose successful, non-empty completion counts as
+# engagement.
+#
+# Spec v1 DEFINES engagement as chat-completions engagement — this is an
+# explicit, versioned scope decision, not an accidental omission.
+# ``/v1/chat/completions`` (streaming + non-streaming) is the dominant surface
+# (all CLI ``chat`` traffic auto-spawns a server that loops through it, plus
+# the bulk of direct API usage) and is the single endpoint instrumented with
+# both a ``request`` event and the ``activation`` emit.
+#
+# ``/v1/completions`` (routes/completions.py) and ``/v1/messages``
+# (routes/anthropic.py) are separate, generative, and NOT part of the v1
+# engagement contract: an install that inferences exclusively through them is
+# out of scope for v1's engaged metric by definition. Listing them here without
+# wiring would over-promise coverage the code doesn't deliver; wiring them is a
+# deliberate v2 item that MUST bump ``ACTIVATION_SPEC_VERSION`` and update the
+# dashboard in lockstep. See docs/telemetry-activation.md.
+INFERENCE_ENDPOINTS: frozenset[str] = frozenset(
+    {
+        "/v1/chat/completions",
+    }
+)
+
+
+def is_successful_inference(status: int, completion_tokens: int) -> bool:
+    """The single success predicate shared by call sites and tests.
+
+    A request is a successful inference iff the HTTP status is 2xx AND the
+    generation was non-empty. An error response or an empty completion is
+    explicitly NOT engagement (see docs/telemetry-activation.md).
+    """
+    try:
+        status_ok = 200 <= int(status) < 300
+        nonempty = int(completion_tokens) > 0
+    except (TypeError, ValueError):
+        return False
+    return status_ok and nonempty

--- a/vllm_mlx/telemetry/consent.py
+++ b/vllm_mlx/telemetry/consent.py
@@ -73,6 +73,11 @@ WHAT WE SEND (only after you say yes):
     from this machine, and -- for `chat` with no model named -- whether we
     auto-picked the starter model for you. Metadata only: no prompt, no
     output, no content.
+  - An "activation" marker the first time this machine does real work: the
+    KIND (first successful inference / model pull / agent setup) and the
+    SURFACE ("cli" or "api"). Two labels only, normally once per machine per
+    kind (a rare duplicate is possible -- it carries the same two labels and
+    nothing more). Metadata: no prompt, no output, no content.
   - The NAMES (only) of CLI flags you passed, sorted and de-duplicated
     (`--api-key sk-XXX` becomes the literal string "api-key"; the value
     "sk-XXX" is never even read).

--- a/vllm_mlx/telemetry/emit.py
+++ b/vllm_mlx/telemetry/emit.py
@@ -99,6 +99,15 @@ _session_end_hook_lock = threading.Lock()
 _session_end_hook: Any | None = None  # callable: () -> None
 _session_end_hook_fired = False
 
+# Activation events fire at most once per install per kind. The persistent
+# ``O_EXCL`` marker in ``state.claim_activation_marker`` is the source of
+# truth across processes; this in-process latch is a cheap short-circuit so
+# that after the first successful request the per-request emit is a set
+# lookup, not a filesystem syscall. Holds the kinds this process has already
+# resolved (claimed OR observed already-claimed).
+_activation_lock = threading.Lock()
+_activation_latched: set[str] = set()
+
 
 def register_session_end_hook(hook: Any) -> None:
     """Register a callable that emits ``session_end`` + drains the
@@ -239,8 +248,24 @@ def _reset_for_tests() -> None:
     with _session_end_hook_lock:
         _session_end_hook = None
         _session_end_hook_fired = False
+    # Clear the activation in-process latch so a test that just cleaned its
+    # HOME/marker dir sees a fresh "not yet claimed this process" state.
+    _reset_activation_latch()
     if q is not None:
         q.shutdown(timeout=0.1)
+
+
+def _reset_activation_latch() -> None:
+    """Drop the in-process ``activation`` latch.
+
+    Focused counterpart to ``_reset_for_tests`` used by ``state.reset_state``:
+    after ``telemetry reset`` wipes the persistent markers, the stale in-memory
+    latch must go too or a reset-then-re-enable in the SAME process would stay
+    silently suppressed. Kept minimal (latch only, no queue/session teardown)
+    so ``reset_state`` doesn't tear down an active session as a side effect.
+    """
+    with _activation_lock:
+        _activation_latched.clear()
 
 
 # ---------------------------------------------------------------- envelope
@@ -607,3 +632,136 @@ def error(
         "phase": _normalize_error_field(phase, _ALLOWED_ERROR_PHASES),
     }
     get_queue().enqueue(payload)
+
+
+def server_surface() -> str:
+    """Resolve the activation ``surface`` for a running server process.
+
+    ``cli`` when this process is a ``rapid-mlx chat``-spawned server (it sets
+    ``RAPID_MLX_CHAT_SPAWN=1`` on the child), else ``api``. Used by the
+    request-success call sites so a chat-driven first inference is attributed
+    to ``cli`` and a standalone ``serve`` to ``api`` — from a single emission
+    site. See ``docs/telemetry-activation.md``.
+    """
+    from vllm_mlx.telemetry.activation_spec import (
+        CHAT_SPAWN_ENV,
+        SURFACE_API,
+        SURFACE_CLI,
+    )
+
+    # The chat front-end sets the marker to "1". Recognize only an EXPLICIT
+    # truthy allowlist as CLI and default everything else — unset, "0"/"false",
+    # AND typos like "treu" — to ``api``. An allowlist (vs. "anything not falsy")
+    # means a malformed value degrades to the standalone-server surface instead
+    # of silently corrupting attribution toward ``cli``.
+    raw = os.environ.get(CHAT_SPAWN_ENV)
+    if raw is not None and raw.strip().lower() in ("1", "true", "yes", "on"):
+        return SURFACE_CLI
+    return SURFACE_API
+
+
+@_safe
+def activation(*, activation_kind: str, surface: str) -> None:
+    """Emit a once-per-install ``activation`` milestone (funnel signal).
+
+    Unlike ``request`` this is NEVER sampled — a first-touch milestone can't
+    be reconstructed from a 1-in-10 sample — but it stays low-frequency by
+    construction: at most one emission per install per ``activation_kind`` in
+    the common case, suppressed by the local marker in
+    ``state.claim_activation_marker`` and the in-process ``_activation_latched``
+    set (a plain membership test on the steady-state per-request path).
+
+    Delivery is **at-least-once, not exactly-once**: see the ordering note in
+    the body. The collector is the authoritative de-duplicator — it counts
+    DISTINCT ``client_id``, so a rare duplicate collapses to one engaged
+    install. This is deliberate; see ``docs/telemetry-activation.md``.
+
+    Consent-gated like every emit. Both ``activation_kind`` AND ``surface`` are
+    validated against the allowlists in ``telemetry.activation_spec``; an
+    off-list value in EITHER drops the event entirely (rather than coercing a
+    bad surface to ``api``, which would silently mislabel data and hide an
+    instrumentation bug). So no caller-controlled free-form text ever reaches
+    the payload. Two enums only: no prompt, no completion, no content. See
+    ``docs/telemetry-activation.md``.
+    """
+    from vllm_mlx.telemetry.activation_spec import (
+        ACTIVATION_KINDS,
+        ACTIVATION_SURFACES,
+    )
+    from vllm_mlx.telemetry.state import (
+        activation_marker_path,
+        claim_activation_marker,
+    )
+
+    if activation_kind not in ACTIVATION_KINDS:
+        return
+    # An off-allowlist surface is an instrumentation bug, not user input; drop
+    # the event (like an unknown kind) so it surfaces as "missing data" rather
+    # than data silently misattributed to ``api``.
+    if surface not in ACTIVATION_SURFACES:
+        return
+    # Cheap, lock-free short-circuit once this process has resolved the kind.
+    # This is the steady-state path: the synchronous marker filesystem work
+    # below (exists / mkdir / O_EXCL create under ``_activation_lock``) runs at
+    # most ONCE per process per kind — the very first successful inference —
+    # after which every later call returns here without touching disk or the
+    # lock. A one-time marker touch on the request path is an acceptable cost
+    # even on a slow HOME; it is not a per-request stall.
+    if activation_kind in _activation_latched:
+        return
+    # Consent is checked BEFORE touching the marker so a disabled install
+    # doesn't burn its once-ever marker — if the user enables telemetry
+    # later, their next successful inference still emits.
+    if not is_enabled():
+        return
+    surface_norm = surface  # already validated against ACTIVATION_SURFACES above
+    with _activation_lock:
+        if activation_kind in _activation_latched:
+            return
+        # If any process already committed this milestone, suppress and latch.
+        try:
+            if activation_marker_path(activation_kind).exists():
+                _activation_latched.add(activation_kind)
+                return
+        except OSError:
+            pass
+        # Ordering: enqueue FIRST, then claim the marker. Delivery is
+        # at-least-once by design. Two processes can race the marker check above
+        # and both enqueue, but the collector counts DISTINCT client_id, so a
+        # duplicate collapses to one engaged install. The inverse
+        # (claim-before-enqueue) would let a single envelope/enqueue failure —
+        # swallowed by @_safe — permanently suppress the milestone and silently
+        # drop the install from the funnel, a strictly worse error for a growth
+        # signal than a harmless dedup-able duplicate. Both the envelope build
+        # and the enqueue sit before the claim so ANY failure here leaves the
+        # marker unclaimed and the next successful inference simply retries.
+        #
+        # ``surface`` under this duplicate is a best-effort SECONDARY label: a
+        # same-install cli+api double-serve race could send both, and the
+        # client_id dedup then picks one order-dependently. The engaged COUNT is
+        # unaffected (deduped to one install); only the cli/api attribution of
+        # that one install may vary. See docs/telemetry-activation.md
+        # ("Surface under the at-least-once duplicate").
+        payload = _envelope("activation")
+        payload["activation"] = {
+            "activation_kind": activation_kind,
+            "surface": surface_norm,
+        }
+        get_queue().enqueue(payload)
+        # Persist "sent" only AFTER the durable enqueue.
+        claimed = claim_activation_marker(activation_kind)
+        if not claimed:
+            # The marker could not be persisted — either another process already
+            # claimed it (normal race; nothing more to do) or the state dir went
+            # read-only after consent was recorded. We latch below regardless so
+            # THIS process never re-enqueues on later requests. The cross-process
+            # duplicate this allows is harmless: activation is only reachable with
+            # consent on disk, which means ~/.rapid-mlx was writable and the
+            # persistent client_id was already created (reads keep working on a
+            # now-read-only dir), so the collector's DISTINCT-client_id dedup
+            # still folds every duplicate into one engaged install. (If the
+            # client_id had ALSO never persisted, no consent could exist and we
+            # would never reach here — so the "rotating client_id inflates the
+            # metric" case cannot occur.)
+            pass
+        _activation_latched.add(activation_kind)

--- a/vllm_mlx/telemetry/schema.py
+++ b/vllm_mlx/telemetry/schema.py
@@ -27,6 +27,21 @@ from vllm_mlx.telemetry.redact import (
     platform_info,
 )
 
+# The wire-envelope version: the shape of the common envelope (client_id,
+# session_id, timestamp, platform, event, + one event-specific payload).
+#
+# The new ``activation`` event does NOT bump this, on purpose. The envelope
+# shape is unchanged — ``activation`` is a new *value* of the existing ``event``
+# field with its own additive payload slot, exactly like ``session_start`` /
+# ``request`` / ``error``. Consumers dispatch on ``event`` and drop unknown
+# ones; they do not misparse. Concretely, the deployed telemetry-worker
+# STRICTLY rejects any event whose ``schema_version`` != its own
+# ``SCHEMA_VERSION`` (index.js: ``schema_version_mismatch``), so bumping this to
+# 2 unilaterally would make the live worker reject EVERY event (not just
+# activation) until a coordinated redeploy — strictly worse than the additive
+# path. The worker was already extended (rapidmlx.com PR #81) to allowlist the
+# ``activation`` event at schema_version 1. The activation CONTRACT is versioned
+# separately by ``activation_spec.ACTIVATION_SPEC_VERSION`` (dashboard + tests).
 SCHEMA_VERSION = 1
 
 
@@ -116,6 +131,20 @@ class ErrorPayload:
 
 
 @dataclass(frozen=True)
+class ActivationPayload:
+    """A once-per-install funnel milestone (see docs/telemetry-activation.md).
+
+    Two enums only — no prompt, no completion, no content — the same privacy
+    class as the ``first_session`` / ``auto_selected`` booleans. Emitted
+    UNSAMPLED (unlike ``request``) but low-frequency by construction: at most
+    once per install per ``activation_kind``.
+    """
+
+    activation_kind: str  # "first_inference" | "model_pull" | "agent_setup"
+    surface: str  # "cli" | "api"
+
+
+@dataclass(frozen=True)
 class TelemetryPayload:
     """The complete on-the-wire envelope.
 
@@ -128,20 +157,21 @@ class TelemetryPayload:
     session_id: str
     rapid_mlx_version: str
     platform: PlatformInfo
-    event: str  # "session_start" | "session_end" | "request" | "error"
+    event: str  # "session_start"|"session_end"|"request"|"error"|"activation"
     timestamp: str  # ISO-8601 UTC, "Z" suffix
     session: SessionPayload | None = None
     request: RequestPayload | None = None
     error: ErrorPayload | None = None
+    activation: ActivationPayload | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Render the envelope as a JSON-ready dict.
 
         ``None`` event-payload fields are dropped so the payload doesn't
-        carry empty placeholders for the two events it isn't.
+        carry empty placeholders for the events it isn't.
         """
         d = asdict(self)
-        for key in ("session", "request", "error"):
+        for key in ("session", "request", "error", "activation"):
             if d.get(key) is None:
                 d.pop(key, None)
         return d
@@ -235,6 +265,7 @@ def sample_request_preview_payload(
 
 
 __all__ = [
+    "ActivationPayload",
     "ErrorPayload",
     "PlatformInfo",
     "RequestPayload",

--- a/vllm_mlx/telemetry/state.py
+++ b/vllm_mlx/telemetry/state.py
@@ -44,10 +44,16 @@ import yaml
 
 ENV_VAR = "RAPID_MLX_TELEMETRY"
 
-# Bump when the on-disk consent file format changes incompatibly. A
-# stored record with a smaller schema_version is treated as "never
-# prompted" so the user gets re-asked under the new disclosure copy.
-CURRENT_CONSENT_SCHEMA_VERSION = 1
+# Bump when the on-disk consent file format OR the disclosure copy changes in
+# a way that materially alters what we collect. A stored record whose
+# schema_version != this is treated as "never prompted" so the user is re-asked
+# under the new disclosure.
+#
+# v1 -> v2: added the unsampled ``activation`` event (docs/telemetry-activation.md).
+# Prior opt-ins consented to a disclosure that never mentioned activation, so
+# they must re-see and re-accept before any activation event is emitted —
+# adding a new data type silently under old consent would be a consent breach.
+CURRENT_CONSENT_SCHEMA_VERSION = 2
 
 
 def _default_telemetry_dir() -> Path:
@@ -75,6 +81,13 @@ class ConsentState:
     consent: bool
     prompted_at: str  # ISO-8601 UTC, "Z" suffix
     prompted_version: str  # rapid-mlx version that showed the prompt
+    # Defaults to the OLDEST schema (1), not the current one: a ConsentState
+    # built without an explicit version is treated as the most conservative
+    # (re-promptable) record. Only ``record_consent`` — the one place that
+    # actually captures a fresh opt-in — stamps ``CURRENT_CONSENT_SCHEMA_VERSION``
+    # explicitly. Defaulting to CURRENT here would let a partially-constructed
+    # or legacy record read as "already consented under the newest disclosure"
+    # and silently bypass the re-consent gate.
     schema_version: int = 1
 
 
@@ -130,6 +143,10 @@ def record_consent(consent: bool, *, rapid_mlx_version: str) -> ConsentState:
         consent=consent,
         prompted_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         prompted_version=rapid_mlx_version,
+        # Stamp the CURRENT schema explicitly — this is the sole place a fresh
+        # opt-in is captured, so it is the sole place that should mint a
+        # newest-version record.
+        schema_version=CURRENT_CONSENT_SCHEMA_VERSION,
     )
     path = consent_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -181,13 +198,119 @@ def get_or_create_client_id() -> str:
     return new_id
 
 
+def _validate_activation_kind(kind: str) -> None:
+    """Reject any ``kind`` not on the fixed allowlist BEFORE it reaches a path.
+
+    Defense in depth: ``kind`` is interpolated into a filename, so an
+    unvalidated value with ``../`` (or a separator) could escape
+    ``~/.rapid-mlx`` and have ``claim_activation_marker`` create dirs/files
+    outside it. Callers in ``emit.activation`` already gate on
+    ``ACTIVATION_KINDS``; validating here makes the state layer safe on its own
+    regardless of caller. Imported lazily to avoid an import cycle
+    (``activation_spec`` is constants-only, but keep state import-light).
+    """
+    from vllm_mlx.telemetry.activation_spec import ACTIVATION_KINDS
+
+    if kind not in ACTIVATION_KINDS:
+        raise ValueError(f"unknown activation kind: {kind!r}")
+
+
+def activation_marker_path(kind: str) -> Path:
+    """Path to the once-per-install marker for an activation ``kind``.
+
+    One file per kind so ``first_inference`` / ``model_pull`` /
+    ``agent_setup`` are claimed independently. Kept beside the consent /
+    client-id files under ``~/.rapid-mlx/``. ``kind`` is validated against the
+    allowlist so no caller-controlled string can be interpolated into a path
+    that escapes the telemetry dir.
+    """
+    _validate_activation_kind(kind)
+    return _default_telemetry_dir() / f"activation_seen_{kind}"
+
+
+def claim_activation_marker(kind: str) -> bool:
+    """Atomically claim the once-per-install activation marker for ``kind``.
+
+    Returns ``True`` for exactly ONE call per machine per kind — the first
+    process to create the marker via exclusive ``O_CREAT | O_EXCL``
+    creation. Every later call (and any concurrent racer that loses) gets
+    ``False``. Same mechanism as ``first_run.mark_first_session``.
+
+    Fail-safe toward ``False`` on any error (invalid kind, unwritable state
+    dir, etc.): under-reporting an activation is conservative — it never
+    inflates the funnel — and never crashes the caller. An out-of-allowlist
+    ``kind`` raises inside ``activation_marker_path`` and is caught here, so no
+    filesystem operation ever runs for it. The marker is a local empty file;
+    only the derived enum ever leaves the machine, and only when telemetry is
+    enabled.
+    """
+    try:
+        marker = activation_marker_path(kind)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        # Mode "x" == O_CREAT | O_EXCL: the OS guarantees only one concurrent
+        # creator succeeds. The context manager closes the fd on every path.
+        with open(marker, "x"):
+            pass
+        return True
+    except FileExistsError:
+        return False
+    except Exception:
+        return False
+
+
 def reset_state() -> None:
-    """Remove both consent + client-id files. Next run re-prompts."""
-    for path in (consent_path(), client_id_path()):
+    """Remove consent + client-id + activation markers. Next run re-prompts.
+
+    Activation dedup is keyed on the install identity: wiping the ``client_id``
+    while leaving the once-per-install ``activation_seen_*`` markers behind
+    would leave the freshly generated identity permanently unable to emit any
+    milestone the old identity already claimed. Reset clears both so a new
+    identity can re-earn its funnel from scratch.
+
+    Also clears the in-process activation latch in ``emit`` so a reset followed
+    by re-enabling telemetry *within the same process* can re-earn milestones:
+    the persistent markers are gone, and a stale in-memory latch would
+    otherwise keep suppressing emission. Late import breaks the state<->emit
+    cycle.
+
+    Attempts EVERY path even when one fails (a single unremovable file must not
+    skip the rest or the latch clear), then — after clearing the latch — raises
+    an aggregated ``OSError`` if any file could not be removed. That last step
+    matters: a caller like ``telemetry reset`` must never print "removed" while
+    consent or client-id state actually survives on disk (which would leave
+    telemetry silently enabled). A file that was already absent is not a
+    failure.
+    """
+    paths = [consent_path(), client_id_path()]
+    try:
+        paths.extend(_default_telemetry_dir().glob("activation_seen_*"))
+    except OSError as exc:
+        # Couldn't even enumerate the markers — record it and press on with the
+        # consent/client-id removals we already know about.
+        failures = [f"{_default_telemetry_dir()}/activation_seen_*: {exc}"]
+    else:
+        failures = []
+    for path in paths:
         try:
             path.unlink()
         except FileNotFoundError:
-            pass
+            pass  # already gone == the desired post-condition
+        except OSError as exc:
+            # Permission error, a path that is unexpectedly a directory, etc. on
+            # ONE entry must not abort the whole cleanup. Record and continue so
+            # the remaining unlinks and the latch clear still run; the collected
+            # failures are surfaced at the end.
+            failures.append(f"{path}: {exc}")
+    # Clear the latch regardless of file-removal outcome, so a same-process
+    # re-enable can re-earn milestones even if some on-disk cleanup failed.
+    try:
+        from vllm_mlx.telemetry import emit
+
+        emit._reset_activation_latch()
+    except Exception:
+        pass
+    if failures:
+        raise OSError("telemetry reset could not remove: " + "; ".join(failures))
 
 
 def _env_kill_switch_active() -> bool:


### PR DESCRIPTION
## Why

DAU / WK1-retention / announcement-recall experiments are only trustworthy if "an active user" means *someone who did real work*, not *a process that started and phoned home*. Today a rise in DAU could be nothing but more `serve` boots, update polls, or health checks — the telemetry has many fields but no fixed, shared definition of **engaged** / **activated**. This pins that definition so the baseline can't drift.

## What

**A versioned spec (the source of truth):**
- `docs/telemetry-activation.md` — human spec.
- `vllm_mlx/telemetry/activation_spec.py` — the code half: `ACTIVATION_SPEC_VERSION`, the `activation_kind` / `surface` allowlists, `INFERENCE_ENDPOINTS`, and the shared success predicate `is_successful_inference(status, completion_tokens)` = **HTTP 2xx AND non-empty completion**. The dashboard and the repo tests key off the same version; changing the rules bumps it. A test parses the version the doc states and asserts it equals the code constant, so the two can't silently drift.

**A new `activation` event** (opt-in, consent-gated, **never sampled** — unlike `request`):
- Payload is two enums only: `activation_kind ∈ {first_inference, model_pull, agent_setup}`, `surface ∈ {cli, api}`. No prompt, no completion, no content — same privacy class as the existing `first_session` booleans.
- **Delivery is at-least-once, deduped downstream by `client_id`.** The client suppresses repeats best-effort with an `O_EXCL` marker under `~/.rapid-mlx/` plus an in-process latch (steady-state per-request cost is a set lookup, not a syscall). It deliberately **enqueues before claiming** the marker: a transient enqueue/envelope failure then leaves the marker unclaimed so the next inference retries, rather than burning the once-ever marker and dropping the install from the funnel forever. The tradeoff — two racing processes can both enqueue — is safe because the collector counts *distinct* `client_id` (and, per the deployed telemetry-worker, excludes `activation` from the per-session engaged-ratio), so a duplicate collapses to one engaged install and can't inflate any metric. Under-counting an install is a strictly worse error for a growth signal than a harmless, dedup-able duplicate.
- **Why a new event and not derivation:** `request` events are 10%-sampled, so ~90% of installs' *first* successful inference is never emitted — a first-touch milestone can't be reconstructed from a 1-in-10 sample.

**Wired triggers:**
- `first_inference` — both `/v1/chat/completions` success sites (streaming + non-streaming). A `2xx` with **zero** completion tokens (empty generation) or an error does **not** count. Non-streaming emits only *after* the response body is successfully serialized (a serialization failure surfaces as an error, never a counted success); streaming emits only after the generator drains normally (a client-cancelled stream is conservatively not counted — under-counting never inflates the funnel).
- `model_pull` — the single `pull_command` success chokepoint (`_print_pull_summary`).
- `surface` = `cli` when the server was spawned by `rapid-mlx chat` (reuses the existing `RAPID_MLX_CHAT_SPAWN` marker; only a genuine truthy value counts, so a stray `=0`/`false` doesn't misattribute standalone `serve`), else `api`. One emission site → no double-counting.

**Endpoint scope (versioned):** spec v1 **defines** engagement as `/v1/chat/completions` engagement — the dominant surface (all CLI `chat` auto-spawns a server that loops through it, plus most direct API use). `/v1/completions` and `/v1/messages` are separate, generative, and explicitly out of scope for v1; wiring them is a v2 item that must bump `ACTIVATION_SPEC_VERSION`. Documented so it reads as a deliberate scope, not a silent gap.

**Deferred (spec'd, not wired):** `agent_setup` — the spec requires "setup **and** a passing engine connection check," but `rapid-mlx launch` performs no connectivity probe today; the enum value is reserved and never emitted.

**Path-safety:** `activation_kind` is validated against the allowlist before it is ever interpolated into a marker filename, so no caller-controlled string can escape `~/.rapid-mlx`.

## ⚠️ Consent re-prompt (behavioral change)

`CURRENT_CONSENT_SCHEMA_VERSION` is bumped **1 → 2**. `activation` is a new collected data type; prior opt-ins consented to a disclosure that never mentioned it, so emitting under their stale consent would be a breach. The bump makes every existing v1 consent record read as "never prompted" — **existing opted-in users are re-shown the (updated) disclosure and must re-accept before any activation event (or any telemetry) is emitted.** The disclosure copy in `consent.py` now describes the activation marker honestly (normally once per machine per kind; a rare duplicate carries the same two labels and nothing more).

## What does NOT count (pinned by tests)

Server startup / `session_start`, `/health`, `/models`, the update ping, error responses, and empty generations. Degenerate-but-non-empty output still counts as engaged (quality is tracked separately via `request.output_degenerate`).

## Tests

`tests/test_telemetry_activation.py` — the versioned caliber contract: success predicate across streaming + non-streaming (2xx/empty/error/redirect); route-level emit on non-streaming + streaming success, no emit on empty; `surface=cli` under `RAPID_MLX_CHAT_SPAWN`; `session_start`/health/models excluded; doc-vs-code version lock; **enqueue-before-claim ordering pinned by a spy** (distinguishes it from claim-first, which a marker-delete-then-recall test cannot); retry-after-enqueue-failure; `claim_activation_marker` cross-process atomicity (real `spawn` pool, exactly one winner); path-traversal kinds rejected (unique `tmp_path` target); `reset_state` clears the in-process latch. `tests/test_telemetry_state.py` adds the v1→v2 re-prompt regression. Full telemetry+consent suite green (271 passed), ruff clean, full unit suite green (17225 passed).

## Notes

No package version bump. Consent **schema** bumped 1→2 (re-prompt, see above). Requires the deployed telemetry-worker that accepts the `activation` event (already live).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8).
