### PR TITLE
fix(image-gen): detect partial unpinned mflux snapshots

### DIFF
--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1149,6 +1149,37 @@ def test_partial_mflux_snapshot_is_not_runnable(tmp_path, monkeypatch):
     assert gate._snapshot_is_complete_mflux_model(repo) is False
 
 
+def test_mflux_missing_weights_checks_single_partial_snapshot_without_ref(
+    tmp_path, monkeypatch
+):
+    """Interrupted first pulls can leave indexes before refs/main is written."""
+    cache_root = tmp_path / "hf-cache"
+    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    _seed_mflux_snapshot(repo_root, "e" * 40, omit=("text_encoder", "1.safetensors"))
+    (repo_root / "refs" / "main").unlink()
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.mflux_missing_weights(repo) == ["text_encoder/1.safetensors"]
+
+
+def test_mflux_missing_weights_no_verdict_for_multiple_unpinned_snapshots(
+    tmp_path, monkeypatch
+):
+    """Never let an old complete snapshot mask a newer partial snapshot."""
+    cache_root = tmp_path / "hf-cache"
+    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    _seed_mflux_snapshot(repo_root, "f" * 40)
+    _seed_mflux_snapshot(repo_root, "0" * 40, omit=("transformer", "0.safetensors"))
+    (repo_root / "refs" / "main").unlink()
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.mflux_missing_weights(repo) is None
+
+
 def test_mflux_missing_weights_names_the_absent_shard(tmp_path, monkeypatch):
     """The gate reports WHICH file is missing, so the error can be acted on."""
     cache_root = tmp_path / "hf-cache"

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -617,7 +617,32 @@ def mflux_missing_weights(repo_id: str) -> list[str] | None:
     )
     resolved_sha = _resolved_snapshot_sha(repo_root)
     if resolved_sha is None:
-        return None
+        # An interrupted first download can leave component indexes and
+        # shards behind before huggingface_hub commits refs/main.  With one
+        # mflux-shaped snapshot there is no ambiguity, so inspect it rather
+        # than letting the loader consume a partial checkpoint.  Never choose
+        # among multiple unpinned snapshots: an older complete snapshot could
+        # otherwise mask the interrupted one.
+        snapshots_root = os.path.join(repo_root, "snapshots")
+        try:
+            candidates = [
+                name
+                for name in os.listdir(snapshots_root)
+                if os.path.isdir(os.path.join(snapshots_root, name))
+            ]
+        except OSError:
+            return None
+        if len(candidates) != 1:
+            return None
+        candidate_dir = os.path.join(snapshots_root, candidates[0])
+        if not any(
+            os.path.lexists(
+                os.path.join(candidate_dir, component, "model.safetensors.index.json")
+            )
+            for component in ("transformer", "text_encoder", "vae")
+        ):
+            return None
+        resolved_sha = candidates[0]
     snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
     if not os.path.isdir(snap_dir):
         return None


### PR DESCRIPTION
## Summary

- inspect a lone mflux-shaped snapshot when an interrupted first Hugging Face download has not written `refs/main` yet
- keep the no-verdict behavior for zero or multiple unpinned snapshots, avoiding selection of a stale complete checkpoint
- cover both the interrupted-first-pull regression and the ambiguous multi-snapshot case

## Root cause

`mflux_missing_weights()` treated a missing `refs/main` as an empty cache. Hugging Face can create the snapshot and component indexes before committing that ref, so mflux was allowed to reuse incomplete local weights and could generate noise without an actionable error.

## Validation

- `179 passed` across download gate, image lane, image-gen serve completeness, and serve notice wiring tests
- `ruff check` passed
- `ruff format --check` passed after formatting
