### PR TITLE
chore: bump version to 0.12.12

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,35 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.12] — 2026-08-13
+
+A vision and reliability release. Images get their first response noticeably
+sooner, a class of image chats that used to come back empty now answer
+correctly, and the app can update itself in the background.
+
+### Added
+
+- Signed background updates: the app now checks for, downloads, and installs
+  new versions on its own, so you stay current without visiting a download
+  page.
+- Support for a new small model, Ling 3.0 tiny.
+
+### Changed
+
+- Sending an image now gets its first words back much faster — on the Gemma
+  vision models the wait before the reply starts is now on par with, and
+  often ahead of, every other way to run them on a Mac.
+
+### Fixed
+
+- Some image chats (the Gemma 3 family) could reply with nothing at all;
+  they now answer normally.
+- Starting a model no longer stalls when the network is slow or a lookup
+  hangs — the app falls back to what it already has on disk.
+- Image and video models no longer pile up in memory; only one stays
+  resident at a time.
+
+
 ## [0.12.11] — 2026-08-12
 
 A speed release. The engine underneath the app got a full tuning pass


### PR DESCRIPTION
## Why

The 0.12.12 engine bump (#1912) landed `pyproject.toml`, `Info.plist`, and the engine release notes but **omitted `apps/rapid-mac/CHANGELOG.md`**. The auto-release `release` job failed at its "Pre-check the desktop app CHANGELOG" step (`no '## [0.12.12]' section — the app release would ship empty notes`) **before anything was tagged or published** — the `detect` and `tier1-agent-gate` jobs passed.

This adds the user-facing `## [0.12.12]` desktop app CHANGELOG section so the pre-check passes. `pyproject.toml` stays `0.12.12` (no version change), so `version-check` treats this as a non-bump edit, while the `chore: bump version to 0.12.12` subject makes `detect` re-fire `should_release=true` on merge and the release completes (tag `v0.12.12` + GitHub Release + PyPI + Homebrew + desktop DMG).

Refs #1912, #1909, #1907, #1908, #1910.