### PR TITLE
fix(chat): return HTTP 400 for MLLM stream preflight errors

### DIFF
--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -38,6 +38,7 @@ from fastapi.testclient import TestClient
 
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.request import ClientRequestError
 from vllm_mlx.routes.chat import router as chat_router
 
 
@@ -89,7 +90,7 @@ class _StubMLLMEngine:
     async def stream_chat(self, messages, **kwargs):
         self.stream_calls.append({"messages": messages, "kwargs": kwargs})
         if self._raise_msg is not None:
-            raise ValueError(self._raise_msg)
+            raise ClientRequestError(self._raise_msg)
         text = "A blue background."
         yield GenerationOutput(
             text=text,
@@ -293,6 +294,54 @@ def test_chat_route_maps_image_fetch_error_to_http_400_still_works():
     }
     resp = client.post("/v1/chat/completions", json=payload)
     assert resp.status_code == 400
+
+
+def test_streaming_bad_image_returns_http_400_before_sse_headers():
+    """A lazy MLLM prefill rejection must not be disguised as SSE HTTP 200."""
+    engine = _StubMLLMEngine(
+        raise_msg=(
+            "Failed to process image: unable to decode the supplied image; "
+            "provide a valid PNG, JPEG, GIF, or WebP file."
+        )
+    )
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3-vl-8b-4bit",
+            "messages": [_multipart_user_message("describe")],
+            "max_tokens": 16,
+            "stream": True,
+        },
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert resp.headers["content-type"].startswith("application/json")
+    assert "Failed to process image" in resp.json()["detail"]
+    assert "data:" not in resp.text
+
+
+def test_streaming_valid_mllm_replays_preflight_chunks_once():
+    """Successful preflight preserves normal role/content/DONE ordering."""
+    engine = _StubMLLMEngine()
+    client = _make_client(engine)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3-vl-8b-4bit",
+            "messages": [_multipart_user_message("describe")],
+            "max_tokens": 16,
+            "stream": True,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.text.count('"role":"assistant"') == 1
+    assert resp.text.count('"content":"A blue background."') == 1
+    assert resp.text.rstrip().endswith("data: [DONE]")
+    assert len(engine.stream_calls) == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -192,6 +192,16 @@ def test_chat_route_forwards_image_url_content_to_mllm_engine():
     image_part = next(p for p in parts if p.get("type") == "image_url")
     assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
 
+    # The streaming path preflights MLLM preprocessing before committing
+    # HTTP 200, then replays its buffered role/content chunks exactly once.
+    payload["stream"] = True
+    stream_resp = client.post("/v1/chat/completions", json=payload)
+    assert stream_resp.status_code == 200, stream_resp.text
+    assert stream_resp.text.count('"role":"assistant"') == 1
+    assert stream_resp.text.count('"content":"A blue background."') == 1
+    assert stream_resp.text.rstrip().endswith("data: [DONE]")
+    assert len(engine.stream_calls) == 1
+
 
 @pytest.mark.parametrize(
     "audio_part",
@@ -295,53 +305,15 @@ def test_chat_route_maps_image_fetch_error_to_http_400_still_works():
     resp = client.post("/v1/chat/completions", json=payload)
     assert resp.status_code == 400
 
-
-def test_streaming_bad_image_returns_http_400_before_sse_headers():
-    """A lazy MLLM prefill rejection must not be disguised as SSE HTTP 200."""
-    engine = _StubMLLMEngine(
-        raise_msg=(
-            "Failed to process image: unable to decode the supplied image; "
-            "provide a valid PNG, JPEG, GIF, or WebP file."
-        )
-    )
-    client = _make_client(engine)
-
-    resp = client.post(
-        "/v1/chat/completions",
-        json={
-            "model": "qwen3-vl-8b-4bit",
-            "messages": [_multipart_user_message("describe")],
-            "max_tokens": 16,
-            "stream": True,
-        },
-    )
-
-    assert resp.status_code == 400, resp.text
-    assert resp.headers["content-type"].startswith("application/json")
-    assert "Failed to process image" in resp.json()["detail"]
-    assert "data:" not in resp.text
-
-
-def test_streaming_valid_mllm_replays_preflight_chunks_once():
-    """Successful preflight preserves normal role/content/DONE ordering."""
-    engine = _StubMLLMEngine()
-    client = _make_client(engine)
-
-    resp = client.post(
-        "/v1/chat/completions",
-        json={
-            "model": "qwen3-vl-8b-4bit",
-            "messages": [_multipart_user_message("describe")],
-            "max_tokens": 16,
-            "stream": True,
-        },
-    )
-
-    assert resp.status_code == 200, resp.text
-    assert resp.text.count('"role":"assistant"') == 1
-    assert resp.text.count('"content":"A blue background."') == 1
-    assert resp.text.rstrip().endswith("data: [DONE]")
-    assert len(engine.stream_calls) == 1
+    # The lazy streaming engine raises only after the route would previously
+    # have committed SSE HTTP 200 plus its synthetic role chunk.  It must now
+    # remain a normal JSON 400 with the actionable message intact.
+    payload["stream"] = True
+    stream_resp = client.post("/v1/chat/completions", json=payload)
+    assert stream_resp.status_code == 400, stream_resp.text
+    assert stream_resp.headers["content-type"].startswith("application/json")
+    assert "Failed to process image" in stream_resp.json()["detail"]
+    assert "data:" not in stream_resp.text
 
 
 if __name__ == "__main__":

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3310,9 +3310,7 @@ async def _preflight_mllm_chat_stream(
         return True
 
     try:
-        completed = await _wait_with_disconnect(
-            _prime(), raw_request, timeout=timeout
-        )
+        completed = await _wait_with_disconnect(_prime(), raw_request, timeout=timeout)
     except BaseException:
         await stream.aclose()
         raise

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -67,6 +67,7 @@ from ..api.utils import (
 from ..config import get_config
 from ..engine import GenerationOutput
 from ..middleware.auth import check_rate_limit, verify_api_key
+from ..request import ClientRequestError
 from ..response_cache import (
     UNCACHEABLE,
     get_response_cache,
@@ -3280,6 +3281,57 @@ def _effective_posthoc_reasoning_cap(sampling_kwargs: dict, request) -> int | No
     return getattr(request, "reasoning_max_tokens", None)
 
 
+async def _preflight_mllm_chat_stream(
+    stream: AsyncIterator[str],
+    raw_request: Request,
+    *,
+    timeout: float,
+) -> AsyncIterator[str] | None:
+    """Prime an MLLM stream through its first engine-backed event.
+
+    ``stream_chat_completion`` yields the assistant role before asking the
+    engine for output.  Reading two items therefore crosses the lazy MLLM
+    preprocessing boundary without putting either item on the wire.  A typed
+    ``ClientRequestError`` can then become an HTTP 400 at the route boundary.
+    The returned iterator replays the buffered items exactly once and delegates
+    the remainder to the original iterator.
+    """
+
+    buffered: list[str] = []
+
+    async def _prime() -> bool:
+        try:
+            buffered.append(await anext(stream))
+            buffered.append(await anext(stream))
+        except StopAsyncIteration:
+            # A valid zero-content completion can terminate after its role
+            # chunk.  Preserve it rather than treating exhaustion as failure.
+            pass
+        return True
+
+    try:
+        completed = await _wait_with_disconnect(
+            _prime(), raw_request, timeout=timeout
+        )
+    except BaseException:
+        await stream.aclose()
+        raise
+    if completed is None:
+        await stream.aclose()
+        return None
+
+    async def _replay() -> AsyncIterator[str]:
+        try:
+            for chunk in buffered:
+                yield chunk
+            async for chunk in stream:
+                yield chunk
+        finally:
+            await stream.aclose()
+
+    return _replay()
+
+
 def _template_generation_prefix(engine, messages, tools, enable_thinking) -> str | None:
     """Return the TEMPLATE-added generation-prefix delta for ``messages``.
 
@@ -4882,7 +4934,6 @@ async def _create_chat_completion_impl(
                         detail=f"Chat template error: {err_msg}",
                     )
                 raise
-        _commit_state[0] = True
         # L-05: surface silent ``enable_thinking`` drop on non-Qwen
         # parsers via response headers. Merging here lets the SSE
         # ``Cache-Control`` / ``Connection`` headers stay intact.
@@ -4916,6 +4967,7 @@ async def _create_chat_completion_impl(
             # synthesize an SSE stream from the buffered output. Falls
             # back to the unconstrained streaming helper on guided
             # failure (logged), matching the non-streaming fallback.
+            _commit_state[0] = True
             return StreamingResponse(
                 _disconnect_guard(
                     stream_chat_completion_guided(
@@ -4952,6 +5004,7 @@ async def _create_chat_completion_impl(
             # retry tokens to the first stream). The strict-request
             # counter has already ticked above when ``strict_mode``
             # was detected — no double-count here.
+            _commit_state[0] = True
             return StreamingResponse(
                 _disconnect_guard(
                     stream_chat_completion_strict_postgen(
@@ -4969,15 +5022,38 @@ async def _create_chat_completion_impl(
                 media_type="text/event-stream",
                 headers=_sse_headers,
             )
+        _chat_stream = stream_chat_completion(
+            engine,
+            messages,
+            request,
+            caller_agent=_caller_ua,
+            **chat_kwargs,
+        )
+        if engine.is_mllm:
+            # #1849: an MLLM does its image/video decode and prompt-cap
+            # validation lazily, on the first engine iteration.  The chat
+            # generator emits a synthetic assistant-role chunk immediately
+            # before that iteration, so constructing StreamingResponse here
+            # used to commit HTTP 200 before a bad image could raise its
+            # typed, client-actionable error.  Prime through the role plus the
+            # first engine-backed chunk while the route can still select an
+            # HTTP status.  Text models retain their immediate role chunk and
+            # SSE keepalive behaviour; only MLLM TTFT waits for prefill, which
+            # is the unavoidable trade-off for a truthful HTTP status.
+            try:
+                _chat_stream = await _preflight_mllm_chat_stream(
+                    _chat_stream,
+                    raw_request,
+                    timeout=request.timeout or cfg.default_timeout,
+                )
+            except ClientRequestError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            if _chat_stream is None:
+                return Response(status_code=499)
+        _commit_state[0] = True
         return StreamingResponse(
             _disconnect_guard(
-                stream_chat_completion(
-                    engine,
-                    messages,
-                    request,
-                    caller_agent=_caller_ua,
-                    **chat_kwargs,
-                ),
+                _chat_stream,
                 raw_request,
                 engine=engine,
                 request_id_holder=request_id_holder,


### PR DESCRIPTION
Closes #1849

## Summary
- preflight MLLM chat streams through the first engine-backed event before committing HTTP 200
- map typed client-correctable prefill/image failures to HTTP 400 with the actionable message intact
- replay buffered successful chunks exactly once; keep text streaming and post-start SSE error semantics unchanged

## Validation
- `pytest tests/test_chat_route_vlm_image.py tests/test_sse_keepalive.py tests/test_mllm_corrupt_image.py -q` (30 passed)
- `pytest tests/test_embeddings_timeout_admission.py -q` (30 passed)
- `ruff check vllm_mlx/routes/chat.py tests/test_chat_route_vlm_image.py`
- `git diff --check`