### PR TITLE
fix(cli): make release smoke portable on clean Macs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -456,7 +456,7 @@ Documentation = "https://github.com/raullenchai/Rapid-MLX#readme"
 Repository = "https://github.com/raullenchai/Rapid-MLX"
 
 [project.scripts]
-rapid-mlx = "vllm_mlx.cli:main"
+rapid-mlx = "vllm_mlx.cli:cli_entrypoint"
 # First-class short command for accessibility and reduced typing (#1279).
 rmlx = "vllm_mlx.cli:main"
 rapid-mlx-chat = "vllm_mlx.gradio_app:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -458,7 +458,7 @@ Repository = "https://github.com/raullenchai/Rapid-MLX"
 [project.scripts]
 rapid-mlx = "vllm_mlx.cli:cli_entrypoint"
 # First-class short command for accessibility and reduced typing (#1279).
-rmlx = "vllm_mlx.cli:main"
+rmlx = "vllm_mlx.cli:cli_entrypoint"
 rapid-mlx-chat = "vllm_mlx.gradio_app:main"
 rapid-mlx-bench = "vllm_mlx.benchmark:main"
 # Deprecated pre-rename aliases — kept so existing users' scripts/muscle

--- a/tests/test_chat_mcp.py
+++ b/tests/test_chat_mcp.py
@@ -10,6 +10,7 @@ import json
 import logging
 import threading
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -658,23 +659,26 @@ def test_server_parameters_use_official_sdk_types():
 
 
 def test_server_parameters_keep_npx_bootstrap_output_off_protocol():
-    quiet = _server_parameters(
-        MCPServerConfig(
-            name="filesystem",
-            command="/opt/homebrew/bin/npx",
-            args=["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+    # Parameter shaping is under test here, not the host's Node installation.
+    with patch("shutil.which", return_value="/opt/homebrew/bin/npx"):
+        quiet = _server_parameters(
+            MCPServerConfig(
+                name="filesystem",
+                command="/opt/homebrew/bin/npx",
+                args=["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            )
         )
-    )
     assert quiet.env["npm_config_loglevel"] == "silent"
 
-    explicit = _server_parameters(
-        MCPServerConfig(
-            name="filesystem",
-            command="npx",
-            args=["server"],
-            env={"NPM_CONFIG_LOGLEVEL": "warn"},
+    with patch("shutil.which", return_value="/opt/homebrew/bin/npx"):
+        explicit = _server_parameters(
+            MCPServerConfig(
+                name="filesystem",
+                command="npx",
+                args=["server"],
+                env={"NPM_CONFIG_LOGLEVEL": "warn"},
+            )
         )
-    )
     assert explicit.env["NPM_CONFIG_LOGLEVEL"] == "warn"
     assert "npm_config_loglevel" not in explicit.env
 

--- a/tests/test_cli_short_alias.py
+++ b/tests/test_cli_short_alias.py
@@ -13,7 +13,7 @@ def test_rmlx_uses_the_canonical_cli_entrypoint():
     with (repo_root / "pyproject.toml").open("rb") as handle:
         scripts = tomllib.load(handle)["project"]["scripts"]
 
-    assert scripts["rmlx"] == scripts["rapid-mlx"] == "vllm_mlx.cli:main"
+    assert scripts["rmlx"] == scripts["rapid-mlx"] == "vllm_mlx.cli:cli_entrypoint"
 
 
 def test_curl_installer_exposes_rmlx_on_path():

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -7,6 +7,7 @@ command injection attacks and other security vulnerabilities.
 """
 
 import re
+from unittest.mock import patch
 
 import pytest
 
@@ -289,13 +290,14 @@ class TestMCPServerConfigSecurity:
 
     def test_valid_stdio_config(self):
         """Test that valid stdio config passes security validation."""
-        # This should not raise
-        config = MCPServerConfig(
-            name="test-server",
-            transport=MCPTransport.STDIO,
-            command="npx",
-            args=["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
-        )
+        # Unit tests must not depend on Node being installed on the host.
+        with patch("shutil.which", return_value="/usr/local/bin/npx"):
+            config = MCPServerConfig(
+                name="test-server",
+                transport=MCPTransport.STDIO,
+                command="npx",
+                args=["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            )
         assert config.command == "npx"
 
     def test_invalid_command_rejected(self):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -10590,5 +10590,19 @@ def main():
         sys.exit(1)
 
 
+def cli_entrypoint() -> None:
+    """Console entry point with normal Unix broken-pipe semantics."""
+    try:
+        main()
+    except BrokenPipeError:
+        # Unix consumers commonly stop reading early (for example,
+        # ``rapid-mlx models | head``).  Treat EPIPE as normal completion
+        # instead of printing a traceback from the CLI entry point.
+        try:
+            sys.stdout.close()
+        finally:
+            sys.exit(0)
+
+
 if __name__ == "__main__":
-    main()
+    cli_entrypoint()


### PR DESCRIPTION
Release dogfood on a clean 32 GB Mac mini found two issues:

- `rapid-mlx models | head` emitted a BrokenPipeError traceback because the console-script entry point did not normalize EPIPE.
- two MCP unit tests implicitly required `npx` to be installed, causing `make smoke` to fail on an otherwise valid clean Mac.

This adds a console wrapper with normal Unix broken-pipe semantics and makes the MCP fixtures hermetic by mocking executable discovery.

Validation:
- `rapid-mlx models | head` exits 0 with no traceback under `pipefail`
- MCP suites: 90 passed
- ruff check/format and diff check pass
- underlying main dogfood: clean install/import passed; real Qwen OpenAI/Anthropic/streaming/tools passed; Rapid Mac 2,175 tests passed; five GUI golden flows passed.