### PR TITLE
ci(release): create the GitHub Release last, after the updater pointer

### DIFF
--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -23,11 +23,21 @@
 #   AC_API_ISSUER_ID             App Store Connect issuer id
 #   AC_API_KEY_P8_BASE64         base64 of the AuthKey_XXX.p8
 #
-#   Required for tagged releases (the "mirror-dist" job at the bottom):
+#   Required for tagged releases (the "mirror-dist" and
+#   "publish-updater-fallback" jobs at the bottom). NOTE: on a tag these are
+#   not optional in any sense — the GitHub Release is created by the LAST of
+#   those jobs, so without these no release is published at all. That is
+#   deliberate: a release that ships while its updater pointer does not is
+#   exactly #1851, and it survived three releases because the two could
+#   diverge.
 #   CLOUDFLARE_API_TOKEN         token scoped to Workers R2 Storage:Edit on
 #                                the distribution bucket and Zone Cache Purge
 #   CLOUDFLARE_ACCOUNT_ID        account id wrangler operates against
 #   CLOUDFLARE_ZONE_ID           zone id for purging dl.rapidmlx.com/latest.json
+#
+#   Presence and usability of all of the above are checked on the version-bump
+#   PR by the PF-2 gate in release-preflight.yml, so a missing or expired
+#   credential surfaces before the tag exists rather than after the build.
 #
 #   Required for tagged releases — as Actions
 #   VARIABLES (not secrets), since they are config, not credentials:
@@ -58,6 +68,11 @@ permissions:
 jobs:
   build:
     runs-on: macos-15   # default Xcode 16 → Swift 6.0 (Package.swift tools 6.0)
+    outputs:
+      # Published so the release-creating job can decide "--prerelease" without
+      # restating the secret expression below. Two copies of the same predicate
+      # would silently disagree the first time the signing secret set changes.
+      signed: ${{ steps.signing_state.outputs.signed }}
     defaults:
       run:
         # All script/shell steps run from the app directory so the
@@ -189,10 +204,49 @@ jobs:
           if [[ ! -s "$OUT" ]]; then
             echo "Release ${TAG:-<dispatch>} (no CHANGELOG.md section found)." > "$OUT"
           fi
+          # Unsigned build: this DMG is ad-hoc signed + un-notarised. macOS
+          # quarantines anything downloaded and Gatekeeper hard-blocks an
+          # un-notarised app ("damaged / can't be opened"), so the download
+          # won't just double-click — prepend the right-click / xattr
+          # workaround. Done HERE, while composing the notes, so the release
+          # body and the updater manifest's ``notes`` field are the same bytes.
+          # Previously the preamble was added at release-creation time only, so
+          # a reader of latest.json saw notes the release page did not.
+          if [[ "${SIGNED:-}" != "true" ]]; then
+            {
+              echo "> ⚠️ **Unsigned internal build.** This DMG is ad-hoc signed and NOT notarised."
+              echo "> macOS Gatekeeper will block it on first open. To run it:"
+              echo ">"
+              echo "> 1. Drag **Rapid-MLX Desktop** to Applications, then **right-click the app → Open** (once), or"
+              echo "> 2. \`xattr -dr com.apple.quarantine \"/Applications/Rapid-MLX Desktop.app\"\`"
+              echo ">"
+              echo "> A signed + notarised build that opens with a normal double-click will replace this once signing is configured."
+              echo ""
+              cat "$OUT"
+            } > "$OUT.tmp"
+            mv "$OUT.tmp" "$OUT"
+          fi
           echo "RELEASE_NOTES_FILE=$OUT" >> "$GITHUB_ENV"
           echo "::group::Release notes"
           cat "$OUT"
           echo "::endgroup::"
+
+      - name: Record whether this build was signed
+        id: signing_state
+        # Exported as a job output so the release-creating job in the
+        # publishing stage does not restate the secret-presence expression.
+        run: echo "signed=${SIGNED}" >> "$GITHUB_OUTPUT"
+
+      - name: Stage release notes for the publishing job
+        # The GitHub Release is now created at the very END of the pipeline
+        # (see publish-updater-fallback), so the notes have to outlive this
+        # job. They are also the manifest's ``notes`` field, which mirror-dist
+        # used to read back off the created release.
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-mac-release-notes
+          path: ${{ runner.temp }}/release-notes.md
+          if-no-files-found: error
 
       - name: Build + sign Rapid-MLX Desktop.app
         # build.sh assembles the .app, builds + signs the bundled sidecar
@@ -306,53 +360,6 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Attach to GitHub Release (tag pushes only)
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#rapid-mac-v}"
-          # Prerelease detection on the VERSION part only — the tag itself
-          # always contains hyphens via the ``rapid-mac-v`` prefix, so we
-          # must strip it before looking for a ``-rc`` style suffix.
-          PRERELEASE=""
-          [[ "$VERSION" == *-* ]] && PRERELEASE="--prerelease"
-          NOTES_FILE="${RELEASE_NOTES_FILE:-}"
-          if [[ -z "$NOTES_FILE" || ! -s "$NOTES_FILE" ]]; then
-            echo "::error::RELEASE_NOTES_FILE is unset or empty."
-            exit 1
-          fi
-          # Unsigned build: this DMG is ad-hoc signed + un-notarised, so it is
-          # ALWAYS a pre-release and carries a Gatekeeper note. macOS quarantines
-          # anything downloaded, and Gatekeeper hard-blocks an un-notarised app
-          # ("damaged / can't be opened"), so the download won't just
-          # double-click — prepend the standard right-click / xattr workaround.
-          if [[ "${SIGNED:-}" != "true" ]]; then
-            PRERELEASE="--prerelease"
-            {
-              echo "> ⚠️ **Unsigned internal build.** This DMG is ad-hoc signed and NOT notarised."
-              echo "> macOS Gatekeeper will block it on first open. To run it:"
-              echo ">"
-              echo "> 1. Drag **Rapid-MLX Desktop** to Applications, then **right-click the app → Open** (once), or"
-              echo "> 2. \`xattr -dr com.apple.quarantine \"/Applications/Rapid-MLX Desktop.app\"\`"
-              echo ">"
-              echo "> A signed + notarised build that opens with a normal double-click will replace this once signing is configured."
-              echo ""
-              cat "$NOTES_FILE"
-            } > "$NOTES_FILE.unsigned"
-            NOTES_FILE="$NOTES_FILE.unsigned"
-          fi
-          # The release object may already exist or not — handle both.
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release edit "$TAG" --notes-file "$NOTES_FILE" $PRERELEASE
-            gh release upload "$TAG" build/rapid-mlx-desktop.dmg --clobber
-          else
-            gh release create "$TAG" build/rapid-mlx-desktop.dmg \
-              --title "$TAG" --notes-file "$NOTES_FILE" $PRERELEASE
-          fi
-
       - name: Clean up temp keychain
         if: always()
         run: security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" 2>/dev/null || true
@@ -382,6 +389,12 @@ jobs:
         with:
           name: rapid-mlx-desktop-dmg
           path: dist
+
+      - name: Download the staged release notes
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: rapid-mac-release-notes
+          path: notes
 
       - name: Mirror DMG and compose updater fallback
         env:
@@ -428,13 +441,25 @@ jobs:
           npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/${VERSIONED_KEY}" \
             --file "$DMG" --content-type application/x-apple-diskimage --remote
 
-          RELEASE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
+          # The GitHub Release does not exist yet — it is created only once this
+          # manifest is live (see publish-updater-fallback), so a failure here
+          # can no longer leave a published release pointing at a stale updater
+          # manifest (#1851). Both fields the release API used to supply are
+          # derivable without it: the release page URL is a pure function of the
+          # tag, and the notes are the same bytes the release is created from.
+          HTML_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
+          NOTES_FILE="notes/release-notes.md"
+          [[ -s "$NOTES_FILE" ]] || { echo "::error::missing $NOTES_FILE"; exit 1; }
+          # published_at is the moment the release becomes fetchable, which is
+          # now rather than whenever the release object is later created. The
+          # client decodes it but drives nothing off it (version comparison is
+          # what orders releases), so the few minutes' difference is cosmetic.
           jq -n \
             --arg version "$VERSION" \
             --arg tag_name "$TAG" \
-            --arg html_url "$(jq -r .html_url <<<"$RELEASE_JSON")" \
-            --arg notes "$(jq -r '.body // ""' <<<"$RELEASE_JSON")" \
-            --arg published_at "$(jq -r .published_at <<<"$RELEASE_JSON")" \
+            --arg html_url "$HTML_URL" \
+            --rawfile notes "$NOTES_FILE" \
+            --arg published_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg dmg_url "$DMG_URL" \
             --arg dmg_sha256 "$DMG_SHA256" \
             --argjson dmg_size "$DMG_SIZE" \
@@ -457,7 +482,7 @@ jobs:
   # serialized here. Turnstyle queues every run (unlike native concurrency,
   # which keeps only one pending run and can drop an intermediate tag).
   publish-updater-fallback:
-    needs: mirror-dist
+    needs: [build, mirror-dist]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -479,6 +504,12 @@ jobs:
         with:
           name: rapid-mlx-desktop-dmg
           path: dist-dmg
+
+      - name: Download the staged release notes
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: rapid-mac-release-notes
+          path: notes
 
       - name: Publish updater fallback monotonically
         env:
@@ -545,3 +576,46 @@ jobs:
             --header "Content-Type: application/json" \
             --data "$PURGE_PAYLOAD" | jq -e '.success == true' >/dev/null
           echo "::notice::Published updater fallback version ${TARGET_VERSION}"
+
+      - name: Create the GitHub Release (last — nothing ships before the pointer)
+        # This used to be the "Attach to GitHub Release" step in ``build``,
+        # which meant the release went public BEFORE mirror-dist ran. When the
+        # fallback publication then failed, the release stayed up with a stale
+        # latest.json behind it and only a red run to say so — three
+        # consecutive times (#1851). Creating it here makes the release the
+        # LAST thing that happens: if anything above fails, no release exists,
+        # which is a state nobody has to notice for it to be safe.
+        #
+        # Escape hatch, if the fallback is broken and a release must go out
+        # anyway: download the ``rapid-mlx-desktop-dmg`` artifact from this run
+        # and create the release by hand. That is deliberately manual — an
+        # automated bypass is the thing that let #1851 survive three releases.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          SIGNED: ${{ needs.build.outputs.signed }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#rapid-mac-v}"
+          # Prerelease detection on the VERSION part only — the tag itself
+          # always contains hyphens via the ``rapid-mac-v`` prefix, so we
+          # must strip it before looking for a ``-rc`` style suffix.
+          PRERELEASE=""
+          [[ "$VERSION" == *-* ]] && PRERELEASE="--prerelease"
+          NOTES_FILE="notes/release-notes.md"
+          [[ -s "$NOTES_FILE" ]] || { echo "::error::missing $NOTES_FILE"; exit 1; }
+          # The unsigned-build Gatekeeper preamble is already baked into these
+          # bytes by the notes step in ``build``, so the release body and the
+          # updater manifest carry identical text.
+          if [[ "${SIGNED:-}" != "true" ]]; then
+            PRERELEASE="--prerelease"
+          fi
+          # A re-run of an already-published tag must stay idempotent.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file "$NOTES_FILE" $PRERELEASE
+            gh release upload "$TAG" dist-dmg/rapid-mlx-desktop.dmg --clobber
+          else
+            gh release create "$TAG" dist-dmg/rapid-mlx-desktop.dmg \
+              --title "$TAG" --notes-file "$NOTES_FILE" $PRERELEASE
+          fi
+          echo "::notice::Published GitHub Release ${TAG}"


### PR DESCRIPTION
Closes the atomic-publish criterion of #1852. Context: #1851.

## Why

The release was published by `build`, before `mirror-dist` ran. So when the fallback publication failed, the release was already out, and the only signal was a red run nobody was watching.

That happened three times in a row — 0.12.8, 0.12.9, 0.12.10 — and each time someone quietly published `latest.json` by hand. The manual fix-up is what let it persist: it removed the symptom and left the defect, so three red release runs looked harmless.

#1859 stops the *credential* gap that triggered it. This stops the *shape* that made it survivable: a pipeline where one step can fail without invalidating the artifact it was supposed to describe.

## What

Release creation moves to the end of `publish-updater-fallback`. If anything upstream fails, no release exists — a state nobody has to notice for it to be safe, which is the property the old ordering lacked.

```
before   build ─(publishes release)─> mirror-dist ─> publish-updater-fallback
after    build ─────────────────────> mirror-dist ─> publish-updater-fallback ─(publishes release)
```

### Why not draft-then-publish

That is the smaller diff and it was the plan, but a draft release has no real tag:

- `GET /releases/tags/{tag}` does not resolve a draft, and `mirror-dist` reads the release back through exactly that call.
- A draft's `html_url` is an `untagged-<hash>` URL that **changes** when the release is published. The manifest would have baked in a link that never resolves.

Creating the release last avoids draft semantics entirely rather than working around them.

### Consequences of the move

`mirror-dist` can no longer read the release back, so the manifest is composed without it. Both fields it took from the API are derivable:

- `html_url` is a pure function of the tag.
- `notes` are the same bytes the release is created from — now staged as an artifact by `build` instead of round-tripped through the release body.
- `published_at` becomes manifest-composition time. That is minutes earlier than the old value; the client decodes the field but orders releases by version and reads nothing from it.

### Two things fixed while moving

- **The unsigned-build Gatekeeper preamble** is now applied where the notes are composed, not at release-creation time. It previously reached only the release body, so a reader of `latest.json` saw notes the release page did not.
- **`signed` becomes a job output** instead of the secret-presence expression being restated in the second job. Two copies of the same predicate would have drifted apart the first time the signing secret set changed.

## The trade this makes

A Cloudflare outage now means **no release**, where before it meant a release with a stale pointer. That is the intended direction, and it is the direction #1852 asked for, but it is a real cost and worth being explicit about.

There is deliberately **no automated bypass**. If the fallback is broken and a release must go out regardless, download the `rapid-mlx-desktop-dmg` artifact from the run and create the release by hand. Manual is the point — an easy bypass is precisely what let #1851 survive three releases.

## Verification

Static only, and that limit is worth stating plainly: **this cannot be exercised without cutting a real tag.** What has been checked —

- every `run:` block parses under `bash -n`
- `check_workflow_expressions.py` and `check_gha_pinning.py` pass
- the workflow's secret/var reference set is unchanged (11 references, all configured), so #1859's PF-2 gate still passes against it
- job graph verified: `publish-updater-fallback` now `needs: [build, mirror-dist]` for the `signed` output; step order confirmed by parsing the YAML
- `auto-release.yml` only creates the engine's `v*` releases and never touches `rapid-mac-v*`, so nothing downstream depends on the mac release existing early

**I would not merge this without a maintainer's eye on the first real tag run.** The failure mode if I got it wrong is no release rather than a bad release, which is the safer direction, but it is still a release-blocking change.

## Ordering

Best merged **after #1859** — the workflow header now points at the PF-2 gate for credential checking, which only exists there. Functionally independent; the two touch different files and do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)