### PR TITLE
feat(models): Ling-3.0-tiny support (fp8)

### DIFF
--- a/tests/test_bailing_hybrid_model.py
+++ b/tests/test_bailing_hybrid_model.py
@@ -213,6 +213,17 @@ def test_glm47_parser_handles_bailing_wire():
     assert json.loads(r.tool_calls[0]["arguments"]) == {"city": "Tokyo"}
 
 
+def test_glm47_parser_accepts_null_tools_from_plain_chat_request():
+    """OpenAI request serialization includes ``tools: null`` for plain chat."""
+    from vllm_mlx.tool_parsers.glm47_tool_parser import Glm47ToolParser
+
+    parser = Glm47ToolParser(None)
+    result = parser.extract_tool_calls("A normal answer", {"tools": None})
+
+    assert not result.tools_called
+    assert result.content == "A normal answer"
+
+
 def test_gate_retain_all_groups():
     """topk_group == n_group keeps every group (codex r3 #1: the drop
     path faulted on argpartition(kth=-1))."""

--- a/tests/test_fp8_repack.py
+++ b/tests/test_fp8_repack.py
@@ -268,12 +268,14 @@ def test_online_load_repacks_and_runs(fp8_bailing_checkpoint):
     src, kept = fp8_bailing_checkpoint
     model = load_fp8_model_online(src)
 
-    # fp8-shipped linear became an mxfp8 quantized module with the exact
-    # source bytes...
-    q = model.model.layers[0].attention.q_proj
-    assert q.mode == "mxfp8" and q.group_size == 32 and q.bits == 8
-    src_bytes = kept["model.layers.0.attention.q_proj"]
-    got_bytes = np.array(q.weight).view(np.uint8).reshape(-1)
+    # fp8-shipped linears became one fused mxfp8 module holding the
+    # exact source bytes row-concatenated in q|k|v order...
+    qkv = model.model.layers[0].attention.qkv_proj
+    assert qkv.mode == "mxfp8" and qkv.group_size == 32 and qkv.bits == 8
+    src_bytes = np.concatenate(
+        [kept[f"model.layers.0.attention.{t}_proj"] for t in "qkv"]
+    )
+    got_bytes = np.array(qkv.weight).view(np.uint8).reshape(-1)
     np.testing.assert_array_equal(got_bytes, src_bytes)
 
     # ...bf16-shipped modules stayed plain (checkpoint fidelity the
@@ -302,7 +304,7 @@ def test_opt_in_lm_head_affine8(fp8_bailing_checkpoint, monkeypatch):
     assert hasattr(head, "scales") and head.bits == 8 and head.group_size == 64
     assert getattr(head, "mode", "affine") == "affine"
     # Everything else untouched: fp8 modules still mxfp8, router still fp.
-    assert model.model.layers[0].attention.q_proj.mode == "mxfp8"
+    assert model.model.layers[0].attention.qkv_proj.mode == "mxfp8"
     assert not hasattr(model.model.layers[1].mlp.gate, "scales")
     logits = model(mx.array([[1, 2, 3]]))
     mx.eval(logits)

--- a/tests/test_fp8_repack.py
+++ b/tests/test_fp8_repack.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the load-time fp8 -> mxfp8 repack (``vllm_mlx/fp8_repack.py``).
+
+Pins:
+
+1. ``_repack_fp8`` is a pure byte move: mlx ``mx.dequantize(mode="mxfp8")``
+   over the repacked (weight, scales) reproduces ``e4m3(byte) *
+   2^(scale-127)`` with the source's 128x128 block scales broadcast to
+   32-element groups — element-identical, no re-rounding.
+2. ``is_fp8_block_checkpoint`` keys off ``quantization_config.quant_method``.
+3. ``load_fp8_model_online`` on a synthetic fp8 bailing_hybrid checkpoint:
+   fp8-shipped linears become mxfp8-quantized modules holding the exact
+   source bytes, ``modules_to_not_convert``-style bf16 tensors stay plain,
+   and the loaded model runs a forward pass.
+
+Real-checkpoint validation (Ling-3.0-tiny-fp8, 4 spot tensors EXACT,
+serve + correctness probe) was run out-of-band; these tests keep the
+synthetic contract in CI.
+"""
+
+import json
+import struct
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mlx.core")
+
+import mlx.core as mx  # noqa: E402
+
+from vllm_mlx.fp8_repack import (  # noqa: E402
+    _repack_fp8,
+    is_fp8_block_checkpoint,
+    load_fp8_model_online,
+)
+
+
+def _e4m3_lut() -> np.ndarray:
+    lut = np.empty(256, dtype=np.float32)
+    for b in range(256):
+        s = -1.0 if b & 0x80 else 1.0
+        e = (b >> 3) & 0x0F
+        m = b & 0x07
+        if e == 0x0F and m == 0x07:
+            lut[b] = np.nan
+        elif e == 0:
+            lut[b] = s * (m / 8.0) * 2.0**-6
+        else:
+            lut[b] = s * (1.0 + m / 8.0) * 2.0 ** (e - 7)
+    return lut
+
+
+def test_repack_is_bit_exact():
+    rng = np.random.default_rng(9)
+    rows, cols, bs = 96, 160, 32  # 3x5 scale blocks, block 32 == group
+    w = rng.integers(0, 0x7F, size=rows * cols, dtype=np.uint8)
+    s = rng.integers(
+        110, 140, size=(rows + bs - 1) // bs * ((cols + bs - 1) // bs), dtype=np.uint8
+    )
+    s_shape = [(rows + bs - 1) // bs, (cols + bs - 1) // bs]
+
+    wq, scales = _repack_fp8(w, [rows, cols], s, s_shape, (bs, bs))
+    got = np.array(
+        mx.dequantize(wq, scales, group_size=32, bits=8, mode="mxfp8").astype(
+            mx.float32
+        )
+    )
+
+    ref = (
+        _e4m3_lut()[w].reshape(rows, cols)
+        * np.repeat(
+            np.repeat(2.0 ** (s.reshape(s_shape).astype(np.int32) - 127), bs, 0)[:rows],
+            bs,
+            1,
+        )[:, :cols]
+    )
+    np.testing.assert_array_equal(got, ref)
+
+
+def test_repack_128_block_broadcast():
+    """128x128 source blocks (the shipped configuration) cover 4 groups."""
+    rng = np.random.default_rng(10)
+    rows, cols = 256, 384  # 2x3 blocks of 128
+    w = rng.integers(0, 0x7F, size=rows * cols, dtype=np.uint8)
+    s = rng.integers(120, 133, size=6, dtype=np.uint8)
+
+    wq, scales = _repack_fp8(w, [rows, cols], s, [2, 3], (128, 128))
+    assert scales.shape == (rows, cols // 32)
+    got = np.array(
+        mx.dequantize(wq, scales, group_size=32, bits=8, mode="mxfp8").astype(
+            mx.float32
+        )
+    )
+    ref = _e4m3_lut()[w].reshape(rows, cols) * np.repeat(
+        np.repeat(2.0 ** (s.reshape(2, 3).astype(np.int32) - 127), 128, 0), 128, 1
+    )
+    np.testing.assert_array_equal(got, ref)
+
+
+def _write_safetensors_raw(path: Path, entries: dict):
+    header, blobs, off = {}, [], 0
+    for name, (raw, dtype, shape) in entries.items():
+        header[name] = {
+            "dtype": dtype,
+            "shape": shape,
+            "data_offsets": [off, off + len(raw)],
+        }
+        blobs.append(raw)
+        off += len(raw)
+    hj = json.dumps(header).encode()
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(hj)))
+        f.write(hj)
+        for b in blobs:
+            f.write(b)
+
+
+def _bf16_bytes(arr: np.ndarray) -> bytes:
+    u = arr.astype(np.float32).view(np.uint32)
+    return (((u + 0x7FFF + ((u >> 16) & 1)) >> 16).astype(np.uint16)).tobytes()
+
+
+@pytest.fixture()
+def fp8_bailing_checkpoint(tmp_path):
+    """Tiny synthetic bailing_hybrid fp8 checkpoint (2 layers, 4 experts)."""
+    rng = np.random.default_rng(21)
+    H, HD, NH, NE, MOE_FFN, FFN, VOCAB, BS = 64, 16, 4, 4, 32, 128, 128, 32
+    src = tmp_path / "fp8src"
+    src.mkdir()
+    entries = {}
+
+    def add_bf16(name, *shape):
+        entries[name] = (
+            _bf16_bytes(rng.standard_normal(shape).astype(np.float32) * 0.02),
+            "BF16",
+            list(shape),
+        )
+
+    def add_f32(name, *shape):
+        entries[name] = (
+            (rng.standard_normal(shape).astype(np.float32) * 0.02).tobytes(),
+            "F32",
+            list(shape),
+        )
+
+    def add_fp8(name, rows, cols):
+        w = rng.integers(0, 0x7F, size=rows * cols, dtype=np.uint8)
+        s = rng.integers(120, 133, size=(rows // BS) * (cols // BS), dtype=np.uint8)
+        entries[name + ".weight"] = (w.tobytes(), "F8_E4M3", [rows, cols])
+        entries[name + ".weight_scale_inv"] = (
+            s.tobytes(),
+            "F8_E8M0",
+            [rows // BS, cols // BS],
+        )
+        return w
+
+    add_bf16("model.word_embeddings.weight", VOCAB, H)
+    add_bf16("lm_head.weight", VOCAB, H)
+    add_bf16("model.norm.weight", H)
+    kept = {}
+    for i in range(2):
+        p = f"model.layers.{i}"
+        add_bf16(f"{p}.input_layernorm.weight", H)
+        add_bf16(f"{p}.post_attention_layernorm.weight", H)
+        if i == 1:  # MLA layer (group of 2 for the tiny config)
+            add_bf16(f"{p}.attention.q_a_proj.weight", 32, H)
+            add_bf16(f"{p}.attention.q_a_layernorm.weight", 32)
+            add_bf16(f"{p}.attention.q_b_proj.weight", NH * 24, 32)
+            add_bf16(f"{p}.attention.kv_a_proj_with_mqa.weight", 40, H)
+            add_bf16(f"{p}.attention.kv_a_layernorm.weight", 32)
+            add_bf16(f"{p}.attention.kv_b_proj.weight", NH * 32, 32)
+            kept[f"{p}.attention.dense"] = add_fp8(f"{p}.attention.dense", H, NH * HD)
+            add_bf16(f"{p}.attention.g_proj.weight", NH, H)
+        else:  # KDA layer
+            for t in ("q", "k", "v", "f", "g"):
+                kept[f"{p}.attention.{t}_proj"] = add_fp8(
+                    f"{p}.attention.{t}_proj", NH * HD, H
+                )
+            for t in ("q", "k", "v"):
+                add_bf16(f"{p}.attention.{t}_conv1d.weight", NH * HD, 1, 4)
+            add_bf16(f"{p}.attention.b_proj.weight", NH, H)
+            add_f32(f"{p}.attention.A_log", NH)
+            add_f32(f"{p}.attention.dt_bias", NH * HD)
+            add_bf16(f"{p}.attention.o_norm.weight", HD)
+            kept[f"{p}.attention.o_proj"] = add_fp8(f"{p}.attention.o_proj", H, NH * HD)
+        if i == 0:
+            add_fp8(f"{p}.mlp.gate_proj", FFN, H)
+            add_fp8(f"{p}.mlp.up_proj", FFN, H)
+            add_fp8(f"{p}.mlp.down_proj", H, FFN)
+        else:
+            add_bf16(f"{p}.mlp.gate.weight", NE, H)
+            add_f32(f"{p}.mlp.gate.expert_bias", NE)
+            for e in range(NE):
+                for t, r, c in (
+                    ("gate", MOE_FFN, H),
+                    ("up", MOE_FFN, H),
+                    ("down", H, MOE_FFN),
+                ):
+                    add_fp8(f"{p}.mlp.experts.{e}.{t}_proj", r, c)
+            for t, r, c in (
+                ("gate", MOE_FFN, H),
+                ("up", MOE_FFN, H),
+                ("down", H, MOE_FFN),
+            ):
+                add_fp8(f"{p}.mlp.shared_experts.{t}_proj", r, c)
+
+    _write_safetensors_raw(src / "model.safetensors", entries)
+    config = {
+        "model_type": "bailing_hybrid",
+        "hidden_size": H,
+        "num_hidden_layers": 2,
+        "num_attention_heads": NH,
+        "num_key_value_heads": NH,
+        "head_dim": HD,
+        "intermediate_size": FFN,
+        "vocab_size": VOCAB,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 6000000.0,
+        "rope_interleave": True,
+        "partial_rotary_factor": 0.5,
+        "max_position_embeddings": 4096,
+        "tie_word_embeddings": False,
+        "layer_group_size": 2,
+        "short_conv_kernel_size": 4,
+        "q_lora_rank": 32,
+        "kv_lora_rank": 32,
+        "qk_nope_head_dim": 16,
+        "qk_rope_head_dim": 8,
+        "v_head_dim": 16,
+        "num_experts": NE,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": MOE_FFN,
+        "moe_shared_expert_intermediate_size": MOE_FFN,
+        "num_shared_experts": 1,
+        "norm_topk_prob": True,
+        "routed_scaling_factor": 2.5,
+        "n_group": 2,
+        "topk_group": 1,
+        "score_function": "sigmoid",
+        "moe_router_enable_expert_bias": True,
+        "first_k_dense_replace": 1,
+        "quantization_config": {
+            "quant_method": "fp8",
+            "fmt": "e4m3",
+            "scale_fmt": "ue8m0",
+            "weight_block_size": [BS, BS],
+        },
+    }
+    (src / "config.json").write_text(json.dumps(config))
+    return src, kept
+
+
+def test_is_fp8_block_checkpoint(fp8_bailing_checkpoint, tmp_path):
+    src, _ = fp8_bailing_checkpoint
+    assert is_fp8_block_checkpoint(src)
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    assert not is_fp8_block_checkpoint(plain)
+    assert not is_fp8_block_checkpoint(tmp_path / "missing")
+
+
+def test_online_load_repacks_and_runs(fp8_bailing_checkpoint):
+    from vllm_mlx.utils.tokenizer import _register_vendored_archs
+
+    _register_vendored_archs()
+    src, kept = fp8_bailing_checkpoint
+    model = load_fp8_model_online(src)
+
+    # fp8-shipped linear became an mxfp8 quantized module with the exact
+    # source bytes...
+    q = model.model.layers[0].attention.q_proj
+    assert q.mode == "mxfp8" and q.group_size == 32 and q.bits == 8
+    src_bytes = kept["model.layers.0.attention.q_proj"]
+    got_bytes = np.array(q.weight).view(np.uint8).reshape(-1)
+    np.testing.assert_array_equal(got_bytes, src_bytes)
+
+    # ...bf16-shipped modules stayed plain (checkpoint fidelity the
+    # offline path can't offer for the router).
+    assert not hasattr(model.model.layers[1].mlp.gate, "scales")
+    assert not hasattr(model.model.layers[1].attention.q_a_proj, "scales")
+
+    # Forward runs and yields finite logits.
+    logits = model(mx.array([[1, 2, 3]]))
+    mx.eval(logits)
+    assert logits.shape == (1, 3, 128)
+    assert bool(mx.all(mx.isfinite(logits.astype(mx.float32))))

--- a/tests/test_fp8_repack.py
+++ b/tests/test_fp8_repack.py
@@ -277,12 +277,33 @@ def test_online_load_repacks_and_runs(fp8_bailing_checkpoint):
     np.testing.assert_array_equal(got_bytes, src_bytes)
 
     # ...bf16-shipped modules stayed plain (checkpoint fidelity the
-    # offline path can't offer for the router).
+    # offline path can't offer for the router), INCLUDING the lm_head —
+    # the affine8 head speedup is opt-in via env var, default faithful.
     assert not hasattr(model.model.layers[1].mlp.gate, "scales")
     assert not hasattr(model.model.layers[1].attention.q_a_proj, "scales")
+    assert not hasattr(model.lm_head, "scales")
 
     # Forward runs and yields finite logits.
     logits = model(mx.array([[1, 2, 3]]))
     mx.eval(logits)
     assert logits.shape == (1, 3, 128)
+    assert bool(mx.all(mx.isfinite(logits.astype(mx.float32))))
+
+
+def test_opt_in_lm_head_affine8(fp8_bailing_checkpoint, monkeypatch):
+    """RAPID_MLX_FP8_LM_HEAD_AFFINE8=1 quantizes ONLY the lm_head."""
+    from vllm_mlx.utils.tokenizer import _register_vendored_archs
+
+    _register_vendored_archs()
+    src, _ = fp8_bailing_checkpoint
+    monkeypatch.setenv("RAPID_MLX_FP8_LM_HEAD_AFFINE8", "1")
+    model = load_fp8_model_online(src)
+    head = model.lm_head
+    assert hasattr(head, "scales") and head.bits == 8 and head.group_size == 64
+    assert getattr(head, "mode", "affine") == "affine"
+    # Everything else untouched: fp8 modules still mxfp8, router still fp.
+    assert model.model.layers[0].attention.q_proj.mode == "mxfp8"
+    assert not hasattr(model.model.layers[1].mlp.gate, "scales")
+    logits = model(mx.array([[1, 2, 3]]))
+    mx.eval(logits)
     assert bool(mx.all(mx.isfinite(logits.astype(mx.float32))))

--- a/tests/test_fp8_repack.py
+++ b/tests/test_fp8_repack.py
@@ -260,6 +260,44 @@ def test_is_fp8_block_checkpoint(fp8_bailing_checkpoint, tmp_path):
     assert not is_fp8_block_checkpoint(plain)
     assert not is_fp8_block_checkpoint(tmp_path / "missing")
 
+    # ``quant_method=fp8`` is not itself a wire format. Float-scaled and
+    # otherwise unspecified FP8 checkpoints must stay on their normal loader
+    # instead of being interpreted as e4m3 + ue8m0 bytes.
+    for name, quantization in {
+        "unspecified": {"quant_method": "fp8", "weight_block_size": [128, 128]},
+        "float_scales": {
+            "quant_method": "fp8",
+            "fmt": "e4m3",
+            "scale_fmt": "float32",
+            "weight_block_size": [128, 128],
+        },
+    }.items():
+        candidate = tmp_path / name
+        candidate.mkdir()
+        (candidate / "config.json").write_text(
+            json.dumps({"quantization_config": quantization})
+        )
+        assert not is_fp8_block_checkpoint(candidate)
+
+
+def test_repack_rejects_payload_and_scale_shape_mismatches():
+    with pytest.raises(ValueError, match="payload size"):
+        _repack_fp8(
+            np.zeros(31, dtype=np.uint8),
+            [1, 32],
+            np.ones(1, dtype=np.uint8),
+            [1, 1],
+            (32, 32),
+        )
+    with pytest.raises(ValueError, match="scale layout"):
+        _repack_fp8(
+            np.zeros(64 * 64, dtype=np.uint8),
+            [64, 64],
+            np.ones(1, dtype=np.uint8),
+            [1, 1],
+            (32, 32),
+        )
+
 
 def test_online_load_repacks_and_runs(fp8_bailing_checkpoint):
     from vllm_mlx.utils.tokenizer import _register_vendored_archs

--- a/tests/test_kv_cache_dtype.py
+++ b/tests/test_kv_cache_dtype.py
@@ -177,6 +177,24 @@ def test_deepseek_v3_config_triggers_downgrade():
     assert "mla" in decision.reason.lower()
 
 
+def test_bailing_hybrid_model_type_triggers_downgrade():
+    """Ling 3.0 (bailing_hybrid) MLA layers share DeepSeek's compressed-K
+    layout; model_type alone must trigger the safelist — the checkpoint
+    name ("ling...") matches no _MLA_PATTERNS entry."""
+    decision = resolve_kv_cache_dtype(
+        "int4",
+        model_name="/models/ling_v3_tiny_fp8",
+        hf_config={
+            "model_type": "bailing_hybrid",
+            "q_lora_rank": 256,
+            "kv_lora_rank": 512,
+        },
+    )
+    assert decision.dtype == "bf16"
+    assert decision.downgraded is True
+    assert "mla" in decision.reason.lower()
+
+
 def test_deepseek_v4_substring_triggers_downgrade():
     decision = resolve_kv_cache_dtype(
         "int4",

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -129,6 +129,13 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # of that changes. Read by ``vllm_mlx.scheduler._get_request_sampler``
         # only, never by config / aliases / model_auto_config.
         "RAPID_MLX_DISABLE_FUSED_SAMPLER",
+        # Opt-in re-quantization of the lm_head when serving fp8-block
+        # checkpoints through the load-time mxfp8 repack
+        # (vllm_mlx/fp8_repack.py). A precision/speed knob on an
+        # already-selected model: which checkpoint loads, which parser
+        # fires, which tier engages — none of that changes. Default off
+        # keeps the load bit-faithful to the published weights.
+        "RAPID_MLX_FP8_LM_HEAD_AFFINE8",
         # Test/integration helpers — server URL for integration suites,
         # not consulted at runtime by the engine.
         "RAPID_MLX_BASE_URL",

--- a/vllm_mlx/fp8_repack.py
+++ b/vllm_mlx/fp8_repack.py
@@ -57,10 +57,32 @@ logger = logging.getLogger(__name__)
 
 _SCALE_SUFFIX = "_scale_inv"
 _MXFP8_GROUP = 32  # mlx mxfp8 group size (fixed by the format)
+_SUPPORTED_FP8_FORMAT = "e4m3"
+_SUPPORTED_SCALE_FORMAT = "ue8m0"
+
+
+def _supported_quantization_config(config: dict) -> bool:
+    """Whether ``config`` describes the exact byte formats we can repack.
+
+    ``quant_method=fp8`` alone is not a wire format: other publishers use
+    float scales, per-channel layouts, or different FP8 encodings. Claiming
+    those checkpoints here would divert them into a byte-level loader whose
+    assumptions do not hold.
+    """
+    qc = config.get("quantization_config") or {}
+    block = qc.get("weight_block_size")
+    return (
+        qc.get("quant_method") == "fp8"
+        and str(qc.get("fmt", "")).lower() == _SUPPORTED_FP8_FORMAT
+        and str(qc.get("scale_fmt", "")).lower() == _SUPPORTED_SCALE_FORMAT
+        and isinstance(block, list | tuple)
+        and len(block) == 2
+        and all(isinstance(v, int) and not isinstance(v, bool) and v > 0 for v in block)
+    )
 
 
 def is_fp8_block_checkpoint(model_path: Path) -> bool:
-    """True when config.json declares DeepSeek-style fp8 block quant."""
+    """True only for the supported e4m3 + ue8m0 block-FP8 wire format."""
     cfg = model_path / "config.json"
     if not cfg.exists():
         return False
@@ -68,7 +90,7 @@ def is_fp8_block_checkpoint(model_path: Path) -> bool:
         qc = json.loads(cfg.read_text()).get("quantization_config") or {}
     except (OSError, json.JSONDecodeError):
         return False
-    return qc.get("quant_method") == "fp8"
+    return _supported_quantization_config({"quantization_config": qc})
 
 
 class _ShardReader:
@@ -80,18 +102,55 @@ class _ShardReader:
 
     def __init__(self, path: Path):
         self.path = path
+        file_size = path.stat().st_size
         with open(path, "rb") as f:
-            hlen = struct.unpack("<Q", f.read(8))[0]
+            prefix = f.read(8)
+            if len(prefix) != 8:
+                raise ValueError(f"invalid safetensors file (truncated header): {path}")
+            hlen = struct.unpack("<Q", prefix)[0]
+            if hlen > file_size - 8:
+                raise ValueError(f"invalid safetensors header length in {path}")
             self.header = json.loads(f.read(hlen))
+        if not isinstance(self.header, dict):
+            raise ValueError(f"invalid safetensors header in {path}")
         self.header.pop("__metadata__", None)
         self.data_start = 8 + hlen
+        data_size = file_size - self.data_start
+        for name, entry in self.header.items():
+            try:
+                off0, off1 = entry["data_offsets"]
+                shape = entry["shape"]
+                dtype = entry["dtype"]
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"invalid safetensors entry {name!r} in {path}"
+                ) from exc
+            if (
+                not isinstance(off0, int)
+                or isinstance(off0, bool)
+                or not isinstance(off1, int)
+                or isinstance(off1, bool)
+                or off0 < 0
+                or off1 < off0
+                or off1 > data_size
+                or not isinstance(shape, list)
+                or any(
+                    not isinstance(dim, int) or isinstance(dim, bool) or dim < 0
+                    for dim in shape
+                )
+                or not isinstance(dtype, str)
+            ):
+                raise ValueError(f"invalid safetensors entry {name!r} in {path}")
 
     def read(self, name: str) -> tuple[np.ndarray, str, list[int]]:
         ent = self.header[name]
         off0, off1 = ent["data_offsets"]
         with open(self.path, "rb") as f:
             f.seek(self.data_start + off0)
-            raw = np.frombuffer(f.read(off1 - off0), dtype=np.uint8)
+            payload = f.read(off1 - off0)
+        if len(payload) != off1 - off0:
+            raise ValueError(f"truncated safetensors payload {name!r} in {self.path}")
+        raw = np.frombuffer(payload, dtype=np.uint8)
         return raw, ent["dtype"], ent["shape"]
 
 
@@ -111,13 +170,21 @@ def _open_shards(model_path: Path) -> tuple[dict[str, str], dict[str, _ShardRead
 
 def _raw_to_mx(raw: np.ndarray, dtype: str, shape: list[int]) -> mx.array:
     """Non-fp8 safetensors payload → mx array (byte-identical)."""
+    elements = int(np.prod(shape, dtype=np.int64))
+    bytes_per_element = {"BF16": 2, "F32": 4, "F16": 2}.get(dtype)
+    if bytes_per_element is None:
+        raise ValueError(f"unsupported non-fp8 dtype {dtype}")
+    if raw.size != elements * bytes_per_element:
+        raise ValueError(
+            f"invalid {dtype} payload size: got {raw.size} bytes for shape {shape}"
+        )
     if dtype == "BF16":
         return mx.array(raw.view(np.uint16)).view(mx.bfloat16).reshape(shape)
     if dtype == "F32":
         return mx.array(raw.view(np.float32)).reshape(shape)
     if dtype == "F16":
         return mx.array(raw.view(np.float16)).reshape(shape)
-    raise ValueError(f"unsupported non-fp8 dtype {dtype}")
+    raise AssertionError("unreachable")
 
 
 def _repack_fp8(
@@ -138,6 +205,17 @@ def _repack_fp8(
         raise ValueError(f"cols {cols} not divisible by mxfp8 group {_MXFP8_GROUP}")
     if bs_c % _MXFP8_GROUP:
         raise ValueError(f"block width {bs_c} not divisible by {_MXFP8_GROUP}")
+    if w_raw.size != rows * cols:
+        raise ValueError(
+            f"invalid F8_E4M3 payload size: got {w_raw.size} bytes for shape {w_shape}"
+        )
+    expected_scale_shape = [(rows + bs_r - 1) // bs_r, (cols + bs_c - 1) // bs_c]
+    if s_shape != expected_scale_shape or s_raw.size != int(np.prod(s_shape)):
+        raise ValueError(
+            "invalid F8_E8M0 scale layout: "
+            f"got shape {s_shape} for weight {w_shape}, block {block}; "
+            f"expected {expected_scale_shape}"
+        )
 
     wq = w_raw.reshape(rows, cols // 4, 4).view(np.uint32).reshape(rows, cols // 4)
 
@@ -152,9 +230,11 @@ def load_fp8_model_online(model_path: Path) -> nn.Module:
     """Build the model and load an fp8-block checkpoint via mxfp8 repack."""
     config = json.loads((model_path / "config.json").read_text())
     qc = config.get("quantization_config") or {}
-    if qc.get("quant_method") != "fp8":
-        raise ValueError(f"{model_path} is not an fp8 block-quantized checkpoint")
-    bs = qc.get("weight_block_size") or [128, 128]
+    if not _supported_quantization_config(config):
+        raise ValueError(
+            f"{model_path} is not a supported e4m3 + ue8m0 block-FP8 checkpoint"
+        )
+    bs = qc["weight_block_size"]
     block = (int(bs[0]), int(bs[1]))
     model_type = config["model_type"]
 

--- a/vllm_mlx/fp8_repack.py
+++ b/vllm_mlx/fp8_repack.py
@@ -24,6 +24,16 @@ load time into mlx's ``mxfp8`` quantized layout — **bit-losslessly**:
   stays bf16, which the offline path could not offer (mlx_lm quantizes
   it 8-bit affine via the model's quant_predicate).
 
+One deliberate, opt-in deviation (default OFF — the default load is
+fully faithful): setting ``RAPID_MLX_FP8_LM_HEAD_AFFINE8=1``
+re-quantizes the untied ``lm_head`` to affine 8-bit (group 64, float
+scale+bias) from its loaded bf16 values. Decode is dominated by the
+bf16 head read (483 MB on tiny — measured 1.0 ms/token, ~90% of the
+faithful-vs-offline gap); affine8 halves that while staying far more
+accurate than the offline path's mxfp8 head (measured on real hidden
+states: top-1 flips 0%, max |Δlogit| 0.08 on a ~41 logit range, vs
+4.2% flips / 1.05 for mxfp8's power-of-two scales).
+
 Memory: the model skeleton's random init and the ``nn.quantize`` graph
 stay lazy (never evaluated); only the repacked arrays materialize, so
 peak RSS is about the checkpoint size (~8.4 GB for tiny), not the bf16
@@ -35,6 +45,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+import os
 import struct
 from pathlib import Path
 
@@ -218,6 +229,23 @@ def load_fp8_model_online(model_path: Path) -> nn.Module:
     if hasattr(model, "sanitize"):
         weights = model.sanitize(weights)
     model.load_weights(list(weights.items()), strict=True)
+
+    # Opt-in (default OFF, keeping the load fully checkpoint-faithful):
+    # RAPID_MLX_FP8_LM_HEAD_AFFINE8=1 quantizes the untied bf16 lm_head
+    # to affine 8-bit from its just-loaded real values — ~+10% decode on
+    # tiny for a measured-zero top-1 change (see module docstring).
+    want_q = os.environ.get("RAPID_MLX_FP8_LM_HEAD_AFFINE8", "") == "1"
+    if want_q and isinstance(getattr(model, "lm_head", None), nn.Linear):
+        nn.quantize(
+            model,
+            class_predicate=lambda path, module: (
+                {"group_size": 64, "bits": 8, "mode": "affine"}
+                if path == "lm_head"
+                else False
+            ),
+        )
+        logger.info("fp8 online repack: lm_head re-quantized to affine8 (opt-in)")
+
     mx.eval(model.parameters())
     model.eval()
     return model

--- a/vllm_mlx/fp8_repack.py
+++ b/vllm_mlx/fp8_repack.py
@@ -180,6 +180,13 @@ def load_fp8_model_online(model_path: Path) -> nn.Module:
         if marker in path:
             head, _, tail = path.partition(marker)
             return has_fp8(f"{head}{marker[:-1]}.0.{tail}")
+        # Fused KDA serving modules (see BailingKDA/sanitize): quantized
+        # iff their first source projection shipped fp8 — row concat of
+        # same-scheme sources is what sanitize produces.
+        if path.endswith(".qkv_proj"):
+            return has_fp8(path[: -len("qkv_proj")] + "q_proj")
+        if path.endswith(".fg_proj"):
+            return has_fp8(path[: -len("fg_proj")] + "f_proj")
         return has_fp8(path)
 
     # Both the skeleton's random init and this quantization graph stay

--- a/vllm_mlx/fp8_repack.py
+++ b/vllm_mlx/fp8_repack.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Online (load-time) repack of DeepSeek-style fp8 checkpoints into mxfp8.
+
+Ling 3.0 fp8 checkpoints (``inclusionAI/Ling-3.0-tiny-fp8``) store weights
+as safetensors ``F8_E4M3`` bytes plus a ``<name>_scale_inv`` companion
+holding e8m0 (``ue8m0``) scales per 128x128 block. mlx has no fp8 dtype
+(ml-explore/mlx#1670), so ``mx.load`` cannot even open the shards.
+
+This module loads the ORIGINAL checkpoint directly, repacking at
+load time into mlx's ``mxfp8`` quantized layout — **bit-losslessly**:
+
+- mlx mxfp8 stores e4m3 bytes packed 4-per-uint32 plus one e8m0 byte per
+  32-element row group. The source's e4m3 weight bytes are copied
+  verbatim into the packed words, and each 128x128 block's e8m0 scale
+  byte is broadcast to its 4 covered column groups (128/32) and 128
+  covered rows. No value is decoded or re-rounded anywhere, so
+  ``mx.dequantize`` reproduces ``e4m3(w) * 2^(scale-127)`` exactly
+  (verified element-identical; contrast with offline
+  ``mx.quantize(mode="mxfp8")`` which re-derives scales per 32-group and
+  re-rounds, ~2^-12 max diff).
+- Tensors the publisher kept unquantized (``modules_to_not_convert``:
+  MLA q/kv LoRA projections, router, embeddings, lm_head, per-head
+  gates …) load as plain bf16/f32 — byte-identical too. The router even
+  stays bf16, which the offline path could not offer (mlx_lm quantizes
+  it 8-bit affine via the model's quant_predicate).
+
+Memory: the model skeleton's random init and the ``nn.quantize`` graph
+stay lazy (never evaluated); only the repacked arrays materialize, so
+peak RSS is about the checkpoint size (~8.4 GB for tiny), not the bf16
+size.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import struct
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_SCALE_SUFFIX = "_scale_inv"
+_MXFP8_GROUP = 32  # mlx mxfp8 group size (fixed by the format)
+
+
+def is_fp8_block_checkpoint(model_path: Path) -> bool:
+    """True when config.json declares DeepSeek-style fp8 block quant."""
+    cfg = model_path / "config.json"
+    if not cfg.exists():
+        return False
+    try:
+        qc = json.loads(cfg.read_text()).get("quantization_config") or {}
+    except (OSError, json.JSONDecodeError):
+        return False
+    return qc.get("quant_method") == "fp8"
+
+
+class _ShardReader:
+    """Minimal safetensors reader returning raw little-endian bytes.
+
+    numpy-side only — deliberately no framework dtype mapping, since the
+    whole point is that mlx (0.31.x) cannot represent F8_E4M3/F8_E8M0.
+    """
+
+    def __init__(self, path: Path):
+        self.path = path
+        with open(path, "rb") as f:
+            hlen = struct.unpack("<Q", f.read(8))[0]
+            self.header = json.loads(f.read(hlen))
+        self.header.pop("__metadata__", None)
+        self.data_start = 8 + hlen
+
+    def read(self, name: str) -> tuple[np.ndarray, str, list[int]]:
+        ent = self.header[name]
+        off0, off1 = ent["data_offsets"]
+        with open(self.path, "rb") as f:
+            f.seek(self.data_start + off0)
+            raw = np.frombuffer(f.read(off1 - off0), dtype=np.uint8)
+        return raw, ent["dtype"], ent["shape"]
+
+
+def _open_shards(model_path: Path) -> tuple[dict[str, str], dict[str, _ShardReader]]:
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.exists():
+        weight_map = json.loads(index_path.read_text())["weight_map"]
+    else:
+        single = model_path / "model.safetensors"
+        weight_map = {n: single.name for n in _ShardReader(single).header}
+    shards = {
+        fname: _ShardReader(model_path / fname)
+        for fname in sorted(set(weight_map.values()))
+    }
+    return weight_map, shards
+
+
+def _raw_to_mx(raw: np.ndarray, dtype: str, shape: list[int]) -> mx.array:
+    """Non-fp8 safetensors payload → mx array (byte-identical)."""
+    if dtype == "BF16":
+        return mx.array(raw.view(np.uint16)).view(mx.bfloat16).reshape(shape)
+    if dtype == "F32":
+        return mx.array(raw.view(np.float32)).reshape(shape)
+    if dtype == "F16":
+        return mx.array(raw.view(np.float16)).reshape(shape)
+    raise ValueError(f"unsupported non-fp8 dtype {dtype}")
+
+
+def _repack_fp8(
+    w_raw: np.ndarray,
+    w_shape: list[int],
+    s_raw: np.ndarray,
+    s_shape: list[int],
+    block: tuple[int, int],
+) -> tuple[mx.array, mx.array]:
+    """(e4m3 bytes, block e8m0 scales) → mlx mxfp8 (packed weight, scales).
+
+    Pure byte moves: e4m3 bytes are packed 4-per-uint32 verbatim; each
+    block scale byte is repeated over the rows/column-groups it covers.
+    """
+    rows, cols = w_shape
+    bs_r, bs_c = block
+    if cols % _MXFP8_GROUP:
+        raise ValueError(f"cols {cols} not divisible by mxfp8 group {_MXFP8_GROUP}")
+    if bs_c % _MXFP8_GROUP:
+        raise ValueError(f"block width {bs_c} not divisible by {_MXFP8_GROUP}")
+
+    wq = w_raw.reshape(rows, cols // 4, 4).view(np.uint32).reshape(rows, cols // 4)
+
+    s = s_raw.reshape(s_shape)
+    scales = np.repeat(np.repeat(s, bs_r, axis=0)[:rows], bs_c // _MXFP8_GROUP, axis=1)
+    scales = scales[:, : cols // _MXFP8_GROUP]
+
+    return mx.array(wq), mx.array(scales)
+
+
+def load_fp8_model_online(model_path: Path) -> nn.Module:
+    """Build the model and load an fp8-block checkpoint via mxfp8 repack."""
+    config = json.loads((model_path / "config.json").read_text())
+    qc = config.get("quantization_config") or {}
+    if qc.get("quant_method") != "fp8":
+        raise ValueError(f"{model_path} is not an fp8 block-quantized checkpoint")
+    bs = qc.get("weight_block_size") or [128, 128]
+    block = (int(bs[0]), int(bs[1]))
+    model_type = config["model_type"]
+
+    arch = importlib.import_module(f"mlx_lm.models.{model_type}")
+    model = arch.Model(arch.ModelArgs.from_dict(config))
+
+    weight_map, shards = _open_shards(model_path)
+
+    def read(name: str):
+        return shards[weight_map[name]].read(name)
+
+    # Quantize exactly the modules the checkpoint shipped as fp8 — the
+    # scale companion's presence is the source of truth. Module paths
+    # mirror checkpoint names, except experts are a stacked SwitchLinear
+    # (`…mlp.experts.gate_proj`) standing in for per-expert tensors.
+    def has_fp8(name: str) -> bool:
+        return f"{name}.weight{_SCALE_SUFFIX}" in weight_map
+
+    def class_predicate(path: str, module: nn.Module) -> bool:
+        if not hasattr(module, "to_quantized"):
+            return False
+        marker = ".mlp.experts."
+        if marker in path:
+            head, _, tail = path.partition(marker)
+            return has_fp8(f"{head}{marker[:-1]}.0.{tail}")
+        return has_fp8(path)
+
+    # Both the skeleton's random init and this quantization graph stay
+    # lazy; load_weights below replaces every parameter before anything
+    # is evaluated, so neither ever materializes.
+    nn.quantize(
+        model,
+        group_size=_MXFP8_GROUP,
+        bits=8,
+        mode="mxfp8",
+        class_predicate=class_predicate,
+    )
+
+    weights: dict[str, mx.array] = {}
+    n_repacked = 0
+    for name in weight_map:
+        if name.endswith(_SCALE_SUFFIX):
+            continue
+        raw, dtype, shape = read(name)
+        if dtype == "F8_E4M3":
+            scale_name = name + _SCALE_SUFFIX
+            if scale_name not in weight_map:
+                raise ValueError(
+                    f"{name} is F8_E4M3 but has no {_SCALE_SUFFIX} companion"
+                )
+            s_raw, s_dtype, s_shape = read(scale_name)
+            if s_dtype != "F8_E8M0":
+                raise ValueError(
+                    f"{scale_name} is {s_dtype}; online mxfp8 repack supports ue8m0 "
+                    "(power-of-two) scales only — f32-scale fp8 sources are not "
+                    "supported yet"
+                )
+            wq, scales = _repack_fp8(raw, shape, s_raw, s_shape, block)
+            base = name[: -len(".weight")]
+            weights[f"{base}.weight"] = wq
+            weights[f"{base}.scales"] = scales
+            n_repacked += 1
+        else:
+            weights[name] = _raw_to_mx(raw, dtype, shape)
+
+    logger.info(
+        "fp8 online repack: %d tensors repacked to mxfp8 (bit-lossless), %d kept fp",
+        n_repacked,
+        len(weights) - 2 * n_repacked,
+    )
+
+    if hasattr(model, "sanitize"):
+        weights = model.sanitize(weights)
+    model.load_weights(list(weights.items()), strict=True)
+    mx.eval(model.parameters())
+    model.eval()
+    return model

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -90,6 +90,12 @@ _MLA_MODEL_TYPES: frozenset[str] = frozenset(
     {
         "deepseek_v3",
         "deepseek_v4",
+        # inclusionAI Ling 3.0/2.6 (vendored KDA+MLA hybrid): the 6 MLA
+        # layers carry the same compressed-K layout as DeepSeek V3, so
+        # quantized KV stacks error the same way. model_type is the
+        # family signal — the "ling" name alone is too generic for
+        # _MLA_PATTERNS.
+        "bailing_hybrid",
     }
 )
 

--- a/vllm_mlx/models/bailing_hybrid.py
+++ b/vllm_mlx/models/bailing_hybrid.py
@@ -248,16 +248,20 @@ class BailingKDA(nn.Module):
         self.scale = float(self.head_dim) ** -0.5
 
         hidden = args.hidden_size
-        self.q_proj = nn.Linear(hidden, self.proj_dim, bias=False)
-        self.k_proj = nn.Linear(hidden, self.proj_dim, bias=False)
-        self.v_proj = nn.Linear(hidden, self.proj_dim, bias=False)
-        self.q_conv1d = ShortConv1d(self.proj_dim, self.conv_kernel)
-        self.k_conv1d = ShortConv1d(self.proj_dim, self.conv_kernel)
-        self.v_conv1d = ShortConv1d(self.proj_dim, self.conv_kernel)
+        # q/k/v (and, on no_kda_lora checkpoints, f/g) are independent
+        # full-rank projections in the checkpoint; decode is dominated
+        # by kernel-launch count at B=T=1, so they are served from
+        # row-concatenated fused weights (5 GEMVs + 3 depthwise convs
+        # -> 2 GEMVs + 1 conv, measured ~0.8 ms/token across the 18 KDA
+        # layers). Row concatenation is mathematically identical and —
+        # because every quantization scheme here packs per row — the
+        # fused quantized bytes are the source rows verbatim.
+        # ``sanitize`` performs the concat at load time.
+        self.qkv_proj = nn.Linear(hidden, 3 * self.proj_dim, bias=False)
+        self.qkv_conv1d = ShortConv1d(3 * self.proj_dim, self.conv_kernel)
 
         if self.no_kda_lora:
-            self.f_proj = nn.Linear(hidden, self.proj_dim, bias=False)
-            self.g_proj = nn.Linear(hidden, self.proj_dim, bias=False)
+            self.fg_proj = nn.Linear(hidden, 2 * self.proj_dim, bias=False)
         else:
             # Ling-2.6 / flash variants use LoRA pairs. The bottleneck is
             # head_dim BY DESIGN — the authoritative reference hard-codes
@@ -286,21 +290,18 @@ class BailingKDA(nn.Module):
         dtype = x.dtype
 
         if cache is not None:
-            q_state, k_state, v_state, ssm_state = cache
+            qkv_state, ssm_state = cache[0], cache[1]
         else:
-            q_state = k_state = v_state = ssm_state = None
+            qkv_state = ssm_state = None
 
-        q_conv, q_state = self.q_conv1d(self.q_proj(x), q_state)
-        k_conv, k_state = self.k_conv1d(self.k_proj(x), k_state)
-        v_conv, v_state = self.v_conv1d(self.v_proj(x), v_state)
+        qkv_conv, qkv_state = self.qkv_conv1d(self.qkv_proj(x), qkv_state)
         if cache is not None:
-            cache[0] = q_state
-            cache[1] = k_state
-            cache[2] = v_state
+            cache[0] = qkv_state
 
-        q = q_conv.reshape(B, T, self.num_heads, self.head_dim)
-        k = k_conv.reshape(B, T, self.num_heads, self.head_dim)
-        v = v_conv.reshape(B, T, self.num_heads, self.head_dim)
+        q, k, v = (
+            t.reshape(B, T, self.num_heads, self.head_dim)
+            for t in mx.split(qkv_conv, 3, axis=-1)
+        )
 
         # fla applies L2-norm to q/k in-kernel plus scale=d^-0.5. Use the
         # exact l2norm form (x / (||x|| + eps)) so the eps placement
@@ -312,8 +313,7 @@ class BailingKDA(nn.Module):
         k = kf / (mx.linalg.norm(kf, axis=-1, keepdims=True) + 1e-6)
 
         if self.no_kda_lora:
-            f = self.f_proj(x)
-            gate = self.g_proj(x)
+            f, gate = mx.split(self.fg_proj(x), 2, axis=-1)
         else:
             f = self.f_b_proj(self.f_a_proj(x))
             gate = self.g_b_proj(self.g_a_proj(x))
@@ -329,7 +329,7 @@ class BailingKDA(nn.Module):
 
         out, ssm_state = _kda_update(q, k, v, g, beta, ssm_state)
         if cache is not None:
-            cache[3] = ssm_state
+            cache[1] = ssm_state
 
         gate = gate.reshape(B, T, self.num_heads, self.head_dim)
         out = self.o_norm(out.astype(dtype)) * mx.sigmoid(gate)
@@ -663,6 +663,42 @@ class Model(nn.Module):
                 elif w.ndim == 3 and w.shape[1] == 1:
                     w = w.swapaxes(1, 2)
                 weights[k[: -len(".weight")] + ".conv.weight"] = w
+
+        # KDA fused serving layout: concatenate the checkpoint's separate
+        # q/k/v projections (+ their convs) and, on no_kda_lora
+        # checkpoints, f/g into single row-fused tensors. Row concat is
+        # exact for plain tensors AND for every per-row-packed quantized
+        # part (weight/scales/biases), so this is a pure relayout.
+        # Idempotent: already-fused checkpoints have no ``q_proj`` keys.
+        def _concat(dst: str, srcs: list[str]) -> None:
+            for part in ("weight", "scales", "biases"):
+                keys = [f"{s}.{part}" for s in srcs]
+                if keys[0] not in weights:
+                    continue
+                weights[f"{dst}.{part}"] = mx.concatenate(
+                    [weights.pop(k) for k in keys], axis=0
+                )
+
+        for li in range(n_layers):
+            attn = f"model.layers.{li}.attention"
+            # KDA layers ship all three of q/k/v; an MLA layer with
+            # q_lora_rank=None ships a lone q_proj (kv via kv_a/kv_b)
+            # and must not be touched.
+            if not all(
+                f"{attn}.{t}_proj.weight" in weights
+                or f"{attn}.{t}_proj.scales" in weights
+                for t in "qkv"
+            ):
+                continue
+            _concat(f"{attn}.qkv_proj", [f"{attn}.{t}_proj" for t in "qkv"])
+            _concat(
+                f"{attn}.qkv_conv1d.conv",
+                [f"{attn}.{t}_conv1d.conv" for t in "qkv"],
+            )
+            # f/g are full-rank (and fusable) only on no_kda_lora
+            # checkpoints; LoRA-pair variants keep f_a/f_b/g_a/g_b.
+            if f"{attn}.f_proj.weight" in weights or f"{attn}.f_proj.scales" in weights:
+                _concat(f"{attn}.fg_proj", [f"{attn}.f_proj", f"{attn}.g_proj"])
         return weights
 
     @property
@@ -670,8 +706,9 @@ class Model(nn.Module):
         return self.model.layers
 
     def make_cache(self):
+        # KDA layers hold [fused qkv conv state, KDA ssm state].
         return [
-            KVCache() if layer.is_mla else ArraysCache(size=4)
+            KVCache() if layer.is_mla else ArraysCache(size=2)
             for layer in self.model.layers
         ]
 

--- a/vllm_mlx/tool_parsers/glm47_tool_parser.py
+++ b/vllm_mlx/tool_parsers/glm47_tool_parser.py
@@ -73,12 +73,11 @@ class Glm47ToolParser(ToolParser):
 
     def _get_tool_names(self, request: dict[str, Any] | None) -> set[str]:
         """Extract valid tool names from the request."""
-        if not request or "tools" not in request:
+        if not request:
             return set()
+        tools = request.get("tools") or []
         return {
-            t.get("function", {}).get("name", "")
-            for t in request.get("tools", [])
-            if isinstance(t, dict)
+            t.get("function", {}).get("name", "") for t in tools if isinstance(t, dict)
         }
 
     def extract_tool_calls(

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1503,8 +1503,19 @@ def _load_with_tokenizer_fallback(model_name: str, *, enable_dspark: bool = Fals
         model_path, enable_dspark=enable_dspark
     )
 
-    # Load model
-    model, _ = load_model(model_path, model_config=model_config)
+    # DeepSeek-style fp8 block checkpoints (Ling 3.0 fp8): mlx has no fp8
+    # dtype, so ``mx.load`` cannot open the shards at all. Repack the
+    # original e4m3 bytes + ue8m0 block scales into mlx's mxfp8 layout at
+    # load time — bit-lossless, no offline conversion needed (see
+    # ``vllm_mlx/fp8_repack.py``).
+    from ..fp8_repack import is_fp8_block_checkpoint, load_fp8_model_online
+
+    if is_fp8_block_checkpoint(model_path):
+        logger.info("fp8 block checkpoint detected — online mxfp8 repack")
+        model = load_fp8_model_online(model_path)
+    else:
+        # Load model
+        model, _ = load_model(model_path, model_config=model_config)
 
     # Try to load tokenizer from tokenizer.json directly
     tokenizer_json = model_path / "tokenizer.json"


### PR DESCRIPTION
## What does this PR do?

Makes [inclusionAI/Ling-3.0-tiny-fp8](https://huggingface.co/inclusionAI/Ling-3.0-tiny-fp8) servable, building on the vendored `bailing_hybrid` backbone:

- **Load-time lossless fp8 → mxfp8 repack** (`vllm_mlx/fp8_repack.py`): mlx has no fp8 dtype ([ml-explore/mlx#1670](https://github.com/ml-explore/mlx/issues/1670)), so the checkpoint's `F8_E4M3` safetensors could not be opened at all. Since the source (e4m3 bytes + ue8m0 128×128-block scales) and mlx's mxfp8 (e4m3 bytes + e8m0 32-element group scales) are the same primitives, the repack is pure byte moves — `mx.dequantize` reproduces `e4m3(w)·2^(s−127)` element-identically, and tensors the publisher kept bf16 (router, lm_head, MLA LoRA projections) load verbatim. `rapid-mlx serve <fp8-dir>` now just works; peak RSS ≈ checkpoint size (~8.6 GB), not the 15.8 GB a bf16 dequant would need.
- **Fused KDA serving layout**: each of the 18 KDA layers dispatched 5 projections + 3 depthwise convs at B=T=1; served row-concatenated as 2 + 1 (mathematically identical; quantized rows are the source bytes verbatim).
- **Opt-in `RAPID_MLX_FP8_LM_HEAD_AFFINE8=1`**: re-quantizes only the untied bf16 lm_head (the single largest per-token read) to affine 8-bit — measured zero top-1 flips on real hidden states. Default stays fully faithful.
- **Fix**: `bailing_hybrid` joins the MLA quantized-KV safelist (its MLA layers carry DeepSeek-V3's compressed-K layout; `--kv-cache-quantization int4` would silently stack error on them).

About the model ([HF card](https://huggingface.co/inclusionAI/Ling-3.0-tiny-fp8)): Ling-3.0-tiny is a lightweight hybrid-reasoning MoE — 7.9B total / 1.3B activated, 3:1 KDA:MLA layer stacking, 128 routed experts (top-8 + 1 shared), MIT-licensed, explicitly validated for Apple Silicon deployment.

## Why is this needed?

The fp8 repo is the reference release for local deployment (the HF card quotes M4 Pro numbers), but mlx/mlx-lm cannot open fp8-block safetensors at all. The repack keeps the published weights bit-faithful with no conversion step and no rewritten weights on disk.

Measured on M4 Pro 48GB (llm-inference-bench v0.4.29, concurrency 1, 60s cells, prefix-cache-busting nonces): faithful serving 89/85 tok/s @2k/4k, 93/90 with the opt-in affine8 head — in line with the HF card's 86–90 tok/s M4 Pro reference.

## AI assistance disclosure

GitHub Copilot (Claude) wrote `vllm_mlx/fp8_repack.py`, the `bailing_hybrid` fusion changes, the `kv_cache_dtype` fix and the tests. I reviewed the changes and verified them with the test suites below, byte-exactness checks against independently decoded weights, a logits/decode/greedy trace against the official torch bf16 implementation, and live serving probes.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Test plan

- `pytest tests/test_fp8_repack.py tests/test_bailing_hybrid_model.py tests/test_kv_cache_dtype.py` — 45 passed
- `ruff check` / `ruff format --check` on touched files
- Live `rapid-mlx serve <local fp8 dir>` + OpenAI chat probes (with and without the affine8 env var)
- Full unit suite via pr_validate: 17433 passed, 5 pre-existing local-env failures (verified identical on unmodified main)

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`) — full suite: 17433 passed, 5 failed; the 5 (ltx23/wan video, metrics_route x3) also fail on unmodified `main` checkouts here (local env, missing optional tooling) and touch nothing in this PR
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate 1910` — fetch/lint/targeted-tests (127 passed)/description/supply-chain/test-env all PASS; full_unit carries only the 5 pre-existing local-env failures above
- [x] If new tests touch a critical code path (parser / scheduler / security), I've spot-checked that they fail when the corresponding production line is broken (see SOP §Step 3) — the byte-exactness pins fail on any repack change
- [x] Updated README/docs if applicable — n/a, no user-facing docs for vendored archs
- [x] No breaking changes to existing API
