### PR TITLE
fix(mac): drop zero-token stopped turns from wire history

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -859,14 +859,32 @@ final class ChatViewModel {
     /// drop the rest — can be pinned by tests. See the call site for
     /// the full motivation (model-switch silent-failure bug).
     static func filterEmptyAssistantsForWire(_ messages: [ChatMessage]) -> [ChatMessage] {
-        messages.filter { msg in
-            guard msg.role == .assistant else { return true }
+        var filtered: [ChatMessage] = []
+        for msg in messages {
+            guard msg.role == .assistant else {
+                filtered.append(msg)
+                continue
+            }
             let proseEmpty = msg.content
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .isEmpty
             let noToolCalls = (msg.toolCalls?.isEmpty ?? true)
-            return !(proseEmpty && noToolCalls)
+            guard proseEmpty && noToolCalls else {
+                filtered.append(msg)
+                continue
+            }
+
+            // If Stop landed before the first token, the transcript contains
+            // an unanswered user prompt followed by an empty assistant row
+            // captioned "Stopped.". Dropping only the assistant leaves that
+            // prompt as the last historical turn, so the next send answers
+            // the cancelled request instead of the new one. Remove the pair
+            // from the wire history while keeping both rows visible in the UI.
+            if msg.errorMessage == "Stopped.", filtered.last?.role == .user {
+                filtered.removeLast()
+            }
         }
+        return filtered
     }
 
     /// Issue #477: strip forward-incompatible ``.unknown``-role messages

--- a/apps/rapid-mac/Tests/RapidTests/ModelSwitchHistoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelSwitchHistoryTests.swift
@@ -55,6 +55,41 @@ struct ModelSwitchHistoryTests {
         #expect(filtered.first?.role == .user)
     }
 
+    @Test("Stop before first token drops the unanswered user/assistant pair from wire history")
+    func dropsZeroTokenCancelledTurn() {
+        var stopped = ChatMessage(role: .assistant, content: "", status: .complete)
+        stopped.errorMessage = "Stopped."
+        let history: [ChatMessage] = [
+            ChatMessage(role: .user, content: "Earlier answered question"),
+            ChatMessage(role: .assistant, content: "Earlier answer", status: .complete),
+            ChatMessage(role: .user, content: "Write 500 numbered lines"),
+            stopped,
+            ChatMessage(role: .user, content: "What is 2 + 2?"),
+        ]
+
+        let filtered = ChatViewModel.filterEmptyAssistantsForWire(history)
+
+        #expect(filtered.map(\.content) == [
+            "Earlier answered question", "Earlier answer", "What is 2 + 2?",
+        ])
+    }
+
+    @Test("A partially emitted stopped answer remains valid conversation history")
+    func preservesPartialCancelledTurn() {
+        var stopped = ChatMessage(role: .assistant, content: "1\n2\n3", status: .complete)
+        stopped.errorMessage = "Stopped."
+        let history: [ChatMessage] = [
+            ChatMessage(role: .user, content: "Write 500 numbered lines"),
+            stopped,
+            ChatMessage(role: .user, content: "Continue"),
+        ]
+
+        let filtered = ChatViewModel.filterEmptyAssistantsForWire(history)
+
+        #expect(filtered.count == 3)
+        #expect(filtered[1].content == "1\n2\n3")
+    }
+
     @Test("Tool-call assistant (empty prose + populated tool_calls) is preserved — load-bearing for the tool loop")
     func preservesToolCallAssistant() {
         var toolAsst = ChatMessage(role: .assistant, content: "", status: .complete)

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1518,6 +1518,27 @@ flow_slow_stream_stop() {
         > "$OUT/stop-assertion.json"
     wait_send_idle "$OUT/slow-settled.json"
     baseline slow-stream-stop.stopped "$OUT/slow-settled.json"
+
+    # Release dogfood found a second Stop edge: cancelling before the first
+    # content token left an unanswered user prompt in wire history. The next
+    # request then answered that cancelled prompt instead of the new one.
+    # Exercise that zero-content lane and prove the immediately-following turn
+    # is routed from its own prompt.
+    send_prompt "cancel this before content" zero-content-stop
+    for _ in {1..40}; do
+        see_main "$OUT/zero-content-streaming.json"
+        if [[ "$(element_field "$OUT/zero-content-streaming.json" ChatView.SendOrStopButton description)" == "Stop generating" ]]; then break; fi
+        sleep 0.05
+    done
+    [[ "$(element_field "$OUT/zero-content-streaming.json" ChatView.SendOrStopButton description)" == "Stop generating" ]] \
+        || die "zero-content request never transitioned to Stop generating"
+    press "$OUT/zero-content-streaming.json" ChatView.SendOrStopButton "$OUT/zero-content-stop.json"
+    wait_send_idle "$OUT/zero-content-stopped.json"
+    send_prompt "shape:list answer the new request" after-stop
+    wait_send_idle "$OUT/after-stop-settled.json"
+    assert_tree_text "$OUT/after-stop-settled.json" "Three things, in order:"
+    jq -n '{success: true, assertion: "a send immediately after zero-content Stop answers the new prompt"}' \
+        > "$OUT/after-stop-assertion.json"
     cleanup_persona
 }
 


### PR DESCRIPTION
## Why

Release dogfood on a real Mac mini GUI found that pressing Stop before the first content token left the cancelled user prompt in API history. The empty assistant row was filtered, but its user prompt was not, so the next request could answer the cancelled prompt instead.

## Fix

- Drop the unanswered user + empty stopped assistant pair from wire history
- Preserve the transcript rows in the UI
- Preserve partially generated stopped answers and tool-call messages
- Extend the `slow-stream-stop` GUI golden flow through the immediately-following send

## Validation

- Targeted Swift tests: 14/14 passed
- GUI golden flow `slow-stream-stop`: passed (`/tmp/rapid-gui-golden-20260813T180847Z`)
- Full Swift suite: 2,176/2,177 passed; the sole failure is the pre-existing wall-clock throughput threshold test, reproduced twice with varying measured values (unrelated code path)
- Real Mac mini GUI + real LFM model: stopped before first content token, then asked 2+2; fixed build returned `4` (pre-fix continued the cancelled numbered-list request)