### PR TITLE
fix(rapid-mac-release): set GH_REPO so the GitHub Release step works without a checkout

### DIFF
--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -752,6 +752,12 @@ jobs:
         # automated bypass is the thing that let #1851 survive three releases.
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job has no ``actions/checkout`` (it only downloads artifacts),
+          # so there is no ``.git`` for ``gh release`` to infer the repo from —
+          # every ``gh release`` call died with "fatal: not a git repository"
+          # once this step moved here from ``build`` (which does check out).
+          # ``GH_REPO`` lets gh resolve the repo without a working tree.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
           SIGNED: ${{ needs.build.outputs.signed }}
         run: |


### PR DESCRIPTION
## Why

The `Create the GitHub Release (last …)` step in the `publish-updater-fallback` job runs `gh release view/edit/upload/create`, but that job has **no `actions/checkout`** — it only downloads artifacts — so there is no `.git` for `gh` to infer the repo from. Every `gh release` call dies with `fatal: not a git repository`, because `gh` needs either a git remote or `GH_REPO`/`--repo` to resolve the target.

This is what failed the **rapid-mac-v0.12.12** desktop release at its final step: the signed+notarized DMG, the Sparkle appcast (EdDSA-signed), and `latest.json` all shipped to `dl.rapidmlx.com`; only the GitHub Release was missing and had to be created via the documented manual escape hatch. It regressed when this step moved here from `build` (which does check out) to make the release the last thing that ships (#1851).

## Fix

Set `GH_REPO: ${{ github.repository }}` in the step env so `gh` resolves the repo without a working tree. All four `gh release` calls in the step are covered by the one env var; no other `gh` calls exist in the job.

Refs #1722.