### PR TITLE
Unify core workspace with Direction D visual system

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -338,6 +338,168 @@ enum DevSnapshot {
         renderHosted(sidebarOnly(), size: sidebarSize,
                      appearance: .darkAqua, to: "\(dir)/sidebar-dark.png")
 
+        // MARK: UI-2 Slice 1 — the core-workspace review matrix
+        //
+        // The captures above review Chat and Launch at 900x640 and at the
+        // 640x560 window floor, which were the sizes the v1.0 pass was
+        // signed off at. Slice 1 is reviewed at three DIFFERENT widths —
+        // 1440, 1000 and 720 — because that is where the lifecycle band
+        // changes shape, and a 900pt capture would silently review only
+        // its middle step.
+        //
+        // Chat and Images are captured at every width in both
+        // appearances. The band is captured separately at all three
+        // widths: a live ``ContentView`` can only show whichever state
+        // the harness is actually in, and staging a real multi-gigabyte
+        // download is not something a capture run can do.
+        let ui2Widths: [CGFloat] = [
+            RapidTheme.Layout.Breakpoint.wide,
+            RapidTheme.Layout.Breakpoint.mid,
+            RapidTheme.Layout.Breakpoint.floor,
+        ]
+        let ui2Appearances: [(NSAppearance.Name, String)] = [(.aqua, "light"), (.darkAqua, "dark")]
+
+        for width in ui2Widths {
+            // 900 tall at every width: the point of the sweep is the
+            // horizontal behaviour, and holding height fixed makes the
+            // three images directly comparable.
+            let size = CGSize(width: width, height: 900)
+            for (appearance, mode) in ui2Appearances {
+                renderHosted(
+                    contentView(width: width, height: 900), size: size,
+                    appearance: appearance,
+                    to: "\(dir)/ui2-chat-\(Int(width))-\(mode).png"
+                )
+                renderHosted(
+                    imagesView(width: width, height: 900), size: size,
+                    appearance: appearance,
+                    to: "\(dir)/ui2-images-result-\(Int(width))-\(mode).png"
+                )
+            }
+        }
+
+        // Images again with the stage cleared, because the capture above
+        // inherits the edit-mode seeding from Scenario 1 and therefore
+        // only ever shows a RESULT. The empty stage is the surface this
+        // slice actually changed — it is where the mascot was replaced by
+        // the aspect preview — so it needs its own sweep.
+        //
+        // Safe to mutate here: every other Images capture has already
+        // been taken by this point in the run.
+        imageGen.cancelEdit()
+        imageGen.prompt = ""
+        // ``activeImage`` is derived from ``results``, so clearing the
+        // list is what empties the stage.
+        imageGen.results = []
+        for width in ui2Widths {
+            let size = CGSize(width: width, height: 900)
+            for (appearance, mode) in ui2Appearances {
+                renderHosted(
+                    imagesView(width: width, height: 900), size: size,
+                    appearance: appearance,
+                    to: "\(dir)/ui2-images-empty-\(Int(width))-\(mode).png"
+                )
+            }
+        }
+        // The aspect preview tracks the live selection, so sweep the
+        // three aspects too — a square-only capture would not show that
+        // the frame actually changes shape.
+        for aspect in ImageGenViewModel.Aspect.allCases {
+            imageGen.aspect = aspect
+            renderHosted(
+                imagesView(width: 1000, height: 900),
+                size: CGSize(width: 1000, height: 900),
+                appearance: .aqua,
+                to: "\(dir)/ui2-images-aspect-\(aspect.rawValue).png"
+            )
+        }
+        imageGen.aspect = .square
+
+        // The band, driven directly by the two states that open it, at
+        // each of its three heights. Rendered over a stub transcript so
+        // the graphite-against-canvas separation is reviewable rather
+        // than the band floating on nothing.
+        func bandProof(_ readiness: ModelReadiness, width: CGFloat) -> AnyView {
+            AnyView(
+                VStack(spacing: 0) {
+                    LifecycleBand(readiness: readiness, width: width)
+                    Spacer(minLength: 0)
+                }
+                .frame(width: width, height: LifecycleBand.height(for: width) + 80)
+                .background(RapidTheme.surfaceCanvas)
+                .tint(RapidTheme.brandAmber)
+            )
+        }
+        let bandStates: [(String, ModelReadiness)] = [
+            ("downloading", .downloading(
+                alias: "qwen3.5-9b-4bit",
+                detail: "1.2 GB of 5.0 GB · 8.4 MB/s · 7 min left",
+                fraction: 0.24
+            )),
+            // No fraction: the indeterminate case, which must render an
+            // honest bare track rather than a bar pinned at zero.
+            ("starting", .starting(
+                alias: "bonsai-1.7b-2bit",
+                detail: "Loading the model into memory…"
+            )),
+        ]
+        for (label, state) in bandStates {
+            for width in ui2Widths {
+                let size = CGSize(width: width, height: LifecycleBand.height(for: width) + 80)
+                for (appearance, mode) in ui2Appearances {
+                    renderHosted(
+                        bandProof(state, width: width), size: size,
+                        appearance: appearance,
+                        to: "\(dir)/ui2-band-\(label)-\(Int(width))-\(mode).png"
+                    )
+                }
+            }
+        }
+
+        // NOTE ON REDUCE MOTION. There is deliberately no capture for it
+        // here, and the reason is a real constraint rather than an
+        // oversight: `\.accessibilityReduceMotion` is a READ-ONLY
+        // environment key on macOS — it mirrors the system setting, and
+        // SwiftUI offers no writable keypath — so a harness cannot stage
+        // the reduced rendering the way it stages an appearance or a
+        // width. Injecting it would need a seam through every call site,
+        // which is a refactor this visual slice has no business making.
+        //
+        // The contract is held instead by ``RapidMotion.shouldPulse`` and
+        // by the source guard asserting both perpetual loops in the
+        // Images HUD route through it. Whether the reduced frame LOOKS
+        // right stays a manual check against the system setting.
+
+        // The rail with a MID-LIST row selected, which the capture above
+        // cannot show: it selects ``.launch``, the last row, so it proves
+        // the bar renders but not that the bar leaves its neighbours
+        // alone. Selecting Images puts a marked row between two unmarked
+        // ones, which is where a leading bar that took layout width —
+        // rather than overlaying it — would visibly step the labels in
+        // and out.
+        //
+        // ``.chat`` is deliberately NOT used here: it marks no nav row at
+        // all (it highlights a conversation row, and this fixture seeds
+        // no history), so it would capture an empty rail and look like
+        // the selection had regressed.
+        func sidebarSelectionProof() -> AnyView {
+            AnyView(
+                SidebarView(
+                    selection: .constant(.images),
+                    chat: chat,
+                    onNewChat: {},
+                    onSelectConversation: { _ in }
+                )
+                .frame(width: SidebarView.columnIdealWidth, height: 640)
+                .background(RapidTheme.surfaceSidebar)
+                .tint(RapidTheme.brandAmber)
+            )
+        }
+        renderHosted(sidebarSelectionProof(), size: sidebarSize,
+                     appearance: .aqua, to: "\(dir)/ui2-sidebar-selected-light.png")
+        renderHosted(sidebarSelectionProof(), size: sidebarSize,
+                     appearance: .darkAqua, to: "\(dir)/ui2-sidebar-selected-dark.png")
+
         // Settings → Model Management. The panel seeds its catalog
         // synchronously from ``ModelCatalogCache``'s mirror, so warm the
         // cache first or every capture is the spinner.

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -352,28 +352,24 @@ enum DevSnapshot {
         // widths: a live ``ContentView`` can only show whichever state
         // the harness is actually in, and staging a real multi-gigabyte
         // download is not something a capture run can do.
-        let ui2Widths: [CGFloat] = [
-            RapidTheme.Layout.Breakpoint.wide,
-            RapidTheme.Layout.Breakpoint.mid,
-            RapidTheme.Layout.Breakpoint.floor,
-        ]
+        let ui2Widths: [CGFloat] = [1440, 1000, 720]
         let ui2Appearances: [(NSAppearance.Name, String)] = [(.aqua, "light"), (.darkAqua, "dark")]
 
-        for width in ui2Widths {
+        for windowWidth in ui2Widths {
             // 900 tall at every width: the point of the sweep is the
             // horizontal behaviour, and holding height fixed makes the
             // three images directly comparable.
-            let size = CGSize(width: width, height: 900)
+            let size = CGSize(width: windowWidth, height: 900)
             for (appearance, mode) in ui2Appearances {
                 renderHosted(
-                    contentView(width: width, height: 900), size: size,
+                    contentView(width: windowWidth, height: 900), size: size,
                     appearance: appearance,
-                    to: "\(dir)/ui2-chat-\(Int(width))-\(mode).png"
+                    to: "\(dir)/ui2-chat-\(Int(windowWidth))-\(mode).png"
                 )
                 renderHosted(
-                    imagesView(width: width, height: 900), size: size,
+                    imagesView(width: windowWidth, height: 900), size: size,
                     appearance: appearance,
-                    to: "\(dir)/ui2-images-result-\(Int(width))-\(mode).png"
+                    to: "\(dir)/ui2-images-result-\(Int(windowWidth))-\(mode).png"
                 )
             }
         }
@@ -391,13 +387,13 @@ enum DevSnapshot {
         // ``activeImage`` is derived from ``results``, so clearing the
         // list is what empties the stage.
         imageGen.results = []
-        for width in ui2Widths {
-            let size = CGSize(width: width, height: 900)
+        for windowWidth in ui2Widths {
+            let size = CGSize(width: windowWidth, height: 900)
             for (appearance, mode) in ui2Appearances {
                 renderHosted(
-                    imagesView(width: width, height: 900), size: size,
+                    imagesView(width: windowWidth, height: 900), size: size,
                     appearance: appearance,
-                    to: "\(dir)/ui2-images-empty-\(Int(width))-\(mode).png"
+                    to: "\(dir)/ui2-images-empty-\(Int(windowWidth))-\(mode).png"
                 )
             }
         }
@@ -443,14 +439,22 @@ enum DevSnapshot {
                 detail: "Loading the model into memory…"
             )),
         ]
+        let ui2DetailWidths: [(window: CGFloat, detail: CGFloat)] = [
+            (1440, RapidTheme.Layout.Breakpoint.wide),
+            (1000, RapidTheme.Layout.Breakpoint.mid),
+            (720, RapidTheme.Layout.Breakpoint.floor),
+        ]
         for (label, state) in bandStates {
-            for width in ui2Widths {
-                let size = CGSize(width: width, height: LifecycleBand.height(for: width) + 80)
+            for widths in ui2DetailWidths {
+                let size = CGSize(
+                    width: widths.detail,
+                    height: LifecycleBand.height(for: widths.detail) + 80
+                )
                 for (appearance, mode) in ui2Appearances {
                     renderHosted(
-                        bandProof(state, width: width), size: size,
+                        bandProof(state, width: widths.detail), size: size,
                         appearance: appearance,
-                        to: "\(dir)/ui2-band-\(label)-\(Int(width))-\(mode).png"
+                        to: "\(dir)/ui2-band-\(label)-\(Int(widths.window))-\(mode).png"
                     )
                 }
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -232,10 +232,25 @@ struct ChatView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            // The band opens ABOVE the transcript, never between it and
+            // the composer: it is context for the whole surface, and
+            // wedging it into the compose zone is exactly the treatment
+            // that made a multi-gigabyte download read as an inline
+            // footnote. It replaces the readiness banner for the duration
+            // — see ``composeBar`` — rather than joining it, so the same
+            // sentence is never on screen twice.
+            if showsLifecycleBand {
+                LifecycleBand(
+                    readiness: readiness,
+                    attentionToken: blockedSendAttempts
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
             transcript
             Divider()
             composeBar
         }
+        .rapidAnimation(RapidMotion.standard, value: showsLifecycleBand)
         .background(RapidTheme.surfaceCanvas)
         // Drop a stale error banner once the server is provably ready.
         .onChange(of: server.state) { _, newState in
@@ -351,25 +366,64 @@ struct ChatView: View {
         return out
     }
 
+    /// Whether the lifecycle band owns the current moment.
+    ///
+    /// Exactly the two states in which the app is doing work the user is
+    /// waiting on. Everything else — nothing chosen, not downloaded, not
+    /// running, failed — is a DECISION, and a decision belongs beside the
+    /// control that resolves it, which is the composer's notice slot.
+    ///
+    /// Streaming is deliberately absent. A reply arriving is work, but it
+    /// is work the user can already see landing token by token, and it
+    /// does not block the surface; opening a graphite band over every
+    /// answer would make the ordinary case of using the product feel like
+    /// an interruption.
+    private var showsLifecycleBand: Bool { readiness.isWorking }
+
     private var emptyState: some View {
+        // Optically centred, not geometrically. The composer is a fixed
+        // object pinned to the bottom of the window, so a block centred
+        // on the transcript's true midpoint reads as sitting low —
+        // drifting toward the composer rather than balancing against it.
+        // Lifting the block by 2.8% of the region's height puts it where
+        // the eye expects the centre to be. The lift is proportional
+        // rather than a fixed offset so it stays correct from the 560pt
+        // window floor to a full-screen 1440.
+        GeometryReader { proxy in
+            VStack(spacing: 0) {
+                Spacer(minLength: RapidTheme.Space.lg)
+                heroBlock
+                Spacer(minLength: RapidTheme.Space.xl)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.bottom, proxy.size.height * 0.056)
+        }
+    }
+
+    private var heroBlock: some View {
         EmptyState(
             title: "Ask anything",
             message: emptyStateSubtitle,
             hint: downloadHint,
-            markDiameter: 92,
-            mark: {
-                // The brand moment on the app's main surface. 68pt
-                // inside a 92pt disc — at the previous 28/44 the mascot
-                // read as a favicon rather than the product's mark.
-                //
-                // 68 is deliberately ≥ 64: ``CheetahLogo`` switches to
-                // the 440×390 master above that threshold, so the
-                // artwork is downsampled from a large source (crisp at
-                // @2x) instead of being upscaled from the 56×50 crop.
-                // ``scaledToFit`` inside a square frame preserves the
-                // asset's own aspect ratio.
-                CheetahLogo(size: 68)
-            }
+            // No disc. The plate was framing an illustration that already
+            // has its own silhouette, and — being amber-tinted — it was
+            // spending a second amber moment on a surface whose whole
+            // budget is one (that one is the send disc).
+            //
+            // 116 is deliberately ≥ 64: ``CheetahLogo`` switches to the
+            // 440×390 master above that threshold, so the artwork is
+            // downsampled from a large source (crisp at @2x) rather than
+            // upscaled from the 56×50 crop. ``scaledToFit`` inside the
+            // square frame preserves the asset's own aspect ratio, which
+            // is why the mark renders ~116×103 rather than square.
+            markDiameter: 116,
+            marksOnBackplate: false,
+            // The chat surface at rest has nothing else in it. A 20pt
+            // line alone in 1440pt of canvas reads as a caption that lost
+            // its picture; at 34/40 the greeting is the object it should
+            // be.
+            titleEmphasis: .display,
+            mark: { CheetahLogo(size: 116) }
         )
     }
 
@@ -396,7 +450,15 @@ struct ChatView: View {
             // the same fact twice. Once the model is ready the slot
             // reverts to turn-level errors (a 500 from a healthy server),
             // which readiness has no opinion about.
-            if !readiness.isReady {
+            if !readiness.isReady && !showsLifecycleBand {
+                // Suppressed while the band is open. The band renders the
+                // same ``ModelReadiness`` — same headline, same detail,
+                // same fraction — so leaving the banner here as well
+                // would print one fact twice, 400pt apart, in two
+                // different visual languages. Nothing is lost: neither
+                // ``downloading`` nor ``starting`` carries a renderable
+                // action, so no control moves and no identifier goes
+                // missing (see ``ModelReadiness.action``).
                 ReadinessBanner(
                     readiness: readiness,
                     attentionToken: blockedSendAttempts,

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -231,24 +231,35 @@ struct ChatView: View {
     private var messages: [ChatMessage] { viewModel.messages }
 
     var body: some View {
-        VStack(spacing: 0) {
-            // The band opens ABOVE the transcript, never between it and
-            // the composer: it is context for the whole surface, and
-            // wedging it into the compose zone is exactly the treatment
-            // that made a multi-gigabyte download read as an inline
-            // footnote. It replaces the readiness banner for the duration
-            // — see ``composeBar`` — rather than joining it, so the same
-            // sentence is never on screen twice.
-            if showsLifecycleBand {
-                LifecycleBand(
-                    readiness: readiness,
-                    attentionToken: blockedSendAttempts
-                )
-                .transition(.move(edge: .top).combined(with: .opacity))
+        // The reader exists for one value: the surface's own width, which
+        // the lifecycle band needs in order to pick its height on the
+        // FIRST layout pass. Reading it here — where the pane already has
+        // a definite size — rather than letting the band measure itself
+        // is what keeps the band's geometry a pure function of its
+        // inputs, and therefore reproducible in a single-pass capture.
+        GeometryReader { proxy in
+            VStack(spacing: 0) {
+                // The band opens ABOVE the transcript, never between it
+                // and the composer: it is context for the whole surface,
+                // and wedging it into the compose zone is exactly the
+                // treatment that made a multi-gigabyte download read as
+                // an inline footnote. It replaces the readiness banner
+                // for the duration — see ``composeBar`` — rather than
+                // joining it, so the same sentence is never on screen
+                // twice.
+                if showsLifecycleBand {
+                    LifecycleBand(
+                        readiness: readiness,
+                        attentionToken: blockedSendAttempts,
+                        width: proxy.size.width
+                    )
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                }
+                transcript
+                Divider()
+                composeBar
             }
-            transcript
-            Divider()
-            composeBar
+            .frame(width: proxy.size.width, height: proxy.size.height)
         }
         .rapidAnimation(RapidMotion.standard, value: showsLifecycleBand)
         .background(RapidTheme.surfaceCanvas)

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/EmptyState.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/EmptyState.swift
@@ -21,23 +21,47 @@ import SwiftUI
 /// offers side-doors, and none of them should out-shout the real
 /// primary action on the surface (in chat, the composer).
 struct EmptyState<Mark: View, Actions: View>: View {
+    /// How loudly the title speaks.
+    ///
+    /// ``page`` (20pt) is right for an empty state that shares a window
+    /// with other content — a results pane, a settings list. ``display``
+    /// (34/40) is for the case where the empty state IS the window:
+    /// the chat surface at rest has nothing else in it, so a 20pt line
+    /// floating in 1440pt of canvas reads as a caption that lost its
+    /// picture rather than as the product greeting you.
+    enum TitleEmphasis {
+        case page
+        case display
+    }
+
     let title: String
     var message: String? = nil
     /// A quieter third line — e.g. "First message will download X".
     var hint: String? = nil
-    /// Diameter of the tinted backing disc. 44 suits a small SF Symbol;
-    /// the chat surface passes ~92 so the mascot reads as a real brand
-    /// moment rather than a favicon.
+    /// Diameter of the mark's frame — and, when ``marksOnBackplate`` is
+    /// true, of the tinted disc behind it. 44 suits a small SF Symbol.
     var markDiameter: CGFloat = 44
+    /// Whether the mark sits on a tinted disc.
+    ///
+    /// Direction D turns this off for the chat mascot. The plate was
+    /// doing two jobs badly: it framed an illustration that already has
+    /// its own silhouette, and — being amber-tinted — it spent a second
+    /// amber moment on a surface whose budget is one. A symbol mark still
+    /// wants the plate, because a 19pt glyph with no ground is a stray
+    /// mark rather than an object.
+    var marksOnBackplate: Bool = true
+    var titleEmphasis: TitleEmphasis = .page
     @ViewBuilder var mark: Mark
     @ViewBuilder var actions: Actions
 
     var body: some View {
         VStack(spacing: RapidTheme.Space.md) {
             ZStack {
-                Circle()
-                    .fill(RapidTheme.brandPrimaryTint)
-                    .frame(width: markDiameter, height: markDiameter)
+                if marksOnBackplate {
+                    Circle()
+                        .fill(RapidTheme.brandPrimaryTint)
+                        .frame(width: markDiameter, height: markDiameter)
+                }
                 mark
             }
             // The mark is decoration; the title carries the meaning.
@@ -45,12 +69,10 @@ struct EmptyState<Mark: View, Actions: View>: View {
             .padding(.bottom, RapidTheme.Space.xs)
 
             VStack(spacing: RapidTheme.Space.xs) {
-                Text(title)
-                    .font(RapidFont.pageTitle)
-                    .foregroundStyle(.primary)
+                titleText
                 if let message {
                     Text(message)
-                        .font(RapidFont.secondary)
+                        .font(messageFont)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
@@ -77,8 +99,41 @@ struct EmptyState<Mark: View, Actions: View>: View {
                 .padding(.top, RapidTheme.Space.xs)
             }
         }
-        .frame(maxWidth: 380)
+        .frame(maxWidth: contentMaxWidth)
         .padding(.horizontal, RapidTheme.Space.xl)
+    }
+
+    @ViewBuilder
+    private var titleText: some View {
+        switch titleEmphasis {
+        case .page:
+            Text(title)
+                .font(RapidFont.pageTitle)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+        case .display:
+            Text(title)
+                .font(RapidFont.displayTitle)
+                // SF tightens as it grows; at 34pt the default spacing
+                // reads loose enough to look like tracked-out display
+                // type from a slide deck.
+                .tracking(RapidFont.displayTitleTracking)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    /// The supporting line steps up with the title. A 12pt subtitle
+    /// under a 34pt display line reads as a footnote that wandered in
+    /// from another surface.
+    private var messageFont: Font {
+        titleEmphasis == .display ? RapidFont.displaySubtitle : RapidFont.secondary
+    }
+
+    /// Display compositions get the reading measure; page-tier ones keep
+    /// the tighter 380 they were laid out for.
+    private var contentMaxWidth: CGFloat {
+        titleEmphasis == .display ? RapidTheme.Layout.decisionMaxWidth : 380
     }
 }
 
@@ -111,6 +166,8 @@ extension EmptyState where Actions == EmptyView {
         message: String? = nil,
         hint: String? = nil,
         markDiameter: CGFloat = 44,
+        marksOnBackplate: Bool = true,
+        titleEmphasis: TitleEmphasis = .page,
         @ViewBuilder mark: () -> Mark
     ) {
         self.init(
@@ -118,6 +175,8 @@ extension EmptyState where Actions == EmptyView {
             message: message,
             hint: hint,
             markDiameter: markDiameter,
+            marksOnBackplate: marksOnBackplate,
+            titleEmphasis: titleEmphasis,
             mark: mark,
             actions: { EmptyView() }
         )

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/LifecycleBand.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/LifecycleBand.swift
@@ -45,14 +45,22 @@ struct LifecycleBand: View {
     /// acknowledgement too — otherwise a blocked Return would go silent
     /// precisely during the longest wait in the product.
     var attentionToken: Int = 0
-
-    /// Last measured width of the band, used only to pick one of the
-    /// three heights. Measured through a background probe rather than by
-    /// wrapping the body in a ``GeometryReader``: the height depends on
-    /// the width, and a GeometryReader claims all the space its parent
-    /// offers, so reading the width from inside one would make the band's
-    /// own height its input.
-    @State private var measuredWidth: CGFloat = RapidTheme.Layout.Breakpoint.mid
+    /// Width of the surface the band spans, supplied by the parent.
+    ///
+    /// An input rather than something the band measures itself, and the
+    /// distinction is load-bearing. The first version read its own width
+    /// through a background ``GeometryReader`` into `@State`, which needs
+    /// a SECOND layout pass to take effect — and a single-pass render
+    /// (the snapshot harness, and by extension every screenshot the
+    /// design gets reviewed from) never gives it one. The 720pt capture
+    /// came out wearing the 1000pt layout, which is exactly the kind of
+    /// defect a screenshot review is supposed to catch and instead
+    /// silently produced.
+    ///
+    /// The parent already has a definite width; passing it down makes the
+    /// band's geometry a pure function of its inputs, correct on the
+    /// first pass, and reproducible in a capture.
+    var width: CGFloat
 
     @State private var attentionActive = false
 
@@ -61,19 +69,8 @@ struct LifecycleBand: View {
             .frame(maxWidth: RapidTheme.Layout.contentMaxWidth)
             .frame(maxWidth: .infinity)
             .padding(.horizontal, RapidTheme.Space.xl)
-            .frame(height: Self.height(for: measuredWidth))
+            .frame(height: Self.height(for: width))
             .background(RapidTheme.surfaceBand)
-            .background {
-                GeometryReader { proxy in
-                    Color.clear.preference(
-                        key: LifecycleBandWidthKey.self,
-                        value: proxy.size.width
-                    )
-                }
-            }
-            .onPreferenceChange(LifecycleBandWidthKey.self) { width in
-                if abs(width - measuredWidth) > 0.5 { measuredWidth = width }
-            }
             .overlay(alignment: .bottom) {
                 // A blocked send flashes the band's leading edge rather
                 // than moving anything. Reduce Motion is handled by
@@ -212,15 +209,5 @@ struct LifecycleBand: View {
         height(for: width) <= 44
     }
 
-    private var isCompact: Bool { Self.isCompact(width: measuredWidth) }
-}
-
-/// Width probe for ``LifecycleBand``. See ``LifecycleBand/measuredWidth``
-/// for why the band measures itself instead of being wrapped in a
-/// ``GeometryReader``.
-private struct LifecycleBandWidthKey: PreferenceKey {
-    static let defaultValue: CGFloat = RapidTheme.Layout.Breakpoint.mid
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
+    private var isCompact: Bool { Self.isCompact(width: width) }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/LifecycleBand.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/LifecycleBand.swift
@@ -52,8 +52,8 @@ struct LifecycleBand: View {
     /// through a background ``GeometryReader`` into `@State`, which needs
     /// a SECOND layout pass to take effect — and a single-pass render
     /// (the snapshot harness, and by extension every screenshot the
-    /// design gets reviewed from) never gives it one. The 720pt capture
-    /// came out wearing the 1000pt layout, which is exactly the kind of
+    /// design gets reviewed from) never gives it one. The compact capture
+    /// came out wearing the middle layout, which is exactly the kind of
     /// defect a screenshot review is supposed to catch and instead
     /// silently produced.
     ///
@@ -101,7 +101,8 @@ struct LifecycleBand: View {
     @ViewBuilder
     private var content: some View {
         if isCompact {
-            // At the 720pt floor the band collapses to one line plus its
+            // At the 720pt window floor (a 520pt detail pane after the
+            // sidebar) the band collapses to one line plus its
             // rule. The detail line is the first thing dropped, because
             // it is the one part the composer placeholder already
             // paraphrases — and dropping the headline instead would take

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/LifecycleBand.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/LifecycleBand.swift
@@ -1,0 +1,226 @@
+import SwiftUI
+
+/// The graphite band a surface opens above its content while the app is
+/// doing lifecycle work the user is waiting on — pulling weights, or
+/// loading them into Metal.
+///
+/// ## Why this exists
+///
+/// A multi-gigabyte download used to be a two-line notice in a ~44pt
+/// strip wedged between the transcript and the compose field: the same
+/// visual weight as "this model doesn't support images". The single
+/// longest wait in the product was also its quietest moment on screen,
+/// and users read the silence as "nothing is happening".
+///
+/// The band gives that wait the priority it earns, and takes it back the
+/// instant the work ends. That is the whole of the rule it implements:
+/// the resting composition is for deciding, reading, and working; this
+/// one is for active AI work that deserves the room. It is not a theme
+/// and not a mode — nothing the user can turn on, nothing that outlives
+/// the task, and nothing the sidebar or the status strip ever adopt.
+///
+/// ## Why horizontal
+///
+/// The obvious shape for "a priority area" is a column down one side.
+/// That fails here for a measurable reason: chat has a 720pt reading
+/// measure, and at the 720pt window floor a graphite column would be
+/// taking width directly out of the conversation. Turned 90° the band
+/// contests nothing — only its own height flexes (see ``height(for:)``),
+/// and the transcript keeps every point of its measure at every width.
+///
+/// ## What it says
+///
+/// Nothing of its own. Every string is read off ``ModelReadiness`` — the
+/// same value the composer's placeholder, the Send tooltip and the
+/// empty-state subtitle read — so the band cannot describe a moment
+/// differently from the surfaces around it. The percentage is the only
+/// thing it formats, and only when a real fraction exists: an
+/// indeterminate bar here would imply a precision the download monitor
+/// does not have.
+struct LifecycleBand: View {
+    let readiness: ModelReadiness
+    /// Bumped by the composer each time a send is attempted while gated,
+    /// exactly as ``ReadinessBanner`` uses it. The band takes over the
+    /// banner's slot during working states, so it has to take over the
+    /// acknowledgement too — otherwise a blocked Return would go silent
+    /// precisely during the longest wait in the product.
+    var attentionToken: Int = 0
+
+    /// Last measured width of the band, used only to pick one of the
+    /// three heights. Measured through a background probe rather than by
+    /// wrapping the body in a ``GeometryReader``: the height depends on
+    /// the width, and a GeometryReader claims all the space its parent
+    /// offers, so reading the width from inside one would make the band's
+    /// own height its input.
+    @State private var measuredWidth: CGFloat = RapidTheme.Layout.Breakpoint.mid
+
+    @State private var attentionActive = false
+
+    var body: some View {
+        content
+            .frame(maxWidth: RapidTheme.Layout.contentMaxWidth)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, RapidTheme.Space.xl)
+            .frame(height: Self.height(for: measuredWidth))
+            .background(RapidTheme.surfaceBand)
+            .background {
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: LifecycleBandWidthKey.self,
+                        value: proxy.size.width
+                    )
+                }
+            }
+            .onPreferenceChange(LifecycleBandWidthKey.self) { width in
+                if abs(width - measuredWidth) > 0.5 { measuredWidth = width }
+            }
+            .overlay(alignment: .bottom) {
+                // A blocked send flashes the band's leading edge rather
+                // than moving anything. Reduce Motion is handled by
+                // ``rapidAnimation`` — the change snaps instead of
+                // fading. The cue still HAPPENS, because it is feedback
+                // the user is actively waiting on, and suppressing it
+                // would answer a keypress with nothing at all.
+                Rectangle()
+                    .fill(attentionActive ? RapidTheme.brandPrimary : RapidTheme.bandTrack)
+                    .frame(height: attentionActive ? 2 : 1)
+            }
+            .rapidAnimation(RapidMotion.quick, value: attentionActive)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(readiness.accessibilityLabel)
+            .accessibilityIdentifier("Readiness.Band")
+            .task(id: attentionToken) {
+                // Token 0 is the initial value — only a real bump should
+                // flash, or the band would emphasise itself the moment it
+                // opens.
+                guard attentionToken > 0 else { return }
+                attentionActive = true
+                try? await Task.sleep(nanoseconds: 1_400_000_000)
+                guard !Task.isCancelled else { return }
+                attentionActive = false
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isCompact {
+            // At the 720pt floor the band collapses to one line plus its
+            // rule. The detail line is the first thing dropped, because
+            // it is the one part the composer placeholder already
+            // paraphrases — and dropping the headline instead would take
+            // the model's name with it.
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xs + 1) {
+                HStack(spacing: RapidTheme.Space.md) {
+                    Text(readiness.headline)
+                        .font(RapidFont.bodyEmphasis)
+                        .foregroundStyle(RapidTheme.bandInk)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    if let percent = percentText {
+                        Text(percent)
+                            .font(RapidFont.bandEyebrow)
+                            .foregroundStyle(RapidTheme.brandPrimary)
+                            .monospacedDigit()
+                            .fixedSize()
+                    }
+                }
+                progressTrack
+            }
+        } else {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+                HStack(alignment: .lastTextBaseline, spacing: RapidTheme.Space.lg) {
+                    Text(readiness.headline)
+                        .font(RapidFont.bandTitle)
+                        .foregroundStyle(RapidTheme.bandInk)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    if let percent = percentText {
+                        Text(percent)
+                            .font(RapidFont.bandMetric)
+                            .foregroundStyle(RapidTheme.brandPrimary)
+                            .monospacedDigit()
+                            .fixedSize()
+                    }
+                }
+                progressTrack
+                if let detail = readiness.detail {
+                    Text(detail)
+                        // Byte counts and ETAs tick every 500 ms;
+                        // monospaced digits stop the line rewriting its
+                        // own width as they do.
+                        .font(RapidFont.metric)
+                        .foregroundStyle(RapidTheme.bandInkSecondary)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    /// The 4pt rule. Determinate when the download monitor has a real
+    /// fraction; a bare track otherwise, which reads honestly as "work is
+    /// happening and we cannot say how far in" rather than as a bar stuck
+    /// at zero.
+    private var progressTrack: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule(style: .continuous)
+                    .fill(RapidTheme.bandTrack)
+                if let fraction = readiness.progressFraction {
+                    Capsule(style: .continuous)
+                        .fill(RapidTheme.brandPrimary)
+                        .frame(width: proxy.size.width * min(max(fraction, 0), 1))
+                }
+            }
+        }
+        .frame(height: 4)
+        .accessibilityHidden(true)
+    }
+
+    /// Whole percent, or `nil` when no real fraction exists.
+    ///
+    /// Static and pure so the rounding and the clamp can be pinned
+    /// directly — a fraction slightly over 1.0 (the byte monitor can
+    /// overshoot on the last chunk) must read "100%", never "101%".
+    static func percentText(for fraction: Double?) -> String? {
+        guard let fraction else { return nil }
+        return "\(Int((min(max(fraction, 0), 1) * 100).rounded()))%"
+    }
+
+    private var percentText: String? { Self.percentText(for: readiness.progressFraction) }
+
+    // MARK: - Geometry
+
+    /// Only the band's HEIGHT responds to window width — never its width,
+    /// which is the property that makes a horizontal band safe beside a
+    /// fixed reading measure.
+    ///
+    /// Static and pure so the three steps can be pinned by a test without
+    /// standing up a window at three sizes.
+    static func height(for width: CGFloat) -> CGFloat {
+        if width >= RapidTheme.Layout.Breakpoint.wide { return 132 }
+        if width >= RapidTheme.Layout.Breakpoint.mid { return 112 }
+        return 44
+    }
+
+    /// True at the compact step, where the band is one line plus its rule.
+    static func isCompact(width: CGFloat) -> Bool {
+        height(for: width) <= 44
+    }
+
+    private var isCompact: Bool { Self.isCompact(width: measuredWidth) }
+}
+
+/// Width probe for ``LifecycleBand``. See ``LifecycleBand/measuredWidth``
+/// for why the band measures itself instead of being wrapped in a
+/// ``GeometryReader``.
+private struct LifecycleBandWidthKey: PreferenceKey {
+    static let defaultValue: CGFloat = RapidTheme.Layout.Breakpoint.mid
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ConversationSearchView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConversationSearchView.swift
@@ -152,7 +152,7 @@ struct ConversationSearchView: View {
                     .foregroundStyle(.secondary)
                     .frame(width: RapidTheme.Layout.iconSlot)
                 Text(conversation.title)
-                    .font(RapidFont.body)
+                    .font(selected ? RapidFont.bodyEmphasis : RapidFont.body)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Spacer(minLength: RapidTheme.Space.sm)
@@ -167,14 +167,29 @@ struct ConversationSearchView: View {
             .frame(height: 40)
             .background(
                 RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
-                    .fill(selected ? RapidTheme.brandPrimaryTint : (hovering ? RapidTheme.hoverFill : .clear))
+                    .fill(selected ? RapidTheme.selectionFill : (hovering ? RapidTheme.hoverFill : .clear))
             )
+            // Same selected treatment as the sidebar rows this panel is a
+            // fast path to — amber bar, neutral fill, semibold label. The
+            // search results ARE the conversation list, so answering
+            // "which row am I on?" differently in the two places would be
+            // two conventions for one question.
+            .overlay(alignment: .leading) {
+                if selected {
+                    Capsule(style: .continuous)
+                        .fill(RapidTheme.selectionBar)
+                        .frame(
+                            width: RapidTheme.Layout.selectionBarWidth,
+                            height: RapidTheme.Layout.selectionBarHeight
+                        )
+                }
+            }
             .contentShape(
                 RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
             )
         }
         .buttonStyle(.plain)
-        .foregroundStyle(selected ? RapidTheme.brandPrimaryDeep : Color.primary)
+        .foregroundStyle(Color.primary)
         .onHover {
             hoveredConversationID = $0 ? conversation.id : nil
             if $0 { selectedConversationID = conversation.id }

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -15,6 +15,8 @@ struct ImagesView: View {
 
     private let contentMaxWidth: CGFloat = RapidTheme.Layout.contentMaxWidth
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @State private var composeFocusToken = 0
     @State private var pickerHovering = false
     /// Bumped when the user tries to submit while gated, so the readiness
@@ -114,9 +116,19 @@ struct ImagesView: View {
         }
     }
 
-    /// The empty hero — the same shape as ChatView's, with the cheetah mark
-    /// and readiness-driven copy. Just "Draw anything" instead of "Ask
-    /// anything", and no Connect-tools / Speed actions.
+    /// The empty stage: a scale drawing of what pressing Generate will
+    /// produce, then the same readiness-driven copy Chat uses.
+    ///
+    /// The mascot is gone from this surface on purpose. It is the brand
+    /// moment for Chat's empty state and for first run, and repeating it
+    /// on every empty surface turned a greeting into wallpaper. What
+    /// belongs here instead is the one thing a user opening Images
+    /// actually needs to know before typing: the shape and the size of
+    /// the thing about to be made. The frame tracks the live aspect and
+    /// resolution selections, so changing either previews itself.
+    ///
+    /// It is a drawing, not a control — every hit target stays in the
+    /// composer's aspect and resolution pickers, which own these values.
     private var emptyStage: some View {
         EmptyState(
             title: "Draw anything",
@@ -124,11 +136,55 @@ struct ImagesView: View {
                 ? "Describe what you want to see, then press Generate."
                 : readiness.emptyStateSubtitle,
             hint: readiness.isReady ? nil : readiness.emptyStateHint,
-            markDiameter: 92,
-            mark: { CheetahLogo(size: 68) },
+            markDiameter: aspectPreviewSize.height,
+            marksOnBackplate: false,
+            mark: { aspectPreview },
             actions: { EmptyView() }
         )
         .accessibilityIdentifier("Images.EmptyState")
+    }
+
+    /// Longest edge of the preview frame. Sized so the tallest aspect
+    /// (3:4 portrait) still leaves the title and subtitle comfortably
+    /// above the composer at the 560pt window floor.
+    private static let aspectPreviewLongEdge: CGFloat = 150
+
+    private var aspectPreviewSize: CGSize {
+        let dimensions = viewModel.aspect.dimensions(for: viewModel.resolution)
+        let long = Self.aspectPreviewLongEdge
+        guard dimensions.width > 0, dimensions.height > 0 else {
+            return CGSize(width: long, height: long)
+        }
+        let ratio = CGFloat(dimensions.width) / CGFloat(dimensions.height)
+        return ratio >= 1
+            ? CGSize(width: long, height: long / ratio)
+            : CGSize(width: long * ratio, height: long)
+    }
+
+    private var aspectPreview: some View {
+        VStack(spacing: RapidTheme.Space.sm - 1) {
+            Image(systemName: "photo")
+                .font(.system(size: 26, weight: .light))
+                .foregroundStyle(RapidTheme.textTertiary)
+            Text(viewModel.aspect.size(for: viewModel.resolution))
+                .font(RapidFont.code)
+                .foregroundStyle(RapidTheme.textTertiary)
+        }
+        .frame(width: aspectPreviewSize.width, height: aspectPreviewSize.height)
+        // Dashed, because the frame describes something that does not
+        // exist yet. A solid border would read as an image that failed
+        // to load.
+        .overlay(
+            RoundedRectangle(cornerRadius: RapidTheme.Radius.panel, style: .continuous)
+                .strokeBorder(
+                    RapidTheme.hairlineStrong,
+                    style: StrokeStyle(lineWidth: 1.5, dash: [5, 4])
+                )
+        )
+        // Redraws should feel like the picker moving, not like the stage
+        // reloading.
+        .rapidAnimation(RapidMotion.quick, value: aspectPreviewSize.width)
+        .rapidAnimation(RapidMotion.quick, value: aspectPreviewSize.height)
     }
 
     // MARK: - Readiness (mirrors ChatView: same "load the model first" flow)
@@ -245,33 +301,50 @@ struct ImagesView: View {
                 VStack(spacing: 14) {
                     HStack(spacing: 10) {
                         if denoising {
+                            // Breathing, and only when Reduce Motion is
+                            // off: this is a perpetual loop, so it is
+                            // fully suppressed rather than merely slowed.
+                            // The decorative glow is gone with it — an
+                            // amber dot on graphite already separates,
+                            // and a halo around a status indicator is
+                            // exactly the ornament this pass removes.
+                            let breathing = RapidMotion.shouldPulse(
+                                isAnimating: true,
+                                reduceMotion: reduceMotion
+                            )
                             Circle()
-                                .fill(RapidTheme.brandAmber)
+                                .fill(RapidTheme.brandPrimary)
                                 .frame(width: 9, height: 9)
-                                .shadow(color: RapidTheme.brandAmber.opacity(0.9), radius: 5)
-                                .scaleEffect(0.65 + 0.35 * (0.5 + 0.5 * sin(phase * .pi * 2)))
+                                .scaleEffect(
+                                    breathing
+                                        ? 0.65 + 0.35 * (0.5 + 0.5 * sin(phase * .pi * 2))
+                                        : 1
+                                )
                             Text(viewModel.cancelling ? "Stopping…" : "Generating")
                                 .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(RapidTheme.bandInk)
                         } else {
                             ProgressView().controlSize(.small)
                             Text(viewModel.cancelling
                                  ? "Stopping…"
                                  : "Warming up \(viewModel.selectedDisplayName)")
                                 .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(RapidTheme.bandInk)
                                 .lineLimit(1).truncationMode(.middle)
                         }
                         Spacer(minLength: 8)
                         if denoising {
                             Text("\(step) / \(total)")
                                 .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                                .foregroundStyle(Color.primary.opacity(0.76))
+                                .foregroundStyle(RapidTheme.bandInkSecondary)
                                 .monospacedDigit()
                         }
                         Button { viewModel.cancel() } label: {
                             Image(systemName: "xmark")
                                 .font(.system(size: 10, weight: .bold))
+                                .foregroundStyle(RapidTheme.bandInk)
                                 .frame(width: 22, height: 22)
-                                .background(Color.primary.opacity(0.08), in: Circle())
+                                .background(RapidTheme.bandTrack, in: Circle())
                         }
                         .buttonStyle(.plain)
                         .disabled(viewModel.cancelling)
@@ -286,7 +359,7 @@ struct ImagesView: View {
                     HStack {
                         Text(String(format: "%.1fs", max(0, elapsed)))
                             .font(.system(size: 12, weight: .medium, design: .monospaced))
-                            .foregroundStyle(Color.primary.opacity(0.76))
+                            .foregroundStyle(RapidTheme.bandInkSecondary)
                             .monospacedDigit()
                         Spacer()
                         // ETA from the denoise-phase clock, not total elapsed —
@@ -297,16 +370,28 @@ struct ImagesView: View {
                              ? (etaText(step: step, total: total, elapsed: denoiseElapsed) ?? "finishing…")
                              : "First run — only happens once")
                             .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(Color.primary.opacity(0.76))
+                            .foregroundStyle(RapidTheme.bandInkSecondary)
                     }
                 }
                 .padding(18)
                 .frame(width: 340)
-                .background(RapidTheme.surfaceOverlay,
+                // The same graphite ground the Chat band paints, in the
+                // shape this surface's geometry calls for. Images cannot
+                // use a band: the subject here IS the canvas, and a strip
+                // above it would push the stage down and shrink the one
+                // thing the user is watching. A HUD over the image keeps
+                // progress on top of its own subject.
+                //
+                // Previously this card took ``surfaceOverlay``, a
+                // near-white plane — so over a bright render it was a
+                // pale card on a pale image with a shadow doing all the
+                // separation. Graphite separates on its own, in both
+                // appearances and over any image.
+                .background(RapidTheme.surfaceBand,
                             in: RoundedRectangle(cornerRadius: 18, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
+                        .strokeBorder(RapidTheme.bandTrack, lineWidth: 1)
                 )
                 .shadow(color: .black.opacity(0.28), radius: 22, y: 10)
             }
@@ -920,44 +1005,49 @@ enum EditImageImporter {
     }
 }
 
-/// The diffusion progress bar: a rounded amber→gold gradient fill with a soft
-/// glow and a sheen that sweeps across it, over a faint track. Determinate
-/// (true step fraction) while denoising; a sliding segment while the model
-/// warms up. The only bar in the app that shows a real diffusion step count.
+/// The diffusion progress bar: a solid amber fill on the lifecycle
+/// track. Determinate (the real step fraction) while denoising; a
+/// sliding segment while the model warms up and no fraction exists.
+/// The only bar in the app that shows a real diffusion step count.
+///
+/// It used to carry an amber→gold gradient, a white sheen sweeping the
+/// fill, and an amber glow. All three are gone. Amber is a signal
+/// colour here, and a two-stop blend with a moving highlight on top
+/// reads as decoration wrapped around the signal rather than as the
+/// signal itself — the same reason the brand spec allows no gradient on
+/// the amber axis anywhere else in the app.
+///
+/// The sliding segment also now stops under Reduce Motion. It is a
+/// perpetual loop, which is the canonical vestibular offender, and it
+/// was running unconditionally because its clock is a ``TimelineView``
+/// in the parent rather than an ``Animation`` the environment could
+/// suppress. Reduced, the segment holds still and the state is carried
+/// by the surrounding copy, which already names the phase.
 private struct ShimmerProgressBar: View {
     var fraction: Double
     var indeterminate: Bool
-    var phase: Double  // 0→1, loops to drive the sheen
+    var phase: Double  // 0→1, loops to drive the indeterminate slide
 
-    private var fillGradient: LinearGradient {
-        LinearGradient(
-            colors: [RapidTheme.brandAmber, Color(red: 1.0, green: 0.85, blue: 0.47)],
-            startPoint: .leading, endPoint: .trailing)
-    }
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         GeometryReader { geo in
             let w = geo.size.width
             let fillW = indeterminate ? max(1, w * 0.34)
                                       : max(10, w * min(1, max(0, fraction)))
-            let slideX = indeterminate ? (w + fillW) * phase - fillW : 0
+            let sliding = RapidMotion.shouldPulse(
+                isAnimating: indeterminate,
+                reduceMotion: reduceMotion
+            )
+            let slideX = sliding ? (w + fillW) * phase - fillW
+                                 : (indeterminate ? (w - fillW) / 2 : 0)
             ZStack(alignment: .leading) {
-                Capsule().fill(Color.primary.opacity(0.12))
-                ZStack(alignment: .leading) {
-                    Capsule().fill(fillGradient)
-                    // A narrow highlight sweeping the filled portion.
-                    Capsule()
-                        .fill(LinearGradient(
-                            colors: [.clear, .white.opacity(0.55), .clear],
-                            startPoint: .leading, endPoint: .trailing))
-                        .frame(width: 64)
-                        .offset(x: (fillW + 64) * phase - 64)
-                }
-                .frame(width: fillW)
-                .clipShape(Capsule())
-                .shadow(color: RapidTheme.brandAmber.opacity(0.55), radius: 6)
-                .offset(x: slideX)
-                .animation(indeterminate ? nil : .easeOut(duration: 0.3), value: fraction)
+                Capsule().fill(RapidTheme.bandTrack)
+                Capsule()
+                    .fill(RapidTheme.brandPrimary)
+                    .frame(width: fillW)
+                    .offset(x: slideX)
+                    .animation(indeterminate ? nil : .easeOut(duration: 0.3), value: fraction)
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
@@ -594,7 +594,28 @@ enum RapidTheme {
 
     /// The leading bar that marks a selected row. Amber, and the one
     /// amber element the rail is allowed.
-    static let selectionBar = brandPrimary
+    ///
+    /// A deeper step of the same hue in Light, raw ``brandPrimary`` in
+    /// Dark — and this is the token where that split is load-bearing
+    /// rather than a nicety. Measured against the rail:
+    ///
+    ///   * Dark: #EFA23A on #191B1E is 8.1:1. Nothing to fix.
+    ///   * Light: #EFA23A on #F3F3F1 is **1.9:1** — a light amber on a
+    ///     near-white plane. The bar carries the whole selection signal
+    ///     under the refined rule, so shipping it at 1.9:1 would have
+    ///     replaced one invisible selected row with another.
+    ///
+    /// #B87317 measures 3.4:1 against the rail and 3.3:1 against the
+    /// selected row's own fill, clearing the 3:1 non-text threshold with
+    /// margin at 3pt wide. It is deeper than ``brandPrimaryDeep``
+    /// (#C9821F, 2.8:1 here) because that token was tuned for TEXT, where
+    /// the glyph's own stroke width and the reader's foveal attention do
+    /// some of the work; a 3pt rule caught in peripheral vision has
+    /// neither.
+    static let selectionBar = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0xEF/255.0, green: 0xA2/255.0, blue: 0x3A/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xB8/255.0, green: 0x73/255.0, blue: 0x17/255.0, alpha: 1.0)
+    }))
 
     /// Hover wash over a neutral row or control.
     ///

--- a/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
@@ -114,8 +114,16 @@ enum RapidTheme {
     static let canvas = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
         // v0.6: warm off-white (was cool #F7F7FA) so the canvas pairs
         // with the amber/cheetah accents; dark = the site's `--bg`.
-        appearance.isDark ? NSColor(deviceRed: 0x15/255.0, green: 0x17/255.0, blue: 0x1B/255.0, alpha: 1.0)
-                          : NSColor(deviceRed: 0xF8/255.0, green: 0xF7/255.0, blue: 0xF4/255.0, alpha: 1.0)
+        //
+        // Phase UI-2 (Direction D refinement, decision 01 "bone →
+        // mineral"): #F8F7F4 → #FAFAF9, and #15171B → #141619. The warm
+        // bone was correct on a card and wrong on a whole window — across
+        // 1440pt it read as beige, which put a second warm surface in
+        // competition with the one amber moment each screen is allowed.
+        // #FAFAF9 is a near-white with a slate cast, so amber stays the
+        // only warm thing on screen.
+        appearance.isDark ? NSColor(deviceRed: 0x14/255.0, green: 0x16/255.0, blue: 0x19/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xFA/255.0, green: 0xFA/255.0, blue: 0xF9/255.0, alpha: 1.0)
     }))
 
     /// Elevated card fill — a hair lighter than the window canvas in
@@ -135,9 +143,13 @@ enum RapidTheme {
     /// Hairline border around cards / inputs (`--line-soft`). A defined
     /// but quiet warm-gray edge in light mode (pairs with the warm
     /// canvas); the site's soft line in dark mode.
+    ///
+    /// Phase UI-2: re-cast onto the mineral ramp alongside ``canvas``
+    /// (#E7E6E1 → #E7E7E4, #262B31 → #26292E). A warm hairline on a
+    /// mineral canvas reads as a faint tan line rather than an edge.
     static let hairline = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
-        appearance.isDark ? NSColor(deviceRed: 0x26/255.0, green: 0x2B/255.0, blue: 0x31/255.0, alpha: 1.0)
-                          : NSColor(deviceRed: 0xE7/255.0, green: 0xE6/255.0, blue: 0xE1/255.0, alpha: 1.0)
+        appearance.isDark ? NSColor(deviceRed: 0x26/255.0, green: 0x29/255.0, blue: 0x2E/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xE7/255.0, green: 0xE7/255.0, blue: 0xE4/255.0, alpha: 1.0)
     }))
 
     /// Standard corner radius for the refresh's rounded cards.
@@ -345,14 +357,21 @@ enum RapidTheme {
     /// The sidebar rail. v1.0: re-warmed from the old cool #F3F5F9,
     /// which read as a blue-grey slab beside the warm canvas and made
     /// the whole left column feel like a different product.
+    ///
+    /// Phase UI-2 re-casts it onto the mineral ramp (#F2F0EB → #F3F3F1,
+    /// #1A1C20 → #191B1E) so it stays one step below ``surfaceCanvas``
+    /// without being a warmer plane than it. Direction D decision 04:
+    /// the rail is mineral in BOTH the resting and the working
+    /// composition — it never goes graphite, because dark chrome that
+    /// persists after the work ends is a theme, and this is not one.
     static let surfaceSidebar = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
-        appearance.isDark ? NSColor(deviceRed: 0x1A/255.0, green: 0x1C/255.0, blue: 0x20/255.0, alpha: 1.0)
-                          : NSColor(deviceRed: 0xF2/255.0, green: 0xF0/255.0, blue: 0xEB/255.0, alpha: 1.0)
+        appearance.isDark ? NSColor(deviceRed: 0x19/255.0, green: 0x1B/255.0, blue: 0x1E/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xF3/255.0, green: 0xF3/255.0, blue: 0xF1/255.0, alpha: 1.0)
     }))
 
     /// A raised surface — cards, popovers, grouped rows.
     static let surfaceRaised = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
-        appearance.isDark ? NSColor(deviceRed: 0x1E/255.0, green: 0x21/255.0, blue: 0x26/255.0, alpha: 1.0)
+        appearance.isDark ? NSColor(deviceRed: 0x1D/255.0, green: 0x20/255.0, blue: 0x24/255.0, alpha: 1.0)
                           : NSColor.white
     }))
 
@@ -374,8 +393,46 @@ enum RapidTheme {
     /// A more present divider for structural separation (card headers,
     /// grouped-row separators) where ``hairline`` disappears.
     static let hairlineStrong = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
-        appearance.isDark ? NSColor(deviceRed: 0x32/255.0, green: 0x38/255.0, blue: 0x40/255.0, alpha: 1.0)
-                          : NSColor(deviceRed: 0xDD/255.0, green: 0xDA/255.0, blue: 0xD3/255.0, alpha: 1.0)
+        appearance.isDark ? NSColor(deviceRed: 0x32/255.0, green: 0x36/255.0, blue: 0x3C/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xD5/255.0, green: 0xD5/255.0, blue: 0xD1/255.0, alpha: 1.0)
+    }))
+
+    // MARK: Lifecycle band (the "active AI work" ground)
+    //
+    // Direction D's second composition. A surface only paints these while
+    // the app is doing work the user is waiting on — a download, a model
+    // load — and drops straight back to the mineral ramp when it ends.
+    // Graphite is the ground, amber is the single progress hue on it, and
+    // the ink on amber is the same near-black every other amber fill uses.
+    //
+    // It is a COMPOSITION, not a theme: the sidebar and the status strip
+    // stay mineral throughout, and nothing here survives the work.
+
+    /// Ground for the lifecycle band. Near-black in Light so the band
+    /// reads as a distinct plane over the near-white canvas; one step
+    /// LIGHTER than the canvas in Dark, where a darker band would simply
+    /// disappear into the window.
+    static let surfaceBand = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x23/255.0, green: 0x26/255.0, blue: 0x2B/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0x1B/255.0, green: 0x1D/255.0, blue: 0x21/255.0, alpha: 1.0)
+    }))
+
+    /// Primary ink on ``surfaceBand``. Appearance-independent, because the
+    /// band's ground is graphite in both modes — flipping it would put
+    /// dark ink on a dark plane in exactly one appearance.
+    static let bandInk = Color(nsColor: .init(name: nil, dynamicProvider: { _ in
+        NSColor(deviceRed: 0xF4/255.0, green: 0xF3/255.0, blue: 0xF1/255.0, alpha: 1.0)
+    }))
+
+    /// Supporting ink on ``surfaceBand`` — the eyebrow, byte counts, ETA.
+    /// ~7:1 on the band ground, so it is quiet without being unreadable.
+    static let bandInkSecondary = Color(nsColor: .init(name: nil, dynamicProvider: { _ in
+        NSColor(deviceRed: 0xA5/255.0, green: 0xA8/255.0, blue: 0xAE/255.0, alpha: 1.0)
+    }))
+
+    /// Unfilled progress track inside the band.
+    static let bandTrack = Color(nsColor: .init(name: nil, dynamicProvider: { _ in
+        NSColor(deviceRed: 0x33/255.0, green: 0x37/255.0, blue: 0x3D/255.0, alpha: 1.0)
     }))
 
     // MARK: Status
@@ -519,8 +576,40 @@ enum RapidTheme {
 
     // MARK: Interaction
 
+    /// Fill behind a SELECTED row.
+    ///
+    /// Direction D decision 02: neutral, not amber. The v1.0 treatment
+    /// was an amber tint plus an amber label, and on the warm rail the
+    /// two were within a few percent of the surface they sat on — the
+    /// selected row was, in practice, invisible. The signal now comes
+    /// from three things that do not depend on a tint being legible: a
+    /// 3pt amber leading bar (``selectionBarWidth``), this neutral fill,
+    /// and a graphite SEMIBOLD label. Weight and a hard-edged bar survive
+    /// Increase Contrast, colour-blindness, and a glance; a 4% wash does
+    /// not.
+    static let selectionFill = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x24/255.0, green: 0x27/255.0, blue: 0x2B/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xEF/255.0, green: 0xEF/255.0, blue: 0xEC/255.0, alpha: 1.0)
+    }))
+
+    /// The leading bar that marks a selected row. Amber, and the one
+    /// amber element the rail is allowed.
+    static let selectionBar = brandPrimary
+
     /// Hover wash over a neutral row or control.
-    static let hoverFill = Color.primary.opacity(0.055)
+    ///
+    /// Phase UI-2: a concrete mineral value rather than
+    /// ``Color.primary.opacity(0.055)``. The opacity form composited
+    /// differently on each of the four surface planes, so the same hover
+    /// landed a visibly different colour in the sidebar than on a card —
+    /// and in Dark it lifted toward blue-white while everything around it
+    /// stayed slate. One value keeps hover reading as the same gesture
+    /// wherever the pointer is, and keeps it a clear step BELOW
+    /// ``selectionFill`` so hovering a row never looks like selecting it.
+    static let hoverFill = Color(nsColor: .init(name: nil, dynamicProvider: { appearance in
+        appearance.isDark ? NSColor(deviceRed: 0x21/255.0, green: 0x24/255.0, blue: 0x29/255.0, alpha: 1.0)
+                          : NSColor(deviceRed: 0xF0/255.0, green: 0xF0/255.0, blue: 0xED/255.0, alpha: 1.0)
+    }))
     /// Pressed wash — one step firmer than hover.
     static let pressedFill = Color.primary.opacity(0.10)
     /// Multiplier applied to a control's opacity when disabled.
@@ -555,6 +644,12 @@ enum RapidTheme {
         static let xl: CGFloat = 24
         /// 32 — major vertical separation.
         static let xxl: CGFloat = 32
+        /// 48 — the gap around a hero composition (the chat empty state's
+        /// breathing room). Above ``xxl`` the rhythm stops being "space
+        /// between things" and becomes "space a thing sits in".
+        static let xxxl: CGFloat = 48
+        /// 72 — full-window compositions only.
+        static let huge: CGFloat = 72
     }
 
     // MARK: - Radii
@@ -587,6 +682,10 @@ enum RapidTheme {
         /// Inset code / endpoint blocks. Tighter than the card that
         /// contains them so the inset reads as recessed, not nested.
         static let code: CGFloat = 6
+        /// A panel that frames a whole composition rather than a control
+        /// — the Images stage, the aspect preview. Softer than ``card``
+        /// because it holds content, not rows.
+        static let panel: CGFloat = 12
     }
 
     // MARK: - Control heights
@@ -621,9 +720,36 @@ enum RapidTheme {
         static let contentMaxWidth: CGFloat = 720
         /// Max width for a settings/tool page's content column.
         static let pageMaxWidth: CGFloat = 640
+        /// Max width for a block asking the user to decide one thing.
+        /// Narrower than a reading measure on purpose — a choice should
+        /// be takeable in one eye movement.
+        static let decisionMaxWidth: CGFloat = 460
         /// Fixed leading slot every row icon occupies, so labels align
         /// down a column regardless of glyph width.
         static let iconSlot: CGFloat = 18
+        /// Width of the amber bar marking a selected row.
+        static let selectionBarWidth: CGFloat = 3
+        /// Height of that bar. Shorter than the 30pt row so it reads as a
+        /// marker beside the label rather than a full-height divider.
+        static let selectionBarHeight: CGFloat = 18
+
+        /// The three window widths the layout is verified at.
+        ///
+        /// These are not CSS media queries — SwiftUI has no such thing,
+        /// and the app resizes continuously. They are the widths the
+        /// design was drawn and reviewed at, named so a view that DOES
+        /// need to change proportion at a threshold reads that threshold
+        /// from one place instead of hard-coding it.
+        enum Breakpoint {
+            /// 720 — the compact floor. Reading measure and window width
+            /// are the same number here, so anything with side margins is
+            /// already compressing.
+            static let floor: CGFloat = 720
+            /// 1000 — the ordinary working width.
+            static let mid: CGFloat = 1000
+            /// 1440 — the wide review width.
+            static let wide: CGFloat = 1440
+        }
     }
 }
 
@@ -686,6 +812,41 @@ enum ModelDisplayName {
 /// that must honour Dynamic Type keep using ``scaledSystemFont``; this
 /// ramp covers the chrome.
 enum RapidFont {
+    /// The one display line on a surface that has nothing else on it —
+    /// the chat empty state's "Ask anything", and nothing else in this
+    /// slice. 34pt semibold over a 40pt leading.
+    ///
+    /// The ramp previously topped out at ``pageTitle`` (20pt), which is a
+    /// *page heading* size: correct above a list of settings rows, far
+    /// too small to be the only object in a 1440pt window. An empty
+    /// surface has no hierarchy to sit inside, so its title has to
+    /// establish one on its own.
+    static let displayTitle = Font.system(size: 34, weight: .semibold)
+
+    /// Optical tracking for ``displayTitle``. SF tightens as it grows;
+    /// at 34pt the default spacing reads loose, and -0.022em is where the
+    /// word closes up without the letters touching.
+    static let displayTitleTracking: CGFloat = -0.75
+
+    /// Supporting line under ``displayTitle``. 14pt — one step above
+    /// ``body``, because at display scale a 12pt subtitle reads as a
+    /// footnote attached to the wrong heading.
+    static let displaySubtitle = Font.system(size: 14)
+
+    /// The model name inside the lifecycle band. Between ``pageTitle``
+    /// and ``displayTitle``: the band is a priority surface, but it is
+    /// still chrome around a transcript, not the subject of the window.
+    static let bandTitle = Font.system(size: 21, weight: .semibold)
+
+    /// The all-caps eyebrow over a band or stage title, and the
+    /// monospaced counters beside it. Monospaced because these values
+    /// tick live (bytes, percent, step counts) and proportional digits
+    /// make a progress line jitter its own width.
+    static let bandEyebrow = Font.system(size: 10, weight: .semibold, design: .monospaced)
+
+    /// The big amber percentage in the lifecycle band.
+    static let bandMetric = Font.system(size: 34, weight: .semibold, design: .default)
+
     /// Window / toolbar title.
     static let windowTitle = Font.system(size: 15, weight: .semibold)
     /// The one big title on a page. Chat empty state, page headers,

--- a/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
@@ -754,7 +754,9 @@ enum RapidTheme {
         /// marker beside the label rather than a full-height divider.
         static let selectionBarHeight: CGFloat = 18
 
-        /// The three window widths the layout is verified at.
+        /// The detail-pane widths produced at the three window widths the
+        /// layout is verified at (720 / 1000 / 1440), after the 200pt ideal
+        /// sidebar is removed.
         ///
         /// These are not CSS media queries — SwiftUI has no such thing,
         /// and the app resizes continuously. They are the widths the
@@ -762,14 +764,12 @@ enum RapidTheme {
         /// need to change proportion at a threshold reads that threshold
         /// from one place instead of hard-coding it.
         enum Breakpoint {
-            /// 720 — the compact floor. Reading measure and window width
-            /// are the same number here, so anything with side margins is
-            /// already compressing.
-            static let floor: CGFloat = 720
-            /// 1000 — the ordinary working width.
-            static let mid: CGFloat = 1000
-            /// 1440 — the wide review width.
-            static let wide: CGFloat = 1440
+            /// 520 — detail pane at the 720pt compact window.
+            static let floor: CGFloat = 520
+            /// 800 — detail pane at the 1000pt working window.
+            static let mid: CGFloat = 800
+            /// 1240 — detail pane at the 1440pt wide window.
+            static let wide: CGFloat = 1240
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ReadinessBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ReadinessBanner.swift
@@ -90,6 +90,11 @@ struct ReadinessBanner: View {
         }
         .padding(.horizontal, RapidTheme.Space.md)
         .padding(.vertical, RapidTheme.Space.sm)
+        // A fixed floor, so the composer's top edge does not step up and
+        // down as the user moves between "no model chosen", "not
+        // downloaded" and "not running". Those are three renderings of
+        // one moment; the surface should not reflow between them.
+        .frame(minHeight: 48)
         .background(
             RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
                 .fill(background)
@@ -97,7 +102,7 @@ struct ReadinessBanner: View {
         .overlay(
             RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
                 .strokeBorder(
-                    tint.opacity(attentionActive ? 0.85 : 0.22),
+                    borderTint.opacity(attentionActive ? 0.85 : 1),
                     lineWidth: attentionActive ? 1.5 : 1
                 )
         )
@@ -127,10 +132,23 @@ struct ReadinessBanner: View {
         }
     }
 
-    /// Subtle tint only — the same pairing ``InlineNotice`` uses, so a
-    /// readiness notice and an error notice sit on the same visual
-    /// footing when they alternate in the same slot.
+    /// Failure keeps its red tint; everything else sits on a plain raised
+    /// surface.
+    ///
+    /// The amber tint this used to paint in every non-failure state was a
+    /// second amber block roughly 40pt above the send disc — the one
+    /// amber moment the composer is allowed. Two of them competing meant
+    /// neither read as the thing to look at. The dot still carries the
+    /// state's colour, which is where a status hue belongs: on the
+    /// indicator, not on the whole plate behind the sentence.
     private var background: Color {
-        readiness.isFailure ? RapidTheme.statusErrorTint : RapidTheme.brandPrimaryTint
+        readiness.isFailure ? RapidTheme.statusErrorTint : RapidTheme.surfaceRaised
+    }
+
+    /// Matching edge — the status hue on a failure, a plain hairline
+    /// otherwise, so a neutral notice does not draw a coloured outline
+    /// around itself for no reason.
+    private var borderTint: Color {
+        readiness.isFailure ? tint.opacity(0.35) : RapidTheme.hairline
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -103,6 +103,7 @@ struct SidebarView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
+            brandLockup
             row(
                 title: "New Chat",
                 systemImage: "square.and.pencil",
@@ -212,6 +213,39 @@ struct SidebarView: View {
         }
     }
 
+    /// The product lockup at the top of the rail: the official Rapid `R`
+    /// beside the product name.
+    ///
+    /// Purely decorative, and marked so. The window already carries the
+    /// app name in its title bar and in the menu bar, so announcing it a
+    /// third time would put a redundant element ahead of "New Chat" in
+    /// every VoiceOver traversal of the sidebar — the rail's first
+    /// element should be the first thing you can DO in it. It is also
+    /// what keeps this addition free of any new accessibility identifier
+    /// or AX node for the identifier inventory to account for.
+    ///
+    /// The mark is ``RapidRMark``'s template image — the same geometry
+    /// the menu-bar status item renders, so the two brand surfaces cannot
+    /// drift apart. Template rendering means it tracks the label colour
+    /// in both appearances rather than needing a second asset for Dark.
+    private var brandLockup: some View {
+        HStack(spacing: RapidTheme.Space.sm) {
+            if let mark = RapidRMark.menuBarTemplateImage(height: 15) {
+                Image(nsImage: mark)
+                    .renderingMode(.template)
+                    .foregroundStyle(RapidTheme.textPrimary)
+                    .frame(width: RapidTheme.Layout.iconSlot, alignment: .center)
+            }
+            Text("Rapid-MLX")
+                .font(RapidFont.bodyEmphasis)
+                .foregroundStyle(RapidTheme.textPrimary)
+        }
+        .padding(.horizontal, RapidTheme.Space.sm)
+        .padding(.top, RapidTheme.Space.xs)
+        .padding(.bottom, RapidTheme.Space.md)
+        .accessibilityHidden(true)
+    }
+
     private func residencyFooter(
         _ snapshot: ModelResidencySnapshot,
         preferredAlias: String?
@@ -258,7 +292,18 @@ struct SidebarView: View {
             }
         }
         .padding(.horizontal, RapidTheme.Space.sm)
-        .padding(.vertical, RapidTheme.Space.sm)
+        .padding(.top, RapidTheme.Space.md)
+        .padding(.bottom, RapidTheme.Space.sm)
+        // A rule, not a gap. The residency block is the one part of the
+        // rail that describes the MACHINE rather than the app's
+        // navigation, and separating it by whitespace alone left it
+        // reading as a fifth, oddly-formatted nav group. A hairline says
+        // "different kind of thing" in the width of one pixel.
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(RapidTheme.hairline)
+                .frame(height: 1)
+        }
         .accessibilityIdentifier("Sidebar.Residency")
     }
 
@@ -490,7 +535,7 @@ struct SidebarView: View {
                     // inset as the nav rows above, so titles and nav labels
                     // align down one column instead of stepping in and out.
                     Text(conv.title)
-                        .font(RapidFont.body)
+                        .font(isActive ? RapidFont.bodyEmphasis : RapidFont.body)
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .padding(.leading, RapidTheme.Layout.iconSlot + RapidTheme.Space.sm)
@@ -762,10 +807,14 @@ struct SidebarView: View {
         ) {
             HStack(spacing: RapidTheme.Space.sm) {
                 Image(systemName: systemImage)
-                    .font(.system(size: 13, weight: .medium))
+                    // Semibold when selected, matching the label. The
+                    // glyph and its word are one object; letting only the
+                    // text thicken made the icon look like it belonged to
+                    // the row above.
+                    .font(.system(size: 13, weight: isSelected ? .semibold : .medium))
                     .frame(width: RapidTheme.Layout.iconSlot, alignment: .center)
                 Text(title)
-                    .font(RapidFont.body)
+                    .font(isSelected ? RapidFont.bodyEmphasis : RapidFont.body)
                     .lineLimit(1)
             }
         }
@@ -773,13 +822,29 @@ struct SidebarView: View {
 }
 
 /// Shared chrome for every sidebar row: fixed height, one row radius,
-/// amber selection, neutral hover.
+/// one selected treatment, neutral hover.
 ///
-/// The selected treatment is the product's canonical "this is chosen"
-/// signal — amber tint fill plus the deep-amber label. Deep amber (not
-/// raw ``brandPrimary``) because a 13pt label in #EFA23A on the light
-/// tint is under 3:1; the deeper shade of the same hue clears AA while
-/// reading as the same colour.
+/// ## The selected treatment
+///
+/// A 3×18pt amber bar in the leading gutter, a neutral fill, and a
+/// graphite SEMIBOLD label. Three signals, none of which is a colour
+/// difference small enough to miss.
+///
+/// It replaces the v1.0 pairing of an amber TINT fill plus a deep-amber
+/// label, which failed for a reason worth recording: the tint
+/// (``brandPrimaryTint``) and the rail it sat on
+/// (``surfaceSidebar``) were within a few percent of each other, so on
+/// the rail — the one place selection matters most — the fill was
+/// effectively invisible, and the whole signal came down to a hue shift
+/// in a 13pt label. That is the single least robust way to encode state:
+/// it is the first thing lost to colour-blindness, to a dim display, and
+/// to peripheral vision.
+///
+/// The bar is a hard-edged shape, so it survives Increase Contrast and
+/// reads at a glance from across the desk; the semibold weight carries
+/// the row even in a screenshot with no colour at all. Amber is spent
+/// here rather than on the fill because the rail's whole budget is one
+/// small brand moment, and a bar is a smaller, sharper one than a slab.
 private struct SidebarRow<Content: View>: View {
     let isSelected: Bool
     let action: () -> Void
@@ -797,19 +862,38 @@ private struct SidebarRow<Content: View>: View {
                     RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
                         .fill(fill)
                 )
+                // The bar is an OVERLAY on the leading edge rather than a
+                // sibling in an HStack: as a sibling it would take layout
+                // width, so every label in the rail would shift sideways
+                // the moment a row became selected. An overlay marks the
+                // row without moving anything in it.
+                .overlay(alignment: .leading) {
+                    if isSelected {
+                        Capsule(style: .continuous)
+                            .fill(RapidTheme.selectionBar)
+                            .frame(
+                                width: RapidTheme.Layout.selectionBarWidth,
+                                height: RapidTheme.Layout.selectionBarHeight
+                            )
+                    }
+                }
                 .contentShape(
                     RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
                 )
         }
         .buttonStyle(.plain)
-        .foregroundStyle(isSelected ? RapidTheme.brandPrimaryDeep : Color.primary)
+        // Graphite in both states. The label's WEIGHT now carries
+        // selection (see ``SidebarView.row`` and ``conversationRow``),
+        // which keeps every row in the rail at full reading contrast
+        // instead of tinting the selected one down to a brand hue.
+        .foregroundStyle(Color.primary)
         .onHover { hovering = $0 }
         .rapidAnimation(RapidMotion.quick, value: hovering)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     private var fill: Color {
-        if isSelected { return RapidTheme.brandPrimaryTint }
+        if isSelected { return RapidTheme.selectionFill }
         return hovering ? RapidTheme.hoverFill : .clear
     }
 }

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
@@ -22,11 +22,11 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
-          AXStaticText value=text enabled=true
-          AXStaticText value=text enabled=true
-          AXGroup desc="Starting <model>, Loading the model into memory…" enabled=true
+          AXGroup id="Readiness.Band" desc="Starting <model>, Loading the model into memory…" enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
@@ -1,0 +1,48 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXStaticText id="Images.EmptyState" value=text enabled=true
+          AXStaticText id="Images.EmptyState" value=text enabled=true
+          AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Readiness.Action" desc="Start" enabled=true
+          AXScrollArea
+            AXButton id="Images.Starter" desc="A cozy ramen shop at night in the rain, neon, steam, 35mm" enabled=true
+            AXButton id="Images.Starter" desc="Studio portrait of an elderly fisherman, dramatic side light" enabled=true
+            AXButton id="Images.Starter" desc="A minimalist product shot of a ceramic mug on linen" enabled=true
+            AXButton id="Images.Starter" desc="A whale drifting through clouds above a city at dusk" enabled=true
+          AXStaticText id="Images.Prompt" value=text enabled=true
+          AXScrollArea id="Images.Prompt"
+            AXTextArea id="rapid.images.compose" desc="Image prompt field" value=empty
+          AXButton id="Images.Aspect" desc="1:1" enabled=true
+          AXButton id="Images.Aspect" desc="3:4" enabled=true
+          AXButton id="Images.Aspect" desc="4:3" enabled=true
+          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 1024 × 1024" value=text enabled=true
+          AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=true
+          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=true
+          AXButton id="Images.Generate" desc="Up" help="Load the model first" enabled=false
+      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+      AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
@@ -1,0 +1,48 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
+          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXBusyIndicator value=number enabled=true
+          AXStaticText value=text enabled=true
+          AXButton id="Images.Cancel" desc="Close" help="Cancel" enabled=true
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXScrollArea id="Images.Prompt"
+            AXTextArea id="rapid.images.compose" desc="Image prompt field" value=text
+          AXButton id="Images.Aspect" desc="1:1" enabled=true
+          AXButton id="Images.Aspect" desc="3:4" enabled=true
+          AXButton id="Images.Aspect" desc="4:3" enabled=true
+          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 1024 × 1024" value=text enabled=true
+          AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=false
+          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=false
+          AXButton id="Images.Generate" desc="Stop" help="Cancel" enabled=true
+      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+      AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -604,13 +604,14 @@ struct CoreWorkspaceVisualFoundationTests {
 
     // MARK: - Responsive contract
 
-    /// The reading measure is fixed, and at the floor the window is
-    /// exactly one measure wide. This is the arithmetic behind "the band
-    /// must not be a column": a vertical priority area of any width at
-    /// all would be taking points out of the conversation here.
-    @Test("At the compact floor the window is exactly one reading measure")
-    func floorEqualsTheReadingMeasure() {
-        #expect(RapidTheme.Layout.contentMaxWidth == RapidTheme.Layout.Breakpoint.floor)
+    /// Breakpoints belong to the view receiving the geometry: Chat's detail
+    /// pane, not the outer window. Pin the conversion so screenshots cannot
+    /// accidentally test one coordinate system while production uses another.
+    @Test("Window review widths map to the intended detail breakpoints")
+    func windowWidthsMapToDetailBreakpoints() {
+        #expect(720 - SidebarView.columnIdealWidth == RapidTheme.Layout.Breakpoint.floor)
+        #expect(1000 - SidebarView.columnIdealWidth == RapidTheme.Layout.Breakpoint.mid)
+        #expect(1440 - SidebarView.columnIdealWidth == RapidTheme.Layout.Breakpoint.wide)
     }
 
     /// The detail pane's floor plus the widest rail has to fit inside the

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -1,0 +1,630 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import Rapid
+
+/// Pins for the UI-2 Slice 1 core-workspace visual refresh.
+///
+/// The claim this slice makes is narrow and checkable: the shell, Chat
+/// and Images draw from one refreshed token set; the selected row is
+/// legible by something other than a hue; the lifecycle band flexes only
+/// in height; and not one production string, action, binding or
+/// accessibility identifier moved. These tests hold that claim. What is
+/// a matter of taste — whether the mineral canvas actually feels calmer
+/// than the bone one — is held by the screenshots, not here.
+///
+/// Source-level guards use the same canonical (comment- and
+/// literal-stripped) form the existing ``SourceGuardSupport`` helpers
+/// produce, so a token named inside a doc comment can neither satisfy
+/// nor break one.
+@Suite("Core workspace visual foundation (UI-2 Slice 1)")
+@MainActor
+// Main-actor for the same reason ``SettingsVisualFoundationTests`` is: the
+// CI toolchain treats several SwiftUI initialisers as MainActor-isolated
+// under its stricter default isolation.
+struct CoreWorkspaceVisualFoundationTests {
+
+    private static var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // package root
+    }
+
+    private func strippedSource(_ relativePath: String) throws -> String {
+        let url = Self.packageRoot.appendingPathComponent(relativePath)
+        let body = try String(contentsOf: url, encoding: .utf8)
+        return CapabilityChipRenderGateSourceGuardTests.stripCommentsAndWhitespace(body)
+    }
+
+    @MainActor
+    private static func resolve(
+        _ color: Color,
+        appearance name: NSAppearance.Name
+    ) -> NSColor? {
+        guard let appearance = NSAppearance(named: name) else { return nil }
+        var resolved: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = NSColor(color).usingColorSpace(.deviceRGB)
+        }
+        return resolved
+    }
+
+    /// Perceived luminance, for the contrast arithmetic below.
+    private static func relativeLuminance(_ color: NSColor) -> Double {
+        func channel(_ raw: CGFloat) -> Double {
+            let v = Double(raw)
+            return v <= 0.03928 ? v / 12.92 : pow((v + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(color.redComponent)
+            + 0.7152 * channel(color.greenComponent)
+            + 0.0722 * channel(color.blueComponent)
+    }
+
+    private static func contrastRatio(_ a: NSColor, _ b: NSColor) -> Double {
+        let la = relativeLuminance(a)
+        let lb = relativeLuminance(b)
+        return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+    }
+
+    /// Straight-line distance in device RGB. A crude perceptual proxy,
+    /// but the right one for the question these tests ask, which is
+    /// "could a person tell these two planes apart at all?"
+    private static func rgbDistance(_ a: NSColor, _ b: NSColor) -> Double {
+        let dr = Double(a.redComponent - b.redComponent)
+        let dg = Double(a.greenComponent - b.greenComponent)
+        let db = Double(a.blueComponent - b.blueComponent)
+        return (dr * dr + dg * dg + db * db).squareRoot()
+    }
+
+    // MARK: - The defect the selection rule exists to fix
+
+    /// The v1.0 selected row was an amber TINT on the rail plus an amber
+    /// label — two colour signals, both weak, and nothing else. This
+    /// pins the replacement's load-bearing part.
+    ///
+    /// Note what is deliberately NOT asserted: that the new fill is
+    /// *stronger* than the amber tint it replaced. It is not, and it is
+    /// not meant to be. Under the refined rule the fill only has to say
+    /// "this row is different"; the thing that says "this row is
+    /// SELECTED" is the amber bar, which is a hard-edged shape with real
+    /// contrast against the rail. Writing this test the other way round
+    /// was the mistake — it measured the quiet part and let the loud part
+    /// go unchecked.
+    @Test("The selection bar carries real contrast against the rail")
+    func selectionBarSeparatesFromTheRail() throws {
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            let rail = try #require(Self.resolve(RapidTheme.surfaceSidebar, appearance: appearance))
+            let fill = try #require(Self.resolve(RapidTheme.selectionFill, appearance: appearance))
+            let bar = try #require(Self.resolve(RapidTheme.selectionBar, appearance: appearance))
+
+            // 3:1 is the non-text threshold, and the bar is a graphic
+            // object rather than a glyph.
+            #expect(
+                Self.contrastRatio(rail, bar) >= 3,
+                """
+                \(appearance.rawValue): the selection bar measures \
+                \(Self.contrastRatio(rail, bar)):1 against the rail. The bar is \
+                the whole signal now — if it stops separating, selection is \
+                invisible again.
+                """
+            )
+            #expect(
+                Self.contrastRatio(fill, bar) >= 3,
+                "\(appearance.rawValue): the bar disappears against the selected row's own fill."
+            )
+            // The fill still has to be doing something, however quiet.
+            #expect(
+                Self.rgbDistance(rail, fill) > 0,
+                "\(appearance.rawValue): the selection fill is identical to the rail."
+            )
+        }
+    }
+
+    /// Hover must stay a clear step BELOW selection, or pointing at a row
+    /// looks like having chosen it.
+    @Test("Hover is weaker than selection on the rail")
+    func hoverIsWeakerThanSelection() throws {
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            let rail = try #require(Self.resolve(RapidTheme.surfaceSidebar, appearance: appearance))
+            let hover = try #require(Self.resolve(RapidTheme.hoverFill, appearance: appearance))
+            let selected = try #require(Self.resolve(RapidTheme.selectionFill, appearance: appearance))
+
+            #expect(
+                Self.rgbDistance(rail, hover) < Self.rgbDistance(rail, selected),
+                "\(appearance.rawValue): hover reads at least as strong as selection."
+            )
+        }
+    }
+
+    /// Selection cannot be carried by colour alone. The rail draws a
+    /// hard-edged amber bar and thickens the label, and both have to
+    /// survive somebody "simplifying" the row later.
+    @Test("The rail marks selection with a bar and a weight, not only a fill")
+    func selectionUsesNonColourSignals() throws {
+        let source = try strippedSource("Sources/Rapid/UI/SidebarView.swift")
+        #expect(
+            source.contains("RapidTheme.selectionBar"),
+            "The sidebar no longer draws the amber selection bar."
+        )
+        #expect(
+            source.contains("RapidTheme.Layout.selectionBarWidth"),
+            "The selection bar stopped reading its width from the shared token."
+        )
+        #expect(
+            source.contains("isSelected?RapidFont.bodyEmphasis:RapidFont.body"),
+            "The nav row's label no longer thickens when selected."
+        )
+        #expect(
+            source.contains("isActive?RapidFont.bodyEmphasis:RapidFont.body"),
+            "The conversation row's title no longer thickens when active."
+        )
+    }
+
+    /// The command palette is the same conversation list reached another
+    /// way, so it has to answer "which row am I on" identically.
+    @Test("The command palette uses the same selection rule as the rail")
+    func searchPanelMatchesTheRailSelection() throws {
+        let source = try strippedSource("Sources/Rapid/UI/ConversationSearchView.swift")
+        #expect(source.contains("RapidTheme.selectionFill"))
+        #expect(source.contains("RapidTheme.selectionBar"))
+    }
+
+    // MARK: - Amber budget
+
+    /// One amber moment per surface. In the composer that moment is the
+    /// send disc, so the readiness notice 40pt above it must not be a
+    /// second amber block.
+    @Test("The readiness notice does not paint a second amber block")
+    func readinessBannerIsNeutralExceptOnFailure() throws {
+        let source = try strippedSource("Sources/Rapid/UI/ReadinessBanner.swift")
+        #expect(
+            source.contains("readiness.isFailure?RapidTheme.statusErrorTint:RapidTheme.surfaceRaised"),
+            """
+            The readiness banner's background is no longer neutral-on-success. \
+            An amber-tinted plate here competes with the send disc, which is \
+            the composer's one amber moment.
+            """
+        )
+    }
+
+    /// Ink on amber is a near-black graphite, never white, and it is
+    /// appearance-independent because the fill is. Re-pinned here because
+    /// this slice repaints several amber surfaces and the pairing is the
+    /// one that fails silently — white on #EFA23A measures ~2:1.
+    @Test("Ink on amber clears AA in both appearances")
+    func inkOnAmberIsLegible() throws {
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            let amber = try #require(Self.resolve(RapidTheme.brandPrimary, appearance: appearance))
+            let ink = try #require(Self.resolve(RapidTheme.brandOnAccent, appearance: appearance))
+            let ratio = Self.contrastRatio(amber, ink)
+            #expect(
+                ratio >= 4.5,
+                "\(appearance.rawValue): ink on amber measures \(ratio):1."
+            )
+        }
+    }
+
+    /// The band's two ink tiers have to be readable on its graphite
+    /// ground — including the quiet tier, which carries the byte counts
+    /// and the ETA a user is actively reading during a long download.
+    @Test("Both band ink tiers are readable on the band ground")
+    func bandInkIsLegible() throws {
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            let ground = try #require(Self.resolve(RapidTheme.surfaceBand, appearance: appearance))
+            let primary = try #require(Self.resolve(RapidTheme.bandInk, appearance: appearance))
+            let secondary = try #require(Self.resolve(RapidTheme.bandInkSecondary, appearance: appearance))
+
+            #expect(
+                Self.contrastRatio(ground, primary) >= 7,
+                "\(appearance.rawValue): band ink measures \(Self.contrastRatio(ground, primary)):1."
+            )
+            // 4.5 rather than 7: this tier is deliberately quiet, but it
+            // is still prose a person reads, not decoration.
+            #expect(
+                Self.contrastRatio(ground, secondary) >= 4.5,
+                """
+                \(appearance.rawValue): the band's supporting ink measures \
+                \(Self.contrastRatio(ground, secondary)):1 — the byte counts and \
+                ETA are the part of a long download a user actually watches.
+                """
+            )
+        }
+    }
+
+    /// Amber has to stand out on the band, or the progress fill and the
+    /// percentage — the band's entire reason for existing — recede into
+    /// their own background.
+    @Test("Amber reads as progress on the band ground")
+    func amberIsVisibleOnTheBand() throws {
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            let ground = try #require(Self.resolve(RapidTheme.surfaceBand, appearance: appearance))
+            let track = try #require(Self.resolve(RapidTheme.bandTrack, appearance: appearance))
+            let amber = try #require(Self.resolve(RapidTheme.brandPrimary, appearance: appearance))
+
+            #expect(Self.contrastRatio(ground, amber) >= 4.5)
+            #expect(
+                Self.contrastRatio(track, amber) >= 3,
+                "\(appearance.rawValue): the progress fill does not separate from its own track."
+            )
+        }
+    }
+
+    // MARK: - The band flexes in height only
+
+    /// The reason the band is horizontal rather than a side column: chat
+    /// has a fixed 720pt reading measure, and at the 720pt window floor a
+    /// vertical priority area would take width straight out of the
+    /// conversation. Turned sideways, width is never contested — so the
+    /// only thing allowed to respond to window width is the height.
+    @Test("The band steps 132 / 112 / 44 across the three verified widths")
+    func bandHeightSteps() {
+        #expect(LifecycleBand.height(for: RapidTheme.Layout.Breakpoint.wide) == 132)
+        #expect(LifecycleBand.height(for: RapidTheme.Layout.Breakpoint.mid) == 112)
+        #expect(LifecycleBand.height(for: RapidTheme.Layout.Breakpoint.floor) == 44)
+    }
+
+    /// Monotonic, and bounded at both ends. A window wider than 1440 or
+    /// narrower than 720 must not fall off a cliff into a zero or a
+    /// runaway height.
+    @Test("Band height is monotonic and bounded outside the verified widths")
+    func bandHeightIsMonotonic() {
+        let widths: [CGFloat] = [320, 640, 719, 720, 999, 1000, 1439, 1440, 2560, 5120]
+        var previous = LifecycleBand.height(for: widths[0])
+        for width in widths.dropFirst() {
+            let height = LifecycleBand.height(for: width)
+            #expect(height >= previous, "height fell going from a narrower width to \(width)")
+            #expect(height >= 44 && height <= 132, "height \(height) at width \(width) is out of range")
+            previous = height
+        }
+    }
+
+    /// Only the floor collapses to the single-line form, and the floor is
+    /// where the detail line is dropped — so this predicate decides
+    /// whether a string disappears and is worth pinning on its own.
+    @Test("Only the compact step collapses the band to one line")
+    func bandCompactStep() {
+        #expect(LifecycleBand.isCompact(width: RapidTheme.Layout.Breakpoint.floor))
+        #expect(!LifecycleBand.isCompact(width: RapidTheme.Layout.Breakpoint.mid))
+        #expect(!LifecycleBand.isCompact(width: RapidTheme.Layout.Breakpoint.wide))
+    }
+
+    /// The percentage is the one thing the band formats itself, so its
+    /// edges are its own to get right. The byte monitor can overshoot on
+    /// the final chunk; "101%" would be the band contradicting the file
+    /// it just finished downloading.
+    @Test("Band percentage clamps and rounds")
+    func bandPercentText() {
+        #expect(LifecycleBand.percentText(for: nil) == nil)
+        #expect(LifecycleBand.percentText(for: 0) == "0%")
+        #expect(LifecycleBand.percentText(for: 0.594) == "59%")
+        #expect(LifecycleBand.percentText(for: 1) == "100%")
+        #expect(LifecycleBand.percentText(for: 1.04) == "100%")
+        #expect(LifecycleBand.percentText(for: -0.2) == "0%")
+    }
+
+    // MARK: - The band and the banner never speak at once
+
+    /// The band renders the same ``ModelReadiness`` the composer's notice
+    /// does. Showing both would print one fact twice, 400pt apart, in two
+    /// visual languages — so the notice stands down for exactly the
+    /// states the band takes.
+    @Test("The composer notice stands down while the band is open")
+    func bannerSuppressedUnderTheBand() throws {
+        let source = try strippedSource("Sources/Rapid/UI/ChatView.swift")
+        #expect(
+            source.contains("if!readiness.isReady&&!showsLifecycleBand{"),
+            "The readiness banner no longer stands down while the band is open."
+        )
+        #expect(
+            source.contains("varshowsLifecycleBand:Bool{readiness.isWorking}"),
+            """
+            The band's gate changed. It must be exactly ModelReadiness.isWorking: \
+            anything wider would open a graphite band over a decision the user \
+            has not made yet, and streaming in particular must never open one.
+            """
+        )
+    }
+
+    /// Suppressing the banner is only safe because the states it covers
+    /// carry no renderable action — otherwise a control (and its
+    /// `Readiness.Action` identifier) would vanish with it.
+    @Test("The states the band covers carry no renderable action")
+    func bandStatesHaveNoRenderableAction() {
+        let banded: [ModelReadiness] = [
+            .downloading(alias: "gemma-4-26b-4bit", detail: "8.4 GB of 14.2 GB", fraction: 0.59),
+            .starting(alias: "gemma-4-26b-4bit", detail: "Loading the model into memory…"),
+        ]
+        for state in banded {
+            #expect(state.isWorking, "\(state) should be a banded state")
+            #expect(
+                state.action == nil,
+                """
+                \(state) now offers an action. The composer notice is suppressed \
+                while the band is open, so that button — and the Readiness.Action \
+                identifier the golden flows address it by — would disappear from \
+                the surface entirely.
+                """
+            )
+        }
+    }
+
+    /// Everything that is NOT a banded state keeps its notice, and the
+    /// actionable ones keep their button.
+    @Test("Decision states keep the composer notice and its action")
+    func decisionStatesKeepTheirNotice() {
+        let decisions: [ModelReadiness] = [
+            .noModel,
+            .needsDownload(alias: "gemma-4-26b-4bit", sizeText: "~14.2 GB"),
+            .needsStart(alias: "gemma-4-26b-4bit"),
+            .unknownModel(alias: "something-custom"),
+            .failed(alias: "gemma-4-26b-4bit", message: "Couldn't start", action: .retry(alias: "gemma-4-26b-4bit")),
+        ]
+        for state in decisions {
+            #expect(!state.isWorking, "\(state) must not open the band")
+            #expect(!state.isReady, "\(state) must still show a notice")
+        }
+    }
+
+    // MARK: - The band invents no copy
+
+    /// Every sentence in the band is read off ``ModelReadiness``. The
+    /// band formats exactly one thing of its own — the percentage — and
+    /// a source guard is the only way to keep a stray literal out of a
+    /// view this test cannot instantiate.
+    @Test("The band renders readiness copy and nothing of its own")
+    func bandUsesOnlyReadinessCopy() throws {
+        let raw = try String(
+            contentsOf: Self.packageRoot
+                .appendingPathComponent("Sources/Rapid/UI/Components/LifecycleBand.swift"),
+            encoding: .utf8
+        )
+        let source = CapabilityChipRenderGateSourceGuardTests.stripCommentsAndWhitespace(raw)
+        #expect(source.contains("readiness.headline"))
+        #expect(source.contains("readiness.detail"))
+        #expect(source.contains("readiness.progressFraction"))
+        #expect(source.contains("readiness.accessibilityLabel"))
+        // The canonicaliser PRESERVES string literals (minus whitespace),
+        // so a hard-coded sentence would survive verbatim. Every Text in
+        // this file must therefore be reading a readiness property; a
+        // `Text("` anywhere means somebody typed copy into the band.
+        #expect(
+            !source.contains("Text(\""),
+            """
+            LifecycleBand has grown a literal string. Every word it shows must \
+            come off ModelReadiness, or the band can describe a moment \
+            differently from the composer placeholder and the Send tooltip that \
+            describe the same one.
+            """
+        )
+    }
+
+    // MARK: - Reduce Motion
+
+    /// The Images HUD's sliding segment and breathing dot are perpetual
+    /// loops driven by a ``TimelineView`` clock in the parent, not by an
+    /// ``Animation`` the environment can suppress — so they ran
+    /// regardless of the setting until this slice. Both now route through
+    /// the shared predicate.
+    @Test("The Images HUD loops stop under Reduce Motion")
+    func imagesHUDHonoursReduceMotion() throws {
+        let source = try strippedSource("Sources/Rapid/UI/ImagesView.swift")
+        let occurrences = source.components(separatedBy: "RapidMotion.shouldPulse(").count - 1
+        #expect(
+            occurrences >= 2,
+            """
+            Expected both perpetual loops in the Images HUD — the indeterminate \
+            progress slide and the breathing status dot — to be gated on \
+            RapidMotion.shouldPulse; found \(occurrences).
+            """
+        )
+    }
+
+    /// The predicate itself, re-pinned here because two new call sites
+    /// now depend on it suppressing a loop rather than shortening one.
+    @Test("A perpetual loop is fully suppressed, not merely slowed")
+    func perpetualLoopsAreSuppressed() {
+        #expect(RapidMotion.shouldPulse(isAnimating: true, reduceMotion: false))
+        #expect(!RapidMotion.shouldPulse(isAnimating: true, reduceMotion: true))
+        #expect(!RapidMotion.shouldPulse(isAnimating: false, reduceMotion: false))
+    }
+
+    // MARK: - Ornament budget
+
+    /// The three ornaments this slice removed from the Images progress
+    /// bar. Amber is a signal here; a two-stop blend with a moving
+    /// highlight and a halo reads as decoration wrapped around the
+    /// signal, and the brand spec allows no gradient on the amber axis
+    /// anywhere else in the app.
+    @Test("The Images progress bar carries no gradient, sheen or glow")
+    func imagesProgressBarIsUnornamented() throws {
+        let source = try strippedSource("Sources/Rapid/UI/ImagesView.swift")
+        #expect(
+            !source.contains("fillGradient"),
+            "The amber→gold gradient is back on the diffusion progress bar."
+        )
+        #expect(
+            !source.contains("RapidTheme.brandAmber.opacity(0.55)"),
+            "The amber glow is back under the diffusion progress bar."
+        )
+        #expect(
+            !source.contains("RapidTheme.brandAmber.opacity(0.9)"),
+            "The amber halo is back around the generating status dot."
+        )
+    }
+
+    // MARK: - Chat empty state
+
+    /// The mascot is the brand moment for Chat's empty state and for
+    /// first run. Repeating it on every empty surface turned a greeting
+    /// into wallpaper, so Images renders the aspect preview instead.
+    @Test("The cheetah appears on the Chat empty state and not on Images")
+    func mascotIsReservedForChat() throws {
+        let chat = try strippedSource("Sources/Rapid/UI/ChatView.swift")
+        let images = try strippedSource("Sources/Rapid/UI/ImagesView.swift")
+        #expect(chat.contains("CheetahLogo("), "The Chat empty state lost the shipped cheetah asset.")
+        #expect(
+            !images.contains("CheetahLogo("),
+            "The cheetah is back on the Images surface, where §17 V2 removes it."
+        )
+    }
+
+    /// The plate is gone and the greeting is at display scale. Both are
+    /// properties of the composition rather than of a token, so a source
+    /// guard is what holds them.
+    @Test("The Chat hero drops its backplate and takes the display tier")
+    func chatHeroIsDisplayScaleAndPlateless() throws {
+        let source = try strippedSource("Sources/Rapid/UI/ChatView.swift")
+        #expect(source.contains("marksOnBackplate:false"))
+        #expect(source.contains("titleEmphasis:.display"))
+    }
+
+    /// The display tier has to actually be bigger than the page tier, and
+    /// its tracking has to be negative — SF opens up as it grows, and an
+    /// untracked 34pt line reads as display type from a slide deck.
+    @Test("The display tier outranks the page tier")
+    func displayTierIsLarger() {
+        #expect(RapidFont.displayTitle != RapidFont.pageTitle)
+        #expect(RapidFont.displayTitleTracking < 0)
+    }
+
+    // MARK: - Nothing moved
+
+    /// The identifiers this slice's surfaces are addressed by. The GUI
+    /// golden flows drive the app by `AXIdentifier` and nothing else, so
+    /// a visual pass that renames one is a broken harness, not a
+    /// restyle. ``AccessibilityIdentifierInventoryTests`` owns the full
+    /// inventory; this is the Slice 1 subset, pinned in the PR that
+    /// touched these files.
+    @Test("Slice 1 surfaces keep every accessibility identifier")
+    func identifiersSurvivedTheRestyle() throws {
+        let expectations: [String: [String]] = [
+            "Sources/Rapid/UI/SidebarView.swift": [
+                "Sidebar.NewChat",
+                "Sidebar.Images",
+                "Sidebar.Audio",
+                "Sidebar.Launch",
+                "Sidebar.Residency",
+                "Toolbar.SearchChats",
+                "Sidebar.DeleteConversation.Confirm",
+                "Sidebar.DeleteConversation.Keep",
+                "Sidebar.Conversation.Action.Rename",
+                "Sidebar.Conversation.Action.Delete",
+            ],
+            "Sources/Rapid/UI/ChatView.swift": [
+                "ChatView.SendOrStopButton",
+                "ChatView.AddPhotos",
+                "ChatView.ConversationInstructions",
+            ],
+            "Sources/Rapid/UI/ImagesView.swift": [
+                "Images.Stage",
+                "Images.EmptyState",
+                "Images.Prompt",
+                "Images.Cancel",
+                "Images.Gallery",
+                "Images.Result.Edit",
+                "Images.Result.Save",
+            ],
+            "Sources/Rapid/UI/ReadinessBanner.swift": [
+                "Readiness.Action",
+            ],
+        ]
+        for (path, identifiers) in expectations {
+            let source = try strippedSource(path)
+            for identifier in identifiers {
+                #expect(
+                    source.contains(".accessibilityIdentifier(\"\(identifier)\")"),
+                    "\(path) no longer declares \(identifier)."
+                )
+            }
+        }
+    }
+
+    /// The nav order and the SF Symbols behind it. §15's audit turns on
+    /// these four rows being untouched, and a symbol swap is the kind of
+    /// thing a visual pass does without noticing.
+    @Test("Navigation keeps its four rows, their symbols and their order")
+    func navigationIsUnchanged() throws {
+        let source = try strippedSource("Sources/Rapid/UI/SidebarView.swift")
+        let rows: [(title: String, symbol: String)] = [
+            ("New Chat", "square.and.pencil"),
+            ("Images", "photo"),
+            ("Audio", "waveform"),
+            ("Launch", "paperplane"),
+        ]
+        var searchStart = source.startIndex
+        for row in rows {
+            // The canonicaliser strips whitespace INSIDE preserved string
+            // literals too, so "New Chat" arrives here as "NewChat".
+            let title = row.title.filter { !$0.isWhitespace }
+            let needle = "title:\"\(title)\",systemImage:\"\(row.symbol)\""
+            guard let found = source.range(of: needle, range: searchStart..<source.endIndex) else {
+                Issue.record("\(row.title) / \(row.symbol) is missing, renamed, or out of order.")
+                return
+            }
+            searchStart = found.upperBound
+        }
+    }
+
+    /// The brand lockup added to the rail must stay decoration. Without
+    /// this it becomes the first element in every VoiceOver traversal of
+    /// the sidebar, ahead of the first thing you can actually do there —
+    /// and it would add an AX node the identifier inventory never
+    /// accounted for.
+    @Test("The sidebar brand lockup is accessibility-hidden")
+    func brandLockupIsDecorative() throws {
+        let source = try strippedSource("Sources/Rapid/UI/SidebarView.swift")
+        guard let lockup = source.range(of: "varbrandLockup:someView{") else {
+            Issue.record("The brand lockup is gone.")
+            return
+        }
+        let block = SourceGuardSupport.balancedBlock(
+            in: source,
+            openingBraceAt: source.index(before: lockup.upperBound)
+        )
+        #expect(
+            block?.contains(".accessibilityHidden(true)") == true,
+            "The sidebar brand lockup is now announced to VoiceOver."
+        )
+    }
+
+    /// The composer's control lane is unchanged, and the send action is
+    /// still the composer's one amber moment.
+    @Test("The composer keeps its controls and its single amber action")
+    func composerControlsAreIntact() throws {
+        let source = try strippedSource("Sources/Rapid/UI/ChatView.swift")
+        #expect(source.contains("ModelPickerBar("))
+        #expect(source.contains("sendOrStopButton"))
+        #expect(
+            source.contains("sendEnabled?RapidTheme.brandPrimary:Color.clear"),
+            "The send disc is no longer the composer's amber moment."
+        )
+    }
+
+    // MARK: - Responsive contract
+
+    /// The reading measure is fixed, and at the floor the window is
+    /// exactly one measure wide. This is the arithmetic behind "the band
+    /// must not be a column": a vertical priority area of any width at
+    /// all would be taking points out of the conversation here.
+    @Test("At the compact floor the window is exactly one reading measure")
+    func floorEqualsTheReadingMeasure() {
+        #expect(RapidTheme.Layout.contentMaxWidth == RapidTheme.Layout.Breakpoint.floor)
+    }
+
+    /// The detail pane's floor plus the widest rail has to fit inside the
+    /// window floor, or the shell clips horizontally before any surface
+    /// gets a say.
+    @Test("The rail and the detail floor fit inside the window floor")
+    func shellFitsAtTheWindowFloor() {
+        let committed = SidebarView.columnIdealWidth + 440
+        #expect(
+            committed <= ContentView.minWindowWidth,
+            """
+            The rail (\(SidebarView.columnIdealWidth)) plus the detail floor (440) \
+            commits \(committed)pt inside a \(ContentView.minWindowWidth)pt window.
+            """
+        )
+    }
+}

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2206,6 +2206,7 @@ flow_image_generation() {
         || die "Images.Aspect is missing — no way to choose an aspect ratio"
     jq -e '.data.ui_elements[]? | select(.identifier == "Images.Resolution")' "$OUT/ig-empty.json" >/dev/null \
         || die "Images.Resolution is missing — no way to choose an output resolution"
+    baseline image-generation.empty "$OUT/ig-empty.json"
 
     # 3. Load the model. rapid-mlx serves one model per process, so opening the
     #    tab cannot silently inherit a ready server: the readiness gate holds
@@ -2254,6 +2255,7 @@ flow_image_generation() {
     done
     [[ "$inflight" == 1 ]] \
         || die "no in-flight progress card: Images.Cancel never appeared during a render"
+    baseline image-generation.inflight "$OUT/ig-inflight.json"
 
     wait_fake_event '.event == "image_request"' \
         "no image_request reached the sidecar — the prompt was never sent"


### PR DESCRIPTION
## Summary

Slice 1 of Phase UI-2: the core workspace — shared visual foundation, primary shell and navigation, Chat, and Images — moved onto the approved Direction D visual system.

This is a visual-only PR. It changes how these surfaces look. It does not change what any of them do.

The largest single change is that a multi-gigabyte model download stops being a two-line notice in a 44pt strip and becomes a composition with the priority it earns. The rest is one token set replacing a drifted one, and a selected row that is legible by something other than a hue.

Six commits, each reviewable on its own:

| | |
|---|---|
| `refactor(mac-ui)` | Direction D visual foundation |
| `style(mac-ui)` | Primary shell and navigation |
| `style(mac-ui)` | Chat and Images surfaces |
| `test(mac-ui)` | Core workspace visual contracts |
| `fix(mac-ui)` | Lifecycle band geometry as a function of its input |
| `test(mac-ui)` | Core workspace review-capture matrix |

## Visual changes by surface

### Shared foundation

Surfaces move from the warm "bone" ramp to the mineral one — canvas `#F8F7F4` → `#FAFAF9`, sidebar `#F2F0EB` → `#F3F3F1`, and both hairlines with them. The warm neutrals were chosen when they only had to work inside a card; across a whole 1440pt window they read as beige, which put a second warm plane in competition with the single amber moment each screen is allowed. The mineral ramp leaves amber as the only warm thing on screen.

`hoverFill` stops being `Color.primary.opacity(0.055)`. An opacity composites against whatever is behind it, so one "hover" landed a different colour on each of the four surface planes and drifted blue in Dark. A concrete value keeps the gesture recognisable wherever the pointer is, and keeps it a clear step below selection.

New: selection tokens, the lifecycle-band ground with its two ink tiers and progress track, the 34/40 display type tier the ramp was missing, the 48/72 spacing steps, a panel radius, the decision measure, and the three verified widths as named constants.

### Primary shell and navigation

The selected row was an amber tint plus an amber label. On the rail those two colours sat within a few percent of the surface behind them, so the fill did no work and the entire signal was a hue shift in a 13pt label — the first thing lost to colour-blindness, to a dim display, and to peripheral vision.

It is now a 3×18pt amber bar in the leading gutter, a neutral fill, and a semibold label with a semibold glyph beside it. Three signals, two of which survive having no colour at all. The bar is an overlay rather than a sibling in the row stack, so selecting a row does not shift every label in the rail sideways.

The command palette takes the same treatment — its results are the same conversation list reached a different way, and "which row am I on" should not have two answers.

The rail gains the product lockup at its top: the official `R`, the same geometry the menu-bar status item draws, so the two brand surfaces cannot drift. It is accessibility-hidden on purpose (see *Behaviour, strings and identifiers* below).

Residency gains a hairline above it. It is the one block in the rail that describes the machine rather than the app's navigation, and separated by whitespace alone it read as a fifth, oddly-formatted nav group.

### Chat

**The lifecycle band.** A graphite band opens above the transcript for exactly the two states where the app is doing work the user is waiting on, and closes the instant the work ends. It is horizontal rather than a side column for a measurable reason: chat has a 720pt reading measure, and at the 720pt window floor a graphite column would take width straight out of the conversation. Turned sideways only its height flexes — 132 / 112 / 44.

Every string in the band is read off `ModelReadiness`, the same value the composer placeholder, the Send tooltip and the empty-state subtitle read. It formats one thing of its own, the percentage, and only when a real fraction exists. The composer's readiness notice stands down while the band is open so the same sentence is never on screen twice.

**The empty state** loses its tinted disc and grows to display scale. The plate was framing an illustration that already has a silhouette, and being amber-tinted it spent a second amber moment on a surface whose budget is one — that one is the send disc. The title moves from a 20pt page heading to 34/40: an empty chat has nothing else in the window, so a page-heading size floating in 1440pt of canvas reads as a caption that lost its picture. The block is optically centred, lifted 2.8% of the region height, because the composer is a fixed object at the bottom and a geometrically centred block drifts toward it. The shipped cheetah asset is reused unchanged.

**The readiness notice** drops its amber tint for a plain raised surface — it was a second amber block 40pt above the send disc, and two of them competing meant neither read as the thing to look at. The status hue stays on the dot. It also takes a 48pt floor so the composer does not reflow between "no model chosen", "not downloaded" and "not running" — three renderings of one moment.

### Images

The mascot leaves this surface. It is the brand moment for Chat's empty state and for first run; repeating it on every empty surface turned a greeting into wallpaper. In its place is the one thing someone opening Images needs before typing — a scale drawing of what Generate will produce, tracking the live aspect and resolution selections, dashed because it describes something that does not exist yet. It is a drawing, not a control: every hit target stays in the composer pickers that own those values.

The progress HUD moves onto the same graphite ground as the Chat band. Images cannot use a band — the subject there *is* the canvas, and a strip above it would shrink the one thing being watched — so the per-surface composition is a HUD over the image. It previously took a near-white plane, which over a bright render was a pale card on a pale image with a shadow doing all the separation.

Three ornaments go with it: the progress bar's amber-to-gold gradient, its sweeping white sheen, and the amber glow around both the bar and the pulsing dot. Amber is a signal here, and a blend with a highlight on top reads as decoration wrapped around the signal.

## Scope boundaries

**In:** shared visual tokens and components required by this slice, primary shell, sidebar and navigation, Chat, Images, the readiness/notice/progress/empty/loading/success/failure/hover/focus/selected/disabled appearances those surfaces already render, Light and Dark, 1440/1000/720 behaviour, and presentational motion for transitions that already existed.

**Out, and absent from the diff:** Onboarding, Quickstart, Settings, secondary surfaces, Section 18, Mac-presence features, new commands or chords, lifecycle changes, copy changes, documentation, and unrelated refactors.

Every changed file is under `apps/rapid-mac/`. A scan of the changed-file list for `quickstart|onboard|settings|audio|menubar|dock|about|update|telemetry|docs/|README` returns nothing.

## Manual runtime verification

Manual verification passed against the real app bundle, in both Light and Dark appearance, across the tested window sizes and the relevant Chat and Images states.

## Automated testing

Rebased onto `upstream/main` at `e76e7e58`. All runs below are on the rebased branch.

| Run | Result |
|---|---|
| `swift build` | clean |
| `swift test --no-parallel` (run 1) | **2146 tests, 193 suites — passed** |
| `swift test --no-parallel` (clean state, `.build` removed) | **2146 tests, 193 suites — passed** |
| Focused: `CoreWorkspaceVisualFoundationTests` | 28 tests — passed |
| Focused: `AccessibilityIdentifierInventoryTests` | 13 tests — passed |
| Focused: `ConversationSearchTests` | 4 tests — passed |
| `verify-recommendation-tiers` | ALL PASS |
| `verify-conversation-ordering` | ok |
| `verify-chat-timeout` | ok |
| `check_rapid_mac_ax_identifiers --base-ref upstream/main` | PASS |
| `git diff --check upstream/main...HEAD` | clean |
| App bundle build (full, with sidecar) | ready |

**On the previously-reported failure.** While this work was developed against `243f9558`, one test failed: `ConversationSearchTests` "Date sections cover recent, monthly, and older history". It was verified as pre-existing by running the same suite on an unmodified `upstream/main` worktree, which produced an identical 2116-tests/1-issue result. It is now fixed upstream by `de087ea7 fix(mac): honor injected calendar for yesterday grouping (#1904)`, which this branch picked up in the rebase. It passes in the focused run and in both full runs above. The test was not weakened, skipped or modified — this branch does not touch it.

### What the new tests pin

28 contracts, including: both band ink tiers and amber-on-band clear their thresholds in both appearances; ink on amber stays above 4.5:1; band height steps 132/112/44 and is monotonic and bounded outside the verified widths; the percentage clamps so a byte-monitor overshoot cannot print `101%`; the composer notice stands down for exactly `ModelReadiness.isWorking`, and those states provably carry no renderable action, so no control and no `Readiness.Action` identifier can vanish with it; the band contains no string literal at all; both perpetual loops in the Images HUD route through the Reduce Motion predicate; the removed gradient, sheen and glow stay removed; the mascot is on Chat and not on Images; the four nav rows keep their symbols and their order; the brand lockup stays accessibility-hidden; and every identifier on the four touched surfaces is still declared.

### Two defects the tests caught

**The selection bar's contrast.** The first version of the selection test asserted the new neutral fill separated from the rail better than the amber tint it replaced. It does not, and it is not meant to — under the refined rule the fill only says "different" and the amber bar says "selected". The test was measuring the quiet part and leaving the loud part unchecked. Rewritten to measure the bar, it failed for real: **amber `#EFA23A` on the light rail is 1.9:1.** In Dark it is 8.1:1, which is why nothing looked wrong by eye. At 1.9:1 on the one element now carrying the whole signal, this change would have replaced one invisible selected row with another. `selectionBar` is therefore its own adaptive token at `#B87317` in Light — 3.4:1 against the rail, 3.3:1 against the selected row's own fill — deeper than the existing `brandPrimaryDeep` because that value was tuned for *text*, where a glyph's stroke and the reader's attention do some of the work a 3pt rule caught in peripheral vision cannot count on.

**The band's geometry.** The band originally picked its height from a width it measured itself, into `@State`. That needs a second layout pass, and a single-pass render never gives it one — so the 720pt capture came out wearing the 1000pt layout. A screenshot review is exactly the thing that should catch that, and instead the screenshot was the thing producing it. Width is now an input, making the band's geometry a pure function of its inputs: correct on the first pass, correct in a capture, with no state to fall out of sync.

## Responsive and Light/Dark coverage

38 isolated captures were rendered through the dev-only snapshot harness, from a preference-isolated bundle copy, with no Rapid instance running:

- Chat at 1440 / 1000 / 720 × Light / Dark
- Images, empty stage, at 1440 / 1000 / 720 × Light / Dark
- Images, result stage, at 1440 / 1000 / 720 × Light / Dark
- Lifecycle band in `downloading` and `starting`, at all three widths × both appearances
- Aspect preview across 1:1, 3:4 and 4:3
- The rail with a last-row and a mid-list row selected, both appearances

States covered: empty, no-model, needs-start, downloading, starting, generating/edit, selected, disabled send, and result. Checked for clipping, overlap, layout shift, low-contrast text and mismatched icon lanes at each width.

## Paper-versus-production decisions

Where a Paper frame conflicted with current production behaviour, production wins and the discrepancy is recorded rather than silently resolved.

1. **Throughput relocation (§16.4 #5, §03D.1 rule 04) — not implemented.** `TokensPerSecondPill` is visible on every section; the composer identity line exists only on Chat. Moving it would change availability on Images, Audio and Launch. Flagged for a follow-up decision.
2. **Readiness banner "moves below the field" (§16.4 #4) — not implemented.** The premise does not hold in production: the composer is bottom-anchored, so the field's y is already invariant. Moving the banner below it would make the field move when the banner appears — the opposite of the intent. Kept above and stabilised with a fixed floor instead.
3. **Sidebar status footer (§15 D1) — not implemented.** Same availability problem: the sidebar is user-collapsible, which would make engine status unreachable.
4. **Band eyebrow.** Paper shows `DOWNLOADING` above a bare model name. This renders `readiness.headline` instead, to avoid introducing a production string.
5. **Selection bar colour deepened** from the implied `--d-amber-deep` — see the contrast measurement above.
6. **Resolution label** reads `1024x1024`, the existing production formatter, not Paper's `1024 × 1024`.
7. **§15's proposals were largely already shipped** (resident size, pin glyph). The board's own staleness notice predicted this.

## Remaining runtime limitations

- **Reduce Motion cannot be captured.** `accessibilityReduceMotion` is a read-only environment key on macOS, so a harness cannot stage it the way it stages an appearance or a width; injecting one would need a seam through every call site, which is a refactor this visual slice has no business making. The contract is held by `RapidMotion.shouldPulse` and by a source guard over both call sites, and the reduced frame was checked manually against the system setting.
- **Hover and keyboard focus** are pointer and responder states a static capture cannot stage; both were checked manually.
- **Live streaming and a real multi-gigabyte download** in the band were verified manually, not in a capture.
- The blank sidebar column in full-window captures is a pre-existing harness limitation (a hosted `NavigationSplitView` does not populate its sidebar offscreen), which is why the rail is captured separately.

## Behaviour, strings and identifiers

A scan of the entire production diff for user-visible text, help strings, accessibility labels, accessibility identifiers, `Label` and `Button` titles found **two added lines and zero removals**:

- `Text("Rapid-MLX")` — the sidebar brand lockup. Accessibility-hidden, because the window title and the menu bar already announce the app, and a third announcement would put a decoration ahead of "New Chat" in every VoiceOver traversal of the rail. That also keeps it free of any new AX node.
- `.accessibilityIdentifier("Readiness.Band")` — a new identifier on a new element. It renames and replaces nothing.

The only altered conditional on an existing branch is the banner/band handoff, which selects a rendering; it does not change when a state transition occurs.

Explicitly unchanged: production strings, user flows and state transitions, actions and command availability, model/server/download/inference/persistence/cache logic, state ownership, keyboard semantics, accessibility identifiers, menu-bar behaviour, focus routing, window restoration and activation policy, Onboarding, Quickstart, Settings, conversation storage, identifiers used by tests or external integrations, Section 18, and future Mac-presence features.

No new delays, holds, auto-advance behaviour, or changes to when state transitions occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
