### PR TITLE
docs(serve): document the --prefill-batch-size latency/throughput trade-off

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -8377,7 +8377,17 @@ Examples:
         ),
     )
     serve_parser.add_argument(
-        "--prefill-batch-size", type=int, default=8, help="Prefill batch size"
+        "--prefill-batch-size",
+        type=int,
+        default=8,
+        help=(
+            "Max prompts prefilled together in one cold wave (default: 8). "
+            "Lower it to cut first-token latency under concurrent cold load — "
+            "requests start decoding sooner instead of all sharing one "
+            "full-wave prefill — at an aggregate-throughput cost on large MoE "
+            "models, where staggered rows carry ragged offsets that push "
+            "batched attention onto a slower path (see #1861)."
+        ),
     )
     serve_parser.add_argument(
         "--completion-batch-size", type=int, default=32, help="Completion batch size"


### PR DESCRIPTION
## Why
`--prefill-batch-size` shipped with the help string `"Prefill batch size"`, which hid the fact that it is the one operator lever for **#1861 Finding A** — the shared-TTFT barrier under concurrent cold load (N co-arriving requests all wait out the full batch prefill before any starts decoding).

The #1861 investigation established there is **no free-lunch fix**: to emit a request's first token you must fully prefill it, so co-arriving prompts either prefill together (one aligned wave — the default: fast decode, shared TTFT) or separately (staggered: first token sooner, but ragged per-row offsets pin mlx-lm's batched attention on the array-mask slow path for the batch's lifetime — measured **−47% aggregate on 35B-A3B**). The default is the deliberate throughput-optimal choice; `--prefill-batch-size` already lets latency-sensitive operators pick the other end. This just makes that discoverable.

## What
- Expand the `--prefill-batch-size` argparse help from `"Prefill batch size"` to state the default, what lowering it buys (first-token latency under concurrent cold load), and its aggregate cost on large MoE models, with an `#1861` pointer.
- **Docs/help-string only — no behaviour change**, no default change.

## Tests
- `ruff check` + `ruff format --check` clean.
- `rapid-mlx serve -h` renders the new help correctly.
- Trade-off verified locally (Qwen3-0.6B-8bit, 8 concurrent cold ~480-word prompts): `--prefill-batch-size 8` (default) → hard TTFT barrier, all 2.96 s (range 0.00 s); `--prefill-batch-size 1` → staggered, 1.00 s first token (~3× sooner).

## Notes
Written with Claude Code (AI-assisted). Finding A is thereby resolved as by-design-with-lever; #1861 remains open scoped to Finding B (serving-layer engine-loop cycle cost at high aggregate on large MoE).