### PR TITLE
feat(rapid-mac): add signed background updates with Sparkle

### DIFF
--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -22,6 +22,8 @@
 #   AC_API_KEY_ID                App Store Connect API key id (notarisation)
 #   AC_API_ISSUER_ID             App Store Connect issuer id
 #   AC_API_KEY_P8_BASE64         base64 of the AuthKey_XXX.p8
+#   SPARKLE_ED_PRIVATE_KEY       private Ed25519 key exported by Sparkle's
+#                                generate_keys tool (base64 text)
 #
 #   Required for tagged releases (the "mirror-dist" and
 #   "publish-updater-fallback" jobs at the bottom). NOTE: on a tag these are
@@ -43,6 +45,7 @@
 #   VARIABLES (not secrets), since they are config, not credentials:
 #   RAPID_MAC_DIST_R2_BUCKET     name of the R2 bucket to mirror the DMG into
 #   RAPID_MAC_DIST_CDN_BASE      public CDN base URL that fronts the bucket
+#   SPARKLE_PUBLIC_ED_KEY        SUPublicEDKey value printed by generate_keys
 #
 # NOTE: Sentry has been removed from the monorepo app; there is no
 # SENTRY_DSN secret here (the desktop workflow had one).
@@ -253,7 +256,18 @@ jobs:
         # from the engine at the repo root (RAPID_MLX_SOURCE defaults to
         # apps/rapid-mac/../.. — the monorepo root), and Developer-ID signs
         # the bundle with CODESIGN_IDENTITY (exported above).
-        run: bash scripts/build.sh
+        env:
+          # Only signed builds enable Sparkle. An ad-hoc build cannot update a
+          # Developer-ID-signed installation because code-signing continuity
+          # validation correctly rejects it.
+          SPARKLE_PUBLIC_ED_KEY: ${{ env.SIGNED == 'true' && vars.SPARKLE_PUBLIC_ED_KEY || '' }}
+        run: |
+          set -euo pipefail
+          if [[ "${SIGNED}" == "true" && -z "${SPARKLE_PUBLIC_ED_KEY:-}" ]]; then
+            echo "::error::signed releases require the SPARKLE_PUBLIC_ED_KEY Actions variable"
+            exit 1
+          fi
+          bash scripts/build.sh
 
       - name: Bundle size gate (block if .app exceeds BUNDLE_SIZE_CAP_MB)
         # Runs BEFORE notarisation so an oversize bundle fails fast without
@@ -296,6 +310,109 @@ jobs:
           set -euo pipefail
           ditto -c -k --keepParent "build/Rapid-MLX Desktop.app" "build/Rapid-MLX-Desktop.zip"
           bash scripts/notarize.sh "build/Rapid-MLX-Desktop.zip" "build/Rapid-MLX Desktop.app"
+
+      - name: Build signed Sparkle archive and appcast
+        if: startsWith(github.ref, 'refs/tags/') && env.SIGNED == 'true'
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          CDN_BASE: ${{ vars.RAPID_MAC_DIST_CDN_BASE }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          [[ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]] || {
+            echo "::error::signed releases require SPARKLE_ED_PRIVATE_KEY"
+            exit 1
+          }
+          [[ "$CDN_BASE" == "https://dl.rapidmlx.com" ]] || {
+            echo "::error::RAPID_MAC_DIST_CDN_BASE must be https://dl.rapidmlx.com"
+            exit 1
+          }
+          VERSION="${TAG#rapid-mac-v}"
+          APP_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' \
+            'build/Rapid-MLX Desktop.app/Contents/Info.plist')"
+          [[ "$APP_BUILD" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::CFBundleVersion must be a positive integer for Sparkle"
+            exit 1
+          }
+          PREVIOUS_TAG="$(git tag -l 'rapid-mac-v*' --sort=v:refname \
+            | awk -v current="$TAG" \
+                '$0 ~ /^rapid-mac-v[0-9]+\.[0-9]+\.[0-9]+$/ { \
+                  if ($0 == current) { print previous; exit } \
+                  previous=$0 \
+                }')"
+          if [[ -n "$PREVIOUS_TAG" ]]; then
+            PREVIOUS_BUILD="$(git show \
+              "${PREVIOUS_TAG}:apps/rapid-mac/Resources/Info.plist" \
+              | plutil -extract CFBundleVersion raw -o - - 2>/dev/null || true)"
+            [[ "$PREVIOUS_BUILD" =~ ^[1-9][0-9]*$ ]] || {
+              echo "::error::cannot read CFBundleVersion from ${PREVIOUS_TAG}"
+              exit 1
+            }
+            (( APP_BUILD > PREVIOUS_BUILD )) || {
+              echo "::error::CFBundleVersion ${APP_BUILD} must exceed ${PREVIOUS_TAG} build ${PREVIOUS_BUILD} for Sparkle"
+              exit 1
+            }
+          fi
+          OUT="build/sparkle"
+          rm -rf "$OUT"
+          mkdir -p "$OUT"
+
+          TEMP_ZIP="$OUT/Rapid-MLX-Desktop-${VERSION}.zip"
+          ditto -c -k --sequesterRsrc --keepParent \
+            "build/Rapid-MLX Desktop.app" "$TEMP_ZIP"
+          ZIP_SHA256="$(shasum -a 256 "$TEMP_ZIP" | awk '{print $1}')"
+          ZIP_NAME="Rapid-MLX-Desktop-${VERSION}-${ZIP_SHA256}.zip"
+          mv "$TEMP_ZIP" "$OUT/$ZIP_NAME"
+          cp "$RELEASE_NOTES_FILE" "$OUT/${ZIP_NAME%.zip}.md"
+
+          GENERATE_APPCAST=".build/artifacts/sparkle/Sparkle/bin/generate_appcast"
+          [[ -x "$GENERATE_APPCAST" ]] || {
+            echo "::error::Sparkle generate_appcast tool missing"
+            exit 1
+          }
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" \
+            | "$GENERATE_APPCAST" --ed-key-file - \
+                --download-url-prefix "${CDN_BASE}/rapid-mac/${VERSION}/" \
+                --embed-release-notes --maximum-versions 1 --maximum-deltas 0 \
+                -o "$OUT/appcast.xml" "$OUT"
+          [[ -s "$OUT/appcast.xml" ]] || { echo "::error::appcast not generated"; exit 1; }
+          grep -Fq "sparkle:edSignature=" "$OUT/appcast.xml" || {
+            echo "::error::appcast enclosure has no EdDSA signature"
+            exit 1
+          }
+          EXPECTED_URL="${CDN_BASE}/rapid-mac/${VERSION}/${ZIP_NAME}"
+          APPCAST_VERSION="$(xmllint --xpath \
+            'string(/*[local-name()="rss"]/*[local-name()="channel"]/*[local-name()="item"][1]/*[local-name()="version"])' \
+            "$OUT/appcast.xml")"
+          APPCAST_SHORT_VERSION="$(xmllint --xpath \
+            'string(/*[local-name()="rss"]/*[local-name()="channel"]/*[local-name()="item"][1]/*[local-name()="shortVersionString"])' \
+            "$OUT/appcast.xml")"
+          APPCAST_URL="$(xmllint --xpath \
+            'string(/*[local-name()="rss"]/*[local-name()="channel"]/*[local-name()="item"][1]/*[local-name()="enclosure"]/@url)' \
+            "$OUT/appcast.xml")"
+          [[ "$APPCAST_VERSION" == "$APP_BUILD" ]] || {
+            echo "::error::appcast build version does not match the signed app"
+            exit 1
+          }
+          [[ "$APPCAST_SHORT_VERSION" == "$VERSION" ]] || {
+            echo "::error::appcast release version does not match the tag"
+            exit 1
+          }
+          [[ "$APPCAST_URL" == "$EXPECTED_URL" ]] || {
+            echo "::error::appcast URL does not match the mirrored Sparkle ZIP"
+            exit 1
+          }
+
+      - name: Upload Sparkle update artifact
+        if: startsWith(github.ref, 'refs/tags/') && env.SIGNED == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-mac-sparkle-update
+          path: |
+            apps/rapid-mac/build/sparkle/*.zip
+            apps/rapid-mac/build/sparkle/appcast.xml
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Build + sign rapid-mlx-desktop.dmg (from the stapled app)
         run: bash scripts/dmg.sh
@@ -396,7 +513,14 @@ jobs:
           name: rapid-mac-release-notes
           path: notes
 
-      - name: Mirror DMG and compose updater fallback
+      - name: Download the signed Sparkle update
+        if: needs.build.outputs.signed == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: rapid-mac-sparkle-update
+          path: sparkle
+
+      - name: Mirror update archives and compose updater fallback
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -441,6 +565,17 @@ jobs:
           npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/${VERSIONED_KEY}" \
             --file "$DMG" --content-type application/x-apple-diskimage --remote
 
+          if [[ "${{ needs.build.outputs.signed }}" == "true" ]]; then
+            SPARKLE_ZIP="$(find sparkle -maxdepth 1 -type f -name '*.zip' -print -quit)"
+            [[ -n "$SPARKLE_ZIP" && -f "$SPARKLE_ZIP" ]] || {
+              echo "::error::missing signed Sparkle ZIP"
+              exit 1
+            }
+            SPARKLE_KEY="rapid-mac/${VERSION}/$(basename "$SPARKLE_ZIP")"
+            npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/${SPARKLE_KEY}" \
+              --file "$SPARKLE_ZIP" --content-type application/zip --remote
+          fi
+
           # The GitHub Release does not exist yet — it is created only once this
           # manifest is live (see publish-updater-fallback), so a failure here
           # can no longer leave a published release pointing at a stale updater
@@ -478,6 +613,14 @@ jobs:
           path: dist/latest.json
           if-no-files-found: error
 
+      - name: Stage Sparkle appcast for serialized publication
+        if: needs.build.outputs.signed == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rapid-mac-sparkle-appcast
+          path: sparkle/appcast.xml
+          if-no-files-found: error
+
   # Every tag mirrors its immutable DMG above. Only the mutable pointer is
   # serialized here. Turnstyle queues every run (unlike native concurrency,
   # which keeps only one pending run and can drop an intermediate tag).
@@ -510,6 +653,13 @@ jobs:
         with:
           name: rapid-mac-release-notes
           path: notes
+
+      - name: Download staged Sparkle appcast
+        if: needs.build.outputs.signed == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: rapid-mac-sparkle-appcast
+          path: sparkle
 
       - name: Publish updater fallback monotonically
         env:
@@ -557,6 +707,13 @@ jobs:
             --file dist/latest.json --content-type application/json \
             --cache-control "no-cache, must-revalidate" --remote
 
+          if [[ "${{ needs.build.outputs.signed }}" == "true" ]]; then
+            [[ -s sparkle/appcast.xml ]] || { echo "::error::missing appcast.xml"; exit 1; }
+            npx --yes wrangler@4.120.0 r2 object put "${R2_BUCKET}/appcast.xml" \
+              --file sparkle/appcast.xml --content-type application/xml \
+              --cache-control "no-cache, must-revalidate" --remote
+          fi
+
           # Preserve the previously documented stable DMG URL only after the
           # canonical updater transaction succeeds. A failure here can leave
           # the compatibility URL old, but can never make latest.json point at
@@ -568,7 +725,10 @@ jobs:
 
           # Cache-Control governs new responses; purge any object cached under
           # the pre-fix policy so this release becomes visible immediately.
-          PURGE_PAYLOAD="$(jq -nc --arg url "${CDN_BASE}/latest.json" '{files: [$url]}')"
+          PURGE_PAYLOAD="$(jq -nc \
+            --arg latest "${CDN_BASE}/latest.json" \
+            --arg appcast "${CDN_BASE}/appcast.xml" \
+            '{files: [$latest, $appcast]}')"
           curl --fail-with-body --silent --show-error \
             --request POST \
             --url "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \

--- a/apps/rapid-mac/PRIVACY.md
+++ b/apps/rapid-mac/PRIVACY.md
@@ -193,7 +193,15 @@ distributions are out of scope but we will help triage.
   Automatic Sentry diagnostics are disabled.
 * **Telemetry collector** — Cloudflare Workers + R2 storage. Subject
   to Cloudflare's data processing terms.
-* **Auto-update channel** — ``UpdateChecker`` polls
+* **Auto-update channel** — signed production builds use Sparkle to poll
+  `https://dl.rapidmlx.com/appcast.xml` every six hours. Sparkle sends a
+  standard app/version user agent but no system profile
+  (`SUSendsSystemProfile=false`), unique identifier, chat content, or usage
+  data. It verifies every update archive with the Ed25519 public key embedded
+  in the signed app, downloads in the background when enabled, and installs
+  the prepared update when Rapid-MLX next quits normally.
+
+  During the migration, ``UpdateChecker`` also polls
   `https://rapidmlx.com/api/desktop-update?v=<app-version>` on launch
   and every 6 hours while running. This is a thin Cloudflare Worker
   that returns the **byte-identical** release manifest the public R2
@@ -209,8 +217,10 @@ distributions are out of scope but we will help triage.
   which skips the request completely — no poll, no signal. No GitHub
   API call, no PAT, no proxy of GitHub — those were the v0.5 shape and
   were retired in v0.6.12 (PR rapid-desktop#225 + rapidmlx.com#8). When a newer release is available the app
-  surfaces an "Update available" entry. If you press "Install and
-  Restart" the in-app ``Installer`` (`Sources/Rapid/Updater/Installer.swift`)
+  surfaces the existing in-app version status. Builds without an injected
+  Sparkle public key (local development and unsigned internal builds) retain
+  the legacy "Install and Restart" fallback in
+  `Sources/Rapid/Updater/Installer.swift`, which
   drives the full download → mount → verify → swap → relaunch flow:
   * **HTTPS host allow-list** on the initial DMG URL **and** every
     HTTP redirect — only the R2 origin (`dl.rapidmlx.com`) and the
@@ -224,26 +234,18 @@ distributions are out of scope but we will help triage.
     v0.5.16 via `codesign -dvv` and `spctl --assess`. The verify
     catches a corrupt download, a mid-flight bit flip, and a
     structurally-tampered resource payload. The remaining gap (the
-    verify call doesn't yet pass `-R "… leaf[subject.OU] =
+    verify call doesn't pass `-R "… leaf[subject.OU] =
     73WQ7ZGSWC"`, so a DMG signed by a *different* valid Developer
-    ID team could also pass) is closed in practice by the HTTPS
-    host-allowlist above and tracked by
-    [issue #16](https://github.com/raullenchai/Rapid-MLX/issues/16)
-    for permanent fix via Sparkle's EdDSA appcast signing.
+    ID team could also pass) is limited to this legacy fallback and
+    mitigated by the HTTPS host allow-list above. Signed production builds
+    use Sparkle's EdDSA verification instead.
   * **No per-artifact SHA-256 enforcement yet.** The worker v1
     schema does not surface one; worker v2 (planned) will add
     `dmg_sha256` and the ``Installer.verifying`` stage will start
     enforcing it as a one-line wiring change.
-  * **Sparkle with EdDSA per-artifact signature verification is on
-    the roadmap** as
-    [issue #16](https://github.com/raullenchai/Rapid-MLX/issues/16).
-    Migration triggers (per the issue) are concrete operational
-    signals — telemetry showing repeat update failures, user-reported
-    silent misses, or a need for delta updates / staged rollout — not
-    a missing prerequisite. The Developer ID + notarisation chain
-    Sparkle assumes is already in place; the migration is a code
-    rewrite plus EdDSA key infrastructure. Design
-    spike: `docs/plans/sparkle-migration-design.md`.
+  * **Signed production builds close the legacy identity gap with Sparkle.**
+    Each ZIP carries an Ed25519 signature from the appcast, while Sparkle also
+    validates Apple code-signing continuity before atomic replacement.
 
   If you want to side-step the in-app installer entirely you can
   download the DMG from the

--- a/apps/rapid-mac/Package.swift
+++ b/apps/rapid-mac/Package.swift
@@ -8,6 +8,11 @@ let package = Package(
     name: "Rapid",
     platforms: [.macOS(.v14)],
     dependencies: [
+        // Sparkle owns signed desktop updates: background checks/downloads,
+        // install-on-quit, authorization when /Applications is not writable,
+        // and atomic replacement. Keep the in-tree updater as a migration
+        // fallback for builds that do not carry a Sparkle public key.
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.5"),
         // Block-level markdown rendering for assistant turns. Apple's
         // ``AttributedString(markdown:)`` only does inline formatting and
         // silently flattens headings, lists, fenced code, and tables.
@@ -55,6 +60,7 @@ let package = Package(
             dependencies: [
                 .product(name: "MarkdownUI", package: "swift-markdown-ui"),
                 .product(name: "Markdown", package: "swift-markdown"),
+                .product(name: "Sparkle", package: "Sparkle"),
                 "SwiftMath",
                 "RapidCrashHandler"
             ],

--- a/apps/rapid-mac/README.md
+++ b/apps/rapid-mac/README.md
@@ -48,10 +48,11 @@ open it, and drag **Rapid-MLX Desktop** to Applications.
   Worker → R2) under one shared anonymous client ID so the app and the
   embedded engine never double-count an install. Paths are PII-redacted
   (`/Users/<name>/` scrubbed); chat content and attachments are never sent.
-- **Self-update.** On launch and every 6 hours the app checks
-  `https://rapidmlx.com/api/desktop-update?v=<app-version>`. The only value
-  sent is the app version; the Worker keeps aggregate version/country counts
-  and never stores the IP. Opt out with `RAPIDMLX_NO_UPDATE_CHECK=1` or
+- **Self-update.** Signed releases use Sparkle to check an EdDSA-signed appcast,
+  download updates in the background, and install them when Rapid-MLX quits.
+  During the migration the existing six-hour version-status request remains;
+  it sends only the app version and records aggregate counts without storing
+  the IP. Opt out of both requests with `RAPIDMLX_NO_UPDATE_CHECK=1` or
   `DO_NOT_TRACK=1`.
 
 See [PRIVACY.md](PRIVACY.md) for the full field list, reset behavior, and

--- a/apps/rapid-mac/RELEASING.md
+++ b/apps/rapid-mac/RELEASING.md
@@ -84,7 +84,7 @@ Add these under **Settings → Secrets and variables → Actions**. The workflow
 `.github/workflows/rapid-mac-release.yml` references every one of them by name
 only.
 
-### Required secrets (6)
+### Required Apple secrets (6)
 
 | Secret name | Value (from Part A) |
 |---|---|
@@ -95,6 +95,24 @@ only.
 | `AC_API_ISSUER_ID` | App Store Connect issuer id (A2) |
 | `AC_API_KEY_P8_BASE64` | base64 of `AuthKey_<KEYID>.p8` (A2) |
 
+### Required Sparkle signing key
+
+Generate this once on a trusted Mac after `swift package resolve`:
+
+```bash
+cd apps/rapid-mac
+.build/artifacts/sparkle/Sparkle/bin/generate_keys --account rapid-mlx
+.build/artifacts/sparkle/Sparkle/bin/generate_keys --account rapid-mlx \
+  -x ~/Desktop/rapid-mlx-sparkle-private-key
+```
+
+The first command prints the public key. Add it as the Actions **variable**
+`SPARKLE_PUBLIC_ED_KEY`. Add the exact contents of the exported file as the
+Actions **secret** `SPARKLE_ED_PRIVATE_KEY`, then move the exported file into
+the team's protected credential store and remove the Desktop copy. Losing this
+private key breaks the automatic-update chain for every installed version;
+rotating it requires a signed transition release.
+
 ### Required for tagged releases — updater fallback publishing
 
 | Name | Kind | Value |
@@ -104,11 +122,14 @@ only.
 | `CLOUDFLARE_ZONE_ID` | secret | zone id owning `dl.rapidmlx.com`, used for single-file cache purge |
 | `RAPID_MAC_DIST_R2_BUCKET` | **variable** | `rapid-desktop-dist` |
 | `RAPID_MAC_DIST_CDN_BASE` | **variable** | `https://dl.rapidmlx.com` |
+| `SPARKLE_ED_PRIVATE_KEY` | secret | exported Sparkle Ed25519 private key |
+| `SPARKLE_PUBLIC_ED_KEY` | **variable** | matching `SUPublicEDKey` value |
 
 The release jobs fail a tagged release if these are absent. They upload the
-content-addressed DMG first, then queue every tag's monotonic `latest.json`
-publication, so the static updater fallback cannot advertise a missing artifact
-or roll back when releases overlap. The two bucket/CDN names are
+content-addressed DMG and Sparkle ZIP first, then queue every tag's monotonic
+`latest.json` + `appcast.xml` publication, so neither updater can advertise a
+missing artifact or roll back when releases overlap. The bucket/CDN and public
+key values are
 **config, not credentials**, so they go in *Variables*, not *Secrets*.
 
 ### Dropped
@@ -174,19 +195,23 @@ No tag, no GitHub Release, no CI. Costs $0.
 ### D2. Public CI release (tag-triggered)
 
 ```bash
-# 1. Bump apps/rapid-mac/Resources/Info.plist CFBundleShortVersionString
-#    and add a "## [X.Y.Z]" section to apps/rapid-mac/CHANGELOG.md, on main.
+# 1. Bump apps/rapid-mac/Resources/Info.plist:
+#      CFBundleShortVersionString = X.Y.Z
+#      CFBundleVersion = a strictly increasing positive integer
+#    Then add a "## [X.Y.Z]" section to apps/rapid-mac/CHANGELOG.md, on main.
 # 2. Cut it (guarded — preflights CHANGELOG/plist/tag, then pushes the tag):
 cd apps/rapid-mac
 scripts/release-local.sh --publish rapid-mac-v0.11.0
 ```
 
 `--publish` does **not** build locally. It preflights (stable
-`rapid-mac-vX.Y.Z` tag, CHANGELOG entry present, tag == plist version, local
+`rapid-mac-vX.Y.Z` tag, CHANGELOG entry present, tag == plist version, monotonic
+`CFBundleVersion`, local
 `main` == the release remote's `main`, tag is new and strictly newer than the latest
 rapid-mac release, and the root workflow triggers on the tag) then pushes the
 tag. `.github/workflows/rapid-mac-release.yml` then builds → signs →
-notarises → size-gates → attaches `rapid-mlx-desktop.dmg` to the GitHub
+notarises → generates an EdDSA-signed Sparkle ZIP/appcast → size-gates →
+publishes both updater feeds → attaches `rapid-mlx-desktop.dmg` to the GitHub
 Release. The script auto-detects the remote whose URL is
 `raullenchai/Rapid-MLX`; set `RAPID_RELEASE_REMOTE=<name>` to select it
 explicitly. (You can equally `git push <release-remote> rapid-mac-v0.11.0` by hand;
@@ -211,9 +236,10 @@ gh run watch $(gh run list --workflow=rapid-mac-release.yml --limit=1 --json dat
 | Build / sign / notarise / staple / DMG | | ✅ scripts + CI |
 | Attach DMG to the GitHub Release | | ✅ CI |
 
-The app is distributed **only** as a direct `.dmg` download from GitHub
-Releases — there is no Homebrew cask. The `rapid-mlx` name is reserved for the
-engine (`pip install rapid-mlx` and `brew install rapid-mlx`, the latter
+First installation is distributed as a direct `.dmg` download from GitHub
+Releases; subsequent signed releases are also published as Sparkle ZIPs for
+automatic update. There is no Homebrew cask. The `rapid-mlx` name is reserved
+for the engine (`pip install rapid-mlx` and `brew install rapid-mlx`, the latter
 already in homebrew-core); the desktop app never claims it.
 
 ## Open TODO(owner) items

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -36,5 +36,21 @@
 	<true/>
 	<key>SentryDSN</key>
 	<string></string>
+	<!--
+	Sparkle's public key is injected by scripts/build.sh from
+	SPARKLE_PUBLIC_ED_KEY. Keeping it out of the source plist lets local and
+	unsigned builds fall back to the legacy updater instead of starting a
+	misconfigured Sparkle session.
+	-->
+	<key>SUFeedURL</key>
+	<string>https://dl.rapidmlx.com/appcast.xml</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>21600</integer>
+	<key>SUSendsSystemProfile</key>
+	<false/>
 </dict>
 </plist>

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -71,6 +71,7 @@ enum DevSnapshot {
             approval: snapshotMCPApproval
         )
         let snapshotInstaller = Installer()
+        let snapshotSparkleUpdater = SparkleUpdateController(infoDictionary: [:])
         let snapshotWebSearch = WebSearchConfig()
         let snapshotPerfDefaults = UserDefaults(suiteName: "rapid.dev-snapshot.perf")!
         snapshotPerfDefaults.removePersistentDomain(forName: "rapid.dev-snapshot.perf")
@@ -592,6 +593,7 @@ enum DevSnapshot {
                     .environment(downloads)
                     .environment(updater)
                     .environment(snapshotInstaller)
+                    .environment(snapshotSparkleUpdater)
                     .environment(dockPromptStore)
                     .environment(snapshotWebSearch)
                     .environment(browseApproval)

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -41,6 +41,10 @@ struct RapidApp: App {
     @State private var updater: UpdateChecker
     /// In-app DMG installer that drives download → mount → swap → relaunch.
     @State private var installer: Installer
+    /// Sparkle is the production update path once a release build carries its
+    /// injected EdDSA public key. The legacy checker/installer above remains a
+    /// transition fallback for local builds and already-published clients.
+    @State private var sparkleUpdater: SparkleUpdateController
     /// Persisted sampling knobs exposed via Settings → Sampling.
     @State private var sampling: SamplingConfig
     /// App-wide custom instructions shared by Settings and every chat turn.
@@ -227,6 +231,7 @@ struct RapidApp: App {
             updateChecker = UpdateChecker()
         }
         let installerInstance = Installer()
+        let sparkleUpdateController = SparkleUpdateController()
         let downloadsInstance = DownloadManager(binaryPath: manager.binaryPath)
         // #253: let ``ServerManager.start(alias:)`` await any in-flight
         // background pull for the same alias before spawning serve.
@@ -243,6 +248,7 @@ struct RapidApp: App {
         _audio = State(initialValue: AudioViewModel(server: manager))
         _updater = State(initialValue: updateChecker)
         _installer = State(initialValue: installerInstance)
+        _sparkleUpdater = State(initialValue: sparkleUpdateController)
         _sampling = State(initialValue: samplingConfig)
         _customInstructions = State(initialValue: customInstructionsConfig)
         _appearance = State(initialValue: appearanceConfig)
@@ -254,6 +260,7 @@ struct RapidApp: App {
         AppDelegate.shared.downloads = downloadsInstance
         AppDelegate.shared.updater = updateChecker
         AppDelegate.shared.installer = installerInstance
+        AppDelegate.shared.sparkleUpdater = sparkleUpdateController
         AppDelegate.shared.chat = chat
         AppDelegate.shared.appearance = appearanceConfig
     }
@@ -271,6 +278,7 @@ struct RapidApp: App {
                 .environment(imageGen)
                 .environment(audio)
                 .environment(updater)
+                .environment(sparkleUpdater)
                 .environment(sampling)
                 .environment(customInstructions)
                 .environment(appearance)
@@ -321,8 +329,14 @@ struct RapidApp: App {
                     }
                 }
                 .task {
-                    // First update check on launch, then re-check every
-                    // 6 hours while the app is open.
+                    if sparkleUpdater.isEnabled {
+                        // Sparkle owns the six-hour schedule, background
+                        // download, signature validation, and install-on-quit.
+                        sparkleUpdater.start()
+                    }
+                    // Keep the legacy manifest as a read-only UI status source
+                    // during the migration. It no longer downloads or installs
+                    // production updates when Sparkle is configured.
                     await updater.check()
                     while !Task.isCancelled {
                         try? await Task.sleep(nanoseconds: 6 * 60 * 60 * 1_000_000_000)
@@ -404,6 +418,7 @@ struct RapidApp: App {
                 .environment(downloads)
                 .environment(updater)
                 .environment(installer)
+                .environment(sparkleUpdater)
                 .environment(dockPromptStore)
                 .environment(webSearch)
                 .environment(browseApproval)
@@ -474,6 +489,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// ``@State`` on ``RapidApp`` owns each for the app's lifetime.
     weak var updater: UpdateChecker?
     weak var installer: Installer?
+    weak var sparkleUpdater: SparkleUpdateController?
     /// The single AppKit menu-bar (tray) surface. Installed in
     /// ``applicationDidFinishLaunching`` and held strongly so the
     /// ``NSStatusItem`` slot stays alive for the app's lifetime —

--- a/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/MenuBarController.swift
@@ -189,8 +189,16 @@ final class MenuBarController: NSObject {
             AppDelegate.shared.chat?.newConversation()
             bringMainWindowForward()
         case .update:
-            openUpdateWindow()
+            if let sparkle = AppDelegate.shared.sparkleUpdater, sparkle.isEnabled {
+                sparkle.checkForUpdates()
+            } else {
+                openUpdateWindow()
+            }
         case .checkForUpdates:
+            if let sparkle = AppDelegate.shared.sparkleUpdater, sparkle.isEnabled {
+                sparkle.checkForUpdates()
+                return
+            }
             // Fire the check AND take the user somewhere that reports it.
             //
             // This used to be `Task { _ = await updater?.check() }` — result

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -40,6 +40,7 @@ struct SettingsView: View {
     /// "Failed: …" inline when the dedicated update window is
     /// closed.
     @Environment(Installer.self) private var appInstaller
+    @Environment(SparkleUpdateController.self) private var sparkleUpdater
     @Environment(\.dismissWindow) private var dismissWindow
     /// #260: persisted "hide Dock icon on close" choice. Settings →
     /// App surfaces a toggle so the user can change their mind
@@ -706,6 +707,15 @@ struct SettingsView: View {
             }
 
             SettingsSection("Updates") {
+                Toggle(isOn: automaticUpdateBinding) {
+                    Text("Automatically download updates")
+                }
+                .accessibilityIdentifier("Settings.App.AutomaticUpdatesToggle")
+                    .disabled(!sparkleUpdater.isEnabled)
+                    .help(sparkleUpdater.isEnabled
+                          ? "Downloaded updates are installed when Rapid-MLX quits."
+                          : "Automatic updates are enabled in signed release builds.")
+                SettingsRowDivider()
                 appUpdateActionRow
                 if let release = appUpdater.availableUpdate,
                    !release.notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -1023,7 +1033,11 @@ struct SettingsView: View {
     @ViewBuilder
     private var appUpdateRecheckButton: some View {
         Button {
-            Task { await appUpdater.check() }
+            if sparkleUpdater.isEnabled {
+                sparkleUpdater.checkForUpdates()
+            } else {
+                Task { await appUpdater.check() }
+            }
         } label: {
             if appUpdater.checking {
                 Label("Checking…", systemImage: "arrow.clockwise")
@@ -1032,8 +1046,21 @@ struct SettingsView: View {
             }
         }
         .buttonStyle(.rapidSecondaryCompact)
-        .disabled(appUpdater.checking)
+        .disabled(sparkleUpdater.isEnabled
+                  ? !sparkleUpdater.canCheckForUpdates
+                  : appUpdater.checking)
         .accessibilityIdentifier("Settings.App.RecheckCTA")
+    }
+
+    private var automaticUpdateBinding: Binding<Bool> {
+        Binding(
+            get: {
+                sparkleUpdater.automaticallyDownloadsUpdates
+            },
+            set: { enabled in
+                sparkleUpdater.setAutomaticallyDownloadsUpdates(enabled)
+            }
+        )
     }
 
     /// Release-notes preview inside ``appPanel``. The dedicated
@@ -1069,6 +1096,10 @@ struct SettingsView: View {
     /// mirror the same pattern (small sleep + activate first)
     /// for the same reason.
     private func appOpenUpdateWindow() {
+        if sparkleUpdater.isEnabled {
+            sparkleUpdater.checkForUpdates()
+            return
+        }
         Task { @MainActor in
             NSApp.activate(ignoringOtherApps: true)
             try? await Task.sleep(nanoseconds: 50_000_000)

--- a/apps/rapid-mac/Sources/Rapid/Updater/Installer.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/Installer.swift
@@ -50,10 +50,8 @@ let updateDownloadHostAllowlist: Set<String> = [
 /// every stage through ``stage`` so the UI can render real progress
 /// instead of a single opaque spinner. Modelled after Ollama's
 /// ``app/updater/updater_darwin.go`` flow — DMG → mount → copy →
-/// detached helper → relaunch — kept in-tree over Sparkle's
-/// installer-agent because the migration to Sparkle is tracked
-/// separately in issue #16 (see
-/// ``docs/plans/sparkle-migration-design.md``).
+/// detached helper → relaunch. It remains as the migration fallback for local
+/// and internal builds that do not carry a Sparkle public key.
 ///
 /// Threat model:
 ///   * The DMG URL comes from the update worker payload that
@@ -74,15 +72,14 @@ let updateDownloadHostAllowlist: Set<String> = [
 ///     ID``). The verify call catches a corrupt download, a
 ///     mid-flight bit flip, AND a structurally-tampered resource
 ///     payload (``--strict`` keeps the resource-rules check on).
-///     **Remaining gap (tracked by issue #16):** the verify call does
+///     **Remaining fallback-only gap:** the verify call does
 ///     NOT pass ``-R "anchor apple generic and identifier
 ///     \"com.rapidmlx.rapid\" and certificate leaf[subject.OU] =
 ///     73WQ7ZGSWC"``, so a DMG signed with a *different* valid
 ///     Developer ID team would also pass. The HTTPS host-allowlist
 ///     (see top of file) closes the network-substitution path that
-///     would otherwise let such a DMG reach this verifier; closing
-///     the residual identity-pin gap is part of the Sparkle migration
-///     (EdDSA appcast sig + ``SUPublicEDKey``).
+///     would otherwise let such a DMG reach this verifier. Signed production
+///     builds use Sparkle's EdDSA verification instead.
 ///   * The post-exit helper is a small bash script we write to disk
 ///     ourselves and exec via ``/bin/bash``. It never touches anything
 ///     outside of two paths the parent already chose (the staged copy
@@ -523,10 +520,9 @@ extension Installer {
     /// ``codesign`` re-derives the CDHash from the bundle contents
     /// and matches it against the embedded signature regardless of
     /// signing identity. Production releases are Developer ID signed
-    /// + notarised + stapled — see the file header threat model and
-    /// ``docs/plans/sparkle-migration-design.md`` for the residual
-    /// identity-pin gap (no ``-R`` requirement string passed yet)
-    /// that issue #16 tracks closing.
+    /// + notarised + stapled — see the file header threat model for this
+    /// fallback's residual identity-pin gap (no ``-R`` requirement string is
+    /// passed).
     ///
     /// We deliberately do NOT pass ``--no-strict`` (which the
     /// original implementation did): ``--no-strict`` disables the
@@ -546,13 +542,14 @@ extension Installer {
         // We deliberately do NOT pass a ``--requirement`` here yet:
         // production builds today are signed with Developer ID
         // (PR #13) but the requirement-string lives in the signing
-        // identity, not in code we can pin. Issue #16 (Sparkle
-        // migration) tracks adding ``-R "anchor apple generic and
+        // identity, not in code we can pin. The fallback could add
+        // ``-R "anchor apple generic and
         // identifier \"com.rapidmlx.rapid\" and certificate
         // leaf[subject.OU] = <TEAMID>"`` so a tampered DMG that
         // re-signs ad-hoc instead of Developer ID can't pass this
-        // gate. Until then the strict-deep verification still
-        // catches structural tampering and bit-flip corruption.
+        // gate. Signed production updates use Sparkle's EdDSA verification;
+        // this strict-deep fallback still catches structural tampering and
+        // bit-flip corruption.
         let (status, _, err) = try await runProcess(
             executable: "/usr/bin/codesign",
             arguments: ["--verify", "--strict", "--deep", app.path]

--- a/apps/rapid-mac/Sources/Rapid/Updater/SparkleUpdateController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/SparkleUpdateController.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Observation
+import Sparkle
+
+/// Owns Sparkle's updater lifecycle for signed production builds.
+///
+/// The source Info.plist deliberately has no `SUPublicEDKey`; build.sh injects
+/// it for release builds. When the key is absent (normal local development),
+/// this controller stays disabled and callers use the legacy manifest/DMG
+/// updater. This also gives already-installed clients a migration bridge
+/// instead of requiring both update systems to change in one release.
+@MainActor
+@Observable
+final class SparkleUpdateController {
+    private var standardController: SPUStandardUpdaterController?
+    private(set) var isStarted = false
+    private(set) var automaticallyDownloadsUpdates: Bool
+
+    let isEnabled: Bool
+
+    init(
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
+        checksEnabled: Bool = UpdateChecker.updateChecksEnabled()
+    ) {
+        isEnabled = checksEnabled && Self.hasValidConfiguration(infoDictionary)
+        automaticallyDownloadsUpdates = isEnabled
+            ? (UserDefaults.standard.object(forKey: "SUAutomaticallyUpdate") as? Bool ?? true)
+            : false
+    }
+
+    /// Start after AppKit has finished constructing the application. Sparkle
+    /// owns its six-hour schedule and automatically downloads updates; a
+    /// downloaded update is installed when Rapid next quits normally.
+    func start() {
+        guard isEnabled, !isStarted else { return }
+        let controller = SPUStandardUpdaterController(
+            startingUpdater: false,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        standardController = controller
+        controller.startUpdater()
+        automaticallyDownloadsUpdates = controller.updater.automaticallyDownloadsUpdates
+        isStarted = true
+    }
+
+    /// Foreground check used by menu and Settings commands. The standard
+    /// Sparkle UI reports current/update/error states and, when an update was
+    /// already downloaded in the background, offers the install action.
+    func checkForUpdates() {
+        guard isEnabled else { return }
+        if !isStarted { start() }
+        standardController?.checkForUpdates(nil)
+    }
+
+    var canCheckForUpdates: Bool {
+        isEnabled && (standardController?.updater.canCheckForUpdates ?? true)
+    }
+
+    func setAutomaticallyDownloadsUpdates(_ enabled: Bool) {
+        guard isEnabled else { return }
+        if !isStarted { start() }
+        standardController?.updater.automaticallyDownloadsUpdates = enabled
+        automaticallyDownloadsUpdates = standardController?.updater.automaticallyDownloadsUpdates ?? enabled
+    }
+
+    nonisolated static func hasValidConfiguration(_ info: [String: Any]?) -> Bool {
+        guard let info,
+              let feed = info["SUFeedURL"] as? String,
+              let url = URL(string: feed),
+              url.scheme?.lowercased() == "https",
+              url.user == nil,
+              url.password == nil,
+              url.host?.isEmpty == false,
+              let publicKey = info["SUPublicEDKey"] as? String,
+              let keyData = Data(base64Encoded: publicKey),
+              keyData.count == 32 else {
+            return false
+        }
+        return true
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Updater/UpdateChecker.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/UpdateChecker.swift
@@ -83,9 +83,9 @@ import Observation
 ///     leaves the app on its current version (no alert, no crash),
 ///     and it is skipped entirely when the user has opted out (see
 ///     ``updateChecksEnabled``).
-///   * In-app install runs through ``Installer.swift``: downloads the
-///     versioned DMG, runs `codesign --verify`, mounts, swaps,
-///     relaunches.
+///   * Signed production builds delegate installation to Sparkle. Builds
+///     without an injected Sparkle public key retain ``Installer.swift`` as a
+///     migration fallback: download DMG, verify, mount, swap, relaunch.
 @MainActor
 @Observable
 final class UpdateChecker {
@@ -125,8 +125,7 @@ final class UpdateChecker {
         // ``BootstrapCoordinator.validateModelFields`` enforces the
         // contract for the install pipeline. UpdateChecker does not
         // surface them today; they live here purely for forward-
-        // compat decoding so a future client (e.g. Sparkle migration
-        // in slice 5 / task #1447) can consume them without
+        // compat decoding so a future client surface can consume them without
         // re-touching the type.
         let modelURL: String?
         let modelSHA256: String?

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -40,6 +40,12 @@ time of writing. Run that command for the exact revisions in your build.
   https://github.com/gonzalezreal/swift-markdown-ui
   Block-level markdown rendering for assistant messages.
 
+* **Sparkle** — Sparkle Project contributors — MIT License
+  `exact: "2.9.5"`
+  https://github.com/sparkle-project/Sparkle
+  Signed application updates, background downloads, install-on-quit, and
+  atomic application replacement.
+
 * **SwiftMath** — Computer Inspirations — MIT License
   Vendored from 1.7.3 (`fa8244ed032f4a1ade4cb0571bf87d2f1a9fd2d7`)
   under `Vendor/SwiftMath` with a resource-resolution patch for the assembled
@@ -71,14 +77,10 @@ though the manifest does not name them.
 `Sources/RapidCrashHandler` is first-party C in this repository, not a
 third-party package.
 
-_Sparkle is on the roadmap as the eventual auto-update framework
-(see [issue #16](https://github.com/raullenchai/Rapid-MLX/issues/16))
-but is not bundled in the current release stream. The shipped
-updater is the in-tree `Sources/Rapid/Updater/UpdateChecker.swift`
-+ `Installer.swift` pair, which polls a Cloudflare Worker proxy of
-GitHub Releases and surfaces an "Update available" CTA — see
-[PRIVACY.md](PRIVACY.md#third-party-services). This file will list
-Sparkle once it actually lands in `Package.resolved`._
+The in-tree `UpdateChecker.swift` + `Installer.swift` pair remains temporarily
+as a migration fallback for builds without an injected Sparkle public key and
+as the existing UI's read-only release-status source. Signed production builds
+delegate archive verification and installation to Sparkle.
 
 ## Assets
 

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.txt
@@ -1,0 +1,96 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Readiness.Action" desc="Start" enabled=true
+          AXStaticText value=text enabled=true
+          AXScrollArea
+            AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
+      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+      AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true
+  AXWindow subrole=AXStandardWindow id="settings" title="Settings"
+    AXGroup subrole=AXHostingView
+      AXScrollArea
+        AXOutline desc="Settings categories" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.tools" desc="Tools" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.performance" desc="Performance" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.privacy" desc="Privacy" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXColumn id="ListColumn"
+      AXScrollArea
+        AXHeading desc="Rapid-MLX, Self-update for Rapid-MLX. New releases bundle the latest models, performance improvements, and bug fixes." enabled=true
+        AXHeading desc="Version" enabled=true
+        AXStaticText value=text enabled=true
+        AXStaticText value=text enabled=true
+        AXStaticText value=text enabled=true
+        AXStaticText value=text enabled=true
+        AXHeading desc="Updates" enabled=true
+        AXCheckBox id="Settings.App.AutomaticUpdatesToggle" desc="Automatically download updates" help="Automatic updates are enabled in signed release builds." value=bool:false enabled=false
+        AXStaticText id="Settings.App.UpToDate" value=text enabled=true
+        AXButton id="Settings.App.RecheckCTA" desc="Check for updates" enabled=true
+        AXHeading desc="Diagnostics, Save a support report to share if something goes wrong. Includes your app version, Mac model, and recent logs — no prompts, files, or personal data." enabled=true
+        AXButton id="Settings.App.ExportDiagnostics" desc="Export diagnostics…" enabled=true
+        AXHeading desc="Window, Choose what happens when you close the main window. Rapid-MLX keeps running in the menu bar either way — this only affects whether the Dock icon stays visible." enabled=true
+        AXCheckBox subrole=AXToggle id="Settings.App.HideDockOnCloseToggle" desc="Hide Dock icon when closing window" help="Rapid-MLX remains available from the menu bar." value=bool:false enabled=true
+        AXButton id="Settings.App.ResetDockOnboardingCTA" desc="Reset onboarding alerts" enabled=true
+        AXScrollBar value=number enabled=true
+          AXValueIndicator value=number
+          AXButton subrole=AXIncrementArrow
+          AXButton subrole=AXDecrementArrow
+          AXButton subrole=AXIncrementPage
+          AXButton subrole=AXDecrementPage
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXZoomButton enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseLocalScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseLocalScriptTests.swift
@@ -17,6 +17,15 @@ struct ReleaseLocalScriptTests {
         #expect(!script.contains("git rev-parse origin/main"))
     }
 
+    @Test("Publish requires a monotonic CFBundleVersion for Sparkle ordering")
+    func sparkleBuildNumberGuard() throws {
+        let script = try String(contentsOf: Self.scriptURL, encoding: .utf8)
+        #expect(script.contains("Print :CFBundleVersion"))
+        #expect(script.contains(#"[[ "$PLIST_BUILD" =~ ^[1-9][0-9]*$ ]]"#))
+        #expect(script.contains("PREVIOUS_BUILD"))
+        #expect(script.contains("(( PLIST_BUILD > PREVIOUS_BUILD ))"))
+    }
+
     private static var scriptURL: URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReleaseManifestWorkflowTests.swift
@@ -99,4 +99,48 @@ struct ReleaseManifestWorkflowTests {
         #expect(publishJob.contains("/purge_cache"))
         #expect(publishJob.contains(".success == true"))
     }
+
+    @Test("Sparkle archive is signed, mirrored, then advertised by the serialized appcast")
+    func sparklePublicationOrderAndSigning() throws {
+        let workflow = Self.workflow
+        let mirrorJob = Self.mirrorJob
+        let publishJob = Self.publishJob
+
+        #expect(workflow.contains("SPARKLE_PUBLIC_ED_KEY"))
+        #expect(workflow.contains("SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}"))
+        #expect(workflow.contains("printf '%s' \"$SPARKLE_ED_PRIVATE_KEY\""))
+        #expect(workflow.contains("--ed-key-file -"))
+        #expect(!workflow.contains("--ed-key-file $SPARKLE_ED_PRIVATE_KEY"))
+        #expect(workflow.contains("sparkle:edSignature="))
+        #expect(workflow.contains("Rapid-MLX-Desktop-${VERSION}-${ZIP_SHA256}.zip"))
+        #expect(workflow.contains(#"-o "$OUT/appcast.xml" "$OUT""#))
+        #expect(workflow.contains("APPCAST_VERSION"))
+        #expect(workflow.contains("appcast build version does not match the signed app"))
+        #expect(workflow.contains("APPCAST_SHORT_VERSION"))
+        #expect(workflow.contains("appcast release version does not match the tag"))
+        #expect(workflow.contains("APPCAST_URL"))
+        #expect(workflow.contains("appcast URL does not match the mirrored Sparkle ZIP"))
+        #expect(workflow.contains("PREVIOUS_TAG"))
+        #expect(workflow.contains("(( APP_BUILD > PREVIOUS_BUILD ))"))
+        #expect(workflow.contains("must exceed ${PREVIOUS_TAG} build"))
+
+        let zipUpload = try #require(
+            mirrorJob.range(of: #"r2 object put "${R2_BUCKET}/${SPARKLE_KEY}""#)
+        )
+        let appcastStaged = try #require(
+            mirrorJob.range(of: "name: rapid-mac-sparkle-appcast")
+        )
+        #expect(zipUpload.lowerBound < appcastStaged.lowerBound)
+
+        let rollbackGuard = try #require(publishJob.range(of: "dpkg --compare-versions"))
+        let appcastUpload = try #require(
+            publishJob.range(of: #"r2 object put "${R2_BUCKET}/appcast.xml""#)
+        )
+        let releaseCreation = try #require(
+            publishJob.range(of: "Create the GitHub Release (last")
+        )
+        #expect(rollbackGuard.lowerBound < appcastUpload.lowerBound)
+        #expect(appcastUpload.lowerBound < releaseCreation.lowerBound)
+        #expect(publishJob.contains(#"--cache-control "no-cache, must-revalidate""#))
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/SparkleUpdateControllerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SparkleUpdateControllerTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Sparkle update configuration")
+struct SparkleUpdateControllerTests {
+    private let publicKey = Data(repeating: 7, count: 32).base64EncodedString()
+
+    @Test("HTTPS feed plus 32-byte EdDSA public key enables Sparkle")
+    func validConfiguration() {
+        #expect(SparkleUpdateController.hasValidConfiguration([
+            "SUFeedURL": "https://dl.rapidmlx.com/appcast.xml",
+            "SUPublicEDKey": publicKey,
+        ]))
+    }
+
+    @Test("local build without injected public key stays on legacy updater")
+    func missingPublicKey() {
+        #expect(!SparkleUpdateController.hasValidConfiguration([
+            "SUFeedURL": "https://dl.rapidmlx.com/appcast.xml",
+        ]))
+    }
+
+    @Test("configuration rejects insecure feeds and malformed public keys")
+    func invalidConfiguration() {
+        #expect(!SparkleUpdateController.hasValidConfiguration([
+            "SUFeedURL": "http://dl.rapidmlx.com/appcast.xml",
+            "SUPublicEDKey": publicKey,
+        ]))
+        #expect(!SparkleUpdateController.hasValidConfiguration([
+            "SUFeedURL": "https://dl.rapidmlx.com/appcast.xml",
+            "SUPublicEDKey": Data(repeating: 7, count: 31).base64EncodedString(),
+        ]))
+    }
+
+    @MainActor
+    @Test("existing update-check opt-out also disables Sparkle")
+    func updateCheckOptOut() {
+        let controller = SparkleUpdateController(
+            infoDictionary: [
+                "SUFeedURL": "https://dl.rapidmlx.com/appcast.xml",
+                "SUPublicEDKey": publicKey,
+            ],
+            checksEnabled: false
+        )
+        #expect(!controller.isEnabled)
+    }
+}

--- a/apps/rapid-mac/scripts/build.sh
+++ b/apps/rapid-mac/scripts/build.sh
@@ -36,10 +36,40 @@ swift build -c "$CONFIG"
 
 echo "==> assembling Rapid-MLX Desktop.app"
 rm -rf "$APP"
-mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources"
+mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources" "$CONTENTS/Frameworks"
 cp "$ROOT/.build/$CONFIG/Rapid" "$CONTENTS/MacOS/Rapid"
 cp "$ROOT/Resources/Info.plist" "$CONTENTS/Info.plist"
 cp "$ROOT/Resources/AppIcon.icns" "$CONTENTS/Resources/AppIcon.icns"
+
+# SwiftPM links Sparkle dynamically but this app is assembled by hand rather
+# than by Xcode, so its normal "Embed & Sign" phase does not run for us. Copy
+# the complete framework (including symlinks and installer helpers), then add
+# the conventional app-framework search path to the executable before any
+# code signing seals it.
+SPARKLE_FRAMEWORK_SRC="$ROOT/.build/$CONFIG/Sparkle.framework"
+SPARKLE_FRAMEWORK_DST="$CONTENTS/Frameworks/Sparkle.framework"
+if [[ ! -d "$SPARKLE_FRAMEWORK_SRC" ]]; then
+    echo "ERR: SwiftPM Sparkle.framework missing: $SPARKLE_FRAMEWORK_SRC" >&2
+    exit 1
+fi
+ditto "$SPARKLE_FRAMEWORK_SRC" "$SPARKLE_FRAMEWORK_DST"
+if ! otool -l "$CONTENTS/MacOS/Rapid" | grep -Fq '@executable_path/../Frameworks'; then
+    install_name_tool -add_rpath '@executable_path/../Frameworks' "$CONTENTS/MacOS/Rapid"
+fi
+
+# The EdDSA public key is release configuration, injected from an Actions
+# variable. A local build without it deliberately omits SUPublicEDKey and the
+# app keeps using the legacy updater fallback. Fail closed on a malformed key
+# instead of shipping a Sparkle client that can never validate an update.
+if [[ -n "${SPARKLE_PUBLIC_ED_KEY:-}" ]]; then
+    if ! printf '%s' "$SPARKLE_PUBLIC_ED_KEY" \
+        | openssl base64 -d -A 2>/dev/null \
+        | wc -c | tr -d ' ' | grep -qx '32'; then
+        echo "ERR: SPARKLE_PUBLIC_ED_KEY must be base64 for a 32-byte Ed25519 public key" >&2
+        exit 1
+    fi
+    plutil -replace SUPublicEDKey -string "$SPARKLE_PUBLIC_ED_KEY" "$CONTENTS/Info.plist"
+fi
 
 # Sentry is being removed from the monorepo app (SENTRY_DSN is no longer
 # a required/plumbed secret). This block is retained as an inert no-op:
@@ -466,6 +496,23 @@ if [[ "$SIGN_IDENTITY" == "-" ]]; then
     codesign --verify --deep --strict "$APP"
 else
     echo "==> Developer ID codesign ($SIGN_IDENTITY)"
+    # Xcode's CodeSignOnCopy phase normally re-signs Sparkle's nested code
+    # with the host application's Team ID. Reproduce that from the inside out
+    # so Sparkle's IPC team checks accept its helpers in this hand-built app.
+    SPARKLE_VERSION="$SPARKLE_FRAMEWORK_DST/Versions/B"
+    for nested in \
+        "$SPARKLE_VERSION/Autoupdate" \
+        "$SPARKLE_VERSION/Updater.app" \
+        "$SPARKLE_VERSION/XPCServices/Downloader.xpc" \
+        "$SPARKLE_VERSION/XPCServices/Installer.xpc"; do
+        codesign --force --options runtime --timestamp \
+            --preserve-metadata=identifier,entitlements,flags \
+            --sign "$SIGN_IDENTITY" "$nested"
+    done
+    codesign --force --options runtime --timestamp \
+        --preserve-metadata=identifier,entitlements,flags \
+        --sign "$SIGN_IDENTITY" "$SPARKLE_FRAMEWORK_DST"
+    codesign --verify --deep --strict "$SPARKLE_FRAMEWORK_DST"
     # No --deep: the sidecar's Mach-Os under Contents/Resources/rapid-mlx/
     # are already individually signed by build-sidecar.sh; this outer
     # (non-deep) codesign hashes their bytes into the .app's resource

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1650,6 +1650,15 @@ flow_update_state() {
     [[ -n "$expected" ]] || die "could not read CFBundleShortVersionString"
     [[ "$shown" == *"$expected"* ]] \
         || die "update panel ($state) says '$shown' but the app is $expected"
+    # PR #1907: the automatic-update preference is part of the shipped App
+    # panel, not just updater plumbing. Local golden builds intentionally omit
+    # SUPublicEDKey, so the control is visible but disabled; signed release
+    # builds enable the same control and default it on through Info.plist.
+    jq -e '.data.ui_elements[]? | select(
+        .identifier == "Settings.App.AutomaticUpdatesToggle"
+    )' "$OUT/update-app-panel.json" >/dev/null \
+        || die "Settings > App does not expose automatic background updates"
+    baseline update-state.app-panel "$OUT/update-app-panel.json"
     log "  update state names the running version ($expected, via ${state##*.})"
     cleanup_persona
 

--- a/apps/rapid-mac/scripts/release-local.sh
+++ b/apps/rapid-mac/scripts/release-local.sh
@@ -187,6 +187,9 @@ if [[ "$MODE" == "publish" ]]; then
     PLIST_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' Resources/Info.plist 2>/dev/null || true)"
     [[ "$PLIST_VERSION" == "$VERSION" ]] \
         || fail "tag $TAG (=$VERSION) != Resources/Info.plist CFBundleShortVersionString ($PLIST_VERSION). Bump the plist first."
+    PLIST_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' Resources/Info.plist 2>/dev/null || true)"
+    [[ "$PLIST_BUILD" =~ ^[1-9][0-9]*$ ]] \
+        || fail "Resources/Info.plist CFBundleVersion must be a positive integer for Sparkle (got '$PLIST_BUILD')."
 
     # NOT --quiet, and NOT bare: `git fetch --tags` exits non-zero when ANY tag
     # would clobber a local one, and `set -e` then killed this script with no
@@ -242,6 +245,12 @@ if [[ "$MODE" == "publish" ]]; then
     if [[ -n "$HIGHEST" ]]; then
         version_gt "$TAG" "$HIGHEST" \
             || fail "tag $TAG is not newer than the latest release $HIGHEST — refusing a backwards release."
+        PREVIOUS_BUILD="$(git show "${HIGHEST}:apps/rapid-mac/Resources/Info.plist" \
+            | plutil -extract CFBundleVersion raw -o - - 2>/dev/null || true)"
+        [[ "$PREVIOUS_BUILD" =~ ^[1-9][0-9]*$ ]] \
+            || fail "cannot read CFBundleVersion from $HIGHEST — Sparkle ordering cannot be verified."
+        (( PLIST_BUILD > PREVIOUS_BUILD )) \
+            || fail "CFBundleVersion $PLIST_BUILD must exceed $HIGHEST build $PREVIOUS_BUILD for Sparkle."
     fi
 
     # Public release RELIES on CI firing on the tag. Refuse if it can't.


### PR DESCRIPTION
## What does this PR do?

Adds signed, in-app automatic updates to Rapid-MLX Desktop using Sparkle 2.9.5.

- Checks the Sparkle appcast every six hours.
- Downloads updates in the background when automatic updates are enabled.
- Installs downloaded updates when Rapid exits normally.
- Provides Sparkle's native update UI for manual checks.
- Verifies update archives with Ed25519 signatures.
- Retains the existing `latest.json` / DMG updater as a fallback for builds without a valid Sparkle public key.
- Adds an automatic-download toggle and manual update action to Settings and the menu bar.
- Extends the release workflow to generate, sign, mirror, and publish Sparkle ZIP archives and `appcast.xml`.
- Enforces monotonic `CFBundleVersion` values and publication ordering so an appcast cannot advertise a missing or older archive.
- Updates release, privacy, third-party, and user documentation.

### Required configuration

Generate the Sparkle key pair once on a trusted Mac after resolving the Swift package:

```bash
cd apps/rapid-mac
swift package resolve

.build/artifacts/sparkle/Sparkle/bin/generate_keys \
  --account rapid-mlx

.build/artifacts/sparkle/Sparkle/bin/generate_keys \
  --account rapid-mlx \
  -x ~/Desktop/rapid-mlx-sparkle-private-key
```

The first command prints the base64 public key. The second exports the matching private key.

Configure them under:

`GitHub repository -> Settings -> Secrets and variables -> Actions`

| Name | GitHub type | Source |
|---|---|---|
| `SPARKLE_PUBLIC_ED_KEY` | Variable | Output printed by `generate_keys` |
| `SPARKLE_ED_PRIVATE_KEY` | Secret | Exact contents of `rapid-mlx-sparkle-private-key` |

The public key is embedded in the application and is not confidential. The private key must never be committed, logged, or stored as a repository variable. Back it up in the team's protected credential store: losing it breaks the update chain for existing installations.

A local Sparkle-enabled build only needs the public key:

```bash
cd apps/rapid-mac

export SPARKLE_PUBLIC_ED_KEY='<public key printed by generate_keys>'
bash scripts/build.sh
```

Without `SPARKLE_PUBLIC_ED_KEY`, local builds deliberately remain on the legacy updater.

Tagged releases also require the existing distribution configuration:

| Name | GitHub type | Value/source |
|---|---|---|
| `RAPID_MAC_DIST_R2_BUCKET` | Variable | `rapid-desktop-dist` |
| `RAPID_MAC_DIST_CDN_BASE` | Variable | `https://dl.rapidmlx.com` |
| `CLOUDFLARE_API_TOKEN` | Secret | Cloudflare API token with R2 Storage Edit and Zone Cache Purge permissions |
| `CLOUDFLARE_ACCOUNT_ID` | Secret | Cloudflare dashboard account ID |
| `CLOUDFLARE_ZONE_ID` | Secret | Zone ID for `rapidmlx.com` in the Cloudflare dashboard |

Developer ID signing and notarization continue to use the existing Apple credentials documented in `apps/rapid-mac/RELEASING.md`.

## Why is this needed?

The existing desktop updater can detect a release and offer the DMG, but users must download and reinstall the application manually. It cannot securely replace the installed app or download an update silently.

This change gives installed Rapid-MLX Desktop users a signed, atomic update path with background downloading and installation on normal exit, while preserving the legacy updater for development builds and existing clients that do not yet carry a Sparkle public key.

## Test plan

- Ran the 9 focused Swift tests covering Sparkle configuration, release publication ordering, archive signing, and monotonic build-number guards.
- Built a Sparkle-enabled local application with an injected Ed25519 public key.
- Verified the native Sparkle update window, embedded release notes, archive download, EdDSA verification, installation, and relaunch for build `155 -> 156`.
- Verified a scheduled background check downloaded build `157` without displaying an update window.
- Verified normal application exit silently replaced build `156 -> 157` without relaunching.
- Verified both installed applications retained a valid and matching designated code-signing requirement.
- Verified the Git worktree remained clean after testing.