### PR TITLE
docs: back the Ollama speed claim with the measured benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <strong>The fastest local AI engine for Apple Silicon.</strong>
   <br>
-  <em>Drop-in OpenAI / Anthropic API · 2–4× faster than Ollama · Runs on any M-series Mac.</em>
+  <em>Drop-in OpenAI / Anthropic API · up to 3× Ollama's throughput (<a href="https://rapidmlx.com/blog/rapid-mlx-vs-ollama-benchmark">measured</a>) · Runs on any M-series Mac.</em>
 </p>
 
 <p align="center">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "rapid-mlx"
 version = "0.12.11"
-description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, 2-4x faster than Ollama."
+description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why
The README tagline and PyPI description claimed '2–4× faster than Ollama' with no citation. We now have a published, reproducible same-machine benchmark (M2 Pro mini, 2026-08-12, raw JSON public): 8-way aggregate decode 82.9 vs 27.2 tok/s on Qwen3.6-35B-A3B (3.0×), 1.5× single-stream MoE decode. This swaps the unsourced range for 'up to 3× Ollama's throughput' linked to https://rapidmlx.com/blog/rapid-mlx-vs-ollama-benchmark.

## What
- README.md tagline: measured claim + link
- pyproject.toml description: same wording (PyPI surface, takes effect next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)