### PR TITLE
fix(gui-golden): collapse macOS 15's lazy toolbar-button copy by structure

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -90,7 +90,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
@@ -90,7 +90,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -53,7 +53,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
@@ -64,7 +64,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
@@ -46,7 +46,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -53,7 +53,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
@@ -26,7 +26,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=false
     AXButton subrole=AXZoomButton enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -26,7 +26,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -50,7 +50,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -103,7 +103,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -53,7 +53,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -35,7 +35,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -35,7 +35,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -35,7 +35,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -35,7 +35,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -35,7 +35,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -35,7 +35,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -35,7 +35,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -53,7 +53,6 @@ AXApplication title="Rapid-MLX"
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-        AXButton id="Toolbar.SearchChats" desc="Search chats" help="Search chats - Command-K" enabled=true
     AXButton subrole=AXCloseButton enabled=true
     AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
     AXButton subrole=AXMinimizeButton enabled=true

--- a/apps/rapid-mac/scripts/ax-baseline.py
+++ b/apps/rapid-mac/scripts/ax-baseline.py
@@ -190,15 +190,7 @@ _ROLE_EQUIVALENTS = {
 
 def is_window_control(record: dict) -> bool:
     """True for a traffic-light / toolbar button whose subtree is AppKit's."""
-    if record.get("subrole") in _WINDOW_CONTROL_SUBROLES:
-        return True
-    # On macOS 15.6 the system sidebar item gained a second, lazily-realized
-    # AXButton child. Keep the public button but ignore its OS-owned internals,
-    # just as we already do for traffic-light controls.
-    return record.get("role") == "AXButton" and record.get("description") in {
-        "Hide Sidebar",
-        "Show Sidebar",
-    }
+    return record.get("subrole") in _WINDOW_CONTROL_SUBROLES
 
 
 # The footer's GPU gauge has no stable cross-machine shape. Apple Silicon
@@ -245,6 +237,56 @@ class Node:
     def __init__(self, record: dict) -> None:
         self.record = record
         self.children: list[Node] = []
+
+
+def is_lazy_button_wrapper(node: Node) -> bool:
+    """True for an ``AXButton`` that only wraps a re-published copy of itself.
+
+    macOS 15 realizes a SwiftUI toolbar ``Button`` as an outer AXButton *plus*
+    a lazily-created inner AXButton that carries the button's own identity — the
+    same identifier and description, with the tooltip surfacing as ``AXHelp`` on
+    the child. macOS 26 publishes the button flat, with no inner copy. Keeping
+    the outer button (so a vanished control is still a diff) and dropping the
+    OS-owned duplicate makes a baseline generated on one release match the
+    other, exactly as ``is_window_control`` already does for the traffic lights.
+
+    #1845 pinned this for the system "Hide/Show Sidebar" toggle by matching its
+    description; keying on the STRUCTURE instead absorbs it for every toolbar
+    button — app-authored ones like ``Toolbar.SearchChats`` (#1879) included —
+    so a new toolbar button no longer has to be added to a hand-kept allowlist.
+
+    The predicate matches only the exact shape observed in the real cross-OS
+    dumps (``tests/fixtures/ax_baseline``): an ``AXButton`` directly under an
+    ``AXToolbar`` (``render`` checks the parent) with an identity of its own,
+    whose SINGLE child is a LEAF ``AXButton`` re-publishing that same identifier
+    and description. Every clause narrows away a way a real control could be
+    hidden:
+
+    * an *anonymous* button (no identifier and no description) has no identity to
+      re-publish, so a button nested in it is a distinct control, never a copy;
+    * a real nested control brings its own children or siblings, so requiring a
+      single leaf child leaves any richer structure — and any change to it —
+      visible in the diff;
+    * a child with a different identifier or description is a different control
+      and is kept.
+
+    Only AppKit's lazy self-copy, which no product change can introduce, matches.
+    """
+    record = node.record
+    if record.get("role") != "AXButton" or len(node.children) != 1:
+        return False
+    identifier = record.get("identifier") or ""
+    description = record.get("description") or ""
+    if not identifier and not description:
+        return False
+    (child,) = node.children
+    child_record = child.record
+    return (
+        not child.children
+        and child_record.get("role") == "AXButton"
+        and (child_record.get("identifier") or "") == identifier
+        and (child_record.get("description") or "") == description
+    )
 
 
 def scrub(text: str, extra_tokens: tuple[str, ...] = ()) -> str:
@@ -420,16 +462,34 @@ def render_node(node: Node, extra_tokens: tuple[str, ...]) -> str:
 def render(root: Node, extra_tokens: tuple[str, ...]) -> list[str]:
     lines: list[str] = []
 
-    def walk(node: Node, depth: int, sort_children: bool) -> None:
+    def walk(
+        node: Node, depth: int, sort_children: bool, parent_is_toolbar: bool
+    ) -> None:
         lines.append("  " * depth + render_node(node, extra_tokens))
-        if is_window_control(node.record):
+        if is_window_control(node.record) or (
+            parent_is_toolbar and is_lazy_button_wrapper(node)
+        ):
             # The traffic-light buttons are AppKit's, not ours. Their anonymous
             # AXGroup descendants are lazily realized: two dumps taken seconds
             # apart in the SAME run recorded one group under AXZoomButton in
             # settings-root and two in models-idle. Keeping the button (so a
             # missing close box is still a diff) and dropping its private
             # innards removes a whole class of false failure that no product
-            # change could ever cause.
+            # change could ever cause. The same holds for a toolbar button whose
+            # only child is macOS 15's lazily-realized copy of itself — scoped to
+            # a button OWNED by the toolbar so an identical-identity nesting
+            # deeper in the tree still surfaces as a diff (see
+            # ``is_lazy_button_wrapper``).
+            #
+            # The dropped copy carries the button's tooltip as ``AXHelp``, and it
+            # is dropped, not lifted onto the parent, ON PURPOSE: macOS 26 does
+            # not publish that tooltip on the toolbar button at all (the flat
+            # button has ``help=None`` in the fixtures), so lifting it would make
+            # the two releases disagree on ``help`` and reintroduce exactly the
+            # un-regenerable baseline this normalizer exists to prevent. A tooltip
+            # that only one OS exposes is not cross-OS structure; the PNG
+            # snapshots under ``Tests/RapidTests/__Snapshots__`` remain the check
+            # for user-visible tooltip text.
             return
         children = node.children
         if sort_children:
@@ -438,10 +498,16 @@ def render(root: Node, extra_tokens: tuple[str, ...]) -> list[str]:
             # rewrite the baseline. Deeper sibling order is the view order and
             # is exactly what we want to detect changing.
             children = sorted(children, key=window_sort_key)
+        # AppKit's lazy button self-copy sits DIRECTLY under the toolbar, so the
+        # collapse in ``is_lazy_button_wrapper`` is armed only for a toolbar's
+        # own children, never for buttons deeper in the subtree.
+        node_is_toolbar = node.record.get("role") == "AXToolbar"
         for child in children:
-            walk(child, depth + 1, sort_children=False)
+            walk(
+                child, depth + 1, sort_children=False, parent_is_toolbar=node_is_toolbar
+            )
 
-    walk(root, 0, sort_children=True)
+    walk(root, 0, sort_children=True, parent_is_toolbar=False)
     return lines
 
 

--- a/tests/test_ax_baseline.py
+++ b/tests/test_ax_baseline.py
@@ -56,6 +56,14 @@ def test_live_memory_pressure_bucket_is_scrubbed(ax_baseline, pressure):
     )
 
 
+def _toolbar_with(ax_baseline, button):
+    """Wrap ``button`` in an AXToolbar, since the lazy-copy collapse is armed
+    only for toolbar descendants (where AppKit's self-copy is observed)."""
+    toolbar = ax_baseline.Node({"role": "AXToolbar", "enabled": True})
+    toolbar.children.append(button)
+    return toolbar
+
+
 @pytest.mark.parametrize("description", ["Hide Sidebar", "Show Sidebar"])
 def test_system_sidebar_button_subtree_is_ignored(ax_baseline, description):
     button = ax_baseline.Node(
@@ -72,8 +80,134 @@ def test_system_sidebar_button_subtree_is_ignored(ax_baseline, description):
         )
     )
 
-    assert ax_baseline.render(button, ()) == [
-        f'AXButton desc="{description}" enabled=true'
+    assert ax_baseline.render(_toolbar_with(ax_baseline, button), ()) == [
+        "AXToolbar enabled=true",
+        f'  AXButton desc="{description}" enabled=true',
+    ]
+
+
+def test_app_toolbar_button_lazy_copy_is_ignored(ax_baseline):
+    """An app-authored toolbar button carries its own identifier, so the old
+    description allowlist could not reach it — every new toolbar button would
+    have had to be added by hand or turn macOS 26 red against a macOS 15
+    baseline. The structural rule collapses macOS 15's lazily-realized inner
+    copy (same identifier and description, tooltip as AXHelp) for any of them.
+    """
+    button = ax_baseline.Node(
+        {
+            "role": "AXButton",
+            "identifier": "Toolbar.SearchChats",
+            "description": "Search chats",
+            "enabled": True,
+        }
+    )
+    button.children.append(
+        ax_baseline.Node(
+            {
+                "role": "AXButton",
+                "identifier": "Toolbar.SearchChats",
+                "description": "Search chats",
+                "help": "Search chats - Command-K",
+                "enabled": True,
+            }
+        )
+    )
+
+    assert ax_baseline.render(_toolbar_with(ax_baseline, button), ()) == [
+        "AXToolbar enabled=true",
+        '  AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true',
+    ]
+
+
+def test_nested_button_with_its_own_identity_is_preserved(ax_baseline):
+    """The collapse is narrow even inside a toolbar: a child button that is a
+    DIFFERENT control keeps its line, so a real reparented button still shows up
+    as a structural diff.
+    """
+    outer = ax_baseline.Node(
+        {"role": "AXButton", "description": "Outer", "enabled": True}
+    )
+    outer.children.append(
+        ax_baseline.Node({"role": "AXButton", "description": "Inner", "enabled": True})
+    )
+
+    assert ax_baseline.render(_toolbar_with(ax_baseline, outer), ()) == [
+        "AXToolbar enabled=true",
+        '  AXButton desc="Outer" enabled=true',
+        '    AXButton desc="Inner" enabled=true',
+    ]
+
+
+def test_anonymous_nested_button_is_preserved(ax_baseline):
+    """An anonymous button (no identifier, no description) has no identity to
+    re-publish, so a button nested inside it is a distinct control — not
+    AppKit's self-copy — even under a toolbar. Collapsing on empty==empty would
+    hide that nesting from every golden diff, so the identity guard keeps both.
+    """
+    outer = ax_baseline.Node({"role": "AXButton", "enabled": True})
+    outer.children.append(ax_baseline.Node({"role": "AXButton", "enabled": True}))
+
+    assert ax_baseline.render(_toolbar_with(ax_baseline, outer), ()) == [
+        "AXToolbar enabled=true",
+        "  AXButton enabled=true",
+        "    AXButton enabled=true",
+    ]
+
+
+def test_identical_identity_nested_button_outside_toolbar_is_preserved(ax_baseline):
+    """The collapse is scoped to toolbar descendants. AppKit's lazy self-copy is
+    only seen there; the identical shape ANYWHERE ELSE is a real nested control,
+    so a change to it must still surface as a golden diff.
+    """
+    outer = ax_baseline.Node(
+        {
+            "role": "AXButton",
+            "identifier": "Some.Button",
+            "description": "Twin",
+            "enabled": True,
+        }
+    )
+    outer.children.append(
+        ax_baseline.Node(
+            {
+                "role": "AXButton",
+                "identifier": "Some.Button",
+                "description": "Twin",
+                "enabled": True,
+            }
+        )
+    )
+
+    assert ax_baseline.render(outer, ()) == [
+        'AXButton id="Some.Button" desc="Twin" enabled=true',
+        '  AXButton id="Some.Button" desc="Twin" enabled=true',
+    ]
+
+
+def test_same_identity_toolbar_button_with_a_deeper_child_is_preserved(ax_baseline):
+    """Even under a toolbar and even sharing its parent's identity, a button that
+    is NOT AppKit's leaf self-copy — here it owns a child of its own — is a real
+    control whose structure must stay in the diff. The lazy copy is always a
+    single leaf, so requiring that shape keeps this nesting visible.
+    """
+    outer = ax_baseline.Node(
+        {"role": "AXButton", "identifier": "Real.Group", "enabled": True}
+    )
+    inner = ax_baseline.Node(
+        {"role": "AXButton", "identifier": "Real.Group", "enabled": True}
+    )
+    inner.children.append(
+        ax_baseline.Node(
+            {"role": "AXStaticText", "description": "count", "enabled": True}
+        )
+    )
+    outer.children.append(inner)
+
+    assert ax_baseline.render(_toolbar_with(ax_baseline, outer), ()) == [
+        "AXToolbar enabled=true",
+        '  AXButton id="Real.Group" enabled=true',
+        '    AXButton id="Real.Group" enabled=true',
+        '      AXStaticText desc="count" enabled=true',
     ]
 
 

--- a/tests/test_ax_baseline_os_variance.py
+++ b/tests/test_ax_baseline_os_variance.py
@@ -71,7 +71,8 @@ def test_fixtures_carry_all_three_known_os_differences():
       1. the conversation menu's role spelling — AXMenuButton on macOS 26,
          AXPopUpButton on macOS 15 (absorbed by ``_ROLE_EQUIVALENTS``);
       2. an extra lazily-realized AXButton child under the "Hide Sidebar"
-         control on macOS 15 (absorbed by ``is_window_control``);
+         control on macOS 15 (absorbed by ``is_lazy_button_wrapper``, which
+         collapses that self-copy for every toolbar button by structure);
       3. an AppKit-synthesised AXTitle="More" on the conversation menu on
          macOS 15 (absorbed by the title rule in ``render_node``).
 


### PR DESCRIPTION
## Why
The AX structural baselines for the rapid-mac golden flows are generated on the **macos-15** CI runner and enforced there. But running them (or `--update-baselines`) on **macOS 26** produces spurious mismatches on the Search-chats toolbar button added in #1879: macOS 15 realizes a SwiftUI toolbar `Button` as an outer `AXButton` **plus** a lazily-created inner `AXButton` that re-publishes the button's identity (same id + description, tooltip as `AXHelp`); macOS 26 publishes it flat. Four AX-only golden flows fail locally on macOS 26 purely on this, and `--update-baselines` on macOS 26 would flip CI red — the exact trap `test_ax_baseline_os_variance.py` exists to prevent.

#1845 already absorbed this same divergence for the system **Hide/Show Sidebar** toggle, but it matched on the *description string*, so every new toolbar button had to be hand-added to an allowlist.

## What
- Replace the description allowlist in `ax-baseline.py` with a **structural** rule (`is_lazy_button_wrapper`): an `AXButton` whose *every* child is an `AXButton` re-publishing its own identifier **and** description is AppKit's lazy self-copy → drop the OS-owned inner node, keep the public button. Covers Hide/Show Sidebar and every app-authored toolbar button (`Toolbar.SearchChats` included) with no allowlist to maintain. A genuinely-nested control carries its own identity and is never collapsed.
- Regenerate the 18 affected baselines (the inner Search-chats line drops on both releases now).
- Add unit coverage for an identifier-bearing toolbar button and for a real nested button that must be preserved; correct the os-variance suite comment.

## Tests
- `test_ax_baseline.py` + `test_ax_baseline_os_variance.py`: **40 passed** (os-variance still green ⇒ the structural rule correctly absorbs the Hide-Sidebar wrapper the fixtures pin).
- `test_rapid_mac_ax_identifiers.py` + `test_gui_preflight_contract.py`: **74 passed**.
- **7 AX-only golden flows PASS** on macOS 26.5.2 / Xcode 16.4 against the regenerated baselines (4 previously failing + 3 unaffected).

## Notes
Found while dogfooding `main` HEAD; the server HTTP surface was fully green (functional + 5-way concurrency + long-context/malformed edge cases). **No product code changes** — test-infra only.

AI-assisted: authored with Claude Code (Opus 4.8).

## Reviewer note — one codex finding intentionally not followed
Codex suggested lifting the dropped child's `AXHelp` (tooltip) onto the parent instead of dropping it. **That would reintroduce the exact OS-variance this PR removes**, and is disproven by the committed fixtures: the flat macOS-26 toolbar button publishes `help=None`, while macOS 15 exposes the tooltip only on the lazy inner copy. Lifting it would make the two releases disagree on `help`. A tooltip only one OS exposes is not cross-OS structure; the PNG snapshots under `Tests/RapidTests/__Snapshots__` remain the check for tooltip text. Rationale captured in a code comment at the collapse site. (Codex rounds 1–3 — anonymous-button guard, toolbar-direct-parent scoping, single-leaf shape — were all valid and adopted.)