### PR TITLE
feat(mac): derive Launch integrations from engine registry

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/IntegrationCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/IntegrationCatalog.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct IntegrationTarget: Codable, Identifiable, Equatable, Sendable {
+    enum Kind: String, Codable, Sendable {
+        case configWriter = "config_writer"
+        case adapterProfile = "adapter_profile"
+    }
+
+    let id: String
+    let name: String
+    let kind: Kind
+    let configPath: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, kind
+        case configPath = "config_path"
+    }
+}
+
+enum IntegrationCatalog {
+    static func decode(_ data: Data) throws -> [IntegrationTarget] {
+        try JSONDecoder().decode([IntegrationTarget].self, from: data)
+    }
+
+    static func load(binary: URL? = ServerLocator.find()) async -> [IntegrationTarget] {
+        guard let binary else { return [] }
+        return await Task.detached(priority: .utility) {
+            let process = Process()
+            process.executableURL = binary
+            process.arguments = ["launch", "list", "--json"]
+            var environment = ProcessInfo.processInfo.environment
+            environment["RAPID_MLX_TELEMETRY"] = "0"
+            process.environment = environment
+            let output = Pipe()
+            process.standardOutput = output
+            process.standardError = FileHandle.nullDevice
+            do {
+                try process.run()
+                let data = output.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                guard process.terminationStatus == 0 else { return [] }
+                return (try? decode(data)) ?? []
+            } catch {
+                return []
+            }
+        }.value
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -36,9 +36,11 @@ struct ConnectToolsView: View {
     /// snapshot harness, which has no live server to resolve against.
     var readiness: ModelReadiness? = nil
     var onReadinessAction: (ModelReadiness.Action) -> Void = { _ in }
+    @State private var integrationTargets: [IntegrationTarget] = []
 
     private var openAIBaseURL: String { "http://\(host):\(port)/v1" }
     private var anthropicBaseURL: String { "http://\(host):\(port)" }
+    private var serverOrigin: String { "http://\(host):\(port)" }
 
     /// The model id to publish in a config, or ``nil`` when no real
     /// model is resolved yet. Deliberately not defaulted to a
@@ -106,6 +108,9 @@ struct ConnectToolsView: View {
         // so we keep it rather than the PR's inline frame.
         .modifier(ConnectToolsFrame(fixedSize: showsCloseButton))
         .background(RapidTheme.surfaceCanvas)
+        .task {
+            integrationTargets = await IntegrationCatalog.load()
+        }
     }
 
     /// The scrollable content. Factored out so the snapshot harness can
@@ -235,6 +240,31 @@ struct ConnectToolsView: View {
     // MARK: - Tool definitions
 
     private var tools: [ConnectTool] {
+        guard !integrationTargets.isEmpty else { return legacyTools }
+        return integrationTargets.map { target in
+            let isWriter = target.kind == .configWriter
+            let command: String
+            if isWriter {
+                command = "rapid-mlx launch \(target.id) --server-url \(serverOrigin) --model \(snippetModel)"
+            } else {
+                command = "rapid-mlx agents \(target.id) --base-url \(openAIBaseURL) --model \(snippetModel)"
+            }
+            let destination = target.configPath.map { " It writes \($0)." } ?? ""
+            return ConnectTool(
+                id: target.id,
+                name: target.name,
+                symbol: isWriter ? "slider.horizontal.3" : "point.3.connected.trianglepath.dotted",
+                blurb: isWriter
+                    ? "Configure this client to use Rapid-MLX.\(destination)"
+                    : "View this adapter's setup guide for the local endpoint.",
+                snippet: command,
+                displaySnippet: command
+            )
+        }
+    }
+
+    /// Available while an older or missing sidecar cannot expose the registry.
+    private var legacyTools: [ConnectTool] {
         [
             ConnectTool(
                 id: "claude-code",
@@ -451,6 +481,7 @@ private struct ConnectToolRow: View {
         }
         .padding(.horizontal, RapidTheme.Space.xl - 4)
         .padding(.vertical, RapidTheme.Space.lg + 1)
+        .accessibilityIdentifier("Launch.Integration.\(tool.id)")
     }
 
     private func copy() {

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -244,21 +244,33 @@ struct ConnectToolsView: View {
         return integrationTargets.map { target in
             let isWriter = target.kind == .configWriter
             let command: String
+            let displayCommand: String
             if isWriter {
-                command = "rapid-mlx launch \(target.id) --server-url \(serverOrigin) --model \(snippetModel)"
+                command = IntegrationLaunchCommand.configWriter(
+                    id: target.id, serverURL: serverOrigin, key: snippetKey, model: snippetModel
+                )
+                displayCommand = IntegrationLaunchCommand.configWriter(
+                    id: target.id, serverURL: serverOrigin, key: snippetKeyMasked, model: snippetModel
+                )
             } else {
-                command = "rapid-mlx agents \(target.id) --base-url \(openAIBaseURL) --model \(snippetModel)"
+                command = IntegrationLaunchCommand.adapterGuide(
+                    id: target.id, baseURL: openAIBaseURL, model: snippetModel
+                )
+                displayCommand = command
             }
             let destination = target.configPath.map { " It writes \($0)." } ?? ""
+            let cursorCaveat = target.id == "cursor"
+                ? " Cursor requires a public HTTPS endpoint; localhost cannot be reached by Cursor's backend."
+                : ""
             return ConnectTool(
                 id: target.id,
                 name: target.name,
                 symbol: isWriter ? "slider.horizontal.3" : "point.3.connected.trianglepath.dotted",
                 blurb: isWriter
-                    ? "Configure this client to use Rapid-MLX.\(destination)"
+                    ? "Configure this client to use Rapid-MLX.\(destination)\(cursorCaveat)"
                     : "View this adapter's setup guide for the local endpoint.",
                 snippet: command,
-                displaySnippet: command
+                displaySnippet: displayCommand
             )
         }
     }
@@ -328,6 +340,16 @@ enum AgentLaunchCommand {
     static func hermes(baseURL: String, key: String, model: String) -> String {
         "env OPENAI_BASE_URL=\(baseURL) OPENAI_API_KEY=\(key) HERMES_INFERENCE_MODEL=\(model) "
             + "hermes --provider openai-api --ignore-user-config"
+    }
+}
+
+enum IntegrationLaunchCommand {
+    static func configWriter(id: String, serverURL: String, key: String, model: String) -> String {
+        "env RAPID_MLX_API_KEY=\(key) rapid-mlx launch \(id) --server-url \(serverURL) --model \(model)"
+    }
+
+    static func adapterGuide(id: String, baseURL: String, model: String) -> String {
+        "rapid-mlx agents \(id) --base-url \(baseURL) --model \(model)"
     }
 }
 

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -1,0 +1,110 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXHeading desc="Connect your agents, Connect any agent or editor that supports a local base URL. It's free and stays on your Mac." enabled=true
+          AXScrollArea
+            AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="Readiness.Action" desc="Start" enabled=true
+            AXHeading desc="Endpoint" enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="doc.on.doc" desc="Copy OpenAI base URL" help="Copy OpenAI base URL" enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="doc.on.doc" desc="Copy Anthropic base URL" help="Copy Anthropic base URL" enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="doc.on.doc" desc="Copy API key" help="Start a model to generate a valid key and configuration." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="doc.on.doc" desc="Copy Model" help="Copy Model" enabled=true
+            AXHeading desc="Editors and agents" enabled=true
+            AXStaticText id="Launch.Integration.cline" value=text enabled=true
+            AXButton id="Launch.Integration.cline" desc="Copy Cline command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.cline" value=text enabled=true
+            AXStaticText id="Launch.Integration.cline" value=text enabled=true
+            AXStaticText id="Launch.Integration.claude-code" value=text enabled=true
+            AXButton id="Launch.Integration.claude-code" desc="Copy Claude Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.claude-code" value=text enabled=true
+            AXStaticText id="Launch.Integration.claude-code" value=text enabled=true
+            AXStaticText id="Launch.Integration.continue-dev" value=text enabled=true
+            AXButton id="Launch.Integration.continue-dev" desc="Copy Continue.dev command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.continue-dev" value=text enabled=true
+            AXStaticText id="Launch.Integration.continue-dev" value=text enabled=true
+            AXStaticText id="Launch.Integration.cursor" value=text enabled=true
+            AXButton id="Launch.Integration.cursor" desc="Copy Cursor command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.cursor" value=text enabled=true
+            AXStaticText id="Launch.Integration.cursor" value=text enabled=true
+            AXStaticText id="Launch.Integration.aider" value=text enabled=true
+            AXButton id="Launch.Integration.aider" desc="Copy Aider command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.aider" value=text enabled=true
+            AXStaticText id="Launch.Integration.aider" value=text enabled=true
+            AXStaticText id="Launch.Integration.codex" value=text enabled=true
+            AXButton id="Launch.Integration.codex" desc="Copy Codex CLI command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.codex" value=text enabled=true
+            AXStaticText id="Launch.Integration.codex" value=text enabled=true
+            AXStaticText id="Launch.Integration.hermes" value=text enabled=true
+            AXButton id="Launch.Integration.hermes" desc="Copy Hermes Agent command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.hermes" value=text enabled=true
+            AXStaticText id="Launch.Integration.hermes" value=text enabled=true
+            AXStaticText id="Launch.Integration.kilo-code" value=text enabled=true
+            AXButton id="Launch.Integration.kilo-code" desc="Copy Kilo Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.kilo-code" value=text enabled=true
+            AXStaticText id="Launch.Integration.kilo-code" value=text enabled=true
+            AXStaticText id="Launch.Integration.langchain" value=text enabled=true
+            AXButton id="Launch.Integration.langchain" desc="Copy LangChain command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.langchain" value=text enabled=true
+            AXStaticText id="Launch.Integration.langchain" value=text enabled=true
+            AXStaticText id="Launch.Integration.opencode" value=text enabled=true
+            AXButton id="Launch.Integration.opencode" desc="Copy OpenCode command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.opencode" value=text enabled=true
+            AXStaticText id="Launch.Integration.opencode" value=text enabled=true
+            AXStaticText id="Launch.Integration.openhands" value=text enabled=true
+            AXButton id="Launch.Integration.openhands" desc="Copy OpenHands command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.openhands" value=text enabled=true
+            AXStaticText id="Launch.Integration.openhands" value=text enabled=true
+            AXStaticText id="Launch.Integration.pydanticai" value=text enabled=true
+            AXButton id="Launch.Integration.pydanticai" desc="Copy PydanticAI command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.pydanticai" value=text enabled=true
+            AXStaticText id="Launch.Integration.pydanticai" value=text enabled=true
+            AXStaticText id="Launch.Integration.qwen-code" value=text enabled=true
+            AXButton id="Launch.Integration.qwen-code" desc="Copy Qwen Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.qwen-code" value=text enabled=true
+            AXStaticText id="Launch.Integration.qwen-code" value=text enabled=true
+            AXStaticText id="Launch.Integration.smolagents" value=text enabled=true
+            AXButton id="Launch.Integration.smolagents" desc="Copy smolagents command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText id="Launch.Integration.smolagents" value=text enabled=true
+            AXStaticText id="Launch.Integration.smolagents" value=text enabled=true
+            AXScrollBar value=number enabled=true
+              AXValueIndicator value=number
+              AXButton subrole=AXIncrementArrow
+              AXButton subrole=AXDecrementArrow
+              AXButton subrole=AXIncrementPage
+              AXButton subrole=AXDecrementPage
+      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+      AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
+        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
@@ -3,6 +3,15 @@ import Testing
 
 @Suite("Connect agents — process-scoped launch commands")
 struct AgentLaunchCommandTests {
+    @Test("registry commands carry authentication only for config writers")
+    func registryCommands() {
+        #expect(IntegrationLaunchCommand.configWriter(
+            id: "cline", serverURL: "http://127.0.0.1:8000", key: "secret", model: "model"
+        ) == "env RAPID_MLX_API_KEY=secret rapid-mlx launch cline --server-url http://127.0.0.1:8000 --model model")
+        #expect(IntegrationLaunchCommand.adapterGuide(
+            id: "aider", baseURL: "http://127.0.0.1:8000/v1", model: "model"
+        ) == "rapid-mlx agents aider --base-url http://127.0.0.1:8000/v1 --model model")
+    }
     private let base = "http://127.0.0.1:8000/v1"
     private let key = "local-key"
     private let model = "qwen-test"

--- a/apps/rapid-mac/Tests/RapidTests/IntegrationCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IntegrationCatalogTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+struct IntegrationCatalogTests {
+    @Test("engine registry JSON decodes both integration kinds")
+    func decodesRegistry() throws {
+        let data = Data(#"[{"id":"cline","name":"Cline","kind":"config_writer","config_path":"/tmp/cline.json"},{"id":"codex","name":"Codex CLI","kind":"adapter_profile","config_path":null}]"#.utf8)
+        let targets = try IntegrationCatalog.decode(data)
+        #expect(targets.count == 2)
+        #expect(targets[0].kind == .configWriter)
+        #expect(targets[0].configPath == "/tmp/cline.json")
+        #expect(targets[1].kind == .adapterProfile)
+        #expect(targets[1].configPath == nil)
+    }
+}

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -45,6 +45,26 @@ import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
+if sys.argv[1:] == ["launch", "list", "--json"]:
+    print(json.dumps([
+        {"id": "cline", "name": "Cline", "kind": "config_writer", "config_path": "~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"},
+        {"id": "claude-code", "name": "Claude Code", "kind": "config_writer", "config_path": "~/.claude/settings.json"},
+        {"id": "continue-dev", "name": "Continue.dev", "kind": "config_writer", "config_path": "~/.continue/config.json"},
+        {"id": "cursor", "name": "Cursor", "kind": "config_writer", "config_path": "~/Library/Application Support/Cursor/User/settings.json"},
+        {"id": "aider", "name": "Aider", "kind": "adapter_profile", "config_path": None},
+        {"id": "codex", "name": "Codex CLI", "kind": "adapter_profile", "config_path": None},
+        {"id": "hermes", "name": "Hermes Agent", "kind": "adapter_profile", "config_path": None},
+        {"id": "kilo-code", "name": "Kilo Code", "kind": "adapter_profile", "config_path": None},
+        {"id": "langchain", "name": "LangChain", "kind": "adapter_profile", "config_path": None},
+        {"id": "opencode", "name": "OpenCode", "kind": "adapter_profile", "config_path": None},
+        {"id": "openhands", "name": "OpenHands", "kind": "adapter_profile", "config_path": None},
+        {"id": "pydanticai", "name": "PydanticAI", "kind": "adapter_profile", "config_path": None},
+        {"id": "qwen-code", "name": "Qwen Code", "kind": "adapter_profile", "config_path": None},
+        {"id": "smolagents", "name": "smolagents", "kind": "adapter_profile", "config_path": None},
+    ]))
+    sys.exit(0)
+
+
 try:
     with open(os.path.join(os.environ.get("HOME", ""), ".rapid-golden-fake.json"), encoding="utf-8") as stream:
         FILE_CONFIG = json.load(stream)

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -36,7 +36,7 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, cached-quickstart, download-progress, settings-persistence, chat-restore, restored-tools, tool-loop-budget, chat-depth, math-rendering,
+Flows: fresh-install, cached-quickstart, download-progress, settings-persistence, chat-restore, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, window-close-prompt, no-dead-controls, catalog-integrity,
@@ -2557,6 +2557,33 @@ flow_resident_load_rejected() {
     log "  resident-load-rejected OK"
 }
 
+flow_launch_integrations() {
+    log "flow: launch-integrations"
+    start_persona launch-integrations
+    dismiss_first_run
+    see_main "$OUT/main.json"
+    press "$OUT/main.json" Sidebar.Launch "$OUT/launch.json"
+
+    # The engine-owned registry currently resolves to fourteen distinct
+    # products after the overlapping Claude Code and Continue entries are
+    # merged. Pin representatives at both ends as well as the exact count so a
+    # new YAML profile cannot silently disappear from the desktop again.
+    for _ in {1..40}; do
+        see_main "$OUT/launch.json"
+        count="$(jq '[.data.ui_elements[]? | (.identifier // "") | select(startswith("Launch.Integration."))] | unique | length' "$OUT/launch.json")"
+        [[ "$count" == 14 ]] && break
+        sleep 0.25
+    done
+    [[ "$count" == 14 ]] || die "Launch rendered $count integrations; engine registry exposes 14 (#1715)"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.cline")' "$OUT/launch.json" >/dev/null \
+        || die "Launch omitted config-writing target Cline"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.smolagents")' "$OUT/launch.json" >/dev/null \
+        || die "Launch omitted adapter profile smolagents"
+    baseline launch-integrations.complete "$OUT/launch.json"
+    log "  launch-integrations OK"
+    cleanup_persona
+}
+
 
 if [[ -d "$OUT_ROOT" && -n "$(ls -A "$OUT_ROOT" 2>/dev/null)" ]]; then
     RESULT_WRITTEN=1
@@ -2584,6 +2611,7 @@ case "$FLOW" in
     browse-all-destination) flow_browse_all_destination ;;
     image-generation) flow_image_generation ;;
     resident-load-rejected) flow_resident_load_rejected ;;
+    launch-integrations) flow_launch_integrations ;;
     all)
         flow_fresh_install
         flow_cached_quickstart
@@ -2604,6 +2632,7 @@ case "$FLOW" in
         flow_browse_all_destination
         flow_image_generation
         flow_resident_load_rejected
+        flow_launch_integrations
         ;;
     *) die "unknown flow: $FLOW" ;;
 esac

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -519,6 +519,7 @@ def _make_args(**overrides):
         port=8000,
         start_server=False,
         dry_run=False,
+        json=False,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -532,6 +533,22 @@ class TestLaunchCommand:
         out = capsys.readouterr().out
         for name in ADAPTERS:
             assert name in out
+
+    def test_list_json_is_complete_deduplicated_registry(self, fake_home, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            launch_cli.launch_command(_make_args(client="list", json=True))
+        assert excinfo.value.code == 0
+        targets = json.loads(capsys.readouterr().out)
+        ids = [target["id"] for target in targets]
+        assert len(ids) == len(set(ids)) == 14
+        assert ids[:4] == ["cline", "claude-code", "continue-dev", "cursor"]
+        assert {target["kind"] for target in targets} == {
+            "config_writer",
+            "adapter_profile",
+        }
+        writer = next(t for t in targets if t["id"] == "claude-code")
+        assert writer["config_path"].startswith("~/")
+        assert next(t for t in targets if t["id"] == "codex")["config_path"] is None
 
     def test_unknown_client_exit_2(self, fake_home, capsys):
         with pytest.raises(SystemExit) as excinfo:

--- a/vllm_mlx/integrations.py
+++ b/vllm_mlx/integrations.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Single source of truth for desktop/CLI integration discovery."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from vllm_mlx.agents import list_profiles
+from vllm_mlx.launch import ADAPTERS
+
+
+@dataclass(frozen=True)
+class IntegrationTarget:
+    id: str
+    name: str
+    kind: str
+    config_path: str | None
+
+
+_LAUNCH_NAMES = {
+    "cline": "Cline",
+    "claude-code": "Claude Code",
+    "continue-dev": "Continue.dev",
+    "cursor": "Cursor",
+}
+_PROFILE_TO_LAUNCH = {"continue": "continue-dev"}
+_CONFIG_DESTINATIONS = {
+    "cline": "Cline's VS Code settings",
+    "claude-code": "~/.claude/settings.json",
+    "continue-dev": "~/.continue/config.json",
+    "cursor": "Cursor's VS Code settings",
+}
+
+
+def list_integration_targets() -> list[IntegrationTarget]:
+    """Return every supported target, merging duplicate setup/profile entries.
+
+    Config-writing targets win when the same product is also represented by an
+    adapter profile.  The launch registry supplies display order; remaining
+    profiles retain the agents registry's order.
+    """
+    targets: list[IntegrationTarget] = []
+    seen: set[str] = set()
+    for target_id, adapter in ADAPTERS.items():
+        targets.append(
+            IntegrationTarget(
+                id=target_id,
+                name=_LAUNCH_NAMES.get(target_id, target_id),
+                kind="config_writer",
+                config_path=_CONFIG_DESTINATIONS[target_id],
+            )
+        )
+        seen.add(target_id)
+
+    for profile in list_profiles():
+        target_id = _PROFILE_TO_LAUNCH.get(profile.name, profile.name)
+        if target_id in seen:
+            continue
+        targets.append(
+            IntegrationTarget(
+                id=target_id,
+                name=profile.display_name,
+                kind="adapter_profile",
+                config_path=None,
+            )
+        )
+        seen.add(target_id)
+    return targets
+
+
+def integration_targets_json() -> list[dict[str, str | None]]:
+    return [asdict(target) for target in list_integration_targets()]

--- a/vllm_mlx/launch/cli.py
+++ b/vllm_mlx/launch/cli.py
@@ -28,6 +28,7 @@ later ``kill $(cat ~/.rapid-mlx/launch.pid)`` shuts it down cleanly.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -41,7 +42,7 @@ from . import ADAPTERS, cursor
 PID_FILE = Path.home() / ".rapid-mlx" / "launch.pid"
 
 
-def _print_list() -> int:
+def _print_list(*, as_json: bool = False) -> int:
     """Print the supported-clients + detection matrix.
 
     Output shape (one line per client):
@@ -53,6 +54,11 @@ def _print_list() -> int:
 
     Always returns 0 — listing is a read-only inspect command.
     """
+    if as_json:
+        from vllm_mlx.integrations import integration_targets_json
+
+        print(json.dumps(integration_targets_json(), ensure_ascii=False))
+        return 0
     width = max(len(name) for name in ADAPTERS) + 2
     print("Supported clients:")
     for name, adapter in ADAPTERS.items():
@@ -128,7 +134,7 @@ def launch_command(args: argparse.Namespace) -> None:
     without touching disk.
     """
     if args.client == "list":
-        sys.exit(_print_list())
+        sys.exit(_print_list(as_json=args.json))
 
     if args.all and args.client:
         print(
@@ -353,4 +359,9 @@ def register(subparsers) -> None:
         "--dry-run",
         action="store_true",
         help="Print what would change without touching disk.",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="With `list`, emit the complete GUI/CLI integration registry as JSON.",
     )


### PR DESCRIPTION
## What

- add an engine-owned JSON integration registry via `rapid-mlx launch list --json`
- merge config writers and adapter profiles into 14 deduplicated products
- render the desktop Launch page from that registry, preserving the three-item fallback for older sidecars
- distinguish config-writing targets (including the destination) from adapter setup guides
- add a GUI golden flow that asserts all 14 engine targets render

## Why

The Launch page hardcoded three Swift rows while the engine supports fourteen distinct integrations. Adding more Swift literals would drift again whenever a profile YAML changes; the engine now owns merging, ordering, names, kinds, and destinations.

Closes #1715.

## Validation

- `tests/test_launch_cli.py`: 77 passed
- `swift test --filter IntegrationCatalogTests`: passed
- release `scripts/build.sh`: passed, including bundled sidecar
- bundled `rapid-mlx launch list --json`: 14 targets
- `gui-golden-flows.sh --flow launch-integrations`: passed; committed AX baseline
- Ruff and `git diff --check`: clean

## AI assistance

Codex implemented and validated this change under maintainer direction.