### PR TITLE
fix(pr_validate): reject reviewer severity directives

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadProgress.swift
@@ -434,7 +434,7 @@ final class DownloadProgress {
         // when a per-file completion line is interleaved on the same
         // poll tick — the heartbeat is the more granular signal.
         if let m = matchR2BytesHeartbeat(trimmed) {
-            // Codex-style review NIT #2: ``setTotalBytes`` writes through
+            // Codex-style raised in review #2: ``setTotalBytes`` writes through
             // an ``@Observable`` setter, which fans out a property-change
             // notification SwiftUI uses to re-render any view that read
             // ``totalBytes``. A 120 s pull fires ~240 heartbeats with the

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -2397,7 +2397,7 @@ final class ServerManager {
         // whose URL the scrubber will redact, while the progress
         // parser only cares about the trailing `[X/Y]`).
         //
-        // v0.7.11 review NIT #3: the R2 puller fires its aggregate
+        // v0.7.11 raised in review #3: the R2 puller fires its aggregate
         // ``[bytes] D/T`` heartbeat at ~2 Hz × 60-120 s, which
         // would otherwise evict every legitimate startup log /
         // warning from the 200-line ``logLines`` ring buffer well

--- a/apps/rapid-mac/Tests/RapidTests/AutoRespawnTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AutoRespawnTests.swift
@@ -253,7 +253,7 @@ struct AutoRespawnTests {
         ))
     }
 
-    // MARK: - manual-stop cancellation pins (internal review NIT)
+    // MARK: - manual-stop cancellation pins (internal raised in review)
 
     @Test("stop() zeros the auto-respawn attempt counter")
     func stopZerosAutoRespawnAttempts() async {
@@ -282,7 +282,7 @@ struct AutoRespawnTests {
 
     @Test("dismissTerminalState() zeros the auto-respawn attempt counter")
     func dismissTerminalStateZerosAutoRespawnAttempts() {
-        // Internal review NIT: the existing ``dismissCancelsAutoRespawn``
+        // Internal raised in review: the existing ``dismissCancelsAutoRespawn``
         // test only asserts the post-dismiss counter is 0, which it
         // always was. Seed a non-zero value first so we actually
         // observe the cancel running.

--- a/scripts/mirror_to_r2.py
+++ b/scripts/mirror_to_r2.py
@@ -184,7 +184,7 @@ def _is_root_keep(relpath: str) -> bool:
 # Without this, ``--subfolder docs`` uploads a documentation directory,
 # verifies the objects it just wrote, and reports success — reproducing
 # the "mirror completed but pull still 404s" failure this flag exists to
-# prevent (review MAJOR).
+# prevent (raised in review).
 _WEIGHT_SUFFIXES = (".safetensors", ".npz", ".bin", ".gguf")
 
 
@@ -505,7 +505,7 @@ def mirror_repo(
     # ``is not None``, not truthiness: ``--subfolder ""`` (an unset shell
     # variable expanding to nothing) is a caller mistake, and treating it
     # as "no filter" silently mirrors the full 20 GB repo the flag exists
-    # to avoid. _select_subfolder rejects it (review MAJOR).
+    # to avoid. _select_subfolder rejects it (raised in review).
     if subfolder is not None:
         before = len(files)
         before_bytes = sum((f.size or 0) for f in files)

--- a/scripts/pr_validate/README.md
+++ b/scripts/pr_validate/README.md
@@ -27,7 +27,8 @@ python3.12 -m scripts.pr_validate <PR#> -v
 | 0.7 | `cl_description_quality` | always (skip via `PR_VALIDATE_SKIP_DESC=1`) | <1s |
 | 0.75 | `supply_chain` | always | ~5s |
 | 0.8 | `test_env_check` | always (auto-install opt-out: `PR_VALIDATE_NO_AUTO_INSTALL=1`) | <1s (≈10s if install runs) |
-| 6 | `codex_review` | always (skip if codex CLI missing / not logged in) | 30–180s |
+| 0.9 | `review_vocabulary` | when a diff is available | <1s |
+| 1 | `codex_review` | always (skip if codex CLI missing / not logged in) | 30–180s |
 | 2 | `lint` | when diff has .py | ~3s |
 | 3 | `targeted_tests` | when diff has .py | 30s–3min |
 | 4 | `full_unit` | blast ≥ medium | ~25s |

--- a/scripts/pr_validate/runner.py
+++ b/scripts/pr_validate/runner.py
@@ -24,6 +24,7 @@ from .steps.diff_coverage import DiffCoverageStep
 from .steps.fetch import FetchStep
 from .steps.full_unit import FullUnitStep
 from .steps.lint import LintStep
+from .steps.review_vocabulary import ReviewVocabularyStep
 from .steps.stress_e2e_bench import StressE2EBenchStep
 from .steps.supply_chain import SupplyChainStep
 from .steps.targeted_tests import TargetedTestsStep
@@ -64,6 +65,7 @@ STEPS: list[Step] = [
     # when the diff touches dep-declaration files — see ``_test_env.py``
     # for the gate.
     TestEnvCheckStep(),
+    ReviewVocabularyStep(),  # reject diff text that can steer that reviewer (#1528)
     CodexReviewStep(),  # 6 — adversarial review (codex exec, gpt-5.6-sol)
     LintStep(),  # 2 — ruff check + format
     TargetedTestsStep(),  # 3 — diff-aware test selection + neg control

--- a/scripts/pr_validate/steps/review_vocabulary.py
+++ b/scripts/pr_validate/steps/review_vocabulary.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reject reviewer-severity directives embedded in added diff lines."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..base import Step, StepResult
+from ..context import Context
+
+_DIRECTIVE = re.compile(
+    r"(?i)\b(?:codex[_ -]?review|re-review|review)\s+(?:blocking|major|minor|nit)(?:-\d+)?\b"
+)
+
+
+def _find_directives(diff_path: Path) -> list[str]:
+    findings: list[str] = []
+    current_file = "unknown"
+    new_line = 0
+    for line in diff_path.read_text(errors="replace").splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+            continue
+        if line.startswith("@@"):
+            match = re.search(r"\+(\d+)", line)
+            new_line = int(match.group(1)) - 1 if match else 0
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            new_line += 1
+            if _DIRECTIVE.search(line[1:]):
+                findings.append(f"{current_file}:{new_line}: {line[1:].strip()}")
+        elif not line.startswith("-"):
+            new_line += 1
+    return findings
+
+
+class ReviewVocabularyStep(Step):
+    name = "review_vocabulary"
+    description = "reject reviewer-severity directives in added lines"
+
+    def should_run(self, ctx: Context) -> bool:
+        return bool(ctx.diff_path)
+
+    def run(self, ctx: Context) -> StepResult:
+        findings = _find_directives(Path(ctx.diff_path))
+        if not findings:
+            return StepResult(name=self.name, status="pass", summary="no directives")
+        details = (
+            "Added lines must describe provenance without using the automated "
+            "reviewer's severity vocabulary:\n\n```\n" + "\n".join(findings) + "\n```"
+        )
+        return StepResult(
+            name=self.name,
+            status="fail",
+            summary=f"{len(findings)} reviewer directive(s) in added lines",
+            details=details,
+        )

--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -204,7 +204,7 @@ class StressE2EBenchStep(Step):
                     # Registered here, not after the matrix: the bench has
                     # already produced its artifact, and an exception in
                     # stress or in any agent below would otherwise discard
-                    # a measurement that was complete (review NIT).
+                    # a measurement that was complete (raised in review).
                     if bench_result.get("artifact"):
                         all_artifacts.append(bench_result["artifact"])
 

--- a/tests/parsers/_harmony_markers.py
+++ b/tests/parsers/_harmony_markers.py
@@ -35,7 +35,7 @@ HARMONY_CONTROL_TOKENS: tuple[str, ...] = (
 # every harmony regression would generate false positives whenever a
 # user-visible response contains them. Tests that need to catch a
 # bare channel-label leak (e.g. ``content="commentary..."``) can
-# import this tuple explicitly. Codex re-review NIT: comment now
+# import this tuple explicitly. raised in Codex re-review: comment now
 # explicitly documents the exclusion rationale rather than leaving it
 # implicit.
 HARMONY_CHANNEL_LABELS: tuple[str, ...] = ("analysis", "commentary", "final")

--- a/tests/parsers/dispatch.py
+++ b/tests/parsers/dispatch.py
@@ -138,7 +138,7 @@ def _run_tool_streaming(
     potential ``<tool_call>`` opener but no call ever fired). Without
     this call the parser-level harness would silently drop the held
     suffix and a regression like #448 would pass even if the held
-    bytes never reached the client (codex re-review BLOCKING).
+    bytes never reached the client (raised in Codex re-review).
     """
     reconstructor = StreamingToolReconstructor(
         assert_one_tool_per_delta=assert_one_tool_per_delta

--- a/tests/parsers/regressions/test_issue_447_gemma4_thought_marker_leak.py
+++ b/tests/parsers/regressions/test_issue_447_gemma4_thought_marker_leak.py
@@ -120,7 +120,7 @@ BUG_CASES: list[_Case] = [
 ]
 
 
-# Codex re-review BLOCKING (2026-06-04): the bare-INIT gate now uses
+# raised in Codex re-review (2026-06-04): the bare-INIT gate now uses
 # 1-token lookahead. A response that legitimately STARTS with one of
 # the channel-word tokens (``thought`` / ``content`` / ``final``)
 # followed by NON-whitespace must surface the word as content rather
@@ -162,7 +162,7 @@ LOOKAHEAD_ROLLBACK_CASES: list[_Case] = [
         ],
         # Without ``\n`` after ``thought``, lookahead rejects the
         # channel intent — the buffered word is just literal content
-        # (codex re-review BLOCKING: routing rejected bare words to
+        # (raised in Codex re-review: routing rejected bare words to
         # reasoning was hiding valid user-visible content). Emit as
         # CONTENT and let the body follow in the CONTENT state.
         expected_content="thoughtHello",
@@ -278,7 +278,7 @@ def test_gemma4_router_no_channel_marker_leaks(case: _Case, router):
     )
 
 
-# ----- Lookahead rollback (codex re-review BLOCKING) --------------------
+# ----- Lookahead rollback (raised in Codex re-review) --------------------
 
 
 @pytest.mark.parametrize("case", LOOKAHEAD_ROLLBACK_CASES, ids=lambda c: c.id)
@@ -292,7 +292,7 @@ def test_gemma4_router_lookahead_rollback_preserves_legit_first_token(
     the lookahead rolls back to emit the buffered token as the channel
     indicated by its semantic meaning, then continues processing the
     body in that channel. Without this guard, the prior implementation
-    silently swallowed the first token (codex re-review BLOCKING).
+    silently swallowed the first token (raised in Codex re-review).
 
     The bare word ALSO sets channel state — that's intentional: if the
     model speaks one of the channel words at INIT, treat it as

--- a/tests/parsers/regressions/test_issue_455_harmony_commentary_tool_channel.py
+++ b/tests/parsers/regressions/test_issue_455_harmony_commentary_tool_channel.py
@@ -301,7 +301,7 @@ def test_harmony_router_sanity(case: _SanityCase, router):
         "tool_calls empty) requires asserting in the parser-level "
         "regression file, not here — keeping this contract single-"
         "outcome avoids a passing-test-but-wrong-router-fix loophole "
-        "(codex re-review NIT)."
+        "(raised in Codex re-review)."
     ),
     strict=True,
 )

--- a/tests/parsers/streaming_reconstructor.py
+++ b/tests/parsers/streaming_reconstructor.py
@@ -206,7 +206,7 @@ class StreamingToolReconstructor:
             existing.arguments += delta_args
         else:
             # R2: id and name must appear on first delta for this index.
-            # Codex re-review BLOCKING: require non-empty strings — pre-fix
+            # raised in Codex re-review: require non-empty strings — pre-fix
             # the ``is not None`` check accepted ``id=""`` / ``name=""``
             # as satisfying the invariant, letting a malformed first delta
             # with blank identifiers slip through silently.

--- a/tests/parsers/test_infra_smoke.py
+++ b/tests/parsers/test_infra_smoke.py
@@ -203,7 +203,7 @@ def test_harmony_markers_match_source():
     token (say a future ``<|new|>``) and every harmony regression
     file would silently let it leak because
     ``HARMONY_CONTROL_TOKENS`` never gained the entry (codex
-    re-review BLOCKING).
+    raised in re-review).
 
     Now: import the parser's exposed
     ``HARMONY_STRIPPED_CONTROL_TOKENS`` constant and assert set
@@ -247,7 +247,7 @@ def test_assert_no_marker_leak_catches_each_marker(marker):
 def test_tool_reconstructor_rejects_malformed_tool_calls():
     """``tool_calls`` must be a list when present — string / dict / int /
     bytes all rejected. Renamed from ``rejects_null_tool_calls`` (codex
-    re-review NIT): the prior name claimed null coverage, but the
+    raised in re-review): the prior name claimed null coverage, but the
     reconstructor deliberately treats ``tool_calls=None`` as equivalent
     to "key absent" (so JSON deltas that explicitly serialize the field
     as ``None`` round-trip cleanly). Only non-list types are rejected.
@@ -278,7 +278,7 @@ def test_tool_reconstructor_rejects_null_function():
 
 
 def test_tool_reconstructor_rejects_non_string_arguments():
-    """Codex re-review BLOCKING: ``arguments`` was previously coerced via
+    """raised in Codex re-review: ``arguments`` was previously coerced via
     ``function.get("arguments") or ""``, silently swallowing ``None`` /
     ``0`` / ``False``. Strict typing now requires the field to be absent
     or a string; any other type fails the reconstructor's assertion.

--- a/tests/test_bench_runs_on_a_clean_server.py
+++ b/tests/test_bench_runs_on_a_clean_server.py
@@ -44,7 +44,7 @@ def _capture_runner_lines():
     call and the agent-matrix call are at different nesting depths — the
     latter lives inside a ``for`` — so a walk-order test would have
     reported an order the file does not have, and would have kept
-    passing with the bench moved back to the end (review BLOCKING).
+    passing with the bench moved back to the end (raised in review).
     """
     lines = {}
     for node in ast.walk(_run_body()):

--- a/tests/test_chat_streaming_spec.py
+++ b/tests/test_chat_streaming_spec.py
@@ -1196,7 +1196,7 @@ def test_synthetic_terminal_chunk_does_not_replay_accumulated_text(monkeypatch):
         f"emitted once by the defensive branch), got {full_content!r}. "
         f"A duplicated prefix like 'HelloHello world<' means the synthetic "
         f"chunk re-emitted processor.accumulated_text on top of already-"
-        f"streamed deltas (codex re-review BLOCKING)."
+        f"streamed deltas (raised in Codex re-review)."
     )
 
 

--- a/tests/test_mid_conversation_system_prefix_cache.py
+++ b/tests/test_mid_conversation_system_prefix_cache.py
@@ -498,7 +498,7 @@ class TestRelocationIsOptInAndOffByDefault:
 class TestFlagReachesTheAdapterEndToEnd:
     """Exercise the REAL chain, not each link in isolation.
 
-    Review MAJOR: the other tests here check `ServerConfig`'s default, the
+    raised in review: the other tests here check `ServerConfig`'s default, the
     merge helper, and a mocked `get_config()` separately. Delete either
     plumbing assignment — `cli.py`'s `server._relocate_mid_conversation_system
     = ...` or `server.py`'s `cfg.relocate_mid_conversation_system = ...` —

--- a/tests/test_no_pydantic_error_leak.py
+++ b/tests/test_no_pydantic_error_leak.py
@@ -379,7 +379,7 @@ def test_responses_no_pydantic_leak(client, case_id, msgs_body, resp_body):
 # ── H-17 round-2 (codex): attacker sentinel inside a KEY name ────────
 
 
-# Codex H-17 round-2 (PR #784 review BLOCKING #2 + #3): exercise the
+# Codex H-17 round-2 (PR #784 raised in review #2 + #3): exercise the
 # loc-sanitizer across the full byte shape an attacker can choose for
 # a dict key or an extra-forbid field name. The original sanitizer's
 # identifier-shape regex passed valid-identifier sentinels (e.g.

--- a/tests/test_pflash_metrics.py
+++ b/tests/test_pflash_metrics.py
@@ -199,7 +199,7 @@ def test_scheduler_counters_untouched_when_pflash_skips():
     # Threshold-skip path: BOTH counters must stay at zero. Asserting only
     # ``pflash_bypass_count`` would let a regression that silently
     # incremented ``pflash_compressed_tokens_dropped`` on threshold skips
-    # slip through unnoticed (codex review nit, M-02 PR).
+    # slip through unnoticed (raised in Codex review, M-02 PR).
     assert scheduler_auto.get_stats()["pflash_bypass_count"] == 0
     assert scheduler_auto.get_stats()["pflash_compressed_tokens_dropped"] == 0
 

--- a/tests/test_pr_validate_review_vocabulary.py
+++ b/tests/test_pr_validate_review_vocabulary.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from scripts.pr_validate.steps.review_vocabulary import _find_directives
+
+
+def test_finds_directives_only_on_added_lines(tmp_path: Path):
+    old_directive = "review " + "BLOCKING"
+    new_directive = "codex_review " + "NIT-2"
+    diff = tmp_path / "pr.diff"
+    diff.write_text(
+        "diff --git a/a.py b/a.py\n"
+        "--- a/a.py\n"
+        "+++ b/a.py\n"
+        "@@ -10,2 +10,3 @@\n"
+        f"-# {old_directive} old text\n"
+        "+# raised during review\n"
+        f"+# {new_directive} new text\n"
+        " context\n"
+    )
+    assert _find_directives(diff) == [f"a.py:11: # {new_directive} new text"]
+
+
+def test_allows_ordinary_review_provenance(tmp_path: Path):
+    diff = tmp_path / "pr.diff"
+    diff.write_text(
+        "diff --git a/a.swift b/a.swift\n"
+        "--- a/a.swift\n"
+        "+++ b/a.swift\n"
+        "@@ -0,0 +1,2 @@\n"
+        "+// Found during PR #123 review round 2.\n"
+        "+let value = 1\n"
+    )
+    assert _find_directives(diff) == []
+
+
+def test_step_is_registered():
+    from scripts.pr_validate.runner import STEPS
+
+    assert "review_vocabulary" in [step.name for step in STEPS]
+    names = [step.name for step in STEPS]
+    assert names.index("review_vocabulary") < names.index("codex_review")

--- a/tests/test_release_check_m3_port_thread.py
+++ b/tests/test_release_check_m3_port_thread.py
@@ -450,7 +450,7 @@ def test_every_integration_base_url_env_is_covered() -> None:
     ``http://`` or ``https://``) rather than by the env-var name. A
     name-based regex would false-positive on unrelated envs like
     ``DATABASE_URL`` (which happens to end in ``BASE_URL`` but points at
-    a DB DSN, not an HTTP API) — codex_review NIT on PR #982.
+    a DB DSN, not an HTTP API) — raised in Codex review on PR #982.
     """
     # Capture the env-var name AND its default. Both single- and
     # double-quoted forms; whitespace tolerant. We require the default

--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -688,7 +688,7 @@ class TestResponsesToOpenai:
         # raw list / dict through — without `_to_text` this would crash
         # with `TypeError: sequence item 0: expected str instance, list
         # found` once a future code path leaves `Message.content` un-
-        # coerced. codex_review NIT: cover the path directly.
+        # coerced. raised in Codex review: cover the path directly.
         msgs = [
             Message.model_construct(
                 role="system",
@@ -707,7 +707,7 @@ class TestResponsesToOpenai:
         assert merged[1].role == "user"
 
     def test_merge_system_messages_drops_empty_system_after_user(self):
-        # codex_review BLOCKING regression: a `developer` item with
+        # raised in Codex review regression: a `developer` item with
         # empty content reaches the merge step as `Message(role="system",
         # content="")`. Old logic branched on whether the merged text
         # was truthy and returned `messages` unchanged when it wasn't —

--- a/tests/test_tool_call_closer_content_integrity.py
+++ b/tests/test_tool_call_closer_content_integrity.py
@@ -199,7 +199,7 @@ class TestStreamingSanitizerHelpersKeepTheCloser:
 class TestRescuePrefixBranchAlsoStrips:
     """The length-cut rescue branch is the OTHER call site that moved.
 
-    Review MINOR, twice: my first attempt at this test passed neither
+    raised in review, twice: my first attempt at this test passed neither
     ``finish_reason="length"`` nor rescue-shaped content, so it ran the
     ORDINARY path and would have stayed green with the rescue line
     reverted. Reviewer mutated that line in memory and confirmed it.

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -605,7 +605,7 @@ def _merge_system_messages(
     # system-role message after `_message_item_to_chat`, so leaving the
     # list untouched when `system_texts` is empty would let a non-leading
     # system message reach Qwen / Llama / Gemma — the exact template
-    # failure this function exists to prevent (codex_review BLOCKING).
+    # failure this function exists to prevent (raised in Codex review).
     has_system = any(m.role == "system" for m in messages)
     if not has_system:
         return messages

--- a/vllm_mlx/audio/probe.py
+++ b/vllm_mlx/audio/probe.py
@@ -1197,7 +1197,7 @@ AUDIO_EXTRA_INSTALL_HINT = "Install with: pip install 'rapid-mlx[audio]'"
 # (``mlx-community/Kokoro-82M-bf16``, ``mlx-community/whisper-large-v3-mlx``)
 # — those are the canonical pass-through cases the STT/TTS routes
 # accept, so the boot guard MUST recognise them as audio too. Codex
-# review NIT: the previous comment claimed HF ids "fell through"; the
+# raised in review: the previous comment claimed HF ids "fell through"; the
 # code (and test ``test_is_audio_model_alias_recognises_common_aliases``)
 # disagree — they ARE matched, and intentionally so.
 #

--- a/vllm_mlx/bench/_server.py
+++ b/vllm_mlx/bench/_server.py
@@ -196,7 +196,7 @@ def _wait_for_health(health_url: str, proc: subprocess.Popen, timeout_s: int) ->
     Uses ``time.monotonic()`` for the deadline so a system clock
     adjustment mid-boot (NTP step, manual ``date`` change) can't
     shorten or extend the health wait incorrectly (Codex PR #623
-    review NIT-2). ``time.time()`` would happily measure negative
+    raised in review). ``time.time()`` would happily measure negative
     elapsed time if the clock stepped backwards.
     """
     deadline = time.monotonic() + timeout_s

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4021,7 +4021,7 @@ def _run_tier_submit_flow(args) -> int:
     # have rejected anything else — a programmatic Namespace (e.g.
     # someone constructing args directly) could bypass argparse, and
     # the previous ``assert`` would be stripped under ``python -O``
-    # (Codex PR #623 review NIT-1). Explicit guard returns 2 with a
+    # (Codex PR #623 raised in review). Explicit guard returns 2 with a
     # readable error rather than blowing up later inside the submit
     # flow with a less targeted traceback.
     if tier not in ("smoke", "speed", "harness", "all"):

--- a/vllm_mlx/embedding.py
+++ b/vllm_mlx/embedding.py
@@ -63,7 +63,7 @@ def mlx_embeddings_available() -> bool:
     transitive dependency raising ``ImportError`` deep inside the
     package surfaces as the real exception (not masked behind the
     "install the extra" hint), making misdiagnosis less likely
-    (codex review nit on PR #800).
+    (raised in Codex review on PR #800).
 
     Lazy resolution — keeps the base install (without the
     ``[embeddings]`` extra) free of ``mlx_embeddings`` at module

--- a/vllm_mlx/output_router.py
+++ b/vllm_mlx/output_router.py
@@ -195,7 +195,7 @@ class OutputRouter:
             return None
         # Rollback: lookahead REJECTED the channel intent — the
         # buffered word is just literal user-visible content (codex
-        # re-review BLOCKING: routing rejected ``thought`` to reasoning
+        # raised in re-review: routing rejected ``thought`` to reasoning
         # was hiding valid plain content). Emit it as CONTENT and set
         # the router state to CONTENT for subsequent processing of the
         # current token via the redo queue.
@@ -407,7 +407,7 @@ class OutputRouter:
         # the marker-preserving router followup.
         if self.state == RouterState.INIT:
             # Buffer the bare channel-word for a 1-token lookahead instead
-            # of swallowing it immediately (codex re-review BLOCKING: a
+            # of swallowing it immediately (raised in Codex re-review: a
             # legitimate plain response that genuinely starts with the
             # literal "final" / "content" / "thought" token would lose its
             # first token under the old immediate-swallow). The decision

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -7292,7 +7292,7 @@ async def stream_chat_completion(
             # ``accumulated_reasoning`` — both were already written
             # to the wire as per-delta chunks during the loop, so
             # replaying them would duplicate the whole response
-            # (codex re-review BLOCKING). The original round-6 fix
+            # (raised in Codex re-review). The original round-6 fix
             # in the postprocessor makes this branch unreachable
             # in the common case, but defense-in-depth: keep this
             # synthetic chunk additive only.


### PR DESCRIPTION
## Summary
- reject reviewer-severity directives in added diff lines before automated review runs
- preserve ordinary review provenance wording
- clean existing directive vocabulary from source and tests

Closes #1528

## Test plan
- [x] `ruff check` / `ruff format --check` on changed validator files
- [x] `python3 -m pytest tests/test_pr_validate_review_vocabulary.py tests/test_pr_validate_lint.py tests/test_pr_validate_runner.py -q` (41 passed)