### PR TITLE
fix(tool-choice): repair forced-call arguments that are not JSON objects [skip-version-bump]

### DIFF
--- a/tests/test_forced_call_args_repair.py
+++ b/tests/test_forced_call_args_repair.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Forced ``tool_choice`` calls must carry OBJECT arguments on the wire.
+
+Dogfood 2026-08-12 (post #1866/#1874/#1878 merge, pre-existing on main):
+the hermes forced-choice prefix hands the model ``..."arguments": ``
+mid-envelope and Qwen3.5-35B-A3B-8bit at temp 0 continues with a bare
+``1`` — the parser surfaces ``arguments="1"``, and every OpenAI client
+``json.loads``\\ es a non-dict and breaks. The repair mirrors the #571
+synthesis fallback (recover from raw text, else ``"{}"``) and holds the
+result to the #1256 schema gate.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from vllm_mlx.routes.chat import _repair_forced_call_arguments
+
+
+def _call(arguments):
+    return SimpleNamespace(
+        id="call_x",
+        type="function",
+        function=SimpleNamespace(name="release_probe", arguments=arguments),
+    )
+
+
+def _tool(name: str = "release_probe", required: list[str] | None = None):
+    schema: dict[str, Any] = {"type": "object", "properties": {}}
+    if required is not None:
+        schema["required"] = required
+    return SimpleNamespace(
+        type="function", function={"name": name, "parameters": schema}
+    )
+
+
+def test_int_arguments_repaired_to_empty_object():
+    tc = _call("1")
+    err = _repair_forced_call_arguments([tc], "", "release_probe", [_tool()])
+    assert err is None
+    assert tc.function.arguments == "{}"
+
+
+def test_valid_object_arguments_untouched():
+    tc = _call('{"note": "ok"}')
+    err = _repair_forced_call_arguments([tc], "", "release_probe", [_tool()])
+    assert err is None
+    assert tc.function.arguments == '{"note": "ok"}'
+
+
+def test_unparseable_arguments_repaired():
+    tc = _call("not json at all {")
+    err = _repair_forced_call_arguments([tc], "", "release_probe", [_tool()])
+    assert err is None
+    assert tc.function.arguments == "{}"
+
+
+def test_recovery_from_raw_text_preferred_over_empty():
+    tc = _call("1")
+    raw = '<tool_call>{"name": "release_probe", "arguments": {"note": "hi"}}'
+    err = _repair_forced_call_arguments([tc], raw, "release_probe", [_tool()])
+    assert err is None
+    assert "note" in tc.function.arguments
+
+
+def test_schema_required_violation_surfaces_error():
+    """The repair must not fabricate a passing call when the tool's
+    schema requires properties the repaired arguments cannot provide —
+    same #1256 contract as the synthesis fallback."""
+    tc = _call("1")
+    err = _repair_forced_call_arguments(
+        [tc], "", "release_probe", [_tool(required=["level"])]
+    )
+    assert err is not None
+    assert "level" in err or "required" in err.lower()

--- a/tests/test_forced_call_args_repair.py
+++ b/tests/test_forced_call_args_repair.py
@@ -57,11 +57,27 @@ def test_unparseable_arguments_repaired():
 
 
 def test_recovery_from_raw_text_preferred_over_empty():
+    import json
+
     tc = _call("1")
     raw = '<tool_call>{"name": "release_probe", "arguments": {"note": "hi"}}'
     err = _repair_forced_call_arguments([tc], raw, "release_probe", [_tool()])
     assert err is None
-    assert "note" in tc.function.arguments
+    assert json.loads(tc.function.arguments) == {"note": "hi"}
+
+
+def test_multiple_broken_calls_never_share_recovered_args():
+    """codex r2: raw-text recovery is unambiguous only for a single
+    broken call — several must all repair to {} rather than every one
+    receiving the same first recovered object."""
+    import json
+
+    a, b = _call("1"), _call("2")
+    raw = '<tool_call>{"name": "release_probe", "arguments": {"note": "hi"}}'
+    err = _repair_forced_call_arguments([a, b], raw, "release_probe", [_tool()])
+    assert err is None
+    assert json.loads(a.function.arguments) == {}
+    assert json.loads(b.function.arguments) == {}
 
 
 def test_schema_required_violation_surfaces_error():

--- a/tests/test_forced_call_args_repair.py
+++ b/tests/test_forced_call_args_repair.py
@@ -125,6 +125,14 @@ def test_wire_envelope_names_decodes_escapes_and_ignores_prose():
     assert _wire_envelope_names(raw3) == ["release_probe"]
     # Undecodable envelope refuses (None), never permits.
     assert _wire_envelope_names("<tool_call>garbage no brace") is None
+    # Multiple same-target envelopes surface as multiple names — the
+    # streaming gate requires exactly one, since synthesis emits a
+    # single call and would otherwise collapse several (codex r4).
+    raw4 = (
+        '<tool_call>{"name": "release_probe", "arguments": 1}</tool_call>'
+        '<tool_call>{"name": "release_probe", "arguments": 2}</tool_call>'
+    )
+    assert _wire_envelope_names(raw4) == ["release_probe", "release_probe"]
 
 
 def test_schema_required_violation_surfaces_error():

--- a/tests/test_forced_call_args_repair.py
+++ b/tests/test_forced_call_args_repair.py
@@ -66,6 +66,34 @@ def test_recovery_from_raw_text_preferred_over_empty():
     assert json.loads(tc.function.arguments) == {"note": "hi"}
 
 
+def test_dict_arguments_normalized_to_json_string():
+    """codex r3: a dict-typed arguments value is valid CONTENT but the
+    wrong wire SHAPE — normalize to a JSON-encoded string, preserving
+    the content, never discarding it."""
+    import json
+
+    tc = _call({"note": "keep me"})
+    err = _repair_forced_call_arguments([tc], "", "release_probe", [_tool()])
+    assert err is None
+    assert isinstance(tc.function.arguments, str)
+    assert json.loads(tc.function.arguments) == {"note": "keep me"}
+
+
+def test_recovery_skipped_when_valid_sibling_call_present():
+    """codex r3: recovery must not lift a VALID sibling call's
+    arguments into the broken one — with any other call present, the
+    broken call repairs to {}."""
+    import json
+
+    good = _call('{"note": "mine"}')
+    bad = _call("1")
+    raw = '<tool_call>{"name": "release_probe", "arguments": {"note": "mine"}}'
+    err = _repair_forced_call_arguments([good, bad], raw, "release_probe", [_tool()])
+    assert err is None
+    assert json.loads(good.function.arguments) == {"note": "mine"}
+    assert json.loads(bad.function.arguments) == {}
+
+
 def test_multiple_broken_calls_never_share_recovered_args():
     """codex r2: raw-text recovery is unambiguous only for a single
     broken call — several must all repair to {} rather than every one

--- a/tests/test_forced_call_args_repair.py
+++ b/tests/test_forced_call_args_repair.py
@@ -80,6 +80,25 @@ def test_multiple_broken_calls_never_share_recovered_args():
     assert json.loads(b.function.arguments) == {}
 
 
+def test_wire_envelope_names_decodes_escapes_and_ignores_prose():
+    """codex r2 on #1880: envelope decoding (not a literal regex) so
+    escaped names cannot evade the mismatch gate and prose outside
+    envelopes contributes nothing."""
+    from vllm_mlx.routes.chat import _wire_envelope_names
+
+    # Escaped different-tool name decodes and mismatches.
+    raw = '<tool_call>{"name": "other\\u005ftool", "arguments": 1}</tool_call>'
+    assert _wire_envelope_names(raw) == ["other_tool"]
+    # Prose mentioning "name": "release_probe" outside an envelope is inert.
+    raw2 = 'the "name": "release_probe" field... <tool_call>{"name": "x", "arguments": 1}</tool_call>'
+    assert _wire_envelope_names(raw2) == ["x"]
+    # The live dogfood shape: valid JSON, scalar arguments, missing closer.
+    raw3 = '<tool_call>\n{"name": "release_probe", "arguments": 1}'
+    assert _wire_envelope_names(raw3) == ["release_probe"]
+    # Undecodable envelope refuses (None), never permits.
+    assert _wire_envelope_names("<tool_call>garbage no brace") is None
+
+
 def test_schema_required_violation_surfaces_error():
     """The repair must not fabricate a passing call when the tool's
     schema requires properties the repaired arguments cannot provide —

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2764,6 +2764,49 @@ def _scrub_tool_wire_literals(text: str | None) -> str:
     return re.sub(r"\s+", " ", result).strip()
 
 
+def _repair_forced_call_arguments(tool_calls, raw_text, target, tools):
+    """Repair parsed forced-call arguments that are not a JSON object.
+
+    The OpenAI function-calling wire requires ``arguments`` to be a JSON
+    OBJECT (serialized as a string). The forced-choice prefix hands the
+    model ``..."arguments": `` mid-envelope, and a weak continuation can
+    close the envelope with a bare scalar — seen live on
+    Qwen3.5-35B-A3B-8bit at temp 0 continuing with ``1`` (dogfood
+    2026-08-12), which the parser dutifully surfaces as
+    ``arguments="1"``. Every OpenAI client ``json.loads``\\ es that into
+    a non-dict and breaks. Mirror the synthesis fallback: recover an
+    object from the raw text when possible, else ``"{}"``, and hold the
+    result to the same #1256 schema gate.
+
+    Mutates repaired calls in place. Returns a schema-violation error
+    string (caller 422s) or ``None``.
+    """
+    for tc in tool_calls or []:
+        args = tc.function.arguments
+        if isinstance(args, dict):
+            continue
+        if isinstance(args, str):
+            try:
+                if isinstance(json.loads(args), dict):
+                    continue
+            except (ValueError, TypeError):
+                pass
+        recovered = _recover_partial_tool_args(raw_text, expected_name=target)
+        repaired = recovered if recovered is not None else "{}"
+        logger.warning(
+            "forced tool_choice call to %r carried non-object arguments %r; "
+            "repaired to %r (OpenAI wire requires an object)",
+            target,
+            args,
+            repaired,
+        )
+        tc.function.arguments = repaired
+        err = _forced_synth_schema_error(target, repaired, tools)
+        if err:
+            return err
+    return None
+
+
 def _synthesize_forced_tool_call(
     name: str, arguments: str = "{}", *, raw_text: str | None = None
 ):
@@ -5578,6 +5621,20 @@ async def _create_chat_completion_impl(
                             "retry with a more direct user message."
                         ),
                     )
+                elif _names:
+                    # Every emitted call names the target, but the wire
+                    # can still be garbage INSIDE the envelope — repair
+                    # non-object arguments to the synthesis fallback's
+                    # semantics (dogfood 2026-08-12: 35B answered the
+                    # forced hermes prefix with a bare ``1``).
+                    _repair_err = _repair_forced_call_arguments(
+                        tool_calls,
+                        output.raw_text or output.text,
+                        _target,
+                        request.tools,
+                    )
+                    if _repair_err:
+                        raise HTTPException(status_code=422, detail=_repair_err)
 
     # Validate tool call parameter values against schemas
     if tool_calls and request.tools:
@@ -6580,7 +6637,6 @@ async def stream_chat_completion(
         if (
             not fallback_tool_calls
             and processor._tool_calls_emitted_to_wire == 0
-            and not processor.tool_calls_detected
             and request.tools
             and request.tool_choice is not None
         ):
@@ -6604,6 +6660,22 @@ async def stream_chat_completion(
                 _raw_text = (
                     processor.tool_accumulated_text or processor.accumulated_text or ""
                 )
+            if _synth_target and processor.tool_calls_detected:
+                # Detected-but-unemitted (codex r1 MAJOR on PR #948 kept
+                # this OFF unconditionally): the parser saw a tool-call
+                # shape but shipped zero deltas. When the wire text names
+                # a DIFFERENT tool, synthesizing would silently replace
+                # the model's intended call — keep refusing (mirrors the
+                # non-stream ``_mismatched`` 422). But when the wire
+                # names exactly the PINNED target, the model attempted
+                # THE forced call with an unusable body (dogfood
+                # 2026-08-12: hermes ``"arguments": 1`` on 35B streams
+                # zero deltas) — synthesis then REPAIRS the same call,
+                # matching the non-stream arguments-repair path.
+                _first_name = re.search(r'"name"\s*:\s*"([^"]*)"', _raw_text or "")
+                if not _first_name or _first_name.group(1) != _synth_target:
+                    _synth_target = None
+            if _synth_target:
                 _synth_call = _synthesize_forced_tool_call(
                     _synth_target, raw_text=_raw_text
                 )

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -6732,11 +6732,14 @@ async def stream_chat_completion(
                 # regexing raw text: JSON decoding handles escaped
                 # names (codex r2 — a regex over literals could be
                 # evaded), and prose outside envelopes can no longer
-                # contribute matches. Any envelope that fails to decode,
-                # or names a different tool, refuses (the conservative
-                # pre-fix behavior).
+                # contribute matches. EXACTLY ONE envelope naming the
+                # target is required: synthesis emits a single call, so
+                # multiple attempted envelopes would silently collapse
+                # into one (codex r4); anything undecodable or
+                # differently-named refuses (the conservative pre-fix
+                # behavior).
                 _wire_names = _wire_envelope_names(_raw_text or "")
-                if not _wire_names or any(n != _synth_target for n in _wire_names):
+                if len(_wire_names or []) != 1 or _wire_names[0] != _synth_target:
                     _synth_target = None
             if _synth_target:
                 _synth_call = _synthesize_forced_tool_call(

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2781,24 +2781,45 @@ def _repair_forced_call_arguments(tool_calls, raw_text, target, tools):
     Mutates repaired calls in place. Returns a schema-violation error
     string (caller 422s) or ``None``.
     """
-    for tc in tool_calls or []:
-        args = tc.function.arguments
+
+    def _is_object_args(args) -> bool:
         if isinstance(args, dict):
-            continue
+            return True
         if isinstance(args, str):
             try:
-                if isinstance(json.loads(args), dict):
-                    continue
+                return isinstance(json.loads(args), dict)
             except (ValueError, TypeError):
-                pass
-        recovered = _recover_partial_tool_args(raw_text, expected_name=target)
-        repaired = recovered if recovered is not None else "{}"
+                return False
+        return False
+
+    broken = [
+        tc for tc in tool_calls or [] if not _is_object_args(tc.function.arguments)
+    ]
+    if not broken:
+        return None
+    # Raw-text recovery is only unambiguous for a SINGLE broken call —
+    # with several, they would all receive the same first recovered
+    # object, silently corrupting the later calls (codex r2). Ambiguous
+    # cases repair to "{}".
+    recovered = (
+        _recover_partial_tool_args(raw_text, expected_name=target)
+        if len(broken) == 1
+        else None
+    )
+    repaired = recovered if recovered is not None else "{}"
+    for tc in broken:
+        # Log shape only — tool arguments can carry user data / secrets
+        # and must not persist in production logs (codex r2).
         logger.warning(
-            "forced tool_choice call to %r carried non-object arguments %r; "
-            "repaired to %r (OpenAI wire requires an object)",
+            "forced tool_choice call to %r carried non-object arguments "
+            "(type=%s, len=%s); repaired to %s (OpenAI wire requires an "
+            "object)",
             target,
-            args,
-            repaired,
+            type(tc.function.arguments).__name__,
+            len(tc.function.arguments)
+            if isinstance(tc.function.arguments, str)
+            else "-",
+            "recovered object" if recovered is not None else '"{}"',
         )
         tc.function.arguments = repaired
         err = _forced_synth_schema_error(target, repaired, tools)
@@ -6672,8 +6693,14 @@ async def stream_chat_completion(
                 # 2026-08-12: hermes ``"arguments": 1`` on 35B streams
                 # zero deltas) — synthesis then REPAIRS the same call,
                 # matching the non-stream arguments-repair path.
-                _first_name = re.search(r'"name"\s*:\s*"([^"]*)"', _raw_text or "")
-                if not _first_name or _first_name.group(1) != _synth_target:
+                # ALL wire-shaped name literals must match the pinned
+                # target — the first-match form was bypassable by prose
+                # mentioning the target ahead of a real call to a
+                # different tool (codex r2). Any different name refuses
+                # (the conservative pre-fix behavior); prose that only
+                # repeats the target adds equal matches and stays safe.
+                _wire_names = re.findall(r'"name"\s*:\s*"([^"]*)"', _raw_text or "")
+                if not _wire_names or any(n != _synth_target for n in _wire_names):
                     _synth_target = None
             if _synth_target:
                 _synth_call = _synthesize_forced_tool_call(

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2764,6 +2764,36 @@ def _scrub_tool_wire_literals(text: str | None) -> str:
     return re.sub(r"\s+", " ", result).strip()
 
 
+def _wire_envelope_names(raw_text: str) -> list[str] | None:
+    """Decode the ``name`` fields of ``<tool_call>`` envelope bodies.
+
+    Used by the streaming detected-but-unemitted synthesis gate: JSON
+    decoding (not a literal regex) so escaped names cannot evade the
+    mismatch check, and prose OUTSIDE envelopes contributes nothing.
+    Returns ``None`` when any envelope body fails to decode — unknown
+    content must refuse synthesis, never permit it.
+    """
+    names: list[str] = []
+    for chunk in raw_text.split("<tool_call>")[1:]:
+        body = chunk.split("</tool_call>")[0].strip()
+        obj = None
+        try:
+            obj = json.loads(body)
+        except ValueError:
+            # Tolerate a stream cut after the closing brace (missing
+            # closer): retry up to the last balanced brace.
+            end = body.rfind("}")
+            if end >= 0:
+                try:
+                    obj = json.loads(body[: end + 1])
+                except ValueError:
+                    obj = None
+        if not isinstance(obj, dict):
+            return None
+        names.append(str(obj.get("name")))
+    return names
+
+
 def _repair_forced_call_arguments(tool_calls, raw_text, target, tools):
     """Repair parsed forced-call arguments that are not a JSON object.
 
@@ -6693,13 +6723,14 @@ async def stream_chat_completion(
                 # 2026-08-12: hermes ``"arguments": 1`` on 35B streams
                 # zero deltas) — synthesis then REPAIRS the same call,
                 # matching the non-stream arguments-repair path.
-                # ALL wire-shaped name literals must match the pinned
-                # target — the first-match form was bypassable by prose
-                # mentioning the target ahead of a real call to a
-                # different tool (codex r2). Any different name refuses
-                # (the conservative pre-fix behavior); prose that only
-                # repeats the target adds equal matches and stays safe.
-                _wire_names = re.findall(r'"name"\s*:\s*"([^"]*)"', _raw_text or "")
+                # Decode names from the tool-call ENVELOPES rather than
+                # regexing raw text: JSON decoding handles escaped
+                # names (codex r2 — a regex over literals could be
+                # evaded), and prose outside envelopes can no longer
+                # contribute matches. Any envelope that fails to decode,
+                # or names a different tool, refuses (the conservative
+                # pre-fix behavior).
+                _wire_names = _wire_envelope_names(_raw_text or "")
                 if not _wire_names or any(n != _synth_target for n in _wire_names):
                     _synth_target = None
             if _synth_target:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2812,28 +2812,33 @@ def _repair_forced_call_arguments(tool_calls, raw_text, target, tools):
     string (caller 422s) or ``None``.
     """
 
-    def _is_object_args(args) -> bool:
+    broken = []
+    for tc in tool_calls or []:
+        args = tc.function.arguments
         if isinstance(args, dict):
-            return True
+            # Content is a valid object — normalize the SHAPE to the
+            # OpenAI wire (arguments is a JSON-encoded string), never
+            # discard it (codex r3 on #1880).
+            tc.function.arguments = json.dumps(args)
+            continue
         if isinstance(args, str):
             try:
-                return isinstance(json.loads(args), dict)
+                if isinstance(json.loads(args), dict):
+                    continue
             except (ValueError, TypeError):
-                return False
-        return False
-
-    broken = [
-        tc for tc in tool_calls or [] if not _is_object_args(tc.function.arguments)
-    ]
+                pass
+        broken.append(tc)
     if not broken:
         return None
-    # Raw-text recovery is only unambiguous for a SINGLE broken call —
-    # with several, they would all receive the same first recovered
-    # object, silently corrupting the later calls (codex r2). Ambiguous
-    # cases repair to "{}".
+    # Raw-text recovery is only unambiguous when the broken call is the
+    # ONLY call in the turn: with several broken they would all receive
+    # the same first recovered object (codex r2), and with a broken call
+    # NEXT TO valid ones the recovery would lift a VALID call's
+    # arguments into the broken one (codex r3). Ambiguous cases repair
+    # to "{}".
     recovered = (
         _recover_partial_tool_args(raw_text, expected_name=target)
-        if len(broken) == 1
+        if len(broken) == 1 and len(tool_calls or []) == 1
         else None
     )
     repaired = recovered if recovered is not None else "{}"


### PR DESCRIPTION
## Why

Post-merge dogfood (2026-08-12) on Qwen3.5-35B-A3B-8bit / hermes: a forced `tool_choice` (named function) returned `"arguments": "1"` — the injected prefix `..."arguments": ` was continued by the model with a bare scalar at temp 0. Reproduced 3/3 deterministically, and identically on pre-merge main (pre-existing, not from #1866/#1874/#1878). The OpenAI function-calling wire requires `arguments` to be a JSON object; every client `json.loads`es a non-dict and breaks.

## What

1. **Non-stream**: new `_repair_forced_call_arguments` — when every emitted call names the pinned target but carries non-object arguments, repair to the #571 synthesis fallback's semantics (recover an object from raw text, else `"{}"`), then hold the result to the #1256 schema gate (422 on `required` violations). Wrong-name calls keep the existing 422.
2. **Stream**: the #447 streaming-parity synthesis was gated OFF whenever `tool_calls_detected=True` (PR #948 guard against replacing a *different* tool's call) — but the hermes streaming state machine emits **zero deltas** for the unusable body, leaving the turn empty. Relaxed precisely: synthesis fires when the wire text names exactly the pinned target (repairing THE forced call); any other name still refuses, so the #948 guard test stays green.

## Testing

- Live 3/3: `scripts/l1_toolcall_check.py` on 35B went FAIL(non-stream) → FAIL(stream) → **PASS(both)** across the two halves of the fix; gpt-oss-20b harmony path unchanged (PASS).
- 123 forced-choice unit tests green (447 / 1256 / enforcement suites + 5 new repair tests incl. the #1256 required-schema surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)