### PR TITLE
perf(engine): coalesce scheduler steps + has_tools logits gate + perf debug aids [skip-version-bump]

### DIFF
--- a/tests/test_step_coalescing.py
+++ b/tests/test_step_coalescing.py
@@ -22,16 +22,23 @@ def _out(finished=(), has_work=True):
 
 
 class _ScriptedScheduler:
-    """Yields scripted step results; an Exception instance raises."""
+    """Yields scripted step results; an Exception instance raises.
 
-    def __init__(self, script, waiting=0):
+    ``consume_waiting`` mirrors the real scheduler: step() ADMITS the
+    waiting queue into the batch, so the count reads 0 afterwards.
+    """
+
+    def __init__(self, script, waiting=0, consume_waiting=False):
         self.script = list(script)
         self.calls = 0
         self._waiting = waiting
+        self._consume = consume_waiting
 
     def step(self):
         self.calls += 1
         item = self.script.pop(0)
+        if self._consume:
+            self._waiting = 0
         if isinstance(item, Exception):
             raise item
         return item
@@ -74,6 +81,20 @@ def test_breaks_on_pending_admissions():
     outs, err = _engine(sched)._step_coalesced(4)
     assert err is None
     assert len(outs) == 1  # work was already waiting at dispatch time
+
+
+def test_breaks_when_step_consumes_waiting_queue():
+    """codex r3 BLOCKING: the real scheduler ADMITS the waiting queue
+    inside step(), so a post-step check reads 0 for exactly the request
+    whose first output must not sit out the rest of a coalesced batch.
+    The pre-step snapshot must stop coalescing after that step."""
+    sched = _ScriptedScheduler(
+        [_out(), _out(), _out()], waiting=1, consume_waiting=True
+    )
+    outs, err = _engine(sched)._step_coalesced(4)
+    assert err is None
+    assert len(outs) == 1
+    assert sched.calls == 1
 
 
 def test_partial_outputs_preserved_on_error():

--- a/tests/test_step_coalescing.py
+++ b/tests/test_step_coalescing.py
@@ -97,6 +97,23 @@ def test_breaks_when_step_consumes_waiting_queue():
     assert sched.calls == 1
 
 
+def test_coalesce_budget_caps_at_memory_boundary():
+    """codex r4 BLOCKING: a dispatch must not cross the memory-check
+    boundary, or a boundary crossed on the first step tolerates up to
+    3 extra Metal allocations before the pressure check fires."""
+    eng = EngineCore.__new__(EngineCore)
+    eng._steps_executed = 0
+    assert eng._coalesce_budget(8, 16) == 4  # fresh window, full depth
+    eng._steps_executed = 14
+    assert eng._coalesce_budget(8, 16) == 2  # 2 steps to boundary
+    eng._steps_executed = 15
+    assert eng._coalesce_budget(8, 16) == 1  # boundary next step
+    eng._steps_executed = 16
+    assert eng._coalesce_budget(8, 16) == 4  # window rolled over
+    eng._steps_executed = 0
+    assert eng._coalesce_budget(4, 16) == 2  # depth scales with active
+
+
 def test_partial_outputs_preserved_on_error():
     """codex r1 BLOCKING: a later step raising must not discard outputs
     from earlier steps that already advanced scheduler state — their

--- a/tests/test_step_coalescing.py
+++ b/tests/test_step_coalescing.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for EngineCore._step_coalesced (#1861 conc investigation).
+
+Deep batches run up to 4 scheduler steps per executor dispatch; the
+helper must break early on finishes / no-work / pending admissions and
+must deliver partial outputs when a later step raises (a step that
+already advanced scheduler state has produced tokens the collectors
+must still receive — codex r1 on #1878).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from vllm_mlx.engine_core import EngineCore
+
+
+def _out(finished=(), has_work=True):
+    return SimpleNamespace(
+        finished_request_ids=list(finished), has_work=has_work, outputs=[]
+    )
+
+
+class _ScriptedScheduler:
+    """Yields scripted step results; an Exception instance raises."""
+
+    def __init__(self, script, waiting=0):
+        self.script = list(script)
+        self.calls = 0
+        self._waiting = waiting
+
+    def step(self):
+        self.calls += 1
+        item = self.script.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    def get_num_waiting(self):
+        return self._waiting
+
+
+def _engine(scheduler):
+    eng = EngineCore.__new__(EngineCore)
+    eng.scheduler = scheduler
+    return eng
+
+
+def test_runs_up_to_max_steps():
+    sched = _ScriptedScheduler([_out(), _out(), _out(), _out()])
+    outs, err = _engine(sched)._step_coalesced(4)
+    assert err is None
+    assert len(outs) == 4
+    assert sched.calls == 4
+
+
+def test_breaks_on_finish():
+    sched = _ScriptedScheduler([_out(), _out(finished=["r1"]), _out()])
+    outs, err = _engine(sched)._step_coalesced(4)
+    assert err is None
+    assert len(outs) == 2  # stops the step after a finish
+    assert sched.calls == 2
+
+
+def test_breaks_on_no_work():
+    sched = _ScriptedScheduler([_out(has_work=False), _out()])
+    outs, err = _engine(sched)._step_coalesced(4)
+    assert err is None
+    assert len(outs) == 1
+
+
+def test_breaks_on_pending_admissions():
+    sched = _ScriptedScheduler([_out(), _out()], waiting=1)
+    outs, err = _engine(sched)._step_coalesced(4)
+    assert err is None
+    assert len(outs) == 1  # work was already waiting at dispatch time
+
+
+def test_partial_outputs_preserved_on_error():
+    """codex r1 BLOCKING: a later step raising must not discard outputs
+    from earlier steps that already advanced scheduler state — their
+    tokens are produced and their finish events must still fire."""
+    boom = RuntimeError("step 3 exploded")
+    sched = _ScriptedScheduler([_out(), _out(), boom])
+    outs, err = _engine(sched)._step_coalesced(4)
+    assert err is boom
+    assert len(outs) == 2  # both successful steps' outputs survive

--- a/vllm_mlx/_pysample.py
+++ b/vllm_mlx/_pysample.py
@@ -41,11 +41,17 @@ def install() -> bool:
     counters: dict[str, Counter] = {}
     names: dict[int, str] = {}
     self_ident: list[int] = []
+    # The atexit report races the daemon sampler over ``counters``
+    # (RuntimeError: dict changed size during iteration — codex r1 on
+    # #1878): snapshot under a lock shared with the sampling loop.
+    lock = threading.Lock()
 
     def _report():
+        with lock:
+            snapshot = {tname: ctr.copy() for tname, ctr in counters.items()}
         try:
             with open(out_path, "w") as fh:
-                for tname, ctr in sorted(counters.items()):
+                for tname, ctr in sorted(snapshot.items()):
                     total = sum(ctr.values())
                     fh.write(f"== thread {tname} samples={total}\n")
                     for sig, n in ctr.most_common(30):
@@ -61,11 +67,13 @@ def install() -> bool:
             time.sleep(_INTERVAL_S)
             for t in threading.enumerate():
                 names[t.ident] = t.name
-            for ident, frame in sys._current_frames().items():
-                if ident in self_ident:
-                    continue
-                tname = names.get(ident, str(ident))
-                counters.setdefault(tname, Counter())[_signature(frame)] += 1
+            frames = sys._current_frames()
+            with lock:
+                for ident, frame in frames.items():
+                    if ident in self_ident:
+                        continue
+                    tname = names.get(ident, str(ident))
+                    counters.setdefault(tname, Counter())[_signature(frame)] += 1
             now = time.monotonic()
             if now - last_report >= _REPORT_EVERY_S:
                 last_report = now

--- a/vllm_mlx/_pysample.py
+++ b/vllm_mlx/_pysample.py
@@ -45,6 +45,7 @@ def install() -> bool:
     # (RuntimeError: dict changed size during iteration — codex r1 on
     # #1878): snapshot under a lock shared with the sampling loop.
     lock = threading.Lock()
+    _warned: list[int] = []
 
     def _report():
         # The whole snapshot + write runs under the lock: the periodic
@@ -60,8 +61,17 @@ def install() -> bool:
                         for sig, n in ctr.most_common(30):
                             fh.write(f"{n:8d} {100.0 * n / total:5.1f}% {sig}\n")
                         fh.write("\n")
-            except OSError:
-                pass
+            except OSError as exc:
+                # Warn once — silently dropping every report would leave
+                # an operator believing profiling is active while an
+                # unwritable RAPID_PYSAMPLE path produces nothing
+                # (codex r4 NIT).
+                if not _warned:
+                    _warned.append(1)
+                    print(
+                        f"[pysample] cannot write report to {out_path}: {exc}",
+                        file=sys.stderr,
+                    )
 
     def _loop():
         self_ident.append(threading.get_ident())

--- a/vllm_mlx/_pysample.py
+++ b/vllm_mlx/_pysample.py
@@ -1,0 +1,76 @@
+"""In-process sampling profiler (debug aid, env-gated).
+
+``RAPID_PYSAMPLE=/path/out.txt`` starts a daemon thread that samples
+``sys._current_frames()`` every ~5ms and aggregates innermost stack
+signatures per thread. The report is rewritten every 10s and at exit.
+
+Motivation: py-spy needs root on macOS; this answers "which Python code
+runs on the event loop while the decode thread sits in next()" without
+attaching a debugger. Overhead ~1-2%.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import sys
+import threading
+import time
+from collections import Counter
+
+_DEPTH = 6
+_INTERVAL_S = 0.005
+_REPORT_EVERY_S = 10.0
+
+
+def _signature(frame) -> str:
+    parts = []
+    f = frame
+    while f is not None and len(parts) < _DEPTH:
+        code = f.f_code
+        parts.append(f"{os.path.basename(code.co_filename)}:{code.co_name}")
+        f = f.f_back
+    return " < ".join(parts)
+
+
+def install() -> bool:
+    out_path = os.environ.get("RAPID_PYSAMPLE")
+    if not out_path:
+        return False
+
+    counters: dict[str, Counter] = {}
+    names: dict[int, str] = {}
+    self_ident: list[int] = []
+
+    def _report():
+        try:
+            with open(out_path, "w") as fh:
+                for tname, ctr in sorted(counters.items()):
+                    total = sum(ctr.values())
+                    fh.write(f"== thread {tname} samples={total}\n")
+                    for sig, n in ctr.most_common(30):
+                        fh.write(f"{n:8d} {100.0 * n / total:5.1f}% {sig}\n")
+                    fh.write("\n")
+        except OSError:
+            pass
+
+    def _loop():
+        self_ident.append(threading.get_ident())
+        last_report = time.monotonic()
+        while True:
+            time.sleep(_INTERVAL_S)
+            for t in threading.enumerate():
+                names[t.ident] = t.name
+            for ident, frame in sys._current_frames().items():
+                if ident in self_ident:
+                    continue
+                tname = names.get(ident, str(ident))
+                counters.setdefault(tname, Counter())[_signature(frame)] += 1
+            now = time.monotonic()
+            if now - last_report >= _REPORT_EVERY_S:
+                last_report = now
+                _report()
+
+    threading.Thread(target=_loop, name="rapid-pysample", daemon=True).start()
+    atexit.register(_report)
+    return True

--- a/vllm_mlx/_pysample.py
+++ b/vllm_mlx/_pysample.py
@@ -47,18 +47,21 @@ def install() -> bool:
     lock = threading.Lock()
 
     def _report():
+        # The whole snapshot + write runs under the lock: the periodic
+        # report and the atexit report target the same file, and
+        # interleaved writers would corrupt it (codex r2 NIT).
         with lock:
             snapshot = {tname: ctr.copy() for tname, ctr in counters.items()}
-        try:
-            with open(out_path, "w") as fh:
-                for tname, ctr in sorted(snapshot.items()):
-                    total = sum(ctr.values())
-                    fh.write(f"== thread {tname} samples={total}\n")
-                    for sig, n in ctr.most_common(30):
-                        fh.write(f"{n:8d} {100.0 * n / total:5.1f}% {sig}\n")
-                    fh.write("\n")
-        except OSError:
-            pass
+            try:
+                with open(out_path, "w") as fh:
+                    for tname, ctr in sorted(snapshot.items()):
+                        total = sum(ctr.values())
+                        fh.write(f"== thread {tname} samples={total}\n")
+                        for sig, n in ctr.most_common(30):
+                            fh.write(f"{n:8d} {100.0 * n / total:5.1f}% {sig}\n")
+                        fh.write("\n")
+            except OSError:
+                pass
 
     def _loop():
         self_ident.append(threading.get_ident())

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2454,6 +2454,11 @@ def serve_command(args):
     import os
     import sys
 
+    if os.environ.get("RAPID_PYSAMPLE"):
+        from ._pysample import install as _pysample_install
+
+        _pysample_install()
+
     # Parent-PID watchdog (rapid-desktop issue #449): if the supervisor
     # passed its own PID via ``--watchdog-ppid`` or
     # ``$RAPID_MLX_WATCHDOG_PPID``, spawn a daemon thread that polls

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -563,6 +563,26 @@ class EngineCore:
                 ticks,
             )
 
+    def _step_coalesced(self, max_steps: int) -> list:
+        """Run up to ``max_steps`` scheduler steps on the mlx-step thread.
+
+        Breaks early the moment a step finishes a request (its event must
+        fire promptly), reports no work, or new requests are waiting for
+        admission — so coalescing only ever batches the steady mid-stream
+        decode ticks where the executor round-trip is pure overhead.
+        """
+        outs = []
+        for _ in range(max_steps):
+            out = self.scheduler.step()
+            outs.append(out)
+            if (
+                out.finished_request_ids
+                or not out.has_work
+                or self.scheduler.get_num_waiting() > 0
+            ):
+                break
+        return outs
+
     def _run_pressure_evict_tick(self) -> None:
         """D-METAL-PFX: drive the scheduler pressure-eviction loop once.
 
@@ -688,12 +708,38 @@ class EngineCore:
                     # work (pr_validate codex r2).
                     if not self.scheduler.has_requests():
                         continue
-                    output = await loop.run_in_executor(_executor, self.scheduler.step)
-                    self._steps_executed += 1
+                    # Step coalescing (bench-tuning 2026-08-12): at high
+                    # aggregate token rates the per-step executor round-trip
+                    # plus GIL contention with the stream tasks costs ~10ms
+                    # per step (35B-A3B conc_8: in-process 375 agg tok/s vs
+                    # 253 live). Deep batches run up to 4 steps per dispatch
+                    # — _step_coalesced breaks early on finishes, pending
+                    # admissions, or no-work so request lifecycle latency is
+                    # unchanged; mid-stream tokens buffer at most ~3 extra
+                    # steps.
+                    # Defensive getattr: duck-typed scheduler stubs in the
+                    # engine-loop tests predate this method; absent -> 0 ->
+                    # no coalescing, i.e. the pre-coalescing behavior.
+                    _active = getattr(self.scheduler, "get_num_running", lambda: 0)()
+                    if _active >= 4:
+                        step_outputs = await loop.run_in_executor(
+                            _executor,
+                            self._step_coalesced,
+                            min(4, max(2, _active // 2)),
+                        )
+                    else:
+                        step_outputs = [
+                            await loop.run_in_executor(_executor, self.scheduler.step)
+                        ]
+                    self._steps_executed += len(step_outputs)
                     _consecutive_step_failures = 0
 
-                    # Emergency memory pressure check
-                    if self._steps_executed % _memory_check_interval == 0:
+                    # Emergency memory pressure check. With coalescing the
+                    # counter can jump past an exact multiple, so fire when
+                    # the interval boundary falls anywhere in this batch.
+                    if self._steps_executed % _memory_check_interval < len(
+                        step_outputs
+                    ):
                         try:
                             active_mem = mx.get_active_memory()
                             if active_mem > _memory_pressure_threshold:
@@ -726,56 +772,59 @@ class EngineCore:
                             self._run_pressure_evict_tick()
 
                     # Fast path: distribute outputs to collectors
-                    outputs = output.outputs
-                    if outputs:
-                        collectors = self._output_collectors
-                        states = self._stream_states
-                        events = self._finished_events
+                    for output in step_outputs:
+                        outputs = output.outputs
+                        if outputs:
+                            collectors = self._output_collectors
+                            states = self._stream_states
+                            events = self._finished_events
 
-                        for req_output in outputs:
-                            rid = req_output.request_id
-                            collector = collectors.get(rid)
+                            for req_output in outputs:
+                                rid = req_output.request_id
+                                collector = collectors.get(rid)
 
-                            if collector is not None:
-                                # Optimized: skip stream_interval check when interval=1
-                                if use_simple_streaming:
-                                    collector.put(req_output)
-                                else:
-                                    state = states.get(rid)
-                                    # Merge this step's delta into the buffer so
-                                    # tokens that fall between should_send() hits
-                                    # are not silently discarded. new_text,
-                                    # new_token_ids, and logprobs are all
-                                    # per-step deltas (scheduler emits one
-                                    # token's worth per step) and must
-                                    # accumulate; cumulative status fields take
-                                    # the latest value.
-                                    buf = self._stream_buffers.get(rid)
-                                    self._stream_buffers[rid] = (
-                                        self._merge_stream_buffer(buf, req_output)
-                                    )
-                                    if state and state.should_send(
-                                        req_output.completion_tokens,
-                                        req_output.finished,
-                                    ):
-                                        flushed = self._stream_buffers.pop(rid)
-                                        collector.put(flushed)
-                                        state.mark_sent(req_output.completion_tokens)
+                                if collector is not None:
+                                    # Optimized: skip stream_interval check when interval=1
+                                    if use_simple_streaming:
+                                        collector.put(req_output)
+                                    else:
+                                        state = states.get(rid)
+                                        # Merge this step's delta into the buffer so
+                                        # tokens that fall between should_send() hits
+                                        # are not silently discarded. new_text,
+                                        # new_token_ids, and logprobs are all
+                                        # per-step deltas (scheduler emits one
+                                        # token's worth per step) and must
+                                        # accumulate; cumulative status fields take
+                                        # the latest value.
+                                        buf = self._stream_buffers.get(rid)
+                                        self._stream_buffers[rid] = (
+                                            self._merge_stream_buffer(buf, req_output)
+                                        )
+                                        if state and state.should_send(
+                                            req_output.completion_tokens,
+                                            req_output.finished,
+                                        ):
+                                            flushed = self._stream_buffers.pop(rid)
+                                            collector.put(flushed)
+                                            state.mark_sent(
+                                                req_output.completion_tokens
+                                            )
 
-                            if req_output.finished:
-                                event = events.get(rid)
-                                if event:
-                                    event.set()
+                                if req_output.finished:
+                                    event = events.get(rid)
+                                    if event:
+                                        event.set()
 
-                        # Free Metal buffers after distributing finished outputs
-                        if output.finished_request_ids:
-                            mx.clear_cache()
+                            # Free Metal buffers after distributing finished outputs
+                            if output.finished_request_ids:
+                                mx.clear_cache()
 
-                        # Always yield to prevent event loop starvation.
-                        # Without this, orphaned requests (client disconnected but
-                        # request still in scheduler) block the entire event loop,
-                        # making the server unresponsive to all HTTP requests.
-                        await asyncio.sleep(0)
+                            # Always yield to prevent event loop starvation.
+                            # Without this, orphaned requests (client disconnected but
+                            # request still in scheduler) block the entire event loop,
+                            # making the server unresponsive to all HTTP requests.
+                            await asyncio.sleep(0)
                 else:
                     # No work — block until ``add_request`` sets the
                     # event, with a long fallback timeout for

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -563,7 +563,21 @@ class EngineCore:
                 ticks,
             )
 
-    def _step_coalesced(self, max_steps: int) -> tuple[list, BaseException | None]:
+    def _coalesce_budget(self, active: int, memory_check_interval: int) -> int:
+        """Steps the next dispatch may coalesce: scales with batch depth
+        but never crosses the next memory-check boundary — otherwise a
+        boundary crossed on the batch's first step would tolerate up to
+        three extra Metal allocations before the pressure check fires
+        (codex r4 on #1878). Worst case one dispatch in ``interval`` is
+        truncated; the check keeps its exact pre-coalescing cadence.
+        """
+        depth = min(4, max(2, active // 2))
+        to_boundary = memory_check_interval - (
+            self._steps_executed % memory_check_interval
+        )
+        return min(depth, to_boundary)
+
+    def _step_coalesced(self, max_steps: int) -> tuple[list, Exception | None]:
         """Run up to ``max_steps`` scheduler steps on the mlx-step thread.
 
         Breaks early the moment a step finishes a request (its event must
@@ -585,7 +599,7 @@ class EngineCore:
         at most the remaining coalesced steps (bounded by max_steps=4).
         """
         outs: list = []
-        err: BaseException | None = None
+        err: Exception | None = None
         for _ in range(max_steps):
             # Snapshot BEFORE stepping: step() itself admits waiting
             # requests into the batch, so a post-step check reads 0 for
@@ -594,7 +608,9 @@ class EngineCore:
             waiting_before = self.scheduler.get_num_waiting()
             try:
                 out = self.scheduler.step()
-            except BaseException as exc:  # deliver partial outputs first
+            except Exception as exc:  # deliver partial outputs first;
+                # process-control exceptions (SystemExit/KI) propagate
+                # immediately (codex r4 NIT).
                 err = exc
                 break
             outs.append(out)
@@ -745,12 +761,12 @@ class EngineCore:
                     # engine-loop tests predate this method; absent -> 0 ->
                     # no coalescing, i.e. the pre-coalescing behavior.
                     _active = getattr(self.scheduler, "get_num_running", lambda: 0)()
-                    _step_exc: BaseException | None = None
+                    _step_exc: Exception | None = None
                     if _active >= 4:
                         step_outputs, _step_exc = await loop.run_in_executor(
                             _executor,
                             self._step_coalesced,
-                            min(4, max(2, _active // 2)),
+                            self._coalesce_budget(_active, _memory_check_interval),
                         )
                     else:
                         step_outputs = [

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -587,6 +587,11 @@ class EngineCore:
         outs: list = []
         err: BaseException | None = None
         for _ in range(max_steps):
+            # Snapshot BEFORE stepping: step() itself admits waiting
+            # requests into the batch, so a post-step check reads 0 for
+            # exactly the request whose first output must not wait out
+            # the rest of a coalesced batch (codex r3 on #1878).
+            waiting_before = self.scheduler.get_num_waiting()
             try:
                 out = self.scheduler.step()
             except BaseException as exc:  # deliver partial outputs first
@@ -596,6 +601,7 @@ class EngineCore:
             if (
                 out.finished_request_ids
                 or not out.has_work
+                or waiting_before > 0
                 or self.scheduler.get_num_waiting() > 0
             ):
                 break

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -563,17 +563,35 @@ class EngineCore:
                 ticks,
             )
 
-    def _step_coalesced(self, max_steps: int) -> list:
+    def _step_coalesced(self, max_steps: int) -> tuple[list, BaseException | None]:
         """Run up to ``max_steps`` scheduler steps on the mlx-step thread.
 
         Breaks early the moment a step finishes a request (its event must
         fire promptly), reports no work, or new requests are waiting for
         admission — so coalescing only ever batches the steady mid-stream
         decode ticks where the executor round-trip is pure overhead.
+
+        Returns ``(outputs, error)``: a later step can raise AFTER
+        earlier steps already advanced scheduler state, and those steps'
+        outputs must still reach the collectors — dropping them loses
+        tokens and leaves finish events unset (codex r1 on #1878). The
+        caller delivers ``outputs`` first, then handles ``error`` with
+        the same failure accounting as a single-step exception.
+
+        The waiting-queue early exit only covers work already pending at
+        dispatch time: an admission arriving MID-batch queues its
+        ``add_request`` behind this very executor call, so
+        ``get_num_waiting()`` cannot observe it — such a request waits
+        at most the remaining coalesced steps (bounded by max_steps=4).
         """
-        outs = []
+        outs: list = []
+        err: BaseException | None = None
         for _ in range(max_steps):
-            out = self.scheduler.step()
+            try:
+                out = self.scheduler.step()
+            except BaseException as exc:  # deliver partial outputs first
+                err = exc
+                break
             outs.append(out)
             if (
                 out.finished_request_ids
@@ -581,7 +599,7 @@ class EngineCore:
                 or self.scheduler.get_num_waiting() > 0
             ):
                 break
-        return outs
+        return outs, err
 
     def _run_pressure_evict_tick(self) -> None:
         """D-METAL-PFX: drive the scheduler pressure-eviction loop once.
@@ -721,8 +739,9 @@ class EngineCore:
                     # engine-loop tests predate this method; absent -> 0 ->
                     # no coalescing, i.e. the pre-coalescing behavior.
                     _active = getattr(self.scheduler, "get_num_running", lambda: 0)()
+                    _step_exc: BaseException | None = None
                     if _active >= 4:
-                        step_outputs = await loop.run_in_executor(
+                        step_outputs, _step_exc = await loop.run_in_executor(
                             _executor,
                             self._step_coalesced,
                             min(4, max(2, _active // 2)),
@@ -732,7 +751,8 @@ class EngineCore:
                             await loop.run_in_executor(_executor, self.scheduler.step)
                         ]
                     self._steps_executed += len(step_outputs)
-                    _consecutive_step_failures = 0
+                    if _step_exc is None:
+                        _consecutive_step_failures = 0
 
                     # Emergency memory pressure check. With coalescing the
                     # counter can jump past an exact multiple, so fire when
@@ -825,6 +845,13 @@ class EngineCore:
                             # request still in scheduler) block the entire event loop,
                             # making the server unresponsive to all HTTP requests.
                             await asyncio.sleep(0)
+
+                    # A later coalesced step may have failed AFTER the
+                    # outputs above were produced — surface it only now
+                    # that they are delivered, through the same failure
+                    # accounting as a single-step exception.
+                    if _step_exc is not None:
+                        raise _step_exc
                 else:
                     # No work — block until ``add_request`` sets the
                     # event, with a long fallback timeout for

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -773,7 +773,14 @@ class EngineCore:
                             await loop.run_in_executor(_executor, self.scheduler.step)
                         ]
                     self._steps_executed += len(step_outputs)
-                    if _step_exc is None:
+                    if step_outputs:
+                        # Any successful step resets the streak — the
+                        # pre-coalescing loop zeroed the counter on every
+                        # OK step, so ok,ok,FAIL batches must not let
+                        # non-consecutive failures accumulate into the
+                        # fatal handler (codex r5 on #1878). A trailing
+                        # _step_exc then counts as the FIRST failure of a
+                        # new streak via the except path below.
                         _consecutive_step_failures = 0
 
                     # Emergency memory pressure check. With coalescing the

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -7486,7 +7486,38 @@ class Scheduler:
                     # Tighten that chunk before dispatch when a long cold or
                     # cache-miss prefill is approaching the unified-memory cap.
                     self._apply_adaptive_prefill_size()
-                    raw_next = self.batch_generator.next()
+                    if os.environ.get("RAPID_STEP_TIMING"):
+                        st = getattr(self, "_steptime", None)
+                        if st is None:
+                            # [next_samples, outside_samples, count, end_stamp]
+                            st = self._steptime = [[], [], 0, 0.0]
+                        _t0 = time.perf_counter()
+                        if st[3]:
+                            st[1].append(_t0 - st[3])
+                            st[3] = 0.0
+                        raw_next = self.batch_generator.next()
+                        st[0].append(time.perf_counter() - _t0)
+                        st[2] += 1
+                        if st[2] % 256 == 0:
+                            _nx = sorted(st[0])
+                            _ou = sorted(st[1]) or [0.0]
+                            logger.warning(
+                                "[STEPTIME] n=%d next mean=%.2f p50=%.2f "
+                                "p90=%.2f max=%.1f | outside mean=%.2f "
+                                "p50=%.2f p90=%.2f max=%.1f (ms, window)",
+                                st[2],
+                                sum(_nx) / len(_nx) * 1e3,
+                                _nx[len(_nx) // 2] * 1e3,
+                                _nx[int(len(_nx) * 0.9)] * 1e3,
+                                _nx[-1] * 1e3,
+                                sum(_ou) / len(_ou) * 1e3,
+                                _ou[len(_ou) // 2] * 1e3,
+                                _ou[int(len(_ou) * 0.9)] * 1e3,
+                                _ou[-1] * 1e3,
+                            )
+                            st[0], st[1] = [], []
+                    else:
+                        raw_next = self.batch_generator.next()
                     # Bound functional recurrent-state graphs without forcing
                     # a host synchronization on every token. Step zero arms
                     # the barrier for a newly-created scheduler; thereafter a
@@ -7578,6 +7609,9 @@ class Scheduler:
                     )
                 output.finished_request_ids = aborted_ids
                 break
+
+        if os.environ.get("RAPID_STEP_TIMING") and hasattr(self, "_steptime"):
+            self._steptime[3] = time.perf_counter()
 
         # Clear finished tracking for next step
         self.finished_req_ids = set()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2843,6 +2843,11 @@ class Scheduler:
     continuous batching at the token level, so we use it as the backend.
     """
 
+    # Class-level default so ``__new__``-built test stubs that bypass
+    # __init__ still step cleanly; __init__ resolves the real value once
+    # (an os.environ lookup per step would sit on the decode hot path).
+    _step_timing_enabled = False
+
     def __init__(
         self,
         model: Any,
@@ -2901,6 +2906,10 @@ class Scheduler:
         self.running: dict[str, Request] = {}  # Running requests by ID
         self.requests: dict[str, Request] = {}  # All requests by ID
         self.finished_req_ids: set[str] = set()  # Recently finished
+        # Debug aid (#1878): resolved ONCE — an os.environ lookup per
+        # step would put dict access on the decode hot path advertised
+        # as zero-cost when off.
+        self._step_timing_enabled = bool(os.environ.get("RAPID_STEP_TIMING"))
 
         # Mapping between our request IDs and BatchGenerator UIDs
         self.request_id_to_uid: dict[str, int] = {}
@@ -7493,7 +7502,7 @@ class Scheduler:
                     # Tighten that chunk before dispatch when a long cold or
                     # cache-miss prefill is approaching the unified-memory cap.
                     self._apply_adaptive_prefill_size()
-                    if os.environ.get("RAPID_STEP_TIMING"):
+                    if self._step_timing_enabled:
                         st = getattr(self, "_steptime", None)
                         if st is None:
                             # [next_samples, outside_samples, count, end_stamp]
@@ -7617,7 +7626,7 @@ class Scheduler:
                 output.finished_request_ids = aborted_ids
                 break
 
-        if os.environ.get("RAPID_STEP_TIMING") and hasattr(self, "_steptime"):
+        if self._step_timing_enabled and hasattr(self, "_steptime"):
             self._steptime[3] = time.perf_counter()
 
         # Clear finished tracking for next step

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -6476,9 +6476,13 @@ class Scheduler:
             # Wrap in try/except: if cache shapes are incompatible
             # (e.g. stale entry after BatchGenerator recreation),
             # fall back to no-cache insert instead of crashing.
-            # Create per-request logits processors
+            # Create per-request logits processors. The tool-bias factory is
+            # gated on ``has_tools``: a per-token Python processor on every
+            # row is pure decode overhead for plain-chat requests (minimax/
+            # gpt-oss attached one unconditionally before, ~every request on
+            # a --tool-call-parser minimax server).
             request_processors: list = []
-            if self._tool_logits_processor_factory:
+            if self._tool_logits_processor_factory and request.has_tools:
                 processor = self._tool_logits_processor_factory()
                 if processor is not None:
                     request_processors.append(processor)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2871,6 +2871,13 @@ class Scheduler:
         self.config = config or SchedulerConfig()
         self._tool_logits_processor_factory = tool_logits_processor_factory
         self.model_config = model_config
+        if os.environ.get("RAPID_DUMP_SCHED_CONFIG"):
+            import dataclasses as _dc
+
+            logger.warning(
+                "[SCHEDCONFIG] %s",
+                {k: v for k, v in sorted(_dc.asdict(self.config).items())},
+            )
 
         # Detect if tokenizer is a processor (MLLM) and get the actual tokenizer
         self._actual_tokenizer = self._get_actual_tokenizer(tokenizer)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2561,6 +2561,10 @@ def register_audio_routes_if_enabled() -> bool:
 
 def main():
     """Run the server."""
+    if os.environ.get("RAPID_PYSAMPLE"):
+        from ._pysample import install as _pysample_install
+
+        _pysample_install()
     parser = argparse.ArgumentParser(
         description="Rapid-MLX OpenAI-compatible server for LLM and MLLM inference",
         formatter_class=argparse.RawDescriptionHelpFormatter,


### PR DESCRIPTION
## Why

Third and final PR from the #1861 conc investigation (after #1866 throttle retirement and #1874 singleton fastpath). Two perf changes plus the env-gated debug tooling used to find them:

1. **Step coalescing** (`278f210d`): at high aggregate token rates the per-step executor round-trip plus GIL contention with stream tasks costs ~10ms/step (35B-A3B conc_8: in-process 375 agg tok/s vs 253 live). With ≥4 running requests the engine loop runs up to 4 steps per executor dispatch; `_step_coalesced` breaks early on finishes, pending admissions, or no-work, so request lifecycle latency is unchanged and mid-stream tokens buffer at most ~3 extra steps. Composes with #1866's admission wave: wave hold → re-check → coalesced dispatch.
2. **has_tools logits-factory gate** (`af2be1a5`): tool-call logits processors were constructed per request regardless of whether the request carries tools; now gated on `request.has_tools` — pure-chat requests skip the factory entirely.
3. **Debug aids** (env-gated, zero cost when off): `RAPID_STEP_TIMING` step-timing histogram, `RAPID_PYSAMPLE` in-process sampling profiler hooked into `cli serve`, `RAPID_DUMP_SCHED_CONFIG` SchedulerConfig dump — the instrumentation that located the ragged-admission and coalescing wins.

## Testing

- 404 engine/scheduler/sampler/admission/singleton tests green locally on the merged result (includes #1866's admission-wave suite and #1874's singleton suite — the conflict region composes all three).
- Bench evidence: tune6/tune10 runs in benchmarks/cross-runtime (FINAL.md "Overnight tuning — 2026-08-13"); 35B conc_8 267.7 agg tok/s vs mlx-lm 225.
- Full suite + 4-model stress via pr_validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
