### PR TITLE
chore: bump version to 0.12.11

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,34 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.11] — 2026-08-12
+
+A speed release. The engine underneath the app got a full tuning pass
+measured against every other way to run these models on a Mac, and it is
+now the fastest of them at answering several conversations at once —
+with single-conversation typing speed matched to the best of them too.
+
+### Changed
+
+- Several chats, agents, or tool calls running at the same time now share
+  the Mac far better. On a large mixture-of-experts model with eight
+  conversations in flight, total throughput went up about 40%; every
+  model size we measure now runs concurrent work faster than the
+  reference implementation rather than behind it.
+- A single conversation types out faster as well, including long ones —
+  the engine no longer pays for machinery it only needs when several
+  conversations are active.
+- Plain chats no longer carry the extra per-word processing that only
+  tool-using requests need.
+
+### Fixed
+
+- A tool call that the app asked a model to make could come back with
+  malformed arguments and either break the client reading it or, when
+  streaming, end the turn with nothing at all. Those calls are now
+  repaired to a valid shape, or reported clearly when the tool's own
+  requirements cannot be met.
+
 ## [0.12.10] — 2026-08-11
 
 Settings got a full visual refresh: every category now shares one design —

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.12.11</string>
 	<key>CFBundleVersion</key>
-	<string>154</string>
+	<string>155</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.10</string>
+	<string>0.12.11</string>
 	<key>CFBundleVersion</key>
 	<string>154</string>
 	<key>LSMinimumSystemVersion</key>

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -48,7 +48,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -48,7 +48,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -46,7 +46,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -48,7 +48,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -30,7 +30,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -30,7 +30,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -30,7 +30,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -30,7 +30,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -30,7 +30,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -48,7 +48,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
-      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> · up to date" help="Rapid-MLX <version> is the latest release. Click to open Settings → App." enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
     AXButton subrole=AXCloseButton enabled=true

--- a/apps/rapid-mac/scripts/ax-baseline.py
+++ b/apps/rapid-mac/scripts/ax-baseline.py
@@ -335,6 +335,25 @@ def quote(text: str) -> str:
     return json.dumps(text, ensure_ascii=False)
 
 
+# The footer version pill states its own version AND the updater's verdict
+# about it ("· up to date" / "· update X.Y.Z available" / bare when the
+# check is inconclusive), with the tooltip phrased around the same three
+# cases. That verdict compares the running build against the latest
+# PUBLISHED release — network state, not UI state — and it INVERTS on
+# every version-bump PR: the bumped app is newer than any release until
+# the release it is cutting exists, so the pill drops to its unknown
+# state and every baseline holding "up to date" goes red for no product
+# reason (first hit: the 0.12.11 bump).
+#
+# Collapsed by IDENTIFIER rather than by a text scrubber so the same
+# phrasing elsewhere — notably Settings → App, whose version line the
+# flows assert against separately — keeps its own value. What survives:
+# the pill exists, is a button, carries this identifier, is enabled. Its
+# three-state wording is covered by DesktopVersionPillTests.
+_UPDATE_VERDICT_IDS = frozenset({"Footer.DesktopVersionPill"})
+_UPDATE_VERDICT_TEXT = "Rapid-MLX <version> <update-state>"
+
+
 def render_node(node: Node, extra_tokens: tuple[str, ...]) -> str:
     record = node.record
     if is_gpu_telemetry(record):
@@ -380,12 +399,16 @@ def render_node(node: Node, extra_tokens: tuple[str, ...]) -> str:
     # — see the scope note at the top of the module; visible text belongs to
     # the PNG snapshots in Tests/RapidTests.
     description = record.get("description")
+    verdict_bearing = identifier in _UPDATE_VERDICT_IDS
     for key, label in (("title", "title"), ("description", "desc"), ("help", "help")):
         if key == "title" and description:
             continue
         text = record.get(key)
         if text:
-            parts.append(f"{label}={quote(scrub(text, extra_tokens))}")
+            value = (
+                _UPDATE_VERDICT_TEXT if verdict_bearing else scrub(text, extra_tokens)
+            )
+            parts.append(f"{label}={quote(value)}")
     kind = value_kind(record)
     if kind is not None:
         parts.append(f"value={kind}")

--- a/docs/release-notes/v0.12.11.md
+++ b/docs/release-notes/v0.12.11.md
@@ -1,0 +1,48 @@
+## Highlights
+
+A performance-focused release from a bench-driven tuning campaign against
+oMLX, mlx-lm, and Ollama on Apple Silicon (M3 Ultra), plus a tool-calling
+correctness fix found while dogfooding it.
+
+### Concurrent throughput: batched decode up 8–20%, flagship +41%
+
+- **Retired the hybrid admission throttle** (#1866). Requests arriving
+  together now prefill as one aligned wave instead of being staggered
+  200 ms apart — staggered admission kept mlx-lm's batched attention on
+  its array-mask slow path for the batch's whole lifetime.
+  Qwen3.6-35B-A3B-8bit at 8 concurrent streams: **190 → 268 aggregate
+  tok/s (+41%)**, now ahead of mlx-lm on every measured concurrency cell
+  (4B +20%, 9B +13%, gpt-oss +12%, 27B +8%, 35B +17%).
+- **Step coalescing under deep batches** (#1878). With ≥4 running
+  requests the engine runs up to 4 scheduler steps per dispatch, cutting
+  per-step executor round-trip and GIL contention overhead (~10 ms/step
+  at high aggregate rates). Finishes, pending admissions, and the
+  memory-pressure check cadence are all preserved.
+
+### Single-stream decode: oMLX parity
+
+- **Singleton KV-cache fast path** (#1874). A lone request keeps its
+  single-sequence KV cache (plain causal mask → `mx.fast` SDPA's native
+  fast path) instead of paying batched-form bookkeeping, promoting to
+  batched caches only when a second request joins.
+- **Dense-sampler fast path now engages at B=1** (#1874).
+- Net: B=1 scheduler step at oMLX parity — 4B 174.8 vs 175 tok/s at
+  short context, 147.5 vs 149 at 16k.
+
+### Tool calling
+
+- **Forced `tool_choice` calls always carry object arguments** (#1880).
+  A weak continuation of the forced-call prefix could produce a bare
+  scalar (`"arguments": "1"`) — shipped as-is on the non-stream path and
+  silently dropped as an empty turn on the streaming path. Both paths
+  now repair to the OpenAI wire contract, with schema-required
+  violations still surfacing explicitly, and per-request tool logits
+  processors are no longer constructed for plain-chat requests (#1878).
+
+### Reliability
+
+- Prefix-cache entries can no longer be corrupted by the new singleton
+  lane: loaned supersequence/LCP state is copied on admission (#1874).
+- Coalesced step errors deliver already-produced tokens before
+  surfacing, and admission-wave timing survives malformed tuning
+  env vars (#1866, #1878).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.10"
+version = "0.12.11"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_ax_baseline.py
+++ b/tests/test_ax_baseline.py
@@ -75,3 +75,63 @@ def test_system_sidebar_button_subtree_is_ignored(ax_baseline, description):
     assert ax_baseline.render(button, ()) == [
         f'AXButton desc="{description}" enabled=true'
     ]
+
+
+@pytest.mark.parametrize(
+    ("description", "help_text"),
+    [
+        (
+            "Rapid-MLX 0.12.10 · up to date",
+            "Rapid-MLX 0.12.10 is the latest release. Click to open Settings → App.",
+        ),
+        (
+            "Rapid-MLX 0.12.11",
+            "Rapid-MLX 0.12.11. Click to open Settings → App.",
+        ),
+        (
+            "Rapid-MLX 0.12.10 · update 0.13.0 available",
+            "Rapid-MLX 0.13.0 is available (you're on 0.12.10). Click to install.",
+        ),
+    ],
+)
+def test_version_pill_collapses_every_update_verdict(
+    ax_baseline, description, help_text
+):
+    """The footer pill states the updater's verdict, which compares the
+    running build against the latest PUBLISHED release. That inverts on
+    every version-bump PR — the bumped app is newer than any release
+    until the one it is cutting exists — so all three states must render
+    identically or the bump PR turns the golden flows red."""
+    pill = ax_baseline.Node(
+        {
+            "role": "AXButton",
+            "identifier": "Footer.DesktopVersionPill",
+            "description": description,
+            "help": help_text,
+            "enabled": True,
+        }
+    )
+
+    assert ax_baseline.render_node(pill, ()) == (
+        'AXButton id="Footer.DesktopVersionPill" '
+        'desc="Rapid-MLX <version> <update-state>" '
+        'help="Rapid-MLX <version> <update-state>" enabled=true'
+    )
+
+
+def test_version_text_elsewhere_keeps_its_wording(ax_baseline):
+    """Scoped by identifier, not by phrasing: Settings → App publishes the
+    same sentence and the flows assert the version it names."""
+    pane = ax_baseline.Node(
+        {
+            "role": "AXStaticText",
+            "identifier": "Settings.App.UpToDate",
+            "description": "Rapid-MLX 0.12.11 is the latest release.",
+            "enabled": True,
+        }
+    )
+
+    assert ax_baseline.render_node(pane, ()) == (
+        'AXStaticText id="Settings.App.UpToDate" '
+        'desc="Rapid-MLX <version> is the latest release." enabled=true'
+    )


### PR DESCRIPTION
## Why

Release 0.12.11 — cut the overnight bench-driven perf campaign to users: #1866 (admission-wave + throttle retirement, 35B conc_8 +41%), #1874 (singleton B=1 fast path + dense-sampler engage, oMLX parity), #1878 (step coalescing + has_tools gate), and #1880 (forced tool_choice arguments repair, found in post-merge dogfood). All four merged with multi-round pr_validate + stress matrix + live dogfood (35B/gpt-oss/gemma-4, coherence + tool-loop gates) — the release exists because these are validated and users should get them.

## What

- `pyproject.toml` 0.12.10 → 0.12.11
- `apps/rapid-mac/Resources/Info.plist` CFBundleShortVersionString 0.12.10 → 0.12.11 (version-coherence gate #1248: one product, one number)
- Curated notes in `docs/release-notes/v0.12.11.md`; fresh `unreleased.md` scratch recreated

🤖 Generated with [Claude Code](https://claude.com/claude-code)