### PR TITLE
fix(cli): connect setup commands carry remote endpoint, IPv6 bracketing, port validation

### DIFF
--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import shlex
 from contextlib import redirect_stdout
 
 import pytest
@@ -306,7 +307,8 @@ def test_render_banner_connect_carries_remote_endpoint():
 
 def test_render_banner_connect_carries_ipv6_endpoint():
     out = connect.render_banner(connect.ServerEndpoints("::1", 8000, model="m1"))
-    assert "--base-url http://[::1]:8000/v1" in out
+    # IPv6 literals contain '['/']', which shlex.quote wraps in single quotes.
+    assert "--base-url 'http://[::1]:8000/v1'" in out
 
 
 def test_resolve_endpoints_preserves_explicit_model(monkeypatch):
@@ -359,4 +361,74 @@ def test_ipv6_scoped_zone_id_config_and_banner_agree():
     """Banner Connect command and endpoint rows both use the %25 form."""
     out = connect.render_banner(connect.ServerEndpoints("fe80::1%en0", 8000, model="m"))
     assert "Ready: http://[fe80::1%25en0]:8000" in out
-    assert "--base-url http://[fe80::1%25en0]:8000/v1" in out
+    assert "--base-url 'http://[fe80::1%25en0]:8000/v1'" in out
+
+
+# --- Review round 3: dynamic URL in copied commands must be shell-quoted ----
+def test_banner_connect_base_url_is_shell_quoted_for_special_hosts():
+    """A crafted host must not smuggle a second shell command into the banner.
+
+    ``render_banner`` builds the Connect: rows that a user copies and pastes
+    into a shell. Every dynamic ``--base-url`` value must be ``shlex.quote``-
+    ed so characters like ``;``, ``$()`` and spaces cannot be interpreted as
+    shell syntax.
+    """
+
+    cases = [
+        "mini.local; touch /tmp/pwned",
+        "ha x",
+        "$(rm -rf /)",
+        "it's",
+    ]
+    for host in cases:
+        out = connect.render_banner(connect.ServerEndpoints(host, 8000, model="m"))
+        expected_url = connect.ServerEndpoints(host, 8000, model="m").openai_url
+        expected = f"--base-url {shlex.quote(expected_url)}"
+        assert expected in out, (
+            f"host {host!r}: expected {expected!r} to be in banner output:\n{out}"
+        )
+
+
+def test_banner_ipv6_zone_id_quoted_and_not_double_encoded():
+    """Scoped IPv6 with a raw zone-id is encoded %25 and then shell-quoted."""
+    out = connect.render_banner(connect.ServerEndpoints("fe80::1%en0", 8000, model="m"))
+    assert "--base-url 'http://[fe80::1%25en0]:8000/v1'" in out
+
+
+def test_banner_already_encoded_zone_id_not_double_encoded():
+    """An already-encoded %25 zone-id is left alone, not turned into %2525."""
+    out = connect.render_banner(
+        connect.ServerEndpoints("fe80::1%25en0", 8000, model="m")
+    )
+    assert "http://[fe80::1%25en0]:8000" in out
+    assert "%2525" not in out
+
+
+def test_banner_already_bracketed_host_not_double_bracketed():
+    """A pre-bracketed [::1] host is normalized, not rendered as [[::1]]."""
+    out = connect.render_banner(connect.ServerEndpoints("[::1]", 8000, model="m"))
+    assert "Ready: http://[::1]:8000" in out
+    assert "[[::1]]" not in out
+
+
+def test_point_command_base_url_is_shell_quoted():
+    """``rapid-mlx connect <agent>`` output must shell-quote --base-url.
+
+    ``_print_point_command`` is what ``connect claude-code`` / ``connect
+    continue`` render, and it carries the same copy-paste security contract as
+    the banner.
+    """
+    from vllm_mlx.cli import _print_point_command
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _print_point_command(
+            "Claude Code",
+            "agents claude-code --setup",
+            "http://mini.local; touch /tmp/pwned:8000/v1",
+        )
+    out = buf.getvalue()
+    expected = shlex.quote("http://mini.local; touch /tmp/pwned:8000/v1")
+    # The copy-paste command's --base-url is shell-quoted. (The human-facing
+    # ``→  <url>`` echo line above it is informational, not a command.)
+    assert f"--base-url {expected}" in out

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the unified server ready/connect output SSOT.
+
+``vllm_mlx.connect`` is the single source of truth for how a running server's
+endpoints are rendered — both the serve lifespan banner and ``rapid-mlx
+connect`` (human + ``--json``) consume it. These tests lock:
+
+* the endpoint URL derivations (base vs OpenAI ``/v1`` vs Anthropic),
+* the rendered banner shape (Ready / OpenAI / Anthropic / Model / Connect),
+* the machine-readable JSON shape (for the desktop / other tooling),
+* the socket-activation (inherited-fd) fallback shape,
+* the ``connect_command`` plumbing for all three target forms.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from contextlib import redirect_stdout
+
+import pytest
+
+from vllm_mlx import connect
+from vllm_mlx.cli import connect_command
+
+
+def _endpoints(host="localhost", port=8000, model="qwen3.6-35b-4bit"):
+    return connect.ServerEndpoints(host, port, model=model)
+
+
+def _run_connect(*, target=None, json_=False, host=None, port=None, model=None):
+    """Invoke ``connect_command`` the way argparse drives it, capturing stdout."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        connect_command(
+            argparse.Namespace(
+                target=target,
+                json=json_,
+                host=host,
+                port=port,
+                model=model,
+            )
+        )
+    return buf.getvalue()
+
+
+# --- SSOT endpoint derivations ----------------------------------------------
+def test_endpoint_urls():
+    ep = _endpoints(host="127.0.0.1", port=9000)
+    assert ep.base_url == "http://127.0.0.1:9000"
+    assert ep.openai_url == "http://127.0.0.1:9000/v1"
+    # Anthropic base has NO trailing /v1 (the SDK appends /v1/messages itself).
+    assert ep.anthropic_url == "http://127.0.0.1:9000"
+
+
+def test_json_shape_matches_banner_endpoints():
+    ep = _endpoints()
+    d = ep.to_dict()
+    assert d == {
+        "ready": "http://localhost:8000",
+        "openai": "http://localhost:8000/v1",
+        "anthropic": "http://localhost:8000",
+        "model": "qwen3.6-35b-4bit",
+    }
+
+
+def test_render_banner_matches_spec():
+    out = connect.render_banner(_endpoints())
+    assert "Ready: http://localhost:8000" in out
+    assert "OpenAI:    http://localhost:8000/v1" in out
+    assert "Anthropic: http://localhost:8000" in out
+    assert "Model:     qwen3.6-35b-4bit" in out
+    assert "rapid-mlx agents claude-code --setup" in out
+    assert "rapid-mlx agents continue --setup" in out
+    assert "rapid-mlx connect openai-python" in out
+
+
+def test_listen_fd_shape():
+    ep = connect.ServerEndpoints("", 0, model=None, listen_fd=7)
+    out = connect.render_banner(ep)
+    assert "Ready: inherited fd 7" in out
+    assert "OpenAI:" not in out  # no known address → no endpoint rows
+    d = ep.to_dict()
+    assert d["ready"] == "inherited fd 7"
+    assert d["openai"] is None
+    assert d["anthropic"] is None
+    assert d["listen_fd"] == 7
+
+
+# --- endpoints_from_bind (serve-lifespan wiring) ----------------------------
+def test_endpoints_from_bind_host_port():
+    ep = connect.endpoints_from_bind("localhost", 9123, model="gpt-oss-20b")
+    assert ep.base_url == "http://localhost:9123"
+    assert ep.model == "gpt-oss-20b"
+    assert ep.listen_fd is None
+
+
+def test_endpoints_from_bind_prefers_fd_when_no_host_port():
+    # Mirrors the serve superisor handoff: fd set but no host/port known.
+    ep = connect.endpoints_from_bind(None, None, listen_fd=5)
+    assert ep.listen_fd == 5
+
+
+def test_endpoints_from_bind_host_port_wins_over_fd():
+    ep = connect.endpoints_from_bind("localhost", 8000, listen_fd=5)
+    assert ep.listen_fd is None
+    assert ep.base_url == "http://localhost:8000"
+
+
+# --- connect_command plumbing ------------------------------------------------
+def test_connect_no_target_renders_banner(monkeypatch):
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("localhost", 8000, model="m1"),
+    )
+    out = _run_connect()
+    assert "Ready: http://localhost:8000" in out
+    assert "Connect:" in out
+    assert "OpenAI:" in out
+
+
+def test_connect_json_is_valid_and_stable(monkeypatch):
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("localhost", 8000, model="m1"),
+    )
+    out = _run_connect(json_=True)
+    payload = json.loads(out)
+    assert payload["ready"] == "http://localhost:8000"
+    assert payload["openai"] == "http://localhost:8000/v1"
+    assert payload["anthropic"] == "http://localhost:8000"
+    assert payload["model"] == "m1"
+
+
+def test_connect_openai_python_snippet(monkeypatch):
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("localhost", 8000, model="m1"),
+    )
+    out = _run_connect(target="openai-python")
+    assert "http://localhost:8000/v1" in out
+    assert "OpenAI(" in out
+    assert "m1" in out
+
+
+def test_connect_claude_code_points_at_setup(monkeypatch):
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("localhost", 8000, model=None),
+    )
+    out = _run_connect(target="claude-code")
+    assert "rapid-mlx agents claude-code --setup" in out
+
+
+def test_connect_continue_points_at_setup(monkeypatch):
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("localhost", 8000, model=None),
+    )
+    out = _run_connect(target="continue")
+    assert "rapid-mlx agents continue --setup" in out
+
+
+def test_connect_unknown_target_exits(monkeypatch):
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("localhost", 8000, model=None),
+    )
+    buf = io.StringIO()
+    with pytest.raises(SystemExit) as exc, redirect_stdout(buf):
+        connect_command(
+            argparse.Namespace(
+                target="nope", json=False, host=None, port=None, model=None
+            )
+        )
+    assert exc.value.code == 1
+    # The helpful supported-target list is printed before exiting.
+    assert "Supported: claude-code, continue, openai-python" in buf.getvalue()

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -71,8 +71,15 @@ def test_render_banner_matches_spec():
     assert "OpenAI:    http://localhost:8000/v1" in out
     assert "Anthropic: http://localhost:8000" in out
     assert "Model:     qwen3.6-35b-4bit" in out
-    assert "rapid-mlx agents claude-code --setup" in out
-    assert "rapid-mlx agents continue --setup" in out
+    # First-class agent setup commands carry the real endpoint so a user
+    # copying from the banner wires up the actual server, not localhost.
+    assert (
+        "rapid-mlx agents claude-code --setup --base-url http://localhost:8000/v1"
+        in out
+    )
+    assert (
+        "rapid-mlx agents continue --setup --base-url http://localhost:8000/v1" in out
+    )
     assert "rapid-mlx connect openai-python" in out
 
 
@@ -235,10 +242,11 @@ def test_ipv6_literal_bracketing():
 
 
 def test_ipv6_scoped_address_bracketing():
-    # Scoped zone-id address must still be bracket-wrapped.
+    # Scoped (zone-id) address must be bracket-wrapped AND the zone-id `%`
+    # percent-encoded as %25 per RFC 6874.
     ep = _endpoints(host="fe80::1%en0", port=8000)
-    assert ep.base_url == "http://[fe80::1%en0]:8000"
-    assert ep.openai_url == "http://[fe80::1%en0]:8000/v1"
+    assert ep.base_url == "http://[fe80::1%25en0]:8000"
+    assert ep.openai_url == "http://[fe80::1%25en0]:8000/v1"
 
 
 def test_ipv6_banner_renders_bracketed(monkeypatch):
@@ -281,3 +289,74 @@ def test_connect_valid_port_accepted():
     args = build_parser().parse_args(["connect", "--port", "9000", "--host", "x"])
     assert args.port == 9000
     assert args.host == "x"
+
+
+# --- Review round 2: banner must carry endpoint; explicit --model must win ----
+def test_render_banner_connect_carries_remote_endpoint():
+    """Copying the Ready banner's setup command must target the real server."""
+    out = connect.render_banner(connect.ServerEndpoints("mini.local", 9000, model="m1"))
+    assert (
+        "rapid-mlx agents claude-code --setup "
+        "--base-url http://mini.local:9000/v1" in out
+    )
+    assert (
+        "rapid-mlx agents continue --setup --base-url http://mini.local:9000/v1" in out
+    )
+
+
+def test_render_banner_connect_carries_ipv6_endpoint():
+    out = connect.render_banner(connect.ServerEndpoints("::1", 8000, model="m1"))
+    assert "--base-url http://[::1]:8000/v1" in out
+
+
+def test_resolve_endpoints_preserves_explicit_model(monkeypatch):
+    """An explicit --model must never be overwritten by a live probe."""
+    from vllm_mlx.config import get_config
+
+    probe_called = []
+
+    def fake_probe(host, port):
+        probe_called.append((host, port))
+        return "server-says-other-model"
+
+    monkeypatch.setattr(connect, "_probe_running_model", fake_probe)
+
+    cfg = get_config()
+    cfg.bind_host = None
+    cfg.bind_port = None
+    cfg.model_alias = None
+    cfg.model_name = None
+
+    ep = connect.resolve_endpoints(model="explicitly-requested")
+    assert ep.model == "explicitly-requested"
+    assert probe_called == []  # probe must not run when --model is explicit
+
+
+def test_resolve_endpoints_probes_when_no_model(monkeypatch):
+    """Live probe still fills in the model when none was supplied anywhere."""
+    from vllm_mlx.config import get_config
+
+    probe_called = []
+
+    def fake_probe(host, port):
+        probe_called.append((host, port))
+        return "probed-model"
+
+    monkeypatch.setattr(connect, "_probe_running_model", fake_probe)
+
+    cfg = get_config()
+    cfg.bind_host = None
+    cfg.bind_port = None
+    cfg.model_alias = None
+    cfg.model_name = None
+
+    ep = connect.resolve_endpoints()
+    assert ep.model == "probed-model"
+    assert probe_called == [("localhost", 8000)]
+
+
+def test_ipv6_scoped_zone_id_config_and_banner_agree():
+    """Banner Connect command and endpoint rows both use the %25 form."""
+    out = connect.render_banner(connect.ServerEndpoints("fe80::1%en0", 8000, model="m"))
+    assert "Ready: http://[fe80::1%25en0]:8000" in out
+    assert "--base-url http://[fe80::1%25en0]:8000/v1" in out

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -183,3 +183,101 @@ def test_connect_unknown_target_exits(monkeypatch):
     assert exc.value.code == 1
     # The helpful supported-target list is printed before exiting.
     assert "Supported: claude-code, continue, openai-python" in buf.getvalue()
+
+
+# --- P1 fixes applied after #1872 revert ------------------------------------
+# (Reviewer feedback on #1871: remote `--host/--port` setup commands must
+# carry `--base-url`; IPv6 literals/scoped addresses must be bracket-wrapped;
+# `connect --port` must reuse the validated `_port_arg`.)
+
+
+def test_claude_remote_endpoint_passthrough(monkeypatch):
+    """`--host/--port` must flow into the suggested `--base-url` for claude."""
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("mini.local", 9000, model=None),
+    )
+    out = _run_connect(target="claude-code")
+    assert "http://mini.local:9000/v1" in out
+    assert "rapid-mlx agents claude-code --setup" in out
+    assert "--base-url http://mini.local:9000/v1" in out
+
+
+def test_continue_remote_endpoint_passthrough(monkeypatch):
+    """`--host/--port` must flow into the suggested `--base-url` for continue."""
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("mini.local", 9000, model=None),
+    )
+    out = _run_connect(target="continue")
+    assert "http://mini.local:9000/v1" in out
+    assert "--base-url http://mini.local:9000/v1" in out
+
+
+def test_claude_localhost_keeps_default_base_url(monkeypatch):
+    """Default localhost:8000 setup command still emits an explicit base url."""
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("localhost", 8000, model=None),
+    )
+    out = _run_connect(target="claude-code")
+    assert "--base-url http://localhost:8000/v1" in out
+
+
+def test_ipv6_literal_bracketing():
+    ep = _endpoints(host="::1", port=8000)
+    assert ep.base_url == "http://[::1]:8000"
+    assert ep.openai_url == "http://[::1]:8000/v1"
+    assert ep.anthropic_url == "http://[::1]:8000"
+
+
+def test_ipv6_scoped_address_bracketing():
+    # Scoped zone-id address must still be bracket-wrapped.
+    ep = _endpoints(host="fe80::1%en0", port=8000)
+    assert ep.base_url == "http://[fe80::1%en0]:8000"
+    assert ep.openai_url == "http://[fe80::1%en0]:8000/v1"
+
+
+def test_ipv6_banner_renders_bracketed(monkeypatch):
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("::1", 8000, model=None),
+    )
+    out = _run_connect()
+    assert "Ready: http://[::1]:8000" in out
+    assert "OpenAI:    http://[::1]:8000/v1" in out
+
+
+def test_ipv6_json_renders_bracketed(monkeypatch):
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("::1", 8000, model="m1"),
+    )
+    payload = json.loads(_run_connect(json_=True))
+    assert payload["ready"] == "http://[::1]:8000"
+    assert payload["openai"] == "http://[::1]:8000/v1"
+    assert payload["anthropic"] == "http://[::1]:8000"
+
+
+def test_connect_invalid_port_rejected():
+    """`connect --port` must reuse `_port_arg`, rejecting 0 / out-of-range."""
+    from vllm_mlx.cli import build_parser
+
+    parser = build_parser()
+    for bad in ("0", "70000", "-1", "65536"):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["connect", "--port", bad])
+
+
+def test_connect_valid_port_accepted():
+    """`connect --port` accepts a legitimate in-range value."""
+    from vllm_mlx.cli import build_parser
+
+    args = build_parser().parse_args(["connect", "--port", "9000", "--host", "x"])
+    assert args.port == 9000
+    assert args.host == "x"

--- a/tests/test_ready_banner_timing.py
+++ b/tests/test_ready_banner_timing.py
@@ -72,9 +72,16 @@ async def test_ready_banner_emitted_when_bind_fields_set():
     assert "OpenAI:    http://localhost:8765/v1" in out
     assert "Anthropic: http://localhost:8765" in out
     assert "Model:     qwen3.6-35b-4bit" in out
-    # Connect section mirrors what a user runs to wire up each tool.
-    assert "rapid-mlx agents claude-code --setup" in out
-    assert "rapid-mlx agents continue --setup" in out
+    # Connect section mirrors what a user runs to wire up each tool. The
+    # setup commands must carry the real endpoint (--base-url) so a user who
+    # copies them connects to the running server, not the localhost default.
+    assert (
+        "rapid-mlx agents claude-code --setup "
+        "--base-url http://localhost:8765/v1" in out
+    )
+    assert (
+        "rapid-mlx agents continue --setup --base-url http://localhost:8765/v1" in out
+    )
     assert "rapid-mlx connect openai-python" in out
     # `ready` flag must be flipped before the banner so /health/ready and
     # the banner agree on the moment of readiness.

--- a/tests/test_ready_banner_timing.py
+++ b/tests/test_ready_banner_timing.py
@@ -7,10 +7,16 @@ immediately got connection-refused while GatedDeltaNet kernels compiled.
 The CLI now prints a "Starting server …" line up-front, stashes bind
 host/port on ServerConfig, and defers the real "Ready:" banner to the
 lifespan hook — fires only after `get_config().ready = True`.
+
+Since the banner is now rendered by the connect SSOT (:mod:`vllm_mlx.connect`),
+these tests drive the real lifespan path and assert against the SSOT's output
+shape (Ready / OpenAI / Anthropic / Connect), keeping the "banner only after
+ready" timing invariant at the source level.
 """
 
 from __future__ import annotations
 
+import inspect
 import io
 from contextlib import redirect_stdout
 
@@ -52,15 +58,24 @@ async def _enter_then_exit_lifespan() -> str:
 
 
 async def test_ready_banner_emitted_when_bind_fields_set():
-    """With bind_host/bind_port stashed by CLI, the lifespan prints the banner."""
+    """With bind_host/bind_port stashed by CLI, the lifespan prints the full
+    Ready / OpenAI / Anthropic / Connect banner from the SSOT."""
     cfg = get_config()
     cfg.bind_host = "localhost"
     cfg.bind_port = 8765
+    cfg.model_alias = "qwen3.6-35b-4bit"
 
     out = await _enter_then_exit_lifespan()
 
-    assert "Ready: http://localhost:8765/v1" in out
-    assert "Docs:  http://localhost:8765/docs" in out
+    # Ready is the base URL (no /v1); OpenAI appends /v1, Anthropic does not.
+    assert "Ready: http://localhost:8765" in out
+    assert "OpenAI:    http://localhost:8765/v1" in out
+    assert "Anthropic: http://localhost:8765" in out
+    assert "Model:     qwen3.6-35b-4bit" in out
+    # Connect section mirrors what a user runs to wire up each tool.
+    assert "rapid-mlx agents claude-code --setup" in out
+    assert "rapid-mlx agents continue --setup" in out
+    assert "rapid-mlx connect openai-python" in out
     # `ready` flag must be flipped before the banner so /health/ready and
     # the banner agree on the moment of readiness.
     assert cfg.ready is False  # reset on shutdown (second next())
@@ -75,7 +90,7 @@ async def test_ready_banner_suppressed_when_no_bind_info():
     out = await _enter_then_exit_lifespan()
 
     assert "Ready:" not in out
-    assert "Docs:" not in out
+    assert "OpenAI:" not in out
 
 
 async def test_ready_banner_uses_displayed_host_not_zero_bind():
@@ -96,13 +111,11 @@ async def test_ready_banner_fires_after_ready_flag_flip():
     lifespan body — otherwise a client racing /health/ready could see
     the banner before the readiness flag is honored. This is a source-level
     invariant; verifying via execution order is impractical, so assert on
-    the source.
+    the source (the SSOT `render_banner` call site).
     """
-    import inspect
-
     src = inspect.getsource(server.lifespan)
     ready_flip_idx = src.index("_cfg.ready = True")
-    banner_idx = src.index("Ready: http://")
+    banner_idx = src.index("render_banner(_ep)")
     assert ready_flip_idx < banner_idx, (
         "Ready banner must print AFTER the readiness flag is set "
         "so the banner and /health/ready agree on the moment of readiness."

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -17,6 +17,7 @@ Usage:
 
 import argparse
 import os
+import shlex
 import sys
 from collections.abc import Callable
 
@@ -7870,7 +7871,7 @@ def _print_point_command(app: str, setup_verb: str, url: str) -> None:
     print(f"  {app}  →  {url}")
     print()
     print(f"      rapid-mlx {setup_verb} \\")
-    print(f"        --base-url {url}")
+    print(f"        --base-url {shlex.quote(url)}")
     print()
     print("  This writes your tool's config to point at the running server")
     print("  (previews a diff, requires consent, verifies the connection).")

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7840,9 +7840,12 @@ def _connect_target(args, eps):
         return
 
     if target in {"claude", "claude-code"}:
-        # Anthropic endpoints are the base URL (the SDK adds /v1/messages itself).
+        # The setup command is rendered by ``agents`` via ``--base-url``. All
+        # agents CLIs uniformly accept the OpenAI-style ``/v1`` base URL (the
+        # adapter strips ``/v1`` for Claude's profile), so we always hand it
+        # the OpenAI endpoint — never the bare Anthropic base.
         _print_point_command(
-            "Claude Code", "agents claude-code --setup", eps.anthropic_url
+            "Claude Code", "agents claude-code --setup", eps.openai_url
         )
         return
     if target in {"continue", "continue-dev"}:
@@ -7855,11 +7858,19 @@ def _connect_target(args, eps):
 
 
 def _print_point_command(app: str, setup_verb: str, url: str) -> None:
-    """Print the canonical setup command for a first-class agent target."""
+    """Print the canonical setup command for a first-class agent target.
+
+    ``setup_verb`` is like ``agents claude-code --setup`` and ``url`` is the
+    endpoint that tool should target (OpenAI-style ``/v1`` base). We append
+    ``--base-url`` so the suggested command carries the requested host/port —
+    otherwise the agent would default to localhost:8000 and write a config
+    that silently points at the wrong server.
+    """
     print()
     print(f"  {app}  →  {url}")
     print()
-    print(f"      rapid-mlx {setup_verb}")
+    print(f"      rapid-mlx {setup_verb} \\")
+    print(f"        --base-url {url}")
     print()
     print("  This writes your tool's config to point at the running server")
     print("  (previews a diff, requires consent, verifies the connection).")
@@ -9826,9 +9837,9 @@ Examples:
     )
     connect_parser.add_argument(
         "--port",
-        type=int,
+        type=_port_arg,
         default=None,
-        help="Server port (default: auto-detect or 8000)",
+        help="Server port 1-65535 (default: auto-detect or 8000)",
     )
     connect_parser.add_argument(
         "--model",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3925,7 +3925,8 @@ def serve_command(args):
     # which shape depends on the bind mode:
     #
     #   * Default (host+port): stamp ``bind_host``/``bind_port`` so the
-    #     banner prints ``Ready: http://host:port/v1``.
+    #     SSOT banner prints ``Ready: http://host:port`` (base URL; the
+    #     OpenAI/Anthropic paths are separate rows).
     #   * ``--listen-fd``: stamp ``bind_listen_fd`` instead. The
     #     supervisor's ``getsockname`` is the only honest source for the
     #     address — stamping ``args.host``/``args.port`` here would lie
@@ -7788,6 +7789,83 @@ def agents_command(args):
     print()
 
 
+def connect_command(args):
+    """Show server connection info and wire up a tool (SSOT-backed).
+
+    Renders from :mod:`vllm_mlx.connect` — the same source the serve
+    lifespan banner uses — so ``ready``/``openai``/``anthropic`` and the
+    machine form can never drift from what a running server prints.
+    """
+    from vllm_mlx.connect import render_banner, resolve_endpoints
+
+    eps = resolve_endpoints(host=args.host, port=args.port, model=args.model)
+
+    # Per-target "how to connect" cheat sheet.
+    if args.target:
+        _connect_target(args, eps)
+        return
+
+    if args.json:
+        print(eps.to_json())
+        return
+
+    print(render_banner(eps), end="")
+
+
+def _connect_target(args, eps):
+    """Print the exact command / snippet for ``rapid-mlx connect <target>``.
+
+    The ``claude-code`` / ``continue`` entries point at the first-class safe
+    setup flow (`rapid-mlx agents <agent> --setup`) rather than re-implementing
+    the config writer here — that keeps a single owner for each tool's config
+    shape while ``connect`` stays the one place a user learns "how do I point
+    this tool at the server?"
+    """
+    target = args.target
+
+    if target in {"openai", "openai-python", "python"}:
+        model = eps.model or "<detected-model>"
+        print()
+        print(f"  Python (OpenAI SDK)  →  {eps.openai_url}")
+        print()
+        print("      pip install openai")
+        print()
+        print("      from openai import OpenAI")
+        print(f"      client = OpenAI(base_url={eps.openai_url!r}, api_key='sk-noop')")
+        print("      resp = client.chat.completions.create(")
+        print(f"          model={model!r},")
+        print('          messages=[{"role": "user", "content": "Hello!"}],')
+        print("      )")
+        print()
+        return
+
+    if target in {"claude", "claude-code"}:
+        # Anthropic endpoints are the base URL (the SDK adds /v1/messages itself).
+        _print_point_command(
+            "Claude Code", "agents claude-code --setup", eps.anthropic_url
+        )
+        return
+    if target in {"continue", "continue-dev"}:
+        _print_point_command("Continue.dev", "agents continue --setup", eps.openai_url)
+        return
+
+    print(f"  Unknown connect target: {args.target}")
+    print("  Supported: claude-code, continue, openai-python")
+    sys.exit(1)
+
+
+def _print_point_command(app: str, setup_verb: str, url: str) -> None:
+    """Print the canonical setup command for a first-class agent target."""
+    print()
+    print(f"  {app}  →  {url}")
+    print()
+    print(f"      rapid-mlx {setup_verb}")
+    print()
+    print("  This writes your tool's config to point at the running server")
+    print("  (previews a diff, requires consent, verifies the connection).")
+    print()
+
+
 def upgrade_command(args):
     """Detect install method and (optionally) run the right upgrade command."""
     import subprocess
@@ -9718,6 +9796,47 @@ Examples:
         help="Agent version for version-specific config (e.g. 0.8.5)",
     )
 
+    # Connect command — the single place to learn "the server is up, now
+    # point a tool at it." Renders from the same SSOT as the serve banner
+    # (:mod:`vllm_mlx.connect`) so ``ready``/``openai``/``anthropic`` and the
+    # ``--json`` machine form can never drift from what the server prints.
+    connect_parser = subparsers.add_parser(
+        "connect",
+        help="Show the server's connection info and wire up a tool",
+    )
+    connect_parser.add_argument(
+        "target",
+        nargs="?",
+        default=None,
+        help=(
+            "Tool to set up: claude-code, continue, or openai-python. "
+            "Omit to print the connection banner."
+        ),
+    )
+    connect_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the rendered banner",
+    )
+    connect_parser.add_argument(
+        "--host",
+        type=str,
+        default=None,
+        help="Server host (default: auto-detect or localhost)",
+    )
+    connect_parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Server port (default: auto-detect or 8000)",
+    )
+    connect_parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Model name to advertise (default: auto-detect from server)",
+    ).completer = alias_completer
+
     # Doctor command — pure env-health probe (≤5 s, no model load, no server).
     # Model-validation tiers (smoke/check/full/benchmark) moved to
     # ``rapid-mlx bench --tier ...`` as of v0.7.22.
@@ -10293,6 +10412,8 @@ def main():
         jlens_command(args)
     elif args.command == "agents":
         agents_command(args)
+    elif args.command == "connect":
+        connect_command(args)
     elif args.command == "doctor":
         from vllm_mlx.doctor.cli import doctor_command
 

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -32,30 +32,50 @@ Constraints encoded here:
 from __future__ import annotations
 
 import json
+import shlex
 from dataclasses import dataclass
 from typing import Any
 
 
 def _authority(host: str) -> str:
-    """Render a host for a URL authority component.
+    """Render a host for a URI authority component, canonicalizing it.
 
     IPv6 literals (and scoped literals like ``fe80::1%en0``) MUST be wrapped
-    in square brackets in a URI authority, e.g. ``http://[::1]:8000``.
-    Uses the same lexical ``":" in host`` rule as the serve CLI's
-    ``_is_ipv6_host`` so zone-id scoped addresses are also detected.
+    in square brackets in a URI authority, e.g. ``http://[::1]:8000``. Uses
+    the same lexical ``":" in host`` rule as the serve CLI's ``_is_ipv6_host``
+    so zone-id scoped addresses are also detected.
 
-    The zone-id separator ``%`` is percent-encoded as ``%25`` to keep the
-    URL well-formed per RFC 6874 (zone identifiers are delimited by ``%25``
-    in URIs), e.g. ``http://[fe80::1%25en0]:8000``.
+    The zone-id separator ``%`` is percent-encoded as ``%25`` per RFC 6874
+    (zone identifiers are delimited by ``%25`` in URIs), e.g.
+    ``http://[fe80::1%25en0]:8000``.
+
+    Accepts and normalizes non-canonical input rather than guessing:
+    an already-bracketed literal (``[::1]``) is not double-bracketed, and an
+    already-encoded ``%25`` is not percent-encoded a second time.
     """
+    # Strip an existing surrounding bracket pair so we never double-bracket.
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+
     if ":" not in host:
         return host
-    bracketed = f"[{host}]"
+
+    # Percent-encode a raw zone-id `%` as `%25` unless it already begins a
+    # valid `%25` escape (case-insensitive). This keeps an already-encoded
+    # ``fe80::1%25en0`` stable while encoding a bare ``fe80::1%en0``.
     if "%" in host:
-        # Percent-encode every raw `%` (the zone-id separator) so the URL
-        # stays well-formed and parser-friendly.
-        bracketed = bracketed.replace("%", "%25")
-    return bracketed
+        out: list[str] = []
+        i = 0
+        while i < len(host):
+            if host[i] == "%" and host[i : i + 3].lower() != "%25":
+                out.append("%25")
+                i += 1
+            else:
+                out.append(host[i])
+                i += 1
+        host = "".join(out)
+
+    return f"[{host}]"
 
 
 @dataclass(frozen=True)
@@ -152,7 +172,7 @@ def render_banner(ep: ServerEndpoints, *, include_connect: bool = True) -> str:
         for app, cmd, needs_endpoint in _CONNECT_ROWS:
             rendered = cmd
             if needs_endpoint:
-                rendered += f" --base-url {ep.openai_url}"
+                rendered += f" --base-url {shlex.quote(ep.openai_url)}"
             lines.append(f"    {app:<{width}}  {rendered}")
 
     return "\n".join(lines) + "\n"

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Single source of truth (SSOT) for "Ready:" / "Connect:" server output.
+
+The "server is up, now point your tools at it" experience is fragmented:
+the serve lifespan prints a ``Ready:`` line, ``agents --setup`` writes a
+tool-specific config, and the desktop app separately assembles its own
+endpoint URLs. Any change to one is invisible to the others, so a user who
+copies the banner URL into a config gets subtly different paths than the
+one the desktop shows.
+
+This module owns the *shape* of every endpoint and its human/machine
+rendering. Both the serve banner and ``rapid-mlx connect`` render from the
+same ``ServerEndpoints`` value, so they can never drift:
+
+* ``ServerEndpoints`` — an immutable description of the ready base URL, the
+  OpenAI and Anthropic endpoint paths, and the served model name.
+* ``render_banner`` — the human-facing block (used by the serve lifespan
+  and by ``rapid-mlx connect``).
+* ``to_dict`` — the stable machine-readable JSON shape (used by
+  ``rapid-mlx connect --json`` for the desktop and other tooling).
+
+Constraints encoded here:
+
+* The ready URL is the *base* (``http://host:port``) — it has no ``/v1``.
+* OpenAI-compatible endpoints append ``/v1`` to the base.
+* Anthropic-compatible endpoints ARE the base (no ``/v1`` — the Anthropic
+  SDK joins ``/v1/messages`` itself; see ``launch/claude_code.py``).
+* Socket-activation (``--listen-fd``) has no known address, so the SSOT
+  renders an fd-shaped banner instead of guessing.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ServerEndpoints:
+    """Immutable description of a running server's connection points."""
+
+    host: str
+    port: int
+    model: str | None = None
+    # True when the server was started via socket activation and the bind
+    # address is unknown (owned by the supervisor). When set, ``ready_url``
+    # and friends are meaningless and callers must render the fd form.
+    listen_fd: int | None = None
+
+    @property
+    def base_url(self) -> str:
+        """Base ``http://host:port`` — the anchor every endpoint hangs off."""
+        if self.listen_fd is not None:
+            raise RuntimeError("socket-activation endpoint has no known base URL")
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def openai_url(self) -> str:
+        """OpenAI-compatible base (``/v1`` is appended by most SDKs)."""
+        if self.listen_fd is not None:
+            raise RuntimeError("socket-activation endpoint has no known base URL")
+        return f"{self.base_url}/v1"
+
+    @property
+    def anthropic_url(self) -> str:
+        """Anthropic-compatible base (no trailing ``/v1``)."""
+        if self.listen_fd is not None:
+            raise RuntimeError("socket-activation endpoint has no known base URL")
+        return self.base_url
+
+    def to_dict(self) -> dict[str, Any]:
+        """Stable machine-readable shape for ``connect --json`` / Desktop."""
+        if self.listen_fd is not None:
+            return {
+                "ready": f"inherited fd {self.listen_fd}",
+                "openai": None,
+                "anthropic": None,
+                "model": self.model,
+                "listen_fd": self.listen_fd,
+            }
+        return {
+            "ready": self.base_url,
+            "openai": self.openai_url,
+            "anthropic": self.anthropic_url,
+            "model": self.model,
+        }
+
+    def to_json(self) -> str:
+        """JSON-encode :meth:`to_dict` for machine consumers."""
+        return json.dumps(self.to_dict(), indent=2, ensure_ascii=False)
+
+
+# The ``--setup`` verbs printed in the human banner's "Connect:" section.
+# These are the exact commands a user runs to point each tool at the
+# server. ``openai-python`` writes no config file, so its entry is the
+# ``rapid-mlx connect openai-python`` snippet-printing command.
+_CONNECT_ROWS: list[tuple[str, str]] = [
+    ("Claude Code", "rapid-mlx agents claude-code --setup"),
+    ("Continue", "rapid-mlx agents continue --setup"),
+    ("Python", "rapid-mlx connect openai-python"),
+]
+
+
+def render_banner(ep: ServerEndpoints, *, include_connect: bool = True) -> str:
+    """Render the human "Ready:" / "OpenAI:" / "Connect:" block.
+
+    Used by the serve lifespan (once warmup completes) and by
+    ``rapid-mlx connect``. Rendered centrally so the served banner and the
+    standalone ``connect`` output can never disagree about an endpoint.
+    """
+    lines: list[str] = []
+
+    if ep.listen_fd is not None:
+        lines.append(f"  Ready: inherited fd {ep.listen_fd}")
+    else:
+        lines.append(f"  Ready: {ep.base_url}")
+        lines.append("")
+        lines.append(f"  OpenAI:    {ep.openai_url}")
+        lines.append(f"  Anthropic: {ep.anthropic_url}")
+        lines.append(f"  Model:     {ep.model or '(not yet loaded)'}")
+
+    if include_connect and ep.listen_fd is None:
+        lines.append("")
+        lines.append("  Connect:")
+        width = max(len(a) for a, _ in _CONNECT_ROWS)
+        for app, cmd in _CONNECT_ROWS:
+            lines.append(f"    {app:<{width}}  {cmd}")
+
+    return "\n".join(lines) + "\n"
+
+
+def endpoints_from_bind(
+    host: str | None,
+    port: int | None,
+    *,
+    model: str | None = None,
+    listen_fd: int | None = None,
+) -> ServerEndpoints:
+    """Build a :class:`ServerEndpoints` from bind source-of-truth fields.
+
+    Mirrors the serve CLI's host/port-or-fd stash on ``ServerConfig``.
+    ``host``/``port`` win when both are set; otherwise a non-None
+    ``listen_fd`` selects the socket-activation shape.
+    """
+    if listen_fd is not None and (host is None or port is None):
+        return ServerEndpoints(host="", port=0, model=model, listen_fd=listen_fd)
+    return ServerEndpoints(host or "localhost", port or 8000, model=model)
+
+
+def resolve_endpoints(
+    *,
+    host: str | None = None,
+    port: int | None = None,
+    model: str | None = None,
+) -> ServerEndpoints:
+    """Resolve connection info for ``rapid-mlx connect``.
+
+    Preference order:
+
+    1. Explicit ``--host`` / ``--port`` / ``--model`` flags.
+    2. A populated ``ServerConfig`` (in-process serve) bind + model fields.
+    3. Sensible defaults (``localhost:8000``, best-effort model probe of a
+       running server).
+
+    Never raises; a defaulted value is always returned so ``connect`` can
+    print a useful banner even when no server is running yet.
+    """
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+
+    out_host = host or cfg.bind_host or "localhost"
+    if port is not None:
+        out_port = port
+    elif cfg.bind_port is not None:
+        out_port = cfg.bind_port
+    else:
+        out_port = 8000
+
+    out_model = model or cfg.model_alias or cfg.model_name
+
+    # Try live detection only when nothing authoritative was supplied.
+    if (out_model is None or out_host == "localhost" and out_port == 8000) and (
+        cfg.bind_host is None and cfg.bind_port is None
+    ):
+        detected_model = _probe_running_model(out_host, out_port)
+        if detected_model:
+            out_model = detected_model
+
+    return ServerEndpoints(out_host, out_port, model=out_model)
+
+
+def _probe_running_model(host: str, port: int) -> str | None:
+    """Best-effort: ask a running server which model it serves. Never raises."""
+    import urllib.error
+    import urllib.request
+
+    base = f"http://{host}:{port}"
+    try:
+        with urllib.request.urlopen(f"{base}/v1/models", timeout=2.0) as resp:
+            payload = json.loads(resp.read())
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    models = payload.get("data", [])
+    if not isinstance(models, list) or not models:
+        return None
+    for m in models:
+        mid = m.get("id") if isinstance(m, dict) else None
+        if isinstance(mid, str) and "/" not in mid and mid != "default":
+            return mid
+    mid = models[0].get("id") if isinstance(models[0], dict) else None
+    return mid if isinstance(mid, str) and mid else None

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -36,6 +36,17 @@ from dataclasses import dataclass
 from typing import Any
 
 
+def _authority(host: str) -> str:
+    """Render a host for a URL authority component.
+
+    IPv6 literals (and scoped literals like ``fe80::1%en0``) MUST be wrapped
+    in square brackets in a URI authority, e.g. ``http://[::1]:8000``.
+    Uses the same lexical ``":" in host`` rule as the serve CLI's
+    ``_is_ipv6_host`` so zone-id scoped addresses are also detected.
+    """
+    return f"[{host}]" if ":" in host else host
+
+
 @dataclass(frozen=True)
 class ServerEndpoints:
     """Immutable description of a running server's connection points."""
@@ -53,7 +64,7 @@ class ServerEndpoints:
         """Base ``http://host:port`` — the anchor every endpoint hangs off."""
         if self.listen_fd is not None:
             raise RuntimeError("socket-activation endpoint has no known base URL")
-        return f"http://{self.host}:{self.port}"
+        return f"http://{_authority(self.host)}:{self.port}"
 
     @property
     def openai_url(self) -> str:
@@ -196,7 +207,7 @@ def _probe_running_model(host: str, port: int) -> str | None:
     import urllib.error
     import urllib.request
 
-    base = f"http://{host}:{port}"
+    base = f"http://{_authority(host)}:{port}"
     try:
         with urllib.request.urlopen(f"{base}/v1/models", timeout=2.0) as resp:
             payload = json.loads(resp.read())

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -43,8 +43,19 @@ def _authority(host: str) -> str:
     in square brackets in a URI authority, e.g. ``http://[::1]:8000``.
     Uses the same lexical ``":" in host`` rule as the serve CLI's
     ``_is_ipv6_host`` so zone-id scoped addresses are also detected.
+
+    The zone-id separator ``%`` is percent-encoded as ``%25`` to keep the
+    URL well-formed per RFC 6874 (zone identifiers are delimited by ``%25``
+    in URIs), e.g. ``http://[fe80::1%25en0]:8000``.
     """
-    return f"[{host}]" if ":" in host else host
+    if ":" not in host:
+        return host
+    bracketed = f"[{host}]"
+    if "%" in host:
+        # Percent-encode every raw `%` (the zone-id separator) so the URL
+        # stays well-formed and parser-friendly.
+        bracketed = bracketed.replace("%", "%25")
+    return bracketed
 
 
 @dataclass(frozen=True)
@@ -103,13 +114,16 @@ class ServerEndpoints:
 
 
 # The ``--setup`` verbs printed in the human banner's "Connect:" section.
-# These are the exact commands a user runs to point each tool at the
-# server. ``openai-python`` writes no config file, so its entry is the
-# ``rapid-mlx connect openai-python`` snippet-printing command.
-_CONNECT_ROWS: list[tuple[str, str]] = [
-    ("Claude Code", "rapid-mlx agents claude-code --setup"),
-    ("Continue", "rapid-mlx agents continue --setup"),
-    ("Python", "rapid-mlx connect openai-python"),
+# Each row is ``(app label, command prefix, OpenAI endpoint?)``. Rows that
+# point a first-class agent at the server (`claude-code`, `continue`) take an
+# OpenAI-style ``/v1`` base URL and get ``--base-url <url>`` appended so the
+# copied command targets the *actual* running server, not the localhost
+# default the agent would otherwise assume. ``openai-python`` writes no config
+# and just prints a snippet, so it carries no ``--base-url``.
+_CONNECT_ROWS: list[tuple[str, str, bool]] = [
+    ("Claude Code", "rapid-mlx agents claude-code --setup", True),
+    ("Continue", "rapid-mlx agents continue --setup", True),
+    ("Python", "rapid-mlx connect openai-python", False),
 ]
 
 
@@ -134,9 +148,12 @@ def render_banner(ep: ServerEndpoints, *, include_connect: bool = True) -> str:
     if include_connect and ep.listen_fd is None:
         lines.append("")
         lines.append("  Connect:")
-        width = max(len(a) for a, _ in _CONNECT_ROWS)
-        for app, cmd in _CONNECT_ROWS:
-            lines.append(f"    {app:<{width}}  {cmd}")
+        width = max(len(a) for a, _, _ in _CONNECT_ROWS)
+        for app, cmd, needs_endpoint in _CONNECT_ROWS:
+            rendered = cmd
+            if needs_endpoint:
+                rendered += f" --base-url {ep.openai_url}"
+            lines.append(f"    {app:<{width}}  {rendered}")
 
     return "\n".join(lines) + "\n"
 
@@ -189,12 +206,14 @@ def resolve_endpoints(
     else:
         out_port = 8000
 
+    # Explicit --model wins outright; then config model fields; neither
+    # present means we may fall back to probing a *running* server.
     out_model = model or cfg.model_alias or cfg.model_name
 
-    # Try live detection only when nothing authoritative was supplied.
-    if (out_model is None or out_host == "localhost" and out_port == 8000) and (
-        cfg.bind_host is None and cfg.bind_port is None
-    ):
+    # Probe (best-effort) only when no model was supplied anywhere AND no
+    # authoritative bind config pins the target. The probe result must never
+    # overwrite an explicit `--model` (flags > config > defaults).
+    if out_model is None and cfg.bind_host is None and cfg.bind_port is None:
         detected_model = _probe_running_model(out_host, out_port)
         if detected_model:
             out_model = detected_model

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -786,22 +786,23 @@ async def lifespan(app: FastAPI):
         global _prefix_cache_load_task
         _prefix_cache_load_task = asyncio.create_task(_deferred_load_prefix_cache())
 
-    # Print the real "Ready:" banner now — only here is the port truly
-    # accepting connections AND the engine warmed up. The CLI's earlier
-    # "Starting server …" line is replaced by this. If neither the
-    # host/port nor inherited-fd source of truth was stashed (e.g.
+    # Render the real "Ready:" / "Connect:" banner now — only here is the
+    # port truly accepting connections AND the engine warmed up. The CLI's
+    # earlier "Starting server …" line is replaced by this. Output is produced
+    # by the connect SSOT (:mod:`vllm_mlx.connect`) so the served banner and
+    # ``rapid-mlx connect`` can never disagree about an endpoint. If neither
+    # the host/port nor inherited-fd source of truth was stashed (e.g.
     # embedded usage where uvicorn is owned elsewhere), fall back silently.
-    if _cfg.bind_host and _cfg.bind_port:
-        print(f"  Ready: http://{_cfg.bind_host}:{_cfg.bind_port}/v1")
-        print(f"  Docs:  http://{_cfg.bind_host}:{_cfg.bind_port}/docs")
-        print()
-    elif _cfg.bind_listen_fd is not None:
-        # Socket-activation branch: the supervisor's ``getsockname`` is the
-        # source of truth for the bind address (we don't probe it). Print
-        # the fd shape so log readers can match it to the supervisor's
-        # ``LISTEN_FDS=1`` handoff record.
-        print(f"  Ready: inherited fd {_cfg.bind_listen_fd}")
-        print()
+    from vllm_mlx.connect import endpoints_from_bind, render_banner
+
+    _ep = endpoints_from_bind(
+        _cfg.bind_host,
+        _cfg.bind_port,
+        model=_cfg.model_alias or _cfg.model_name,
+        listen_fd=_cfg.bind_listen_fd,
+    )
+    if _ep.listen_fd is not None or (_cfg.bind_host and _cfg.bind_port):
+        print(render_banner(_ep), end="")
 
     yield
 


### PR DESCRIPTION
Re-introduces the unified server ready/connect SSOT feature (#1871 was reverted in #1872) with the reviewer's P1 and minor feedback applied across three review rounds.

## Background
#1871 added `vllm_mlx/connect.py` as the single source of truth for `Ready:`/`Connect:` output and new `rapid-mlx connect` / `connect --json` commands. It was reverted in #1872 pending review fixes. This PR restores the feature (cherry-picked) and applies the review feedback.

## Round-1 fixes (from review of #1871)

### P1 — Remote `--host/--port` now flows into the suggested setup command
`rapid-mlx connect claude-code --host mini.local --port 9000` previously only showed the address in the header but suggested a bare `rapid-mlx agents claude-code --setup` with no `--base-url`. Now it prints:
```
rapid-mlx agents claude-code --setup \
  --base-url http://mini.local:9000/v1
```
Same for `continue`. All agents CLIs uniformly accept the OpenAI-style `/v1` base URL.

### P1 — IPv6 literals render valid bracket-wrapped URLs
`http://::1:8000` → `http://[::1]:8000`, driven by a shared `_authority()` helper (same lexical rule as the serve CLI's `_is_ipv6_host`).

### Minor — `connect --port` reuses the validated `_port_arg`
Rejects `0`, negatives, and `>65535` with a clear argparse error instead of producing an invalid URL.

## Round-2 fixes (from second review)

### P1 — Ready banner's Connect: section now carries the real endpoint
The *serve banner itself* (via `render_banner`) previously still printed bare `rapid-mlx agents claude-code --setup` / `agents continue --setup` — a user who copied from the Ready banner would configure localhost instead of the running server. Both agent setup commands now append `--base-url <openai_url>` dynamically from the SSOT, so the served banner and `connect <target>` agree.

### P1 — Explicit `--model` is never overwritten by a live probe
`connect --model X` (on default address) previously still probed the server and could clobber the user's explicit model. The live model probe now runs only when no model was supplied anywhere (flags > config > defaults), so an explicit `--model` always wins.

### Minor — scoped IPv6 zone-ids are percent-encoded (`%25`)
RFC 6874: `http://[fe80::1%en0]:8000` → `http://[fe80::1%25en0]:8000`, so scoped URLs stay well-formed.

## Round-3 fixes (from third review)

### P1 — Dynamic `--base-url` in copied commands is shell-quoted
Both the Ready banner (`render_banner`) and `connect <agent>` output (`_print_point_command`) build commands a user copies and pastes into a shell. A crafted `--host` value such as `'mini.local; touch /tmp/pwned'` would otherwise be interpolated raw, letting the shell interpret the semicolon as a command separator. Every dynamic `--base-url` is now passed through `shlex.quote()`, e.g.:
```
rapid-mlx agents claude-code --setup \
  --base-url 'http://mini.local; touch /tmp/pwned:8000/v1'
```

### Minor — `_authority()` canonicalizes non-canonical host input
- An already-bracketed `[::1]` is no longer double-bracketed as `[[::1]]`.
- An already-encoded `%25` zone-id is left alone, not encoded a second time to `%2525` (case-insensitive).

## Tests
Added/updated regression tests covering: remote endpoint passthrough for `claude-code`/`continue`; banner `Connect:` rows carrying `--base-url` (remote, IPv6, default localhost); IPv6 literal + scoped `%25` bracketing (endpoint derivations, banner, JSON); invalid port rejection/valid port acceptance; explicit-model-preserved vs. probe-when-no-model for `resolve_endpoints`; and shell-quoting for malicious hosts (spaces, `;`, `$(...)`, single quotes) plus IPv6 zone-id / already-bracketed normalization across both the banner and point-command paths.

## Note on Scope
SSOT currently unifies the Python serve banner + `connect --json`. Desktop does not consume it yet — this is documented future work, not part of this PR's scope.