### PR TITLE
chore: bump version to 0.12.12

### DIFF
--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.11</string>
+	<string>0.12.12</string>
 	<key>CFBundleVersion</key>
-	<string>155</string>
+	<string>156</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.12.12.md
+++ b/docs/release-notes/v0.12.12.md
@@ -1,0 +1,31 @@
+## Highlights
+
+**Vision lane — faster first token, and a gemma-3 crash fixed.** The
+output-router detection that runs on every streaming request was rebuilding the
+full tokenizer vocab (~262k entries for Gemma) on *each* call; it is now detected
+once and memoized. Vision first-token latency versus `mlx-vlm` closed from
+~30-40% behind to within +1-16%, and Rapid now leads `oMLX` by 23-42% on Gemma
+vision TTFT, with decode throughput at parity. gemma-3 image requests that
+previously returned an empty completion (or crashed) now answer correctly, and
+the MLLM scheduler wakes on an event instead of a 10 ms idle poll. (#1909)
+
+**Model loads no longer hang on a cold network.** Warm starts could stall on
+unbounded Hugging Face metadata calls; the loader now hands a local snapshot path
+to the model so a poisoned-DNS or offline start can't wedge the server. (#1908,
+#1888)
+
+## Also in this release
+
+- **Prefix cache:** keep the per-layer cache class when trimming a hybrid
+  sliding/full KV cache, so hybrid models don't lose their cache shape on reset.
+  (#1863)
+- **Scheduler:** batch-adaptive recurrent-barrier interval for B=1 decode. (#1895)
+- **Chat:** MLLM streaming preflight errors now return HTTP 400 instead of a
+  silent 200 with empty content. (#1897)
+- **New model:** Ling 3.0 tiny (block-FP8) support. (#1910)
+- **Residency:** image/video models are single-slot so they stop accumulating in
+  memory. (#1889)
+- Rapid Mac: **signed background updates via Sparkle** (#1907), streaming aligned
+  with native chat, conversation search, global and per-conversation custom
+  instructions, and Launch integrations derived from the engine registry. (#1906,
+  #1879, #1883, #1894)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.11"
+version = "0.12.12"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cut release **0.12.12** so the vision-lane work and the load/scheduler/desktop fixes that landed since v0.12.11 reach users. The engine and desktop app ship one version number, so this bumps both `pyproject.toml` and `apps/rapid-mac/Resources/Info.plist` and promotes the release notes — merging this commit is what the auto-release pipeline tags.

Refs #1909, #1908, #1907, #1913, #1910, #1863, #1895, #1897.

## What ships

**Vision lane (headline, #1909)** — output-router detection is memoized instead of rebuilding the 262k-entry tokenizer vocab on every streaming request, because that rebuild was the dominant per-request cost. Vision TTFT vs `mlx-vlm` closed from ~30-40% behind to +1-16%; leads `oMLX` 23-42% on Gemma vision TTFT; decode at parity. gemma-3 image crash → correct. MLLM scheduler wakes on an event, not a 10ms idle poll.

**Also:** warm loads no longer hang on HF metadata (#1908); hybrid prefix-cache class preserved on trim (#1863); B=1 scheduler barrier (#1895); MLLM stream preflight 400 (#1897); Ling 3.0 tiny block-FP8 (#1910); Rapid Mac signed background updates via Sparkle (#1907); portable release smoke on clean Macs (#1913).

## Dogfood (main HEAD, before this bump)

- **Server:** gemma-3-4b / gemma-4-e4b / gemma-4-26b vision + Qwen3.6-35B chat/tool/5-way-concurrency — all 200, zero control-token leaks, reasoning traps passed.
- **Bundled sidecar** (the engine that ships in the desktop): headless boot ~3s, chat, streaming, forced tool-call — clean.
- **Interactive GUI:** fresh-built Desktop app, full round-trip (consent → model start → chat → correct response at 231 tok/s / 183ms TTFT).
- **Static:** ruff clean, 318 MLLM/vision/router/scheduler unit tests green; version-sync check + 23 version-sync tests green.

Full release notes: `docs/release-notes/v0.12.12.md`.
