### PR TITLE
fix(desktop): stop the failed-update banner firing for dev builds under /Applications

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
@@ -141,8 +141,16 @@ final class InstallTracker {
         currentVersion: String,
         currentBundleURL: URL
     ) -> Bool {
-        let bundlePath = currentBundleURL.standardizedFileURL.path
-        guard bundlePath.hasPrefix("/Applications/") else {
+        // Only a bundle sitting DIRECTLY in /Applications is a Finder-Replace
+        // release install. `hasPrefix("/Applications/")` matched at any depth,
+        // so a dev build under a subdirectory
+        // (e.g. /Applications/RapidDev/Rapid-MLX Desktop.app) slipped through:
+        // rebuilds bump the Info.plist mtime while keeping the same version,
+        // which then read as a "failed replace" and flashed the banner. A
+        // parent-directory equality check keeps the sibling-prefix exclusion
+        // (/ApplicationsBackup/…) and adds the subdirectory one.
+        let bundleURL = currentBundleURL.standardizedFileURL
+        guard bundleURL.deletingLastPathComponent().path == "/Applications" else {
             return false
         }
         guard let previousMtime, let previousVersion, let currentMtime else {

--- a/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
@@ -134,6 +134,10 @@ struct InstallTrackerTests {
             "/Users/developer/DerivedData/Rapid-MLX Desktop.app",
             "/Volumes/Rapid-MLX/Rapid-MLX Desktop.app",
             "/ApplicationsBackup/Rapid-MLX Desktop.app",
+            // Dev build under a /Applications SUBdirectory: rebuilds bump the
+            // mtime while the version is unchanged, but this is not the
+            // canonical Finder-Replace install and must never flag.
+            "/Applications/RapidDev/Rapid-MLX Desktop.app",
         ]
     )
     func nonInstalledBundleNeverFlags(path: String) {


### PR DESCRIPTION
## Why
`InstallTracker.detect` gated the "An update attempt didn't take" banner on `bundlePath.hasPrefix("/Applications/")`, which matches at **any depth**. A dev build placed in a subdirectory (e.g. `/Applications/RapidDev/Rapid-MLX Desktop.app`) satisfied the prefix, so a rebuild that bumps the `Info.plist` mtime while keeping the same `CFBundleShortVersionString` read as a "failed Finder Replace" and flashed the banner on every launch.

## What
Tighten the location gate to a parent-directory equality check — `deletingLastPathComponent().path == "/Applications"` — so only a bundle sitting **directly** in `/Applications` (the canonical release install) qualifies. Reuses the exact idiom `InstallerTests` already uses, keeps the existing sibling-prefix exclusion (`/ApplicationsBackup/…`), and adds the subdirectory case.

## Tests
- Extends the parameterized `nonInstalledBundleNeverFlags` with `/Applications/RapidDev/Rapid-MLX Desktop.app` — fails on `main` (banner fires), passes after the fix. Happy-path cases (canonical `/Applications/Rapid-MLX Desktop.app` still flags a real failed replace) stay green.
- `swift test --filter InstallTrackerTests`: 14 tests pass locally.

🤖 Investigated, implemented, and validated with Claude Code.