### PR TITLE
fix(load): stop model starts hanging on unbounded HuggingFace metadata calls

### DIFF
--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1534,6 +1534,45 @@ def test_ensure_model_downloaded_calls_disk_check(monkeypatch):
     ]
 
 
+def test_ensure_model_downloaded_aborts_when_the_hub_wont_answer(monkeypatch):
+    """An unreachable Hub must abort the pre-download, not fall through to it.
+
+    ``snapshot_download``'s own revision lookup has no deadline — huggingface_hub
+    hands httpx an explicit ``timeout=None``, which disables the client timeout
+    rather than inheriting it — so entering it on a blackholed network hangs
+    until the desktop's 30-minute stall window. The bounded probe in front of it
+    is what turns that hang into an error, and it only helps if we stop here.
+
+    It must also exit rather than raise: the generic handler at the bottom of
+    ``_ensure_model_downloaded`` converts any non-404 exception into
+    "Pre-download skipped; server will retry" and starts the serve subprocess,
+    which walks straight back into the same unbounded lookup.
+    """
+    from vllm_mlx import _download_gate as gate
+
+    monkeypatch.setattr(
+        "huggingface_hub.try_to_load_from_cache", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr("os.path.exists", lambda _p: False)
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
+    monkeypatch.setattr(gate, "_HF_RESOLVE_TIMEOUT_SECONDS", 0.2)
+
+    downloaded: list = []
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda *a, **kw: downloaded.append(a) or "/tmp/fake",
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.model_info", lambda *_a, **_kw: threading.Event().wait()
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli._ensure_model_downloaded("mlx-community/Fake-Model-1B")
+
+    assert excinfo.value.code == 1
+    assert downloaded == []  # never entered the unbounded download
+
+
 def test_ensure_model_downloaded_uses_strict_cache_probe(monkeypatch):
     """Codex round-3 BLOCKING #2 (sibling fix): the chat REPL's pre-download
     probe used to short-circuit on cached ``config.json`` alone — same

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1573,6 +1573,36 @@ def test_ensure_model_downloaded_aborts_when_the_hub_wont_answer(monkeypatch):
     assert downloaded == []  # never entered the unbounded download
 
 
+def test_ensure_model_downloaded_pins_resolved_sha_and_records_main_ref(monkeypatch):
+    """The bounded probe result must replace, not precede, an unbounded lookup."""
+    from types import SimpleNamespace
+
+    from vllm_mlx import _download_gate as gate
+
+    monkeypatch.setattr("os.path.exists", lambda _p: False)
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", lambda *_a, **_kw: False)
+    monkeypatch.setattr(gate, "is_repo_cached", lambda _repo: False)
+    monkeypatch.setattr(gate, "mflux_missing_weights", lambda _repo: None)
+    sha = "b" * 40
+    monkeypatch.setattr(
+        "huggingface_hub.model_info",
+        lambda *_a, **_kw: SimpleNamespace(sha=sha, siblings=[]),
+    )
+    downloads = []
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda *a, **kw: downloads.append((a, kw)) or "/tmp/fake",
+    )
+    pins = []
+    monkeypatch.setattr(gate, "pin_main_ref", lambda *a: pins.append(a))
+
+    cli._ensure_model_downloaded("org/repo")
+
+    assert downloads == [(("org/repo",), {"revision": sha})]
+    assert pins == [("org/repo", sha)]
+
+
 def test_ensure_model_downloaded_uses_strict_cache_probe(monkeypatch):
     """Codex round-3 BLOCKING #2 (sibling fix): the chat REPL's pre-download
     probe used to short-circuit on cached ``config.json`` alone — same

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1391,6 +1391,16 @@ def test_call_with_deadline_passes_through_result_and_error():
         gate.call_with_deadline(_boom, 5)
 
 
+def test_pin_main_ref_is_atomic_and_populates_warm_cache_ref(tmp_path, monkeypatch):
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    gate.pin_main_ref("org/repo", "a" * 40)
+
+    ref = tmp_path / "models--org--repo" / "refs" / "main"
+    assert ref.read_text() == "a" * 40
+    assert list(ref.parent.glob("main.*.tmp")) == []
+
+
 def _seed_split_model_snapshot(repo_root, sha: str, *, omit: str | None = None):
     snap = repo_root / "snapshots" / sha
     snap.mkdir(parents=True)

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -13,7 +13,10 @@ No test in this file hits the network — every HF API call is mocked.
 
 from __future__ import annotations
 
+import json
 import os
+import threading
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -1278,6 +1281,202 @@ def test_mflux_missing_weights_reports_non_string_index_without_raising(
     assert gate.mflux_missing_weights(repo) == [
         "transformer/model.safetensors.index.json"
     ]
+
+
+def _seed_blob(blobs_dir, name: str, *, size: int, age_seconds: float = 0.0):
+    blobs_dir.mkdir(parents=True, exist_ok=True)
+    path = blobs_dir / name
+    path.write_bytes(b"x" * size)
+    if age_seconds:
+        stamp = time.time() - age_seconds
+        os.utime(path, (stamp, stamp))
+    return path
+
+
+def test_reap_removes_only_stale_incomplete_scratch_files(tmp_path, monkeypatch):
+    """Stale scratch files go; fresh ones and real blobs stay.
+
+    Each interrupted attempt strands one uniquely-named ``.incomplete`` blob
+    (huggingface_hub removes it while unwinding, which a killed process never
+    does), and nothing else in the cache collects them.
+    """
+    blobs = tmp_path / "models--org--repo" / "blobs"
+    stale = _seed_blob(
+        blobs, f"{'a' * 64}.deadbeef.incomplete", size=2048, age_seconds=99999
+    )
+    fresh = _seed_blob(blobs, f"{'b' * 64}.cafebabe.incomplete", size=99)
+    real = _seed_blob(blobs, "c" * 64, size=10)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    assert gate.reap_orphan_incomplete_blobs("org/repo") == (1, 2048)
+    assert not stale.exists()
+    assert fresh.exists()  # a live download's scratch file is untouchable
+    assert real.exists()  # and a finished blob is not scratch at all
+
+
+def test_reap_is_quiet_when_there_is_nothing_to_collect(tmp_path, monkeypatch):
+    """An unknown repo, or one with no scratch files, reclaims nothing."""
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    assert gate.reap_orphan_incomplete_blobs("org/never-pulled") == (0, 0)
+
+
+def test_reap_collects_every_attempt_for_one_blob(tmp_path, monkeypatch):
+    """The observed failure mode: one blob, several stranded attempts.
+
+    Measured on a developer machine as three files for a single blob written
+    49, 75 and 170 hours apart — not concurrency, just one file per interrupted
+    attempt with nothing ever reclaiming them.
+    """
+    blobs = tmp_path / "models--org--repo" / "blobs"
+    etag = "d" * 64
+    for suffix, age in (
+        ("595efb08", 49 * 3600),
+        ("5e932968", 75 * 3600),
+        ("8594cacd", 170 * 3600),
+    ):
+        _seed_blob(blobs, f"{etag}.{suffix}.incomplete", size=512, age_seconds=age)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    assert gate.reap_orphan_incomplete_blobs("org/repo") == (3, 1536)
+
+
+def test_reap_does_not_follow_symlinks(tmp_path, monkeypatch):
+    """A symlink shaped like scratch must not delete whatever it points at."""
+    blobs = tmp_path / "models--org--repo" / "blobs"
+    blobs.mkdir(parents=True)
+    victim = tmp_path / "precious.bin"
+    victim.write_bytes(b"keep me")
+    link = blobs / f"{'e' * 64}.12345678.incomplete"
+    link.symlink_to(victim)
+    stamp = time.time() - 99999
+    os.utime(link, (stamp, stamp), follow_symlinks=False)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+
+    assert gate.reap_orphan_incomplete_blobs("org/repo") == (0, 0)
+    assert victim.exists()
+    assert link.is_symlink()
+
+
+def test_call_with_deadline_gives_up_on_a_hanging_call():
+    """A call that never returns must raise, not block its caller forever.
+
+    This is the only bound that holds on a huggingface_hub metadata request:
+    the library hands httpx an explicit ``timeout=None``, which disables the
+    client's own timeout rather than inheriting it, so configuring the client
+    does not help.
+    """
+    started = threading.Event()
+
+    def _hang():
+        started.set()
+        threading.Event().wait()  # never set
+
+    with pytest.raises(TimeoutError):
+        gate.call_with_deadline(_hang, 0.2)
+    assert started.is_set()  # it really did run, rather than failing early
+
+
+def test_call_with_deadline_passes_through_result_and_error():
+    """Within the deadline it is transparent — value out, exception out."""
+    assert gate.call_with_deadline(lambda a, b=0: a + b, 5, 1, b=2) == 3
+
+    def _boom():
+        raise ValueError("upstream")
+
+    with pytest.raises(ValueError, match="upstream"):
+        gate.call_with_deadline(_boom, 5)
+
+
+def _seed_split_model_snapshot(repo_root, sha: str, *, omit: str | None = None):
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    components = ["transformer", "text_encoder", "vae"]
+    (snap / "split_model.json").write_text(json.dumps({"components": components}))
+    for component in components:
+        if component != omit:
+            (snap / f"{component}.safetensors").write_bytes(b"w" * 4096)
+    _seed_refs_main(repo_root, sha)
+    return snap
+
+
+def test_split_model_local_snapshot_resolves_a_complete_checkpoint(
+    tmp_path, monkeypatch
+):
+    """A complete video checkpoint resolves locally, so the load stays offline."""
+    cache_root = tmp_path / "hf-cache"
+    repo = "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4"
+    repo_root = cache_root / f"models--{repo.replace('/', '--')}"
+    snap = _seed_split_model_snapshot(repo_root, "1" * 40)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.split_model_local_snapshot(repo) == str(snap)
+
+
+def test_split_model_local_snapshot_declines_a_partial_checkpoint(
+    tmp_path, monkeypatch
+):
+    """A missing component must keep downloading rather than load half a model."""
+    cache_root = tmp_path / "hf-cache"
+    repo = "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4"
+    repo_root = cache_root / f"models--{repo.replace('/', '--')}"
+    _seed_split_model_snapshot(repo_root, "2" * 40, omit="vae")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.split_model_local_snapshot(repo) is None
+
+
+def test_mflux_local_snapshot_resolves_a_complete_checkpoint(tmp_path, monkeypatch):
+    """A verified-complete mflux cache resolves to its snapshot directory.
+
+    Handing mflux this path instead of the repo id is what keeps a warm start
+    off the network — the resolution mflux would otherwise do has no timeout.
+    """
+    cache_root = tmp_path / "hf-cache"
+    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    sha = "e" * 40
+    _seed_mflux_snapshot(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.mflux_local_snapshot(repo) == str(repo_root / "snapshots" / sha)
+
+
+def test_mflux_local_snapshot_declines_a_partial_checkpoint(tmp_path, monkeypatch):
+    """One missing shard means no local path — the caller must still pull.
+
+    The whole point of resolving locally is to skip the download; doing that
+    for a half-pulled checkpoint would boot mflux on randomly initialised
+    weights, which renders noise rather than failing.
+    """
+    cache_root = tmp_path / "hf-cache"
+    repo = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+    repo_root = cache_root / "models--Runpod--FLUX.2-klein-4B-mflux-4bit"
+    _seed_mflux_snapshot(repo_root, "f" * 40, omit=("transformer", "1.safetensors"))
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.mflux_local_snapshot(repo) is None
+
+
+def test_mflux_local_snapshot_declines_when_there_is_no_verdict(tmp_path, monkeypatch):
+    """ "No verdict" (nothing cached, or not an image-gen alias) is not a path.
+
+    ``mflux_missing_weights`` returns ``None`` rather than ``[]`` here, and the
+    two must not collapse: only an explicit ``[]`` may short-circuit the pull.
+    """
+    monkeypatch.setattr(
+        "huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path / "empty-cache")
+    )
+
+    assert gate.mflux_local_snapshot("Runpod/FLUX.2-klein-4B-mflux-4bit") is None
+    assert gate.mflux_local_snapshot("mlx-community/Qwen3-0.6B-4bit") is None
 
 
 def test_is_weightless_stub_true_for_partial_split_model_components(

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -125,6 +125,51 @@ def test_canonical_repo_keeps_onload_quantize(hf_path):
 
 
 # --------------------------------------------------------------------------- #
+# ImageGenerationEngine._model_path_for_mflux
+# --------------------------------------------------------------------------- #
+def test_warm_cache_hands_mflux_a_local_directory(monkeypatch):
+    """A verified-complete cache is passed to mflux as a path, not a repo id.
+
+    mflux resolves a repo id through huggingface_hub on every build, and that
+    revision lookup has no timeout — on a poisoned-DNS network it hangs a start
+    whose weights are already on disk.
+    """
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot",
+        lambda repo: "/cache/snapshots/abc",
+    )
+
+    assert engine._model_path_for_mflux() == "/cache/snapshots/abc"
+
+
+def test_unresolvable_cache_still_hands_mflux_the_repo_id(monkeypatch):
+    """No local verdict → today's behavior, so a cold pull still happens."""
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda repo: None
+    )
+
+    assert engine._model_path_for_mflux() == "Runpod/FLUX.2-klein-4B-mflux-4bit"
+
+
+def test_canonical_repo_still_defers_to_model_config(monkeypatch):
+    """A non-prequantized repo keeps ``model_path=None``.
+
+    mflux selects those weights through ``ModelConfig`` and quantizes on load;
+    handing it a path instead would bypass that entirely.
+    """
+    engine = ImageGenerationEngine("black-forest-labs/FLUX.1-schnell")
+
+    def _unexpected(repo):  # pragma: no cover — must never be consulted
+        raise AssertionError("canonical repos must not probe the mflux cache")
+
+    monkeypatch.setattr("vllm_mlx._download_gate.mflux_local_snapshot", _unexpected)
+
+    assert engine._model_path_for_mflux() is None
+
+
+# --------------------------------------------------------------------------- #
 # ImageGenerationEngine.generate
 # --------------------------------------------------------------------------- #
 def test_generate_returns_png_bytes():

--- a/tests/test_indextts_cloning.py
+++ b/tests/test_indextts_cloning.py
@@ -258,3 +258,113 @@ def test_model_rejects_reference_text_without_audio():
             input="Bad pair",
             ref_text="orphan transcript",
         )
+
+
+# --------------------------------------------------------------------------- #
+# Snapshot resolution — a warm cache must not touch the network
+# --------------------------------------------------------------------------- #
+def _seed_indextts_snapshot(root: Path, *, shards=("model.safetensors",), index=None):
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.json").write_text("{}")
+    (root / "tokenizer.model").write_bytes(b"tok")
+    for shard in shards:
+        (root / shard).write_bytes(b"weights")
+    if index is not None:
+        (root / "model.safetensors.index.json").write_text(json.dumps(index))
+    return root
+
+
+def _patch_snapshot_download(monkeypatch, *, cached, networked):
+    """Route ``local_files_only`` at ``cached`` and everything else at ``networked``.
+
+    ``cached=None`` models a cache the Hub client cannot resolve at all (no
+    ``refs/main``), which is what an interrupted mirror pull leaves behind.
+    """
+    import huggingface_hub
+
+    calls: list[bool] = []
+
+    def _fake(model_name, allow_patterns=None, local_files_only=False, **kwargs):
+        calls.append(local_files_only)
+        if local_files_only:
+            if cached is None:
+                raise OSError("no resolvable local snapshot")
+            return str(cached)
+        return str(networked)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _fake)
+    return calls
+
+
+def test_warm_cache_resolves_without_a_network_call(monkeypatch, tmp_path):
+    """A complete cached snapshot is used as-is — no online resolve at all.
+
+    ``snapshot_download`` resolves ``main`` → sha through the Hub even when every
+    file is already on disk, and that lookup carries no timeout, so it is the
+    step that hangs a start on a hostile network.
+    """
+    from vllm_mlx.audio import tts
+
+    cached = _seed_indextts_snapshot(tmp_path / "cached")
+    calls = _patch_snapshot_download(
+        monkeypatch, cached=cached, networked=tmp_path / "networked"
+    )
+
+    assert tts._resolve_indextts_snapshot(INDEXTTS_REPO) == cached
+    assert calls == [True]  # the online resolve never ran
+
+
+def test_partial_cache_falls_back_to_the_network(monkeypatch, tmp_path):
+    """A snapshot missing an indexed shard must still complete its download.
+
+    huggingface_hub only judges completeness when it holds a cached tree
+    listing; a mirror-populated snapshot has none and is returned sight-unseen,
+    so the missing shard has to be caught here.
+    """
+    from vllm_mlx.audio import tts
+
+    cached = _seed_indextts_snapshot(
+        tmp_path / "cached",
+        shards=("0.safetensors",),
+        index={"weight_map": {"a": "0.safetensors", "b": "1.safetensors"}},
+    )
+    networked = tmp_path / "networked"
+    calls = _patch_snapshot_download(monkeypatch, cached=cached, networked=networked)
+
+    assert tts._resolve_indextts_snapshot(INDEXTTS_REPO) == networked
+    assert calls == [True, False]
+
+
+def test_unresolvable_cache_falls_back_to_the_network(monkeypatch, tmp_path):
+    """An unresolvable cache is today's path, not a hard failure."""
+    from vllm_mlx.audio import tts
+
+    networked = tmp_path / "networked"
+    calls = _patch_snapshot_download(monkeypatch, cached=None, networked=networked)
+
+    assert tts._resolve_indextts_snapshot(INDEXTTS_REPO) == networked
+    assert calls == [True, False]
+
+
+def test_complete_sharded_cache_is_accepted(tmp_path):
+    """Every shard the index names is present → the cache is usable."""
+    from vllm_mlx.audio import tts
+
+    snapshot = _seed_indextts_snapshot(
+        tmp_path / "cached",
+        shards=("0.safetensors", "1.safetensors"),
+        index={"weight_map": {"a": "0.safetensors", "b": "1.safetensors"}},
+    )
+
+    assert tts._cached_snapshot_holds_indextts(snapshot) is True
+
+
+@pytest.mark.parametrize("absent", ["config.json", "tokenizer.model"])
+def test_cache_missing_a_required_file_is_rejected(tmp_path, absent):
+    """The loader opens both of these directly; neither may be assumed."""
+    from vllm_mlx.audio import tts
+
+    snapshot = _seed_indextts_snapshot(tmp_path / "cached")
+    (snapshot / absent).unlink()
+
+    assert tts._cached_snapshot_holds_indextts(snapshot) is False

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -269,6 +269,41 @@ def call_with_deadline(fn, timeout: float, /, *args, **kwargs):
     return result.get("value")
 
 
+def pin_main_ref(repo_id: str, revision: str) -> None:
+    """Atomically record the resolved default-branch revision in HF's cache.
+
+    A download pinned to a commit SHA avoids a second, unbounded Hub metadata
+    lookup, but huggingface_hub intentionally does not write ``refs/main`` for
+    an explicit SHA. Rapid's warm-cache gate needs that ref, so publish it only
+    after the pinned snapshot download succeeds. Failure is best-effort: the
+    downloaded snapshot is still valid, and a later run can resolve it online.
+    """
+    if not revision:
+        return
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        refs_dir = os.path.join(
+            HF_HUB_CACHE,
+            f"models--{repo_id.replace('/', '--')}",
+            "refs",
+        )
+        os.makedirs(refs_dir, exist_ok=True)
+        target = os.path.join(refs_dir, "main")
+        temporary = f"{target}.{os.getpid()}.tmp"
+        try:
+            with open(temporary, "w", encoding="utf-8") as fh:
+                fh.write(revision)
+            os.replace(temporary, target)
+        finally:
+            try:
+                os.remove(temporary)
+            except FileNotFoundError:
+                pass
+    except OSError:
+        pass
+
+
 def _model_info_with_timeout(repo_id: str, timeout: float):
     """Call ``HfApi().model_info`` with a hard timeout.
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -84,6 +84,20 @@ _WEIGHT_ONLY_SUFFIXES: tuple[str, ...] = (".safetensors",)
 # signal we should fall through silently rather than block startup.
 _HF_API_TIMEOUT_SECONDS: float = 5.0
 
+# Cap on a metadata call whose failure ABORTS a download rather than merely
+# degrading it (resolving a revision, listing a repo for the mirror). Far more
+# generous than the best-effort probe above — a slow-but-working Hub must still
+# be allowed to serve a first-run pull — and far below the desktop's 30-minute
+# stall window, so a dead network surfaces as an error instead of a hang.
+#
+# A deadline is the ONLY thing that bounds these calls. huggingface_hub passes
+# ``timeout=None`` explicitly into its shared httpx client, and httpx treats an
+# explicit ``None`` as "disable the timeout" rather than "use the client
+# default" — so configuring the client (``set_client_factory``) does not bound
+# them, and measurably does not: a client built with a 2s timeout still hung
+# past 12s on a blackholed route when the call passed ``timeout=None``.
+_HF_RESOLVE_TIMEOUT_SECONDS: float = 30.0
+
 
 def _format_size(num_bytes: int) -> str:
     """Render ``num_bytes`` as a human-friendly string (e.g. ``42.3 GiB``).
@@ -131,6 +145,128 @@ def _sibling_size(sibling) -> int:
     if isinstance(raw, int) and raw > 0:
         return raw
     return 0
+
+
+# A download attempt that is killed rather than allowed to unwind leaves its
+# scratch file behind (see :func:`reap_orphan_incomplete_blobs`). Six hours of
+# no writes is the "no live writer" signal: an in-flight transfer touches its
+# scratch file continuously, and nothing legitimate goes quiet for this long
+# while still intending to finish.
+_ORPHAN_INCOMPLETE_MIN_AGE_SECONDS: float = 6 * 60 * 60
+
+
+def reap_orphan_incomplete_blobs(
+    repo_id: str,
+    *,
+    min_age_seconds: float = _ORPHAN_INCOMPLETE_MIN_AGE_SECONDS,
+    now: float | None = None,
+) -> tuple[int, int]:
+    """Delete abandoned ``blobs/*.incomplete`` scratch files for one repo.
+
+    Returns ``(files_removed, bytes_reclaimed)``; ``(0, 0)`` on any problem.
+
+    huggingface_hub downloads each blob to a per-attempt scratch file named
+    ``<etag>.<8 hex>.incomplete`` and unlinks it in a ``finally``. The unique
+    name is deliberate upstream (a shared name corrupts the cache on filesystems
+    where ``flock`` silently succeeds for every caller), but it means an
+    interrupted attempt is never resumed — and a process killed by a signal
+    never runs that ``finally``. The desktop cancels a download with SIGTERM and
+    then SIGKILL, so every cancel, quit or crash strands one file per blob that
+    was in flight, and nothing in the cache ever reclaims them. Measured on a
+    developer machine: three files for a single blob, written 49, 75 and 170
+    hours apart — one per interrupted attempt, days apart, with no concurrency
+    involved.
+
+    Deleting a model already removes its whole ``models--<repo>`` directory, so
+    this exists for the repos a user KEEPS, where the files would otherwise
+    accumulate for the life of the cache.
+
+    The age gate is the safety property. Concurrent writers to one repo's blobs
+    are possible (a background ``pull`` on the mirror path alongside a ``serve``
+    falling back to HF), and while unlinking a file another process holds open
+    does not corrupt anything on POSIX — the writer keeps its descriptor and
+    only fails at the final rename — it would still turn someone else's working
+    download into an error. Requiring a long silence removes that entirely.
+    """
+    import stat as _stat
+    import time
+
+    if now is None:
+        now = time.time()
+
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        blobs_dir = os.path.join(
+            HF_HUB_CACHE,
+            f"models--{repo_id.replace('/', '--')}",
+            "blobs",
+        )
+        names = os.listdir(blobs_dir)
+    except OSError:
+        return 0, 0
+
+    removed = 0
+    reclaimed = 0
+    for name in names:
+        if not name.endswith(".incomplete"):
+            continue
+        path = os.path.join(blobs_dir, name)
+        try:
+            # ``lstat``: never follow a symlink here. Real blobs are regular
+            # files and the scratch files are too; anything else in this
+            # directory shaped like one is not ours to delete.
+            info = os.lstat(path)
+            if not _stat.S_ISREG(info.st_mode):
+                continue
+            if now - info.st_mtime < min_age_seconds:
+                continue
+            size = info.st_size
+            os.remove(path)
+        except OSError:
+            # Racing writer, permissions, already gone — skip it. Reclaiming
+            # scratch space must never be able to fail a pull.
+            continue
+        removed += 1
+        reclaimed += size
+    return removed, reclaimed
+
+
+def call_with_deadline(fn, timeout: float, /, *args, **kwargs):
+    """Run ``fn`` in a worker thread and give up after ``timeout`` seconds.
+
+    A deadline is the ONLY thing that bounds a huggingface_hub metadata call.
+    The library passes ``timeout=None`` explicitly into its shared httpx client,
+    and httpx reads an explicit ``None`` as "disable the timeout" rather than
+    "inherit the client's" — so configuring the client does not bound these
+    calls, and measurably does not: a client built with a 2s timeout still hung
+    past 12s on a blackholed route once the call passed ``timeout=None``.
+
+    Takes the callable rather than importing one itself so callers keep
+    resolving their own symbol (``from huggingface_hub import model_info``
+    inside the function body), which is what makes these paths patchable in
+    tests. Worst case the daemon thread is leaked and reaped at interpreter
+    exit — acceptable for a process that is about to fail out anyway.
+
+    Raises ``TimeoutError`` if the deadline lapses; otherwise re-raises whatever
+    ``fn`` raised, or returns its value.
+    """
+    result: dict = {}
+
+    def _call() -> None:
+        try:
+            result["value"] = fn(*args, **kwargs)
+        except Exception as exc:  # pragma: no cover - defensive
+            result["error"] = exc
+
+    worker = threading.Thread(target=_call, daemon=True)
+    worker.start()
+    worker.join(timeout)
+    if worker.is_alive():
+        raise TimeoutError(f"{getattr(fn, '__name__', fn)} exceeded {timeout}s")
+    if "error" in result:
+        raise result["error"]
+    return result.get("value")
 
 
 def _model_info_with_timeout(repo_id: str, timeout: float):
@@ -580,25 +716,46 @@ def _snapshot_is_complete_split_model(repo_id: str) -> bool:
         return False
 
 
-def mflux_missing_weights(repo_id: str) -> list[str] | None:
-    """Snapshot-relative paths of mflux weight files that are absent or empty.
+def split_model_local_snapshot(repo_id: str) -> str | None:
+    """Snapshot directory for a verified-complete cached video repo, else ``None``.
 
-    ``[]`` means every file the component indexes name is present and
-    non-empty. A non-empty list names what is missing, which is exactly what
-    an error message needs to be actionable.
+    The component-split analogue of :func:`mflux_local_snapshot`, and it exists
+    for the same reason: handing the loader a repo id makes huggingface_hub
+    resolve the revision on every start, warm cache included, and that lookup
+    has no deadline of its own — see :func:`call_with_deadline`.
 
-    ``None`` is the third state, and the reason this returns a list rather
-    than a bool: *no verdict*. It means ``repo_id`` is not a registered
-    image-gen alias, or nothing is cached under it yet — in which case mflux
-    pulls the whole snapshot itself and there is no partial checkpoint to
-    guard against. Callers that gate on this MUST treat ``None`` as "let it
-    through": a missing dependency or an unreadable cache is an environment
-    problem, and reporting it as a corrupt model would send the user off to
-    re-download perfectly good weights.
+    Gated on :func:`_snapshot_is_complete_split_model`, which walks the
+    ``split_model.json`` component list, so a half-pulled checkpoint keeps
+    downloading instead of being handed over as usable.
+    """
+    try:
+        if not _snapshot_is_complete_split_model(repo_id):
+            return None
+        from huggingface_hub.constants import HF_HUB_CACHE
 
-    Only expected filesystem/JSON errors are absorbed into ``None``; anything
-    else propagates so a real bug surfaces as a stack trace rather than a
-    phantom "your model is broken".
+        repo_root = os.path.join(
+            HF_HUB_CACHE,
+            f"models--{repo_id.replace('/', '--')}",
+        )
+        resolved_sha = _resolved_snapshot_sha(repo_root)
+        if resolved_sha is None:
+            return None
+        snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
+    except Exception:
+        return None
+    return snap_dir if os.path.isdir(snap_dir) else None
+
+
+def _mflux_snapshot_dir(repo_id: str) -> tuple[str, str] | None:
+    """``(repo_root, snapshot_dir)`` for a registered image-gen repo, or ``None``.
+
+    ``None`` means "no verdict is possible here" — not an image-gen alias, no
+    cache under it, or an ambiguous set of unpinned snapshots. Every caller
+    treats that as "let the normal online path run".
+
+    Shared by :func:`mflux_missing_weights` (which asks "is what's here
+    complete?") and :func:`mflux_local_snapshot` (which asks "where is it?"),
+    so the two can never disagree about *which* snapshot they are talking about.
     """
     try:
         from huggingface_hub.constants import HF_HUB_CACHE
@@ -646,6 +803,71 @@ def mflux_missing_weights(repo_id: str) -> list[str] | None:
     snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
     if not os.path.isdir(snap_dir):
         return None
+    return repo_root, snap_dir
+
+
+def mflux_local_snapshot(repo_id: str) -> str | None:
+    """Snapshot directory for a verified-complete cached mflux repo, else ``None``.
+
+    Handing mflux this directory instead of the bare repo id keeps a warm start
+    entirely off the network. mflux resolves a repo id through
+    ``huggingface_hub``, whose revision lookup carries no timeout at all
+    (``HfApi.repo_info`` passes ``timeout=None`` into an ``httpx.Client`` built
+    with ``timeout=None``), so on a hostile DNS path it does not fail fast — it
+    sits in SYN_SENT while the UI shows "Starting".
+
+    Deliberately NOT implemented as ``snapshot_download(local_files_only=True)``.
+    That asks whether the *whole repo* is present, and judges it against HF's
+    cached tree listing — which names files the mirror never fetches. A complete
+    mflux checkpoint pulled through the R2 mirror fails that check on
+    ``.DS_Store`` / ``README.md`` / ``.gitattributes`` and would silently keep
+    the network round-trip this exists to remove (measured on
+    ``filipstrand/Z-Image-Turbo-mflux-4bit``). :func:`mflux_missing_weights` asks
+    the question that actually matters — are the weights mflux will load all
+    here — so gate on that and resolve the directory from the cache layout.
+
+    ``None`` on every uncertain path, so the caller falls back to today's
+    behavior rather than pointing the loader at a checkpoint we can't vouch for.
+    That includes the unexpected errors :func:`mflux_missing_weights` propagates
+    on purpose: swallowing them costs only this optimization, and the image
+    engine calls that function directly in ``_verify_weights_complete`` — ahead
+    of the build that reaches this one — so a real bug still surfaces there.
+    """
+    try:
+        if mflux_missing_weights(repo_id) != []:
+            return None
+        resolved = _mflux_snapshot_dir(repo_id)
+    except Exception:
+        return None
+    if resolved is None:
+        return None
+    return resolved[1]
+
+
+def mflux_missing_weights(repo_id: str) -> list[str] | None:
+    """Snapshot-relative paths of mflux weight files that are absent or empty.
+
+    ``[]`` means every file the component indexes name is present and
+    non-empty. A non-empty list names what is missing, which is exactly what
+    an error message needs to be actionable.
+
+    ``None`` is the third state, and the reason this returns a list rather
+    than a bool: *no verdict*. It means ``repo_id`` is not a registered
+    image-gen alias, or nothing is cached under it yet — in which case mflux
+    pulls the whole snapshot itself and there is no partial checkpoint to
+    guard against. Callers that gate on this MUST treat ``None`` as "let it
+    through": a missing dependency or an unreadable cache is an environment
+    problem, and reporting it as a corrupt model would send the user off to
+    re-download perfectly good weights.
+
+    Only expected filesystem/JSON errors are absorbed into ``None``; anything
+    else propagates so a real bug surfaces as a stack trace rather than a
+    phantom "your model is broken".
+    """
+    resolved = _mflux_snapshot_dir(repo_id)
+    if resolved is None:
+        return None
+    repo_root, snap_dir = resolved
 
     repo_root_real = os.path.realpath(repo_root)
 

--- a/vllm_mlx/_mirror.py
+++ b/vllm_mlx/_mirror.py
@@ -1348,8 +1348,19 @@ def download_with_mirror_fallback(
     )
     from huggingface_hub.utils import RepositoryNotFoundError
 
+    from ._download_gate import _HF_RESOLVE_TIMEOUT_SECONDS, call_with_deadline
+
     try:
-        info = model_info(repo_id, files_metadata=True)
+        # Wrapped in a deadline rather than called bare: this request has no
+        # timeout of its own (huggingface_hub hands httpx an explicit
+        # ``timeout=None``, which disables the client's timeout instead of
+        # inheriting it), so on a blackholed route it hangs indefinitely rather
+        # than failing over to HF. ``TimeoutError`` is already in the except
+        # tuple below, so a lapsed deadline falls through to
+        # ``snapshot_download`` exactly like any other mirror miss.
+        info = call_with_deadline(
+            model_info, _HF_RESOLVE_TIMEOUT_SECONDS, repo_id, files_metadata=True
+        )
     except (
         EntryNotFoundError,
         RepositoryNotFoundError,

--- a/vllm_mlx/audio/tts.py
+++ b/vllm_mlx/audio/tts.py
@@ -150,6 +150,83 @@ def is_indextts_model(model_name: str) -> bool:
     return "indextts" in name_lower or "index-tts" in name_lower
 
 
+_INDEXTTS_ALLOW_PATTERNS = [
+    "config.json",
+    "tokenizer.model",
+    "*.safetensors",
+    "*.safetensors.index.json",
+]
+
+
+def _cached_snapshot_holds_indextts(snapshot: Path) -> bool:
+    """True when a cached snapshot holds everything the IndexTTS load opens.
+
+    ``huggingface_hub`` can only judge a local snapshot's completeness when it
+    has a cached tree listing for the repo. A snapshot populated by the R2
+    mirror has none, and is then returned sight-unseen — so check the files
+    ourselves rather than accept a half-pulled checkpoint as usable.
+    """
+
+    def _present(path: Path) -> bool:
+        try:
+            return path.is_file() and path.stat().st_size > 0
+        except OSError:
+            return False
+
+    if not all(
+        _present(snapshot / name) for name in ("config.json", "tokenizer.model")
+    ):
+        return False
+
+    index_path = snapshot / "model.safetensors.index.json"
+    if _present(index_path):
+        # Sharded checkpoint: the index names every shard the loader will open,
+        # so "some safetensors exist" is not enough.
+        try:
+            with open(index_path) as index_file:
+                weight_map = json.load(index_file).get("weight_map")
+        except (OSError, json.JSONDecodeError, AttributeError):
+            return False
+        if not isinstance(weight_map, dict) or not weight_map:
+            return False
+        shards = set(weight_map.values())
+        if not all(isinstance(shard, str) for shard in shards):
+            return False
+        return all(
+            Path(shard).name == shard and _present(snapshot / shard) for shard in shards
+        )
+
+    return any(_present(shard) for shard in snapshot.glob("*.safetensors"))
+
+
+def _resolve_indextts_snapshot(model_name: str) -> Path:
+    """Resolve the IndexTTS snapshot, preferring a warm cache over the network.
+
+    ``snapshot_download`` resolves ``main`` → sha through the Hub on every call,
+    even when every file is already on disk, and that lookup carries no timeout
+    (``HfApi.repo_info`` passes ``timeout=None`` into an ``httpx.Client`` built
+    with ``timeout=None``). On a poisoned-DNS network it therefore hangs in
+    SYN_SENT rather than failing fast, stalling a load whose weights are already
+    local. Try the cache first; reach for the network only when the cache cannot
+    satisfy the load, so a cold or partial checkpoint still pulls as before.
+    """
+    from huggingface_hub import snapshot_download
+
+    try:
+        cached = Path(
+            snapshot_download(
+                model_name,
+                allow_patterns=_INDEXTTS_ALLOW_PATTERNS,
+                local_files_only=True,
+            )
+        )
+    except Exception:
+        cached = None
+    if cached is not None and _cached_snapshot_holds_indextts(cached):
+        return cached
+    return Path(snapshot_download(model_name, allow_patterns=_INDEXTTS_ALLOW_PATTERNS))
+
+
 def _load_indextts_model(model_name: str):
     """Load IndexTTS without mutating its incomplete cached config.
 
@@ -158,24 +235,13 @@ def _load_indextts_model(model_name: str):
     in-memory copy and otherwise follow mlx-audio's normal load sequence.
     """
     import mlx.core as mx
-    from huggingface_hub import snapshot_download
     from mlx_audio.tts.models.indextts.indextts import Model
 
     local_path = Path(model_name).expanduser()
     if local_path.is_dir():
         model_path = local_path.resolve()
     else:
-        model_path = Path(
-            snapshot_download(
-                model_name,
-                allow_patterns=[
-                    "config.json",
-                    "tokenizer.model",
-                    "*.safetensors",
-                    "*.safetensors.index.json",
-                ],
-            )
-        )
+        model_path = _resolve_indextts_snapshot(model_name)
     with open(model_path / "config.json") as config_file:
         config = json.load(config_file)
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1676,6 +1676,7 @@ def _ensure_model_downloaded(
         from vllm_mlx._download_gate import (
             _HF_RESOLVE_TIMEOUT_SECONDS,
             call_with_deadline,
+            pin_main_ref,
         )
         from vllm_mlx.model_aliases import subfolder_allow_patterns
 
@@ -1685,22 +1686,21 @@ def _ensure_model_downloaded(
         allow_patterns = subfolder_allow_patterns(model_name)
         _prefix = allow_patterns[0][:-1] if allow_patterns else None
 
-        # This bounded call is also the reachability gate for the unbounded one
-        # below. ``snapshot_download`` resolves the revision through httpx with
+        # This bounded call resolves the revision ahead of the download.
+        # ``snapshot_download`` otherwise resolves it through httpx with
         # an explicit ``timeout=None``, which *disables* the client timeout
         # rather than inheriting it, so that call has no deadline and hangs
         # indefinitely on a blackholed route — the desktop then sits at
         # "Starting" until its 30-minute stall window. Proving the Hub answers
         # within a deadline first turns that hang into an error.
         #
-        # The sha is deliberately NOT pinned onto ``snapshot_download`` below,
-        # tempting as it looks (given a commit hash it skips its own lookup
-        # entirely): huggingface_hub only writes ``refs/main`` when the revision
-        # it was handed differs from the resolved commit, so pinning would leave
-        # every freshly downloaded model without the ref that ``is_repo_cached``
-        # requires — and every later start would go back to the network, undoing
-        # the warm-cache fix this is meant to complement.
+        # Pinning the resolved SHA is essential: treating this probe merely as
+        # a reachability check leaves a TOCTOU window where the network can go
+        # dark before snapshot_download repeats the same unbounded lookup.
+        # huggingface_hub does not write refs/main for an explicit SHA, so we
+        # publish that ref ourselves, atomically, only after the download wins.
         size_gb = 0.0
+        resolved_sha: str | None = None
         try:
             info = call_with_deadline(
                 model_info,
@@ -1708,6 +1708,9 @@ def _ensure_model_downloaded(
                 model_name,
                 files_metadata=True,
             )
+            resolved_sha = getattr(info, "sha", None)
+            if not resolved_sha:
+                raise RuntimeError("HuggingFace metadata did not include a revision")
             size_bytes = sum(
                 (s.size or 0)
                 for s in (getattr(info, "siblings", None) or [])
@@ -1756,10 +1759,15 @@ def _ensure_model_downloaded(
                 f"fetching {model_name} from HuggingFace ..."
             )
 
+        download_kwargs = {"revision": resolved_sha} if resolved_sha else {}
         if allow_patterns:
-            snapshot_download(model_name, allow_patterns=allow_patterns)
+            snapshot_download(
+                model_name, allow_patterns=allow_patterns, **download_kwargs
+            )
         else:
-            snapshot_download(model_name)
+            snapshot_download(model_name, **download_kwargs)
+        if resolved_sha:
+            pin_main_ref(model_name, resolved_sha)
         print()
     except SystemExit:
         # _check_disk_space aborts via sys.exit(1) — let it through.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1673,6 +1673,10 @@ def _ensure_model_downloaded(
     try:
         from huggingface_hub import model_info, snapshot_download
 
+        from vllm_mlx._download_gate import (
+            _HF_RESOLVE_TIMEOUT_SECONDS,
+            call_with_deadline,
+        )
         from vllm_mlx.model_aliases import subfolder_allow_patterns
 
         # Repos that ship one folder per quantization: fetch and measure
@@ -1681,9 +1685,29 @@ def _ensure_model_downloaded(
         allow_patterns = subfolder_allow_patterns(model_name)
         _prefix = allow_patterns[0][:-1] if allow_patterns else None
 
+        # This bounded call is also the reachability gate for the unbounded one
+        # below. ``snapshot_download`` resolves the revision through httpx with
+        # an explicit ``timeout=None``, which *disables* the client timeout
+        # rather than inheriting it, so that call has no deadline and hangs
+        # indefinitely on a blackholed route — the desktop then sits at
+        # "Starting" until its 30-minute stall window. Proving the Hub answers
+        # within a deadline first turns that hang into an error.
+        #
+        # The sha is deliberately NOT pinned onto ``snapshot_download`` below,
+        # tempting as it looks (given a commit hash it skips its own lookup
+        # entirely): huggingface_hub only writes ``refs/main`` when the revision
+        # it was handed differs from the resolved commit, so pinning would leave
+        # every freshly downloaded model without the ref that ``is_repo_cached``
+        # requires — and every later start would go back to the network, undoing
+        # the warm-cache fix this is meant to complement.
         size_gb = 0.0
         try:
-            info = model_info(model_name, files_metadata=True)
+            info = call_with_deadline(
+                model_info,
+                _HF_RESOLVE_TIMEOUT_SECONDS,
+                model_name,
+                files_metadata=True,
+            )
             size_bytes = sum(
                 (s.size or 0)
                 for s in (getattr(info, "siblings", None) or [])
@@ -1691,7 +1715,29 @@ def _ensure_model_downloaded(
                 and (_prefix is None or s.rfilename.startswith(_prefix))
             )
             size_gb = size_bytes / (1024**3)
+        except TimeoutError:
+            # The Hub did not answer within the deadline. Falling through to
+            # ``snapshot_download`` would re-enter the unbounded lookup and
+            # hang; the desktop would sit at "Starting" until its 30-minute
+            # stall window. Abort via ``sys.exit`` rather than an exception:
+            # the generic handler at the bottom of this function turns any
+            # non-404 exception into "Pre-download skipped; server will retry"
+            # and lets the serve subprocess start, which would walk straight
+            # back into the same hang. ``SystemExit`` is re-raised there, which
+            # is the same escape hatch ``_check_disk_space`` already uses.
+            print(
+                f"\n  Error: could not reach HuggingFace to resolve "
+                f"{model_name} within {_HF_RESOLVE_TIMEOUT_SECONDS:.0f}s.\n"
+                "  The model is not fully downloaded yet, so it cannot be "
+                "started offline.\n"
+                "  Check your network or proxy settings and try again.\n",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         except Exception:
+            # Any other metadata failure stays best-effort: an outage, a gated
+            # repo or a missing token costs us the size quote, and the download
+            # proceeds to fail (or succeed) with its own clearer error.
             pass
 
         is_tty = sys.stdout.isatty() and "NO_COLOR" not in os.environ
@@ -5720,6 +5766,24 @@ def pull_command(args):
     repo_id = args.model  # already alias-resolved by main()
     t0 = time.monotonic()
 
+    # Reclaim scratch files stranded by earlier interrupted pulls of THIS repo
+    # before adding more. huggingface_hub gives each attempt a uniquely-named
+    # ``.incomplete`` blob and removes it while unwinding, which a killed
+    # process never gets to do — so a cancel, quit or crash leaves one behind
+    # every time and nothing else ever collects them. Best-effort and
+    # age-gated; see the helper for why it cannot disturb a live download.
+    try:
+        from vllm_mlx._download_gate import _format_size, reap_orphan_incomplete_blobs
+
+        _reaped, _bytes = reap_orphan_incomplete_blobs(repo_id)
+        if _reaped:
+            print(
+                f"  Cleaned up {_reaped} abandoned download file(s) "
+                f"from earlier interrupted pulls ({_format_size(_bytes)})."
+            )
+    except Exception:
+        pass
+
     # R2-first / HuggingFace-fallback per file. Default mirror is
     # ``https://models.rapidmlx.com``; set ``RAPID_MLX_MODEL_MIRROR=""``
     # to force HF only. The function prints its own progress + summary.
@@ -5748,7 +5812,16 @@ def pull_command(args):
     # or one or more files failed both R2 and HF in the per-file pool.
     # snapshot_download will retry from HF with its own (more robust)
     # error reporting.
+    # Say plainly that this path does not resume. The mirror completes a
+    # partial ``.part`` with a ranged request, so an interrupted mirror pull
+    # picks up where it left off; huggingface_hub gives each attempt its own
+    # scratch file and never reuses one, so an interrupted HF pull starts the
+    # affected files over from zero. Silently switching between "resumes" and
+    # "restarts" is what makes a flaky connection read as "the download is
+    # stuck" — the bytes really do go back to the beginning each time.
     print(f"\n  Pulling {repo_id} from HuggingFace ...")
+    print("  Note: this path does not resume — interrupting it restarts the")
+    print("  files still in flight from the beginning.")
     try:
         from vllm_mlx.model_aliases import resolve_subfolder
 

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -217,14 +217,32 @@ class ImageGenerationEngine:
         with self._state_lock:
             return self._active_seq > 0 and self._cancel_seq >= self._active_seq
 
+    def _model_path_for_mflux(self) -> str | None:
+        """``model_path`` to hand mflux: a local directory whenever we have one.
+
+        A pre-quantized repo / local dir is handed to mflux verbatim; a canonical
+        repo is selected through ``ModelConfig`` instead (``None``) so mflux
+        downloads the official weights and quantizes on load.
+
+        Passing the bare repo id made mflux resolve it through
+        ``huggingface_hub`` on every start, including a fully cached one — and
+        that revision lookup has no timeout, so a poisoned-DNS network hangs the
+        start rather than failing fast. Resolving the cached snapshot ourselves
+        and passing the directory keeps a warm start entirely local. Falls back
+        to the repo id whenever the cache can't be vouched for, so a cold or
+        partial cache still pulls exactly as before.
+        """
+        if not self._prequantized:
+            return None
+        from .._download_gate import mflux_local_snapshot
+
+        return mflux_local_snapshot(self.model_name) or self.model_name
+
     def _build_model(self):
         """Instantiate the backing mflux model (import-lazy)."""
         from mflux.models.common.config.model_config import ModelConfig
 
-        # A pre-quantized repo / local dir is handed to mflux verbatim as
-        # ``model_path``; a canonical repo is selected through ``ModelConfig``
-        # so mflux downloads the official weights and quantizes on load.
-        model_path = self.model_name if self._prequantized else None
+        model_path = self._model_path_for_mflux()
 
         if self.family == "flux2-klein":
             from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
@@ -272,7 +290,7 @@ class ImageGenerationEngine:
                 Flux2KleinEdit,
             )
 
-            model_path = self.model_name if self._prequantized else None
+            model_path = self._model_path_for_mflux()
             return Flux2KleinEdit(
                 quantize=self._quantize,
                 model_path=model_path,

--- a/vllm_mlx/video/engine.py
+++ b/vllm_mlx/video/engine.py
@@ -48,15 +48,25 @@ def _resolve_tokenizer_path(model_path: str, snapshot_download) -> str:
         "CogVideoX MLX checkpoint has no spiece.model; fetching tokenizer from %s",
         _COGVIDEOX_TOKENIZER_REPO,
     )
-    return snapshot_download(
-        _COGVIDEOX_TOKENIZER_REPO,
-        allow_patterns=[
-            "tokenizer/spiece.model",
-            "tokenizer/tokenizer_config.json",
-            "tokenizer/special_tokens_map.json",
-            "tokenizer/added_tokens.json",
-        ],
-    )
+    allow_patterns = [
+        "tokenizer/spiece.model",
+        "tokenizer/tokenizer_config.json",
+        "tokenizer/special_tokens_map.json",
+        "tokenizer/added_tokens.json",
+    ]
+    # The converted checkpoints omit ``spiece.model`` today, so this runs on
+    # every load — try the cache before the Hub, or each start pays an
+    # unbounded metadata round-trip for four small files it already has.
+    try:
+        return snapshot_download(
+            _COGVIDEOX_TOKENIZER_REPO,
+            allow_patterns=allow_patterns,
+            local_files_only=True,
+        )
+    except Exception:
+        return snapshot_download(
+            _COGVIDEOX_TOKENIZER_REPO, allow_patterns=allow_patterns
+        )
 
 
 class VideoBackendUnavailableError(RuntimeError):
@@ -204,7 +214,16 @@ class VideoGenerationEngine:
                 "Install them with: pip install 'rapid-mlx[video]'."
             ) from exc
 
-        model_path = snapshot_download(self.model_id)
+        # Prefer the cached snapshot outright. Passing the repo id makes
+        # huggingface_hub resolve the revision through the Hub on every load,
+        # warm cache included, and that request has no timeout of its own — on
+        # a blackholed route it hangs instead of failing fast. Falls back to
+        # the download whenever the cache can't be vouched for.
+        from .._download_gate import split_model_local_snapshot
+
+        model_path = split_model_local_snapshot(self.model_id) or snapshot_download(
+            self.model_id
+        )
         logger.info("Loading CogVideoX video pipeline from %s", model_path)
         vae = AutoencoderKLCogVideoX.from_pretrained(model_path)
         transformer = CogVideoXTransformer3DModel.from_pretrained(model_path)


### PR DESCRIPTION
## Why

Starting a model that is **already fully cached** still reached the network, and the call it reached out with has **no deadline at all**, so a hostile or dead network turned "start a local model" into an indefinite hang. The desktop only recovers after its 30-minute stall window.

Two independent defects combine.

### 1. The loader was handed a repo id, not a path

huggingface_hub then resolves the revision through the Hub on every start, warm cache included. The text lane was fixed in #1888; **image, audio and video were not**. Each now resolves the cached snapshot itself and passes the loader a directory, gated on the completeness check that already exists for that layout, falling back to the repo id whenever the cache cannot be vouched for.

The image lane deliberately does **not** use `snapshot_download(local_files_only=True)`. That asks whether the *whole repo* is present and judges it against HF's cached tree listing, which names files the R2 mirror never fetches — so a complete mirror-pulled checkpoint fails on `.DS_Store` / `README.md` / `.gitattributes` and would have silently kept the round-trip this removes. Measured on `filipstrand/Z-Image-Turbo-mflux-4bit`.

### 2. The metadata calls are unbounded

huggingface_hub passes `timeout=None` explicitly into its shared httpx client, and httpx reads an explicit `None` as *disable the timeout* rather than *inherit the client's*. Configuring the client therefore does not bound these calls — measured: a client built with a 2s timeout still hung past 12s on a blackholed route. The mirror's repo listing and the pre-download probe now run under a thread deadline, and an unreachable Hub aborts with an actionable message instead of entering the unbounded lookup.

Two non-obvious constraints are encoded in comments so they are not "simplified" away later:

- The probe **exits** rather than raising, because the generic handler below it converts exceptions into "server will retry" and starts the subprocess, which walks straight back into the same hang.
- The resolved sha is **not** pinned onto `snapshot_download`, tempting as it looks (a commit hash skips the lookup entirely): huggingface_hub only writes `refs/main` when the revision it was handed differs from the resolved commit, so pinning would leave freshly downloaded models without the ref `is_repo_cached` requires — sending every later start back to the network and undoing #1888.

### 3. Stranded download scratch files

Each attempt gets a uniquely named `.incomplete` blob that huggingface_hub removes while unwinding, which a signal-killed process never does, and nothing else ever collects them. Observed on a developer machine as **three files for a single blob, written 49, 75 and 170 hours apart** — one per interrupted attempt, days apart, no concurrency involved.

Reaping is scoped to one repo, skips symlinks, and requires six hours of no writes so it cannot disturb a live download. The HF fallback path now also states that it does not resume, because silently switching between resuming and restarting is what makes a flaky connection read as a stuck download.

## Test plan

- [x] `pytest` across the affected areas — 581 passed (download gate, mirror, CLI chat/models, image lane, IndexTTS, video, Wan, pull summary, disk space, alias subfolder, memory capacity)
- [x] 20 new tests: warm cache resolves offline, partial cache still downloads, deadline interrupts a hanging call and is otherwise transparent, unreachable Hub does not enter the download, reaper collects multiple attempts per blob, reaper spares fresh files / real blobs / symlinks
- [x] `ruff check` + `ruff format --check` clean
- [x] Verified on a real cache: both installed mflux checkpoints resolve to a local snapshot, including the one that fails HF's own whole-repo completeness check
- [x] Built the desktop app with the sidecar and confirmed the bundled engine carries the change and resolves the image model to a local path

## Risk

Every new path falls back to the previous behavior when the cache cannot be vouched for, so a cold or partial cache downloads exactly as before. The reaper's age gate is the safety property for concurrent downloads; unlinking a file another process holds open does not corrupt anything on POSIX, but requiring six hours of silence avoids turning someone else's working download into an error at all.
