### PR TITLE
fix(prefix-cache): keep per-layer cache class when trimming hybrid sliding/full KV (#1863)

### DIFF
--- a/tests/test_sliding_window_prefix_reuse.py
+++ b/tests/test_sliding_window_prefix_reuse.py
@@ -363,3 +363,173 @@ def test_fix_preserves_kvcache_reuse_and_rotated_skip():
     assert rot.is_trimmable() is False
     assert _layer_forbids_trim(rot) is True
     assert _cache_has_non_trimmable([KVCache(), rot]) is True
+
+
+# ---------------------------------------------------------------------------
+# Hybrid sliding/full per-layer TYPE STABILITY across a trimming fetch
+# ---------------------------------------------------------------------------
+# Regression coverage for the batched-generation crash on hybrid
+# sliding/full-attention models (Muse-Glimmer-30B: 52 layers,
+# ``[sliding, sliding, sliding, full]`` repeating). ``_trim_cache_offset``
+# rebuilt EVERY keys/offset layer as a plain ``KVCache``, so a trim-requiring
+# fetch (supersequence-with-excess / LCP) returned a uniform ``KVCache`` list
+# for a mixed model. mlx-lm then merged those into a uniform ``BatchKVCache``,
+# and extending that batch against a correctly-typed one
+# (``BatchRotatingKVCache`` on the sliding layers) raised
+# ``AttributeError: 'BatchKVCache' object has no attribute 'rotated'``.
+#
+# The tests above already prove the ROTATED case is refused. These cover the
+# UNROTATED case, which is what actually shipped broken: the rotation gate
+# passes it, so the trim helper must preserve the class.
+
+_HYBRID_LAYER_TYPES = ["sliding", "sliding", "sliding", "full"] * 3
+
+
+def _make_hybrid_cache(n_tokens: int, window: int = W):
+    """A Muse-Glimmer-shaped mixed cache with ``n_tokens`` pushed through."""
+    caches = [
+        RotatingKVCache(max_size=window, keep=0) if t == "sliding" else KVCache()
+        for t in _HYBRID_LAYER_TYPES
+    ]
+    for c in caches:
+        x = mx.random.normal((B, H, n_tokens, D))
+        c.update_and_fetch(x, x)
+        mx.eval(c.keys, c.values)
+    return caches
+
+
+def test_trim_preserves_hybrid_per_layer_cache_types():
+    """An UNROTATED hybrid cache keeps its per-layer classes across a trim."""
+    from vllm_mlx.memory_cache import _trim_cache_offset
+
+    cache = _make_hybrid_cache(n_tokens=8)
+    before = [type(c).__name__ for c in cache]
+    assert set(before) == {"RotatingKVCache", "KVCache"}, "fixture is not mixed"
+
+    trimmed = _trim_cache_offset(cache, 2)
+    assert trimmed is not None, "unrotated hybrid cache should be trimmable"
+    assert [type(c).__name__ for c in trimmed] == before
+
+    for original, tc in zip(cache, trimmed):
+        assert tc.offset == 6
+        if isinstance(tc, RotatingKVCache):
+            # Sliding-window identity AND the ring write cursor must survive:
+            # a stale ``_idx`` would append the continuation at the wrong slot.
+            assert tc.max_size == original.max_size
+            assert tc.keep == original.keep
+            assert tc._idx == 6
+
+
+def test_trim_does_not_mutate_the_retained_hybrid_entry():
+    """Trimming returns copies — the cached entry stays reusable at full length."""
+    from vllm_mlx.memory_cache import _trim_cache_offset
+
+    cache = _make_hybrid_cache(n_tokens=8)
+    assert _trim_cache_offset(cache, 2) is not None
+    for c in cache:
+        assert c.offset == 8
+        if isinstance(c, RotatingKVCache):
+            assert c._idx == 8
+
+
+def test_trimmed_hybrid_cache_merges_to_same_batch_types_as_fresh():
+    """HIT and MISS paths must agree per layer, or ``_extend_cache`` crashes.
+
+    This is the assertion that fails with the pre-fix helper: the restored
+    (trimmed) side merged to ``BatchKVCache`` on the sliding layers while a
+    fresh sequence merged to ``BatchRotatingKVCache``, and ``extend`` then read
+    ``other.rotated`` off a cache that has no such attribute.
+    """
+    from vllm_mlx.memory_cache import _trim_cache_offset
+
+    restored = _trim_cache_offset(_make_hybrid_cache(n_tokens=8), 2)
+    assert restored is not None
+    fresh = [
+        RotatingKVCache(max_size=W, keep=0) if t == "sliding" else KVCache()
+        for t in _HYBRID_LAYER_TYPES
+    ]
+
+    restored_batch = [type(c).merge([c]) for c in restored]
+    fresh_batch = [type(c).merge([c]) for c in fresh]
+    assert [type(c).__name__ for c in restored_batch] == [
+        type(c).__name__ for c in fresh_batch
+    ]
+    # The crash was an AttributeError, so assert the attribute is really there
+    # rather than trusting the class name alone.
+    for a, b in zip(restored_batch, fresh_batch):
+        assert hasattr(a, "rotated") == hasattr(b, "rotated")
+
+
+def test_rotated_hybrid_cache_is_refused_rather_than_mistyped():
+    """Once the ring wraps, refuse the trim — never silently downgrade the type.
+
+    Returning a plain ``KVCache`` here would stop the crash but corrupt the
+    sliding layers' KV, which is the failure mode this fix must NOT trade into.
+    """
+    from vllm_mlx.memory_cache import _trim_cache_offset
+
+    rotated = _make_hybrid_cache(n_tokens=W + 8)
+    assert any(
+        isinstance(c, RotatingKVCache) and not c.is_trimmable() for c in rotated
+    ), "fixture did not actually rotate"
+    assert _trim_cache_offset(rotated, 2) is None
+
+
+def test_trim_offset_plain_kvcache_path_unchanged():
+    """Full-attention-only models keep their previous behaviour exactly."""
+    from vllm_mlx.memory_cache import _trim_cache_offset
+
+    plain = []
+    for _ in range(4):
+        c = KVCache()
+        x = mx.random.normal((B, H, 10, D))
+        c.update_and_fetch(x, x)
+        mx.eval(c.keys, c.values)
+        plain.append(c)
+
+    trimmed = _trim_cache_offset(plain, 3)
+    assert trimmed is not None
+    assert all(type(c) is KVCache for c in trimmed)
+    assert all(c.offset == 7 for c in trimmed)
+    assert all(c.offset == 10 for c in plain)
+
+
+def test_trim_scope_is_limited_to_rotating_layers():
+    """The #1863 fix must not change behaviour for any OTHER cache class.
+
+    ``_trim_cache_offset``'s duck-typed branch accepts anything exposing
+    non-list ``keys`` + ``offset``. A "has a trim() method" test would have
+    silently re-routed ``ChunkedKVCache``, ``ConcatenateKVCache`` and the
+    quantized ``_QuantizableKVCache`` through the class-preserving path too —
+    classes whose semantics this helper has never applied (and which
+    ``_TRIM_UNSAFE_CACHE_CLASSES`` / the quantization normalizer handle
+    separately). Pin the narrow scope so a future refactor can't widen it.
+    """
+    from mlx_lm.models.cache import ChunkedKVCache
+
+    from vllm_mlx.memory_cache import _trim_cache_offset
+    from vllm_mlx.quantized_batch_cache import _QuantizableKVCache
+
+    def _filled(layer, n=8):
+        x = mx.random.normal((B, H, n, D))
+        layer.update_and_fetch(x, x)
+        mx.eval(layer.keys, layer.values)
+        return layer
+
+    # Rotating -> preserved (the fix).
+    out = _trim_cache_offset([_filled(RotatingKVCache(max_size=64, keep=0))], 2)
+    assert out is not None and type(out[0]) is RotatingKVCache
+
+    # Everything else -> still rebuilt as a plain KVCache, exactly as before.
+    for layer in (
+        KVCache(),
+        ChunkedKVCache(chunk_size=256),
+        _QuantizableKVCache(64, 8),
+    ):
+        out = _trim_cache_offset([_filled(layer)], 2)
+        assert out is not None, f"{type(layer).__name__} unexpectedly refused"
+        assert type(out[0]) is KVCache, (
+            f"{type(layer).__name__} was re-routed off the legacy rebuild path — "
+            "the fix's scope widened beyond RotatingKVCache"
+        )
+        assert out[0].offset == 6

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1218,7 +1218,7 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
     (keys/values are 3-tuples of arrays). Returns ``None`` when a DeepSeek V4
     wrapper's nested pooling state cannot rewind by exactly ``trim_by`` tokens.
     """
-    from mlx_lm.models.cache import KVCache
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
 
     try:
         from mlx_lm.models.cache import QuantizedKVCache
@@ -1265,6 +1265,32 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
             return None
         return tc if trim(trim_by) == trim_by else None
 
+    def trim_rotating(layer: RotatingKVCache) -> RotatingKVCache | None:
+        """Rewind a ``RotatingKVCache`` via its OWN ``trim``, keeping its class.
+
+        A sliding-window layer carries bookkeeping beyond ``offset``
+        (``max_size`` / ``keep`` / the ring write cursor ``_idx``), and its
+        ``trim`` moves that cursor in lockstep with ``offset``. Rebuilding it as
+        a plain ``KVCache`` would both drop the sliding-window identity (the
+        layer would later merge into a ``BatchKVCache`` instead of a
+        ``BatchRotatingKVCache`` — the #1863 crash) and leave the cursor stale,
+        so delegate instead of reconstructing.
+
+        ``is_trimmable()`` is rotation-aware: it reports False once the ring has
+        wrapped and the front of the window has been overwritten, at which point
+        no offset arithmetic can reconstruct the shorter prefix. Both call sites
+        already refuse such an entry via ``_layer_forbids_trim`` before reaching
+        here, so this check is defense-in-depth for a future caller — refusing
+        (``None``) makes the caller fall back to a correct full prefill.
+        """
+        if not layer.is_trimmable():
+            return None
+        # Shallow copy: keys/values are immutable MLX arrays that can be
+        # shared, while the scalar bookkeeping we mutate below must NOT be
+        # written back into the retained cache entry.
+        tc = copy.copy(layer)
+        return tc if tc.trim(trim_by) == trim_by else None
+
     trimmed: list[Any] = []
     for layer_cache in cache:
         if layer_cache is None:
@@ -1288,11 +1314,30 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any] | None:
             and hasattr(layer_cache, "keys")
             and not isinstance(layer_cache.keys, (list, tuple))
         ):
-            tc = KVCache.__new__(KVCache)
-            tc.keys = layer_cache.keys
-            tc.values = layer_cache.values
-            tc.offset = max(layer_cache.offset - trim_by, 0)
-            trimmed.append(tc)
+            # Sliding-window layers are the ONLY class routed away from the
+            # rebuild below (#1863). Deliberately narrow: a duck-typed "has a
+            # trim() method" test would also capture ``ChunkedKVCache`` /
+            # ``ConcatenateKVCache`` / the quantized ``_QuantizableKVCache``,
+            # whose semantics this function has never applied and which the
+            # trim-liar denylist above handles separately. ``isinstance`` (not
+            # an exact type check) mirrors how ``mlx_lm.generate._make_cache``
+            # dispatches a layer to ``BatchRotatingKVCache``, so any vendored
+            # subclass that batches as rotating is trimmed as rotating too.
+            if isinstance(layer_cache, RotatingKVCache):
+                tc = trim_rotating(layer_cache)
+                if tc is None:
+                    return None
+                trimmed.append(tc)
+            else:
+                # Plain full-attention ``KVCache`` (append-only, so ``offset``
+                # alone governs the reusable length) and every other duck-typed
+                # keys/offset layer. Rebuilt directly, sharing the immutable
+                # key/value arrays — behaviour unchanged from before #1863.
+                tc = KVCache.__new__(KVCache)
+                tc.keys = layer_cache.keys
+                tc.values = layer_cache.values
+                tc.offset = max(layer_cache.offset - trim_by, 0)
+                trimmed.append(tc)
         else:
             if has_deepseek_pooling(layer_cache):
                 # DeepSeek pooling state must rewind with the local KV state;


### PR DESCRIPTION
## What does this PR do?

Fixes a crash that aborted every request in `rapid-mlx bench muse-glimmer-30b-4bit` at default concurrency:

```
AttributeError: 'BatchKVCache' object has no attribute 'rotated'
```

On hybrid sliding/full-attention models, a prefix-cache hit that required *trimming* rebuilt **every** KV layer as a plain `KVCache` — including the sliding-window layers, which must stay `RotatingKVCache`. mlx-lm then merged that uniform list into a uniform `BatchKVCache`, and extending it against a correctly-typed batch (`BatchRotatingKVCache` on the sliding layers) read `.rotated` off a cache that has no such attribute.

The crash was the *lucky* outcome. The same mistyping also discarded the ring buffer's `max_size` / `keep` / write-cursor `_idx`, so on a rotated window the old code returned a cache that looked usable and was quietly wrong.

### Root cause

`vllm_mlx/memory_cache.py: _trim_cache_offset()` rewinds a cached KV state by `trim_by` tokens so the tail is recomputed rather than duplicated. Its duck-typed branch matched any layer exposing non-list `.keys` plus `.offset`, then hard-coded the reconstruction:

```python
elif hasattr(layer_cache, "offset") and hasattr(layer_cache, "keys") and not isinstance(layer_cache.keys, (list, tuple)):
    tc = KVCache.__new__(KVCache)                       # <-- class discarded
    tc.keys = layer_cache.keys
    tc.values = layer_cache.values
    tc.offset = max(layer_cache.offset - trim_by, 0)    # <-- _idx never moved
```

`RotatingKVCache` satisfies that predicate, so on Muse-Glimmer-30B (52 layers, `[sliding, sliding, sliding, full]` repeating, `sliding_window=2048`) a stored `[Rot, Rot, Rot, KV] × 13` came back as `KVCache × 52`.

Chain confirmed by instrumenting the live run:

1. `_make_new_cache` → correct `[Rot×3, KV] × 13` ✅
2. `extract_cache` / `store()` → correct mixed list ✅
3. **`fetch()` → `KVCache × 52`** ❌ ← the defect
4. Scheduler passes that to `insert_segments(caches=[...])`
5. `_merge_caches` calls `caches[0][i].merge(...)`, so `KVCache.merge` → `BatchKVCache` *on a sliding layer*
6. `PromptProcessingBatch.extend` → `_extend_cache` pairs it against a correctly-typed batch → `AttributeError`

Two notes for anyone who looked at this earlier:

- **The corruption is on `fetch`, not `store`.** The first `store()` calls in a run are correctly mixed; the *later* uniform stores are downstream fallout — a poisoned fetch gets inserted, generated from, then re-extracted and re-stored. That also explains the "same uid extracted twice, second one wrong" symptom, so no dedup guard was needed in `_snapshot_promoted_prompts`.
- **Only the trimming reuse paths are affected** (LCP / supersequence-with-excess). That is why `bench` reproduces and `serve` never did: bench's ten prompts are `"Write a short poem about {topic}."` — a shared prefix with a divergent tail, i.e. an LCP-with-excess match. The plain prefix-match path uses `copy.deepcopy` and preserves classes. It was never about concurrency, threading, or `AsyncEngineCore` vs `BatchedEngine`; `--max-num-seqs 1` only avoided the batch merge that surfaces the mistyping.

### The fix

`_trim_cache_offset` now keeps a layer's class and delegates the rewind to that class's own `trim()`:

- **Plain `KVCache`** — unchanged. Append-only, so `offset` alone governs the reusable length; still rebuilt directly, sharing the immutable key/value arrays.
- **`RotatingKVCache`** — shallow-copied so class, `max_size`, `keep` and `_idx` survive, then rewound via its own `trim()`, which moves `_idx` in lockstep with `offset`. Guarded by `is_trimmable()` first and an exact-amount check (`trim(trim_by) == trim_by`) after — the convention the neighbouring `trim_wrapper_exact` already uses. Either guard failing returns `None`, which callers already treat as "skip reuse, full prefill".
- **Every other layer** — unchanged legacy rebuild.

**The predicate is deliberately narrow.** It tests `isinstance(layer, RotatingKVCache)`, *not* a duck-typed "exposes a `trim()` method". The duck-typed form would also have captured `ChunkedKVCache`, `ConcatenateKVCache` and the quantized `_QuantizableKVCache` — classes whose semantics this helper has never applied, and which `_TRIM_UNSAFE_CACHE_CLASSES` and `normalize_caches_for_quantization` handle separately. That would be silent scope creep in a bug fix, and it cuts against the convention this codebase states repeatedly (`install_quantized_batch_cache`: *"Only exact top-level `KVCache` layers are swapped"*; `singleton_cache_fastpath`: *"Exact types only — subclasses (e.g. the quantized `_QuantizableKVCache`) carry semantics their `merge()` must apply"*). `test_trim_scope_is_limited_to_rotating_layers` pins the scope so a future refactor can't widen it.

`isinstance` rather than an exact `type(...) is` check is intentional: it mirrors how `mlx_lm.generate._make_cache` dispatches a layer to `BatchRotatingKVCache`, so a vendored rotating subclass is trimmed as rotating too — precisely the property whose absence caused this bug.

**Performance — no measurable cost, and none on other workloads.** `_trim_cache_offset` runs once per request admission (only on the two trim-requiring match paths), never per token. Measured on an M2 Max the branch predicate is ~20 ns/layer, ≈1 µs across all 52 layers of a fetch. Full-attention, KV-quantized and chunked workloads take byte-identical paths to before this change. The new `is_trimmable()` refusal also costs no cache hit that was previously served: both call sites already reject a rotated entry via `_layer_forbids_trim` *before* reaching this helper, so that check is defense-in-depth for a future caller rather than a new gate. End-to-end, `bench muse-glimmer-30b-4bit` measures 38.94 tok/s with the narrowed predicate vs 38.71 / 38.81 / 38.69 before it (same interpreter).

The shallow copy matters both ways: MLX arrays are immutable and can be shared, but the scalar bookkeeping we rewind must not be written back into the retained entry, which stays reusable at full length.

**Why not stub `.rotated` on `BatchKVCache`:** that would stop the traceback and merge a genuinely rotating sliding-window cache with one that never rotated — trading a loud crash for silently wrong output. This removes the mistyping instead, so the HIT path reconstructs the *same* per-layer batch types as the MISS path and `_extend_cache` only ever pairs like with like.

Correctness of the reuse rests on `RotatingKVCache.is_trimmable()` (`offset < max_size`), which is rotation-aware: once the ring wraps the front of the window is overwritten and no offset arithmetic can reconstruct a shorter prefix, so we refuse and fall back to a correct full prefill. Pre-fix that case returned a `KVCache` list — a real if unreported correctness bug, now covered by a test.

No change to `vllm_mlx/models/muse_glimmer.py` (its `make_cache()` was always right), and nothing patched in mlx-lm — the defect was entirely in how Rapid-MLX round-trips the cache.

## Why is this needed?

Fixes #1863 — `rapid-mlx bench muse-glimmer-30b-4bit` aborts every request at default concurrency and prints no results. The only workaround, `--max-num-seqs 1`, disables the batched generation the benchmark exists to measure, costing 1.8× throughput (21.65 → 38.81 tok/s).

Beyond the reported crash it also closes a silent-correctness hole: a rotated sliding-window entry was being reused with a mistyped, stale-cursor cache instead of being refused.

## AI assistance disclosure

Claude Code (Opus 5) did the investigation, the fix, and the tests; I directed the work and reviewed the result. Specifically:

- **`vllm_mlx/memory_cache.py`** — AI-written. The root cause was located by instrumenting a live `bench` run (per-layer cache-type logging on `fetch` / `store` / `extract_cache` / `_merge_caches` / `_extend_cache`), not by guessing; the instrumentation was throwaway and is not in this diff. An earlier, broader version of this change regressed two `CacheList` mock tests in `tests/test_memory_cache.py`, which is why the fix is scoped to layers that own a `trim` rather than to "everything that isn't `KVCache`".
- **`tests/test_sliding_window_prefix_reuse.py`** — AI-written. Verified as genuine regression guards by stashing the production change and confirming 3 of the 5 fail without it (the other 2 are unchanged-behaviour guards).

Verification I can speak to: reproduced the crash on an editable install before the change, confirmed the fixed run three times at default concurrency, and confirmed via the instrumented re-run that every fetch hit returns the correct mixed signature with zero `_extend_cache` mismatches.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

**Primary — the reported failure, at default concurrency (no `--max-num-seqs`):**

```
$ rapid-mlx bench muse-glimmer-30b-4bit
Results:
  Total time: 27.90s
  Prompts: 10
  Total tokens: 1080
  Tokens/second: 35.84
  Throughput: 38.71 tok/s
```

No `AttributeError`, no aborted requests. Repeated three times (38.71 / 38.81 / 38.69 tok/s) to rule out a flaky pass.

`--max-num-seqs 1` still works, and the comparison shows what the workaround cost:

| Configuration | Throughput | Total time |
|---|---|---|
| default concurrency (this PR) | **38.81 tok/s** | 27.83s |
| `--max-num-seqs 1` (old workaround) | 21.65 tok/s | 49.89s |

**Instrumented confirmation.** Re-run with per-layer type logging: every fetch hit returns `[Rot×3, KV] × 13`, with **0** `_extend_cache` type mismatches and **0** uniform-`KVCache` stores (pre-fix: uniform `KVCache × 52` from the first trimming fetch onward).

**Regression tests** added to `tests/test_sliding_window_prefix_reuse.py`, which previously covered only the *rotated/refused* cases and so missed the unrotated path that actually shipped broken:

| Test | Asserts |
|---|---|
| `test_trim_preserves_hybrid_per_layer_cache_types` | classes, `max_size`, `keep`, `offset`, `_idx` all survive a trim |
| `test_trim_does_not_mutate_the_retained_hybrid_entry` | the cached entry stays at full length |
| `test_trimmed_hybrid_cache_merges_to_same_batch_types_as_fresh` | HIT and MISS merge to identical batch types; `.rotated` presence matches |
| `test_rotated_hybrid_cache_is_refused_rather_than_mistyped` | a wrapped ring returns `None` instead of a downgraded type |
| `test_trim_offset_plain_kvcache_path_unchanged` | full-attention-only models behave exactly as before |

3 of the 5 fail on `main` and pass with the fix (verified by stashing the change); the other 2 are unchanged-behaviour guards.

**Suites:**
- `tests/test_sliding_window_prefix_reuse.py tests/test_memory_cache.py tests/test_turboquant.py tests/test_prefix_cache.py` — **148 passed**
- Full unit suite (with `.[test]` installed) — **17150 passed, 124 skipped, 0 failed**
- `ruff check` + `ruff format --check` on the changed files — clean

**`pr_validate` scorecard — FULL pipeline, every step run, no skips and no
opt-outs.** Unmodified `scripts.pr_validate.pr_validate 1881` against this PR at
its rebased head:

| step | status | detail | time |
|---|---|---|---:|
| `fetch` | PASS | 2 files, +221/−6 LOC, **blast=high** | 1.4s |
| `test_plan_check` | PASS | all 6 items checked | 0.0s |
| `cl_description_quality` | PASS | title + body rationale | 0.0s |
| `supply_chain` | PASS | 3 findings, all false positives (see below) | 0.0s |
| `test_env_check` | PASS | all 6 required test packages importable | 1.9s |
| `codex_review` | PASS | **no blocking issues** | 19.8s |
| `lint` | PASS | clean (2 files) | 0.1s |
| `targeted_tests` | PASS | 72 passed, incl. negative control | 2.0s |
| `full_unit` | PASS | **17327 passed, 0 failed**, 113 skipped, 6 xfailed | 3:39 |
| `stress_e2e_bench` | PASS | **matrix 4×3 PASSED** (detail below) | 22:11 |
| `diff_coverage` | PASS | **100% patch coverage, 16/16 changed lines** (advisory) | 5:14 |

### **Verdict: `MERGE-SAFE` (exit 0).**

**`stress_e2e_bench` — models actually exercised.** All four golden families were
selected on this host (no RAM override; the probe reported 48.1 GB free → 40.1 GB
usable, which admits the `ram_gb_required: 36` candidates, so **no 4-bit fallback
was used for the qwen families**):

| family | model | tier | stress | agents |
|---|---|---|---|---|
| qwen3.5 | `mlx-community/Qwen3.5-35B-A3B-8bit` | golden | 8/8 | Anthropic 5/5 · LangChain 6/6 · PydanticAI 6/6 |
| qwen3.6 | `unsloth/Qwen3.6-27B-MLX-8bit` | golden | 8/8 | Anthropic 5/5 · LangChain 6/6 · PydanticAI 6/6 |
| diffusion-gemma | `mlx-community/diffusiongemma-26B-A4B-it-4bit` | smoke | 8/8 | skipped per registry `skip_for_models` / `skip_for_smoke` |
| harmony | `mlx-community/gpt-oss-20b-MXFP4-Q8` | golden | 8/8 | Anthropic 5/5 · LangChain 6/6 · PydanticAI 6/6 |

Totals: **stress 4/4 pass**, **agents 9 pass + 3 skipped** (all three skips are the
registry's own `diffusiongemma` exclusions, not failures). The four bench entries
are recorded-only, not scored: `harness/baselines/` is captured on an Apple M3
Ultra and this host is an M2 Max, so the step correctly declines to grade cold/warm
ratios across different silicon (qwen3.5 cold=371ms warm=462ms; qwen3.6 894/1950;
diffusion-gemma 1834/2686; harmony 424/481).

**`codex_review` ran with `gpt-5.6-terra`, not the pinned `gpt-5.6-sol`.** The
pinned default is currently unusable on a ChatGPT-auth account — `codex exec`
returns `400 invalid_request_error: The 'gpt-5.6-sol' model is not supported when
using Codex with a ChatGPT account`, which persists across re-auth cycles and
appears to be an OpenAI-side provisioning/rollout gap rather than a local
misconfiguration. I used the documented `PR_VALIDATE_CODEX_MODEL` override with
`gpt-5.6-terra`, the same-generation sibling, which completed the review normally
and found no blocking issues. Worth noting the code comment at
`steps/codex_review.py` now asserts the opposite of current behaviour (it says the
bare `gpt-5.6` id is the one that 400s under ChatGPT auth and that `-sol` is
required); happy to file that separately.

**One flaky test observed, unrelated to this change.**
`tests/test_pr_validate_test_env.py::TestCheckTestEnv::test_reports_missing_module_on_broken_host`
failed once in a `full_unit` run, then passed on re-run (a subsequent full pipeline run came back clean: 17327 passed, 0 failed). It builds a throwaway venv
and shells out to `pip install pytest` inside it, so it depends on live PyPI
access: the failing attempt took 10.2s (cold fetch, `CalledProcessError` from
pip), the passing ones 2.5–4.0s (warm cache). I confirmed it is not
branch-related — same command, same branch: 1 fail / 2 pass; and it passes on the
base commit `afbd5d27` too. Flagging per CONTRIBUTING's "fails on main too"
guidance rather than papering over it; a network-dependent assertion in the unit
suite may be worth an `xfail`/marker upstream.

`supply_chain`'s three findings all flag `mx.eval(c.keys, c.values)` in the new
tests as `eval()`. That is MLX's array-materialisation call, not Python's
built-in `eval` — it's the idiom the rest of this test file already uses to force
evaluation before assertions. No untrusted data, no dynamic code execution.

Environment: macOS 26.5.2 (Darwin 25.5.0), Apple M2 Max 64 GB, mlx 0.31.2,
mlx-lm 0.31.3, **Python 3.12.9** (matching `mise.toml`'s `python = "3.12"` pin —
`stress_e2e_bench` shells out to a bare `python3.12`, so the validator needs a
3.12 environment with `.[test]` plus the agent SDKs installed).

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`) — 17327 passed, 0 failed
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1881` — **full pipeline, all 11 steps PASS, `MERGE-SAFE` (exit 0)**, including `stress_e2e_bench` (4×3 matrix) and `codex_review`. Scorecard in the test plan above.
- [x] If new tests touch a critical code path (parser / scheduler / security), I've spot-checked that they fail when the corresponding production line is broken (see SOP §Step 3)
- [x] Updated README/docs if applicable — n/a; corrected one now-stale in-file comment about `_trim_cache_offset`'s behaviour
- [x] No breaking changes to existing API
