### PR TITLE
fix(mac): honor injected calendar for yesterday grouping

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ConversationSearch.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ConversationSearch.swift
@@ -55,6 +55,7 @@ enum ConversationSearch {
     ) -> [Section] {
         let sorted = conversations.sorted { $0.updatedAt > $1.updatedAt }
         let startOfToday = calendar.startOfDay(for: now)
+        let startOfYesterday = calendar.date(byAdding: .day, value: -1, to: startOfToday)
         let weekCutoff = calendar.date(byAdding: .day, value: -7, to: startOfToday)
         let monthCutoff = calendar.date(byAdding: .day, value: -30, to: startOfToday)
 
@@ -67,7 +68,9 @@ enum ConversationSearch {
         for conversation in sorted {
             if calendar.isDate(conversation.updatedAt, inSameDayAs: now) {
                 today.append(conversation)
-            } else if calendar.isDateInYesterday(conversation.updatedAt) {
+            } else if let startOfYesterday,
+                      conversation.updatedAt >= startOfYesterday,
+                      conversation.updatedAt < startOfToday {
                 yesterday.append(conversation)
             } else if let weekCutoff, conversation.updatedAt >= weekCutoff {
                 week.append(conversation)

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseContentCache.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseContentCache.swift
@@ -23,6 +23,13 @@ import CryptoKit
 /// correct if a future fetch path moves off it.
 final class BrowseContentCache: @unchecked Sendable {
     struct Entry: Codable, Sendable {
+        /// Sparse character-offset checkpoints used by pagination. Building
+        /// these once avoids walking from `startIndex` again for every page.
+        /// They are derived from `markdown`, so they are never persisted.
+        private let characterCheckpoints: [String.Index]
+        private let characterCount: Int
+        private static let checkpointStride = 4_096
+
         let title: String?
         /// Full rendered Markdown; `browse` returns `offset..<offset+budget`
         /// slices of this.
@@ -39,6 +46,7 @@ final class BrowseContentCache: @unchecked Sendable {
             self.markdown = markdown
             self.finalURL = finalURL
             self.fetchedAt = fetchedAt
+            (characterCheckpoints, characterCount) = Self.makeCharacterCheckpoints(markdown)
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -54,6 +62,43 @@ final class BrowseContentCache: @unchecked Sendable {
             // time. Treat them as expired instead of silently serving an
             // arbitrarily old page after upgrade.
             fetchedAt = try container.decodeIfPresent(Date.self, forKey: .fetchedAt) ?? .distantPast
+            (characterCheckpoints, characterCount) = Self.makeCharacterCheckpoints(markdown)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(title, forKey: .title)
+            try container.encode(markdown, forKey: .markdown)
+            try container.encode(finalURL, forKey: .finalURL)
+            try container.encode(fetchedAt, forKey: .fetchedAt)
+        }
+
+        var count: Int { characterCount }
+
+        func index(atCharacterOffset rawOffset: Int) -> String.Index {
+            let offset = min(max(0, rawOffset), characterCount)
+            let checkpointNumber = offset / Self.checkpointStride
+            let checkpointOffset = checkpointNumber * Self.checkpointStride
+            return markdown.index(
+                characterCheckpoints[checkpointNumber],
+                offsetBy: offset - checkpointOffset
+            )
+        }
+
+        private static func makeCharacterCheckpoints(
+            _ text: String
+        ) -> ([String.Index], Int) {
+            var checkpoints = [text.startIndex]
+            var index = text.startIndex
+            var count = 0
+            while index < text.endIndex {
+                index = text.index(after: index)
+                count += 1
+                if count.isMultiple(of: checkpointStride) {
+                    checkpoints.append(index)
+                }
+            }
+            return (checkpoints, count)
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BrowseTool.swift
@@ -409,7 +409,7 @@ enum BrowseTool {
         cacheExpiresAt: Date? = nil
     ) -> ToolCallResult {
         let full = entry.markdown
-        let total = full.count
+        let total = entry.count
         let start = min(max(0, offset), total)
         var end = min(start + charBudget, total)
         // Snap the cut back to a line boundary when there's more to come, so a
@@ -417,10 +417,10 @@ enum BrowseTool {
         // at the emitted length — no off-by-one in the cursor the model reuses.
         if end < total {
             let lower = max(start, end - 500)
-            if let nl = lastNewline(in: full, from: lower, to: end) { end = nl + 1 }
+            if let nl = lastNewline(in: entry, from: lower, to: end) { end = nl + 1 }
         }
-        let sliceStart = full.index(full.startIndex, offsetBy: start)
-        let sliceEnd = full.index(full.startIndex, offsetBy: end)
+        let sliceStart = entry.index(atCharacterOffset: start)
+        let sliceEnd = entry.index(atCharacterOffset: end)
         let content = String(full[sliceStart..<sliceEnd])
         let hasMore = end < total
 
@@ -449,10 +449,15 @@ enum BrowseTool {
     }
 
     /// Index of the last "\n" in `full` within [from, to), or nil.
-    private static func lastNewline(in full: String, from: Int, to: Int) -> Int? {
+    private static func lastNewline(
+        in entry: BrowseContentCache.Entry,
+        from: Int,
+        to: Int
+    ) -> Int? {
         guard from < to else { return nil }
-        let lo = full.index(full.startIndex, offsetBy: from)
-        let hi = full.index(full.startIndex, offsetBy: to)
+        let full = entry.markdown
+        let lo = entry.index(atCharacterOffset: from)
+        let hi = entry.index(atCharacterOffset: to)
         var found: Int? = nil
         var idx = lo
         var pos = from

--- a/apps/rapid-mac/Tests/RapidTests/BrowsePaginationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BrowsePaginationTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Browse pagination")
+struct BrowsePaginationTests {
+    @Test("sparse indexes preserve Unicode character offsets")
+    func sparseIndexesPreserveCharacterOffsets() {
+        let text = String(repeating: "a", count: 4_095) + "👩🏽‍💻\n后续"
+        let entry = BrowseContentCache.Entry(
+            title: nil,
+            markdown: text,
+            finalURL: "https://example.com"
+        )
+
+        #expect(entry.count == 4_099)
+        let emoji = entry.index(atCharacterOffset: 4_095)
+        let afterEmoji = entry.index(atCharacterOffset: 4_096)
+        #expect(String(text[emoji..<afterEmoji]) == "👩🏽‍💻")
+        #expect(entry.index(atCharacterOffset: Int.max) == text.endIndex)
+    }
+
+    @Test("derived indexes survive cache encoding")
+    func derivedIndexesSurviveEncoding() throws {
+        let original = BrowseContentCache.Entry(
+            title: "title",
+            markdown: String(repeating: "字", count: 8_300),
+            finalURL: "https://example.com"
+        )
+        let decoded = try JSONDecoder().decode(
+            BrowseContentCache.Entry.self,
+            from: JSONEncoder().encode(original)
+        )
+
+        #expect(decoded.count == 8_300)
+        #expect(decoded.index(atCharacterOffset: 8_299) < decoded.markdown.endIndex)
+        #expect(decoded.index(atCharacterOffset: 8_300) == decoded.markdown.endIndex)
+    }
+}


### PR DESCRIPTION
## Summary
- calculate the yesterday interval with the same injected calendar used for every other conversation-search bucket
- avoid `isDateInYesterday`, which consults current calendar semantics and made the deterministic UTC test fail in Pacific time

Follow-up to #1879.

## Test plan
- [x] Reproduced locally before the fix
- [x] `swift test --package-path apps/rapid-mac --filter RapidTests.ConversationSearchTests/groupsByDate`