### PR TITLE
feat(models): add NVIDIA Nemotron 3.5 Lightning 30B A3B alias

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -187,6 +187,30 @@ def test_alias_reasoning_parser_is_registered(alias: str) -> None:
 # =============================================================================
 
 
+def test_nemotron_3_5_lightning_profile() -> None:
+    """Pin the NVIDIA Nemotron 3.5 Lightning 30B A3B profile.
+
+    This is a ``nemotron_h`` hybrid MoE (Mamba-2 + MoE + sparse attention),
+    already implemented by mlx-lm and served through the standard hybrid path
+    (smoke-verified: load, streaming + non-streaming, tool-calling, prefix cache
+    across turns). Two choices are load-bearing and easy to "fix" wrong:
+
+    - ``tool_call_parser == "nemotron"`` (NOT ``hermes`` like the older
+      Nemotron-3-Nano entry): the model's chat template emits the
+      ``<tool_call><function=name><parameter=p>v</parameter></function></tool_call>``
+      XML form that ``NemotronToolParser`` handles, not hermes JSON.
+    - ``is_hybrid`` / ``is_moe`` true and ``supports_spec_decode`` false — a
+      Mamba/attention mix breaks the spec-decode drafter state.
+    """
+    profile = list_profiles()["nemotron-3.5-lightning-30b-4bit"]
+    assert profile.hf_path == "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit"
+    assert profile.tool_call_parser == "nemotron"
+    assert profile.reasoning_parser == "qwen3"
+    assert profile.is_hybrid is True
+    assert profile.is_moe is True
+    assert profile.supports_spec_decode is False
+
+
 @pytest.mark.parametrize("alias", _alias_ids())
 def test_hybrid_disables_spec_decode(alias: str) -> None:
     """``is_hybrid=true`` and ``supports_spec_decode=true`` cannot both

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1338,6 +1338,14 @@
     "supports_spec_decode": false,
     "is_moe": true
   },
+  "nemotron-3.5-lightning-30b-4bit": {
+    "hf_path": "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit",
+    "tool_call_parser": "nemotron",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false,
+    "is_moe": true
+  },
   "bonsai-1.7b-2bit": {
     "hf_path": "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit",
     "tool_call_parser": "hermes",

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -17,6 +17,7 @@
     "lmstudio-community/LFM2-24B-A2B-MLX-4bit": 13420011411,
     "lmstudio-community/MiniMax-M2.5-MLX-4bit": 128682605730,
     "lmstudio-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4bit": 17792584863,
+    "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit": 17792584702,
     "lmstudio-community/Phi-4-mini-reasoning-MLX-4bit": 2179993954,
     "lmstudio-community/Qwen3-Coder-Next-MLX-4bit": 44855912113,
     "lmstudio-community/Qwen3-Coder-Next-MLX-8bit": 84667197908,


### PR DESCRIPTION
## Why

NVIDIA just released **Nemotron 3.5 Lightning 30B A3B** — a model built for the high-volume execution layer of long-running agents (fast, accurate tool calls / validation / formatting / subagent work). Users want to run it locally on Apple Silicon via rapid-mlx.

## What

Everything the model needs already exists in the stack — this PR is just the alias + capability flags:
- **Architecture** `nemotron_h` (Mamba-2 + MoE + sparse attention hybrid; 128 routed + 1 shared expert, 6 active; MTP head) is already implemented by **mlx-lm** (`nemotron_h.py`, with `NemotronHMoE` / `SwitchMLP` / shared experts / `hybrid_override_pattern`).
- **Weights**: **mlx-community** publishes MLX conversions (4bit ≈ 16 GB fits a 32 GB Mac); no local conversion needed (NVIDIA ships only NVFP4, which MLX can't read).
- **Predecessor** Nemotron-3-Nano-30B-A3B is already a registered `is_hybrid` alias, so rapid-mlx's hybrid Mamba+attention cache path already handles this family.

Added `nemotron-3.5-lightning-30b-4bit` → `mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit`:
- `tool_call_parser: "nemotron"` — the model's chat template emits `<tool_call><function=name><parameter=p>v</parameter></function></tool_call>`, which `NemotronToolParser` handles (NOT hermes JSON like the older Nano entry).
- `reasoning_parser: "qwen3"` — the template wraps reasoning in `<think>…</think>`.
- `is_hybrid: true`, `is_moe: true`, `supports_spec_decode: false` (Mamba/attention mix breaks the spec-decode drafter).

## Tests

- `tests/test_aliases_contract.py`: full contract suite green (2756), plus a focused `test_nemotron_3_5_lightning_profile` pinning the load-bearing choices (nemotron parser, hybrid/moe, no spec-decode) with the rationale so they don't silently drift to hermes.
- **Smoke-verified on M2 Pro** (rapid-mlx `serve nemotron-3.5-lightning-30b-4bit --enable-prefix-cache --metal-cap-kv-bytes-per-token 8192`): loads in ~6 s (MTP head weights tolerated, ignored by the base model), mamba cache handled natively (`[MambaCache] … native batching support`), plain + streaming inference, tool-calling parsed correctly (`get_weather{"city":"Paris"}`, `finish_reason=tool_calls`), reasoning parser no-leak, and prefix cache hits across a multi-turn conversation (correct `84` = 42×2). No errors/tracebacks in the serve log.

## Notes

No package version bump. No engine code changes — the architecture and hybrid-cache plumbing already exist; this is purely a model registry entry + regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8).