### PR TITLE
fix(residency): make image/video models single-slot so they stop accumulating

### DIFF
--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -244,6 +244,60 @@ async def test_replacing_assistant_promotes_target_and_keeps_image_resident():
 
 
 @pytest.mark.asyncio
+async def test_second_image_model_evicts_the_first_without_an_explicit_group():
+    """Generative-media lanes are single-slot server-side.
+
+    The desktop loads image models with no ``replace_group`` (unlike the chat
+    picker's explicit ``assistant``). Image engines therefore only ever
+    accumulated — two multi-GB checkpoints resident at once (measured 9.1 GB).
+    A second image load must now evict the first even with no group supplied,
+    while the ``assistant`` group is left untouched — including a NON-primary
+    resident chat model, which (unlike the eviction-protected primary) would
+    actually disappear if media replacement leaked across groups.
+    """
+    registry = ModelRegistry()
+    primary = entry("chat")
+    registry.add(primary, is_default=True)
+    loaded: dict[str, FakeEngine] = {}
+
+    async def loader(name: str, path: str | None, performance=None):
+        engine = FakeImageEngine() if name.startswith("image") else FakeEngine()
+        loaded[name] = engine
+        return ModelEntry(
+            engine=engine,
+            model_name=name,
+            model_path=path or f"repo/{name}",
+        )
+
+    manager = ResidentModelManager(
+        registry,
+        loader,
+        memory_limit_bytes=50 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    # A second, NON-primary chat model in the assistant group. It has no
+    # independent eviction protection, so it is the real probe for cross-group
+    # isolation: if media replacement touched the assistant group it would be
+    # evicted here.
+    await manager.load("chat-2", estimated_bytes=4 * GIB)
+
+    await manager.load("image-a", estimated_bytes=5 * GIB)
+    await manager.load("image-b", estimated_bytes=5 * GIB)
+
+    ids = {item["id"] for item in manager.snapshot()["models"]}
+    # image-a evicted by image-b; both assistant-group models survive.
+    assert ids == {"chat", "chat-2", "image-b"}
+    assert loaded["image-a"].stopped is True
+    assert loaded["image-b"].stopped is False
+    assert loaded["chat-2"].stopped is False
+    assert "image-a" not in registry
+    assert "image-b" in registry
+    assert "chat-2" in registry
+
+
+@pytest.mark.asyncio
 async def test_failed_assistant_replacement_rolls_back_newly_loaded_model():
     manager, registry, loaded, _ = manager_fixture(limit_gib=20)
     registry.get_engine("chat").running = 1

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -179,6 +179,31 @@ def _replacement_group(entry: ModelEntry) -> str:
     return "assistant" if modality in {"text", "mllm"} else modality
 
 
+# Generative-media lanes hold multi-GB checkpoints and are driven one model at
+# a time, so they are inherently single-slot: loading another image/video model
+# should evict the previous one even when the client sends no ``replace_group``.
+# Text/VLM stay client-controlled through the explicit ``assistant`` group so
+# the chat picker's replacement semantics are unchanged. Without this, image
+# engines only ever accumulated (two resident image models measured at 9.1 GB).
+_SINGLE_SLOT_MEDIA_GROUPS = frozenset({"image-gen", "video-gen"})
+
+
+def _effective_replace_group(
+    entry: ModelEntry, replace_group: str | None
+) -> str | None:
+    """Resolve the replacement group to enforce for a just-touched model.
+
+    An explicit ``replace_group`` always wins. Otherwise a generative-media
+    entry derives its own single-slot group; everything else stays unmanaged
+    (``None``) so a bare text load never evicts a sibling.
+    """
+
+    if replace_group is not None:
+        return replace_group
+    derived = _replacement_group(entry)
+    return derived if derived in _SINGLE_SLOT_MEDIA_GROUPS else None
+
+
 def estimate_model_bytes(model_name: str) -> int:
     """Conservative fallback charge when the caller has no catalog estimate.
 
@@ -465,8 +490,9 @@ class ResidentModelManager:
                 record.last_used_at = self._clock()
                 if pin:
                     record.pinned = True
-                if replace_group is not None:
-                    await self._replace_group_locked(record, replace_group)
+                group = _effective_replace_group(record.entry, replace_group)
+                if group is not None:
+                    await self._replace_group_locked(record, group)
                 return record
 
             await self._evict_for_locked(estimate, exclude={model_name})
@@ -495,8 +521,9 @@ class ResidentModelManager:
 
             try:
                 await self._evict_for_locked(0, exclude={record.model_id})
-                if replace_group is not None:
-                    await self._replace_group_locked(record, replace_group)
+                group = _effective_replace_group(record.entry, replace_group)
+                if group is not None:
+                    await self._replace_group_locked(record, group)
             except BaseException:
                 # Once the loader returns, this manager owns the engine.  A
                 # later admission/replacement failure must not leave a model


### PR DESCRIPTION
## Why
Chat models replace each other through the explicit `assistant` lifecycle group, but image-generation models are loaded with **no** `replace_group`, so each new image engine was simply added and the previous one stayed resident. Two multi-GB image checkpoints piled up (**measured 9.1 GB**) with only the memory-pressure LRU as a backstop.

## What
Generative-media lanes hold multi-GB weights and are driven one model at a time, so they are inherently single-slot. Derive their replacement group **server-side**: when no explicit `replace_group` is supplied and the just-loaded model's modality is `image-gen`/`video-gen`, enforce its own group so loading a second one evicts the first (`_effective_replace_group`). Text/VLM stay client-controlled through the explicit `assistant` group — chat-picker semantics are unchanged. Reuses the existing `_replace_group_locked` evictor unchanged; no route-contract or GUI change needed.

## Tests
- `test_second_image_model_evicts_the_first_without_an_explicit_group` — two image models loaded with no group leave only the second resident (first's engine torn down) while a resident chat model in the `assistant` group is untouched. Fails on `main` (both accumulate).
- Full `tests/test_resident_models.py` green (17).

🤖 Investigated, implemented, and validated with Claude Code.