### PR TITLE
fix(agents): report saved config on check failure

### DIFF
--- a/tests/test_agent_first_class_setup.py
+++ b/tests/test_agent_first_class_setup.py
@@ -111,3 +111,36 @@ def test_cli_parser_exposes_setup_safety_flags(monkeypatch):
     assert captured["setup"] is True
     assert captured["dry_run"] is True
     assert captured["yes"] is False
+
+
+def test_cli_reports_saved_config_when_connection_check_fails(
+    setup_paths, monkeypatch, capsys
+):
+    import vllm_mlx.cli as cli
+
+    _, continue_path = setup_paths
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "rapid-mlx",
+            "agents",
+            "continue",
+            "--setup",
+            "--yes",
+            "--model",
+            "qwen3.5-4b-4bit",
+        ],
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.setup.verify_server",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("connection refused")),
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
+
+    assert exit_info.value.code == 1
+    assert continue_path.exists()
+    output = capsys.readouterr().out
+    assert "Configuration was saved, but the connection check failed" in output
+    assert "Setup incomplete" not in output

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7704,16 +7704,25 @@ def agents_command(args):
             if plan.changed and not args.yes and not confirm_plan(plan):
                 print("\n  Setup cancelled; nothing was written.\n")
                 return
-            try:
-                if plan.changed:
+            if plan.changed:
+                try:
                     apply_setup_plan(plan)
-                    print(f"\n  Configured {profile.display_name} at {plan.path}.")
-                if not args.no_check:
+                except RuntimeError as exc:
+                    print(f"\n  {profile.display_name} setup failed: {exc}\n")
+                    sys.exit(1)
+                print(f"\n  Configured {profile.display_name} at {plan.path}.")
+            if not args.no_check:
+                try:
                     advertised = verify_server(base_url, model_id)
-                    print(f"  Connection check passed (model: {advertised}).")
-            except RuntimeError as exc:
-                print(f"\n  Setup incomplete: {exc}\n")
-                sys.exit(1)
+                except RuntimeError as exc:
+                    status = (
+                        "Configuration was saved"
+                        if plan.changed
+                        else "Configuration is unchanged"
+                    )
+                    print(f"\n  {status}, but the connection check failed: {exc}\n")
+                    sys.exit(1)
+                print(f"  Connection check passed (model: {advertised}).")
             print()
             return
 


### PR DESCRIPTION
## Summary
- distinguish config-write failures from post-write connection-check failures
- tell users truthfully when their configuration was saved or was already unchanged
- add a CLI regression test for the offline-server path

## Local validation
- built and ran the CLI from a clean `origin/main` worktree
- exercised Claude Code and Continue dry-run, apply, backup, preservation, idempotency, invalid-model rejection, live health/model validation, and offline-server behavior with an isolated temporary HOME
- `uv run pytest -q tests/test_agent_first_class_setup.py` (6 passed)
- `uv run ruff check vllm_mlx/cli.py tests/test_agent_first_class_setup.py`
- `git diff --check`