### PR TITLE
Require explicit confirmation to complete macOS onboarding

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -445,6 +445,30 @@ final class ChatViewModel {
         messages = seeded
     }
 
+    /// Append a locally authored assistant message to the open conversation.
+    ///
+    /// The one caller is the onboarding completion transaction, which lands
+    /// its welcome message in the chat the user is about to be dropped into.
+    /// There is no network round trip and no stream: the text is written
+    /// straight into the transcript as a finished assistant turn, so it can
+    /// never wedge the typing indicator or the streaming gate.
+    ///
+    /// A transcript that already holds messages is left alone. Onboarding
+    /// completion is a one-shot event, but the app can reach it with a live
+    /// conversation on screen (a user who skipped setup, chatted, then came
+    /// back to it), and injecting a stray intro into the middle of somebody's
+    /// conversation is worse than skipping the pleasantry.
+    ///
+    /// - Returns: ``true`` when the message landed in the transcript.
+    @discardableResult
+    func seedAssistantWelcome(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard messages.isEmpty else { return false }
+        appendMessage(ChatMessage(role: .assistant, content: trimmed))
+        return true
+    }
+
     /// Append the user message, open a placeholder assistant row, and
     /// kick off the streaming task. The text field clears immediately on
     /// the caller's side.

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -202,6 +202,15 @@ struct ChatView: View {
     /// & start, retry). Owned by ``ContentView`` because starting a model
     /// is a window-level concern, not a chat-surface one.
     var onReadinessAction: (ModelReadiness.Action) -> Void = { _ in }
+    /// Monotonic counter the parent bumps when something outside this view
+    /// wants the composer to take keyboard focus — today, the onboarding
+    /// completion transaction dropping the user into their first chat.
+    ///
+    /// A counter rather than a Bool so a second request is distinguishable
+    /// from the first and nothing has to be reset afterwards. Zero is the
+    /// "never asked" value; ``ComposeTextEditor`` ignores it, so a plain
+    /// mount does not steal focus from whatever the user was doing.
+    var composerFocusRequest: Int = 0
 
     /// Backing state for the composer's inline model picker (Ollama-style).
     /// The picker lives in the compose box now, not a top control bar.
@@ -271,6 +280,14 @@ struct ChatView: View {
         // Drop a stale error banner once the server is provably ready.
         .onChange(of: server.state) { _, newState in
             if case .ready = newState { viewModel.clearStaleErrorBanner() }
+        }
+        // Forward an external focus request onto the composer's own token.
+        // Routed through the existing token rather than a second mechanism
+        // so every focus request in this view — Send, Cmd+L, onboarding
+        // completion — reaches the editor by the same path.
+        .onChange(of: composerFocusRequest) { _, request in
+            guard request != 0 else { return }
+            composeFocusToken &+= 1
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -40,6 +40,10 @@ struct ContentView: View {
     @SceneStorage("Rapid.showLogs") private var showLogs: Bool = false
     /// Per-session "browse all models" dismissal of the Quickstart card.
     @State private var quickstartDismissedThisSession: Bool = false
+    /// Monotonic composer-focus request forwarded to ``ChatView``. Bumped
+    /// by the onboarding completion transaction so the user lands in their
+    /// first chat with the caret already in the message field.
+    @State private var composerFocusRequest: Int = 0
     @Environment(SettingsRouter.self) private var settingsRouter
     /// #223: launch-time auto-start "needs download" state — the empty
     /// state names the pending pull when non-nil.
@@ -164,6 +168,16 @@ struct ContentView: View {
             // ``.ready(<alias>)`` against a different alias than shown.
             if case .ready(let serving) = newState, !serving.isEmpty, serving != alias {
                 alias = serving
+            }
+            // Retire pending-Ready provenance the moment the app serves some
+            // OTHER model. The record names the alias it is about precisely
+            // so it can be falsified like this: once the user has moved on,
+            // offering to confirm the old flow on the next launch would be
+            // confirming something that is no longer true.
+            if case .ready(let serving) = newState,
+               quickstart.hasPendingReady,
+               serving != quickstart.selection.alias {
+                quickstart.clearPendingReady()
             }
         }
         .alert(
@@ -529,7 +543,8 @@ struct ContentView: View {
                 readiness: readiness,
                 catalogRefreshEnabled: !telemetryConsentPending,
                 onUserModelSelection: selectChatModel,
-                onReadinessAction: performReadinessAction
+                onReadinessAction: performReadinessAction,
+                composerFocusRequest: composerFocusRequest
             )
         case .missing:
             missingOverlay
@@ -552,7 +567,16 @@ struct ContentView: View {
                 // selection and left them on the alphabetical fallback
                 // (#1653). It opens Settings → Models now and leaves the
                 // wizard standing.
-                if !presented { quickstartDismissedThisSession = true }
+                //
+                // Routed through ``skipForNow`` for the same reason it is the
+                // same intent: a user who escapes the Ready screen has
+                // answered it, and returning them to it on the next launch
+                // would be re-asking. Safe on the completion path too — the
+                // record is already retired and this never touches ``done``.
+                if !presented {
+                    quickstartDismissedThisSession = true
+                    quickstart.skipForNow()
+                }
             }
         )
     }
@@ -564,9 +588,16 @@ struct ContentView: View {
             downloads: downloads,
             server: server,
             cachedModels: catalogEntries,
-            onSkip: { quickstartDismissedThisSession = true },
+            onSkip: {
+                quickstartDismissedThisSession = true
+                // Skip keeps its existing meaning — no completion flag — but
+                // it does retire a pending Ready confirmation, so walking
+                // away is not re-asked on the next launch.
+                quickstart.skipForNow()
+            },
             onBrowseAll: { quickstartDismissedThisSession = true },
-            onSeedWelcome: { true }
+            onSeedWelcome: seedQuickstartWelcome,
+            onCompleted: finishOnboardingHandoff
         )
         // QuickstartView was written for the detail column and its comments
         // cite a ~360pt worst case (the 640pt window floor minus the sidebar).
@@ -574,6 +605,43 @@ struct ContentView: View {
         // collapse to its content's ideal width. Pin it near the window floor
         // so the model cards keep the room they were laid out for.
         .frame(minWidth: 620, minHeight: Self.minWindowHeight)
+    }
+
+    /// Steps 1 + 2 of the Start chatting transaction: make sure the chat the
+    /// user is about to land in exists, and put the welcome message in it —
+    /// exactly once, enforced by the coordinator that calls this.
+    ///
+    /// ``ChatViewModel`` always holds an open conversation, so "ensure the
+    /// session exists" is a matter of making that conversation the one on
+    /// screen rather than creating anything. Returning the append's own
+    /// verdict (rather than an unconditional ``true``) is what lets the
+    /// coordinator tell a landed welcome from one still owed.
+    private func seedQuickstartWelcome() -> Bool {
+        section = .chat
+        // A transcript that already holds messages is not a failed seed —
+        // it is somebody's conversation, and dropping an onboarding intro
+        // into the middle of it would be worse than skipping the greeting.
+        // Either way nothing is left owed, so this reports success and the
+        // coordinator does not record a pending welcome.
+        guard chat.messages.isEmpty else { return true }
+        return chat.seedAssistantWelcome(quickstart.seedMessage)
+    }
+
+    /// The parent's half of the Start chatting transaction, run once, only
+    /// after the coordinator confirms it performed the completion.
+    ///
+    /// Order matters here. The surface is already gone by this point (the
+    /// coordinator moved to ``.dismissed``, so ``quickstartVisible`` is
+    /// false and the ordinary shell is back — same window, same size, no
+    /// second window and nothing to fade). What is left is: land on Chat,
+    /// SAY that setup finished, and only then move the caret. The
+    /// announcement is posted before the focus request because a VoiceOver
+    /// user who hears the field described first never learns that the thing
+    /// they just activated actually worked.
+    private func finishOnboardingHandoff() {
+        section = .chat
+        VoiceOverAnnouncer.announce("Setup complete. Opening your first chat.")
+        composerFocusRequest &+= 1
     }
 
     /// True when the Quickstart card should render in place of the chat
@@ -608,11 +676,32 @@ struct ContentView: View {
         ) {
             return true
         }
-        // Keep the card up while the user is mid-flow (download / start).
-        switch quickstart.phase {
-        case .downloading, .starting, .failed, .lowDiskWarning:
+        // A flow that reached Ready and was never confirmed is still owed a
+        // confirmation, and ``isEligible`` cannot say so: it reads
+        // ``lastServedAlias``, which that flow has by definition already
+        // written. Without this clause the relaunch case is unreachable —
+        // the user would be dropped straight into the app having never been
+        // asked, which is the automatic hand-off under another name.
+        if quickstart.hasPendingReady, !quickstart.done {
             return true
-        case .idle, .ready:
+        }
+        // Keep the card up while the user is mid-flow (download / start /
+        // waiting to confirm Ready).
+        return ContentView.quickstartRetainsSurface(phase: quickstart.phase)
+    }
+
+    /// Does onboarding still own the window in this phase?
+    ///
+    /// Pure so the one rule that decides whether setup is on screen can be
+    /// pinned exhaustively. ``.ready`` is the load-bearing case: readiness
+    /// used to release the surface, and the whole point of Onboarding V3 is
+    /// that it no longer does — the screen stays until the user confirms.
+    /// Only the two terminal states let the shell back through.
+    static func quickstartRetainsSurface(phase: QuickstartCoordinator.Phase) -> Bool {
+        switch phase {
+        case .downloading, .starting, .failed, .lowDiskWarning, .ready:
+            return true
+        case .idle, .dismissed:
             return false
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -1682,19 +1682,25 @@ struct ModelPickerBar: View {
 
     /// Pure helper: ``true`` iff a Quickstart flow currently owns
     /// the Start CTA. Disabled phases are ``.lowDiskWarning``,
-    /// ``.downloading``, ``.starting`` (everything between
-    /// "Get started" and "model ready to chat"). ``.idle`` /
-    /// ``.ready`` / ``.failed`` release the gate — ``.idle`` means
+    /// ``.downloading``, ``.starting`` and ``.ready`` (everything
+    /// between "Get started" and the user finishing setup). ``.idle`` /
+    /// ``.dismissed`` / ``.failed`` release the gate — ``.idle`` means
     /// the user hasn't clicked yet (or dismissed the card),
-    /// ``.ready`` means Quickstart finished and ChatView owns the
-    /// frame, ``.failed`` means the user can pick a different model
+    /// ``.dismissed`` means onboarding has released the frame,
+    /// ``.failed`` means the user can pick a different model
     /// from the picker to recover.
+    ///
+    /// ``.ready`` moved from released to in-flight with Onboarding V3.
+    /// It used to mean "Quickstart finished and ChatView owns the frame";
+    /// it now means the onboarding surface is still up, holding the whole
+    /// window, waiting for Start chatting. Releasing the gate there would
+    /// claim the picker owns a CTA the user cannot even see.
     static func isQuickstartInFlight(phase: QuickstartCoordinator.Phase?) -> Bool {
         guard let phase else { return false }
         switch phase {
-        case .lowDiskWarning, .downloading, .starting:
+        case .lowDiskWarning, .downloading, .starting, .ready:
             return true
-        case .idle, .ready, .failed:
+        case .idle, .dismissed, .failed:
             return false
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
@@ -42,9 +42,15 @@ struct OnboardingBrandMark: View {
 /// buttons (#1792). A labelled linear meter communicates position without
 /// advertising swipe, drag, or arbitrary-page navigation.
 /// ``current`` is 0-indexed.
+///
+/// ``total`` defaults to ``QuickstartCoordinator.Step.total`` so the public
+/// step count lives in exactly one place. Onboarding V3 (Paper 05.1.G,
+/// "Four public steps, and Ready is confirmed") makes that four — Welcome,
+/// Choose a model, Download, Start — and no "Step N of 3" language survives
+/// anywhere in production.
 struct OnboardingStepProgress: View {
     let current: Int
-    let total: Int
+    var total: Int = QuickstartCoordinator.Step.total
 
     var body: some View {
         VStack(alignment: .trailing, spacing: 5) {
@@ -68,16 +74,18 @@ struct OnboardingStepProgress: View {
 // MARK: - Top bar
 
 /// The interior-step header: brand mark + wordmark on the left, step
-/// dots on the right. ``step`` is the 0-indexed current step.
+/// dots on the right. ``step`` is the public macro step this screen
+/// belongs to — never a raw ordinal, so a screen can't drift out of the
+/// four-step model by miscounting.
 struct OnboardingTopBar: View {
-    let step: Int
+    let step: QuickstartCoordinator.Step
 
     var body: some View {
         HStack(spacing: 10) {
             OnboardingBrandMark(size: 26)
             Text("Rapid-MLX").scaledSystemFont(13, weight: .semibold)
             Spacer()
-            OnboardingStepProgress(current: step, total: 3)
+            OnboardingStepProgress(current: step.rawValue)
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1531,7 +1531,6 @@ struct QuickstartView: View {
             .accessibilityIdentifier("Quickstart.Ready.StartChatting")
             .accessibilityLabel("Start chatting with \(coordinator.selection.displayName)")
         }
-        .accessibilityIdentifier("Quickstart.Ready")
     }
 
     /// Run the Start chatting transaction.

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -176,6 +176,47 @@ struct QuickstartModelChoice: Equatable, Identifiable, Sendable {
 @MainActor
 @Observable
 final class QuickstartCoordinator {
+    /// The four PUBLIC onboarding steps (Paper 05.1.G — "Four public
+    /// steps, and Ready is confirmed").
+    ///
+    /// Everything the user can be doing during setup collapses onto one of
+    /// these four. Micro-states are NOT steps: hardware detection,
+    /// recommendation loading, choosing a recommended / cached /
+    /// alternative model and reviewing a model all live inside
+    /// ``chooseModel``; preparing, offline, insufficient disk, an
+    /// interrupted download, a download failure and its retry all live
+    /// inside ``download``; starting, the pre-load memory confirmation and
+    /// Ready all live inside ``start``.
+    ///
+    /// A failure never becomes a fifth step — it keeps the macro step that
+    /// owns it (see ``FailureOrigin``), so the rail does not jump when
+    /// something goes wrong.
+    enum Step: Int, CaseIterable, Equatable, Sendable {
+        case welcome = 0
+        case chooseModel = 1
+        case download = 2
+        case start = 3
+
+        /// The one place the public step count is stated. Onboarding V3
+        /// moves the production progress model from three steps to four;
+        /// every "Step N of M" label reads M from here.
+        static let total: Int = Step.allCases.count
+
+        /// 1-based number as spoken and displayed ("Step 3 of 4").
+        var displayNumber: Int { rawValue + 1 }
+    }
+
+    /// Which macro step owns a terminal failure. Carried on ``Phase/failed``
+    /// so the progress rail keeps reporting the step the user was actually
+    /// in when it broke — a download failure is still Step 3, a load failure
+    /// is still Step 4.
+    enum FailureOrigin: Equatable, Sendable {
+        /// The pull did not finish (network, mirror, disk, cancellation).
+        case download
+        /// The weights are on disk but the serve did not come up.
+        case start
+    }
+
     /// Phases the Quickstart UI walks through.
     enum Phase: Equatable {
         /// Initial state — the hero card is showing or the surface
@@ -193,14 +234,28 @@ final class QuickstartCoordinator {
         case downloading
         /// Download finished, ``ServerManager.start`` is in flight.
         case starting
-        /// Server is serving ``alias`` and the seeded assistant message
-        /// has been appended to the active session. Quickstart hands off
-        /// to the normal chat surface.
+        /// The selected model is serving and onboarding is STOPPED here,
+        /// waiting for the user.
+        ///
+        /// This is the Onboarding V3 change of meaning (Paper 05.1.G —
+        /// "Readiness does not dismiss setup"). Before, readiness itself
+        /// completed the flow and handed off to chat; the user was never
+        /// asked and never confirmed. Now readiness only moves us here: the
+        /// full-window surface stays up, nothing is persisted, and the flow
+        /// ends only when the user activates Start chatting
+        /// (``confirmStartChatting(seedWelcome:)``).
         case ready
+        /// Terminal. The onboarding surface has released the frame, either
+        /// because the user confirmed Ready or because they revised their
+        /// intent mid-flow (``releaseInFlight``). Whether onboarding was
+        /// actually COMPLETED is ``done``'s business, not this phase's —
+        /// only the confirmed path writes it.
+        case dismissed
         /// Download or serve failed. ``message`` is a single-line
-        /// human-readable summary suitable for inline display.
+        /// human-readable summary suitable for inline display; ``origin``
+        /// pins the macro step that owns the failure so the rail stays put.
         /// "Retry" is offered; the persistent done-flag is NOT set.
-        case failed(message: String)
+        case failed(message: String, origin: FailureOrigin)
     }
 
     /// The default + recommended starter — the first-run decision.
@@ -365,6 +420,40 @@ Open the picker any time to switch models.
     }
     private(set) var stage: Stage = .welcome
 
+    /// The public macro step the current (phase, stage) pair belongs to.
+    ///
+    /// Pure and static so the four-step mapping can be pinned exhaustively
+    /// without a SwiftUI host, and so every rendered rail reads the SAME
+    /// function rather than hard-coding an ordinal per screen — which is
+    /// how the old model ended up with two screens both claiming step 3.
+    static func step(phase: Phase, stage: Stage) -> Step {
+        switch phase {
+        case .idle:
+            // The pre-download wizard screens are the only place ``stage``
+            // is load-bearing; once a download is in flight the lifecycle
+            // machine owns the step.
+            switch stage {
+            case .welcome:     return .welcome
+            case .chooseModel: return .chooseModel
+            }
+        case .lowDiskWarning, .downloading:
+            // Insufficient disk is a download-time interstitial, not a step
+            // of its own — the user is being asked about the pull they just
+            // authorised.
+            return .download
+        case .starting, .ready, .dismissed:
+            return .start
+        case .failed(_, let origin):
+            switch origin {
+            case .download: return .download
+            case .start:    return .start
+            }
+        }
+    }
+
+    /// Live macro step for the current state.
+    var step: Step { Self.step(phase: phase, stage: stage) }
+
     /// Advance from the hero to the model chooser ("Get started").
     func advanceToChooseModel() { stage = .chooseModel }
 
@@ -389,9 +478,17 @@ Open the picker any time to switch models.
     /// Set the model the wizard will download. No-op once a download is
     /// in flight (``phase != .idle``) so a late tap can't retarget an
     /// active pull.
+    ///
+    /// Moving to a different alias invalidates any pending-Ready
+    /// provenance: the flow that reached Ready was about the OLD model, and
+    /// keeping the record would let a later relaunch offer to confirm a
+    /// model the user has since walked away from.
     func select(_ choice: QuickstartModelChoice) {
         guard case .idle = phase else { return }
         selection = choice
+        if let pending = pendingReadyAlias, pending != choice.alias {
+            clearPendingReady()
+        }
     }
 
     /// True once ``markDone`` has been called. Read on every eligibility
@@ -459,6 +556,50 @@ Open the picker any time to switch models.
     /// true; cleared in lockstep by the ``awaitingWelcomeSeed`` didSet.
     static let awaitingSeedAliasKey: String = "rapid.quickstart.v1.awaitingSeedAlias"
 
+    /// Provenance for an onboarding flow that reached ``Phase/ready`` but
+    /// has NOT been confirmed with Start chatting (Paper 05.1.G —
+    /// "Completion is what persists, not readiness").
+    ///
+    /// ## Why a second key rather than reusing ``storageKey``
+    ///
+    /// ``storageKey`` answers "is onboarding finished?" and must stay
+    /// truthful: it is written only by the user's confirmation. But
+    /// "finished" and "never started" are not the only two states any more
+    /// — a user can quit while the Ready screen is on screen, and on the
+    /// next launch we owe them that same screen rather than either the
+    /// normal shell (which would silently swallow the flow) or the welcome
+    /// hero (which would pretend nothing happened). This key records
+    /// exactly that third state, and names the alias it is about so the
+    /// claim can be re-verified instead of trusted.
+    ///
+    /// ## What it is NOT
+    ///
+    /// It is not a readiness cache. A stored alias alone never re-enters
+    /// Ready — ``QuickstartView.handleServerStateChange`` re-enters it only
+    /// when ``ServerManager`` genuinely reports ``.ready`` for that alias
+    /// on this launch. If the model is no longer ready the user lands back
+    /// on the ordinary chooser with their pick preselected, and nothing
+    /// claims a download or a selection was "resumed".
+    ///
+    /// Cleared on: confirmation, ``releaseInFlight``, a fresh
+    /// ``enterDownloading``, ``skipForNow``, selecting a different alias,
+    /// and ``_testingReset``.
+    static let pendingReadyAliasKey: String = "rapid.quickstart.v1.pendingReadyAlias"
+
+    /// Alias of an unconfirmed Ready flow, or ``nil`` when there is none.
+    private(set) var pendingReadyAlias: String? {
+        didSet {
+            if let pendingReadyAlias {
+                UserDefaults.standard.set(pendingReadyAlias, forKey: Self.pendingReadyAliasKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.pendingReadyAliasKey)
+            }
+        }
+    }
+
+    /// True while an unconfirmed Ready flow is on the books.
+    var hasPendingReady: Bool { pendingReadyAlias != nil }
+
     init() {
         self.done = UserDefaults.standard.bool(forKey: Self.storageKey)
         self.legacyDone = UserDefaults.standard.bool(forKey: Self.legacyStorageKey)
@@ -468,12 +609,25 @@ Open the picker any time to switch models.
         // property in ``init`` does NOT trigger the didSet, so this read
         // can't clobber the persisted alias below.)
         self.awaitingWelcomeSeed = UserDefaults.standard.bool(forKey: Self.awaitingSeedKey)
+        self.pendingReadyAlias = UserDefaults.standard.string(forKey: Self.pendingReadyAliasKey)
         // #1524: if a deferred seed survived a quit, restore the model it
         // was waiting on so the seed observers match the served alias and
         // the welcome copy names the right model (not the reset default).
         if self.awaitingWelcomeSeed,
            let alias = UserDefaults.standard.string(forKey: Self.awaitingSeedAliasKey) {
             self.selection = Self.choice(forAlias: alias)
+        }
+        // An unconfirmed Ready flow restores its model and drops the user
+        // back at the chooser rather than the welcome hero — they already
+        // made this choice, and re-asking "would you like to get started?"
+        // of somebody who downloaded and loaded a model reads as amnesia.
+        //
+        // Deliberately NOT ``phase = .ready``: at init nothing has verified
+        // the model is actually up on this launch. The Ready screen is
+        // re-entered by the live server observer or not at all.
+        if let alias = self.pendingReadyAlias {
+            self.selection = Self.choice(forAlias: alias)
+            self.stage = .chooseModel
         }
     }
 
@@ -515,9 +669,29 @@ Open the picker any time to switch models.
         selection = Self.defaultChoice
         hasSeededWelcome = false
         awaitingWelcomeSeed = false
+        pendingReadyAlias = nil
         UserDefaults.standard.removeObject(forKey: Self.storageKey)
         UserDefaults.standard.removeObject(forKey: Self.awaitingSeedKey)
         UserDefaults.standard.removeObject(forKey: Self.awaitingSeedAliasKey)
+        UserDefaults.standard.removeObject(forKey: Self.pendingReadyAliasKey)
+    }
+
+    /// Drop the record of an unconfirmed Ready flow. Idempotent.
+    func clearPendingReady() {
+        pendingReadyAlias = nil
+    }
+
+    /// The user asked to leave setup for now ("Skip for now", Esc, or a
+    /// swipe-down on the sheet).
+    ///
+    /// Skip keeps its existing semantics — it does NOT write the completion
+    /// flag, so onboarding is still owed on a later launch — but it does
+    /// retire any pending-Ready record. Someone who deliberately walked away
+    /// from the Ready screen has answered the question it was asking; coming
+    /// back to it on the next launch would be re-asking.
+    func skipForNow() {
+        clearPendingReady()
+        awaitingWelcomeSeed = false
     }
 
     /// External clearer for the awaiting-seed provenance flag. Called
@@ -538,6 +712,9 @@ Open the picker any time to switch models.
     func enterDownloading() {
         phase = .downloading
         awaitingWelcomeSeed = false
+        // A fresh pull is a fresh flow: whatever reached Ready before is no
+        // longer the thing being confirmed.
+        clearPendingReady()
     }
 
     /// Surface the non-blocking low-disk warning between the hero card
@@ -565,8 +742,12 @@ Open the picker any time to switch models.
     /// Record a terminal failure. Does NOT flip ``done`` so the next
     /// surface render shows Quickstart again (with "Retry" if the
     /// failure was the download, plain "Get started" otherwise).
-    func enterFailed(message: String) {
-        phase = .failed(message: message)
+    ///
+    /// ``origin`` is the macro step that owns the failure. It exists so a
+    /// failure never reads as its own step: a broken pull still reports
+    /// Step 3, a serve that would not come up still reports Step 4.
+    func enterFailed(message: String, origin: FailureOrigin) {
+        phase = .failed(message: message, origin: origin)
     }
 
     /// Release the in-flight phase WITHOUT seeding the welcome or
@@ -582,54 +763,72 @@ Open the picker any time to switch models.
     /// parent's ``.onChange(of: activeID)`` retry observer doesn't
     /// fire a stray welcome message after the user revised intent.
     func releaseInFlight() {
-        phase = .ready
+        phase = .dismissed
         awaitingWelcomeSeed = false
+        clearPendingReady()
     }
 
-    /// Drop into ready state, seed the welcome assistant message into
-    /// the active session exactly once, and persist the done flag.
+    /// Readiness landed for the selected model: park onboarding on the
+    /// Ready screen and record that a confirmation is outstanding.
     ///
-    /// Idempotent on the second call: multiple ``.ready`` notifications
-    /// (auto-respawn cycle, scheduler tick) flip ``done`` once and seed
-    /// the message once. Returns ``true`` when the seed actually
-    /// landed.
+    /// This is deliberately the WHOLE of what readiness does. Before
+    /// Onboarding V3 this method also seeded the welcome message and wrote
+    /// the completion flag, so the app decided on the user's behalf that
+    /// setup was finished the instant a subprocess reported a port was
+    /// listening. Paper 05.1.G retires that ending explicitly ("Kept for the
+    /// record, not for build … must not be re-introduced"): readiness is
+    /// something to state, and completion is something to confirm.
     ///
-    /// Codex r2 MAJOR: ``seed`` returns ``true`` only when the welcome
-    /// message actually landed in a session. The parent's seed closure
-    /// short-circuits on ``store.activeID == nil`` (no active session
-    /// available — possible during the brief window before
-    /// ``SessionStore.awaitInitialLoad`` lands or if the user deleted
-    /// every session mid-Quickstart). We must NOT mark the flow as
-    /// done in that case: ``hasSeededWelcome`` would lock out the
-    /// retry on the next ``.ready`` fire, and the persistent done flag
-    /// would silently skip the welcome message forever.
-    @discardableResult
-    func markReady(seed: () -> Bool) -> Bool {
+    /// So nothing is persisted here except the provenance saying a
+    /// confirmation is owed, and the surface stays up.
+    ///
+    /// Idempotent, because readiness is not a single event: an auto-respawn
+    /// cycle, a residency refresh or a scheduler tick can all republish
+    /// ``.ready`` for the same serve. Repeat calls re-affirm the same state
+    /// and change nothing. A flow that has already been confirmed or
+    /// released is never dragged back onto the Ready screen.
+    func enterReady() {
+        guard !done else { return }
+        guard phase != .dismissed else { return }
         phase = .ready
-        if hasSeededWelcome {
-            // Already done on a prior tick — re-affirm ``done`` so a
-            // restored coordinator that lost the flag still persists
-            // it, but don't try to seed again.
-            markDone()
-            awaitingWelcomeSeed = false
-            return false
+        pendingReadyAlias = selection.alias
+    }
+
+    /// The user activated **Start chatting** — the single completion
+    /// transaction for onboarding.
+    ///
+    /// Runs, in order: seed the welcome message exactly once, persist the
+    /// completion flag, retire the pending-Ready provenance, and release the
+    /// surface. Everything outside this object's ownership — routing to
+    /// Chat, announcing completion, moving keyboard focus — is the caller's
+    /// half of the transaction and runs only when this returns ``true``.
+    ///
+    /// Idempotent by construction: the guard is the phase itself, so a
+    /// double-click, a repeated key activation, or a stray re-entry after
+    /// completion all return ``false`` without seeding a second welcome,
+    /// re-writing the flag, or re-running the caller's transition.
+    ///
+    /// - Parameter seedWelcome: appends the welcome assistant message to the
+    ///   intended chat session, returning ``true`` when it actually landed.
+    ///   A ``false`` return does NOT block completion — the user asked to
+    ///   start chatting and must not be stranded on a screen they already
+    ///   dismissed — but it does leave ``awaitingWelcomeSeed`` set so the
+    ///   parent's retry observer can land the message once a session exists.
+    /// - Returns: ``true`` when this call performed the transaction.
+    @discardableResult
+    func confirmStartChatting(seedWelcome: () -> Bool) -> Bool {
+        guard case .ready = phase else { return false }
+        if !hasSeededWelcome {
+            if seedWelcome() {
+                hasSeededWelcome = true
+                awaitingWelcomeSeed = false
+            } else {
+                awaitingWelcomeSeed = true
+            }
         }
-        let seeded = seed()
-        guard seeded else {
-            // Welcome couldn't land — leave the door open for the
-            // next ``.ready`` tick (or a retry after the user creates
-            // a session). Phase still flips to ``.ready`` so the
-            // visibility predicate's "in-flight" guard releases. Flag
-            // the deferred-seed provenance (codex r4 MAJOR) so the
-            // parent's activeID retry observer knows this is a real
-            // pending seed (not a user who manually picked the
-            // Quickstart alias from the picker after dismissing).
-            awaitingWelcomeSeed = true
-            return false
-        }
-        hasSeededWelcome = true
         markDone()
-        awaitingWelcomeSeed = false
+        clearPendingReady()
+        phase = .dismissed
         return true
     }
 
@@ -819,13 +1018,27 @@ struct QuickstartView: View {
     var onBrowseAll: () -> Void
 
     /// Callback the parent supplies for seeding the welcome message
-    /// into the active session. Closing over ``SessionStore`` /
-    /// ``ChatViewModel`` from outside keeps Quickstart from importing
-    /// the entire chat module surface. Returns ``true`` when the
-    /// message actually landed (an active session existed and the
-    /// append succeeded) so the coordinator can defer ``markDone``
-    /// until the welcome has reached the user (codex r2 MAJOR).
+    /// into the intended chat session. Closing over ``ChatViewModel``
+    /// from outside keeps Quickstart from importing the entire chat
+    /// module surface. Returns ``true`` when the message actually landed
+    /// (a session existed and the append succeeded) so the coordinator
+    /// can tell "seeded" from "still owed" (codex r2 MAJOR).
+    ///
+    /// Called from exactly one place — the Start chatting transaction —
+    /// so the welcome is a consequence of the user finishing setup rather
+    /// than of a subprocess reporting a listening port.
     var onSeedWelcome: () -> Bool
+
+    /// The parent's half of the Start chatting transaction, run ONLY after
+    /// ``QuickstartCoordinator/confirmStartChatting(seedWelcome:)`` reports
+    /// it performed the state change.
+    ///
+    /// Split this way so the two halves cannot disagree about whether
+    /// completion happened: the coordinator owns seeding, persistence and
+    /// dismissal; the parent owns routing to Chat, the accessibility
+    /// announcement and composer focus — none of which this view has the
+    /// environment to do, and all of which must fire exactly once.
+    var onCompleted: () -> Void = {}
 
     /// Test seam: override the pre-flight free-bytes probe so the
     /// unit / integration test suite can drive the low-disk-warning
@@ -877,8 +1090,17 @@ struct QuickstartView: View {
                 lowDiskCard(freeBytes: freeBytes, requiredBytes: requiredBytes)
             }
         case .downloading:
-            centeredCard(progressStep: 2) { downloadingCard }
-        case .starting, .ready:
+            centeredCard(progressStep: .download) { downloadingCard }
+        case .ready:
+            // Onboarding V3: readiness is a destination, not a hand-off.
+            // The surface stays here until the user confirms.
+            centeredCard(progressStep: .start) { readyCard }
+        case .dismissed:
+            // Terminal — the parent's visibility predicate has already
+            // dropped this surface. A one-frame race can still render here,
+            // so paint nothing rather than a step that is no longer true.
+            Color.clear
+        case .starting:
             // #1503: a serve handed off from Quickstart funnels through
             // ServerManager's pre-load memory guard. On a Mac under heavy
             // memory pressure the guard PARKS the load on
@@ -901,18 +1123,17 @@ struct QuickstartView: View {
                 // .ready is transitional — the parent swaps to ChatView, but
                 // a one-frame race can land here; the starting copy is a calm
                 // fallback so the user never sees a blank pane.
-                centeredCard(progressStep: 2) { startingCard }
+                centeredCard(progressStep: .start) { startingCard }
             }
-        case .failed(let message):
+        case .failed(let message, _):
             centeredCard(progressStep: nil) { failedCard(message: message) }
         }
     }
 
     /// The centered card chrome shared by the download-lifecycle states.
-    /// ``progressStep`` (0-indexed) shows the top progress bar on the
-    /// happy path (download / starting); ``nil`` omits it for the
-    /// low-disk / failed interstitials, where a "progress" bar would
-    /// misread.
+    /// ``progressStep`` shows the top progress bar on the happy path
+    /// (download / starting / ready); ``nil`` omits it for the low-disk /
+    /// failed interstitials, where a "progress" bar would misread.
     ///
     /// The card caps at 460pt but SHRINKS on a narrow detail pane rather
     /// than overflowing — ``QuickstartView`` lives in the split view's
@@ -922,7 +1143,7 @@ struct QuickstartView: View {
     /// the outer horizontal inset keeps the chrome inside the column.
     @ViewBuilder
     private func centeredCard<Content: View>(
-        progressStep: Int?,
+        progressStep: QuickstartCoordinator.Step?,
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(spacing: 0) {
@@ -1039,7 +1260,8 @@ struct QuickstartView: View {
             .accessibilityLabel("Skip onboarding and go to the app")
             .padding(.bottom, 18)
 
-            OnboardingStepProgress(current: 0, total: 3).padding(.bottom, 34)
+            OnboardingStepProgress(current: QuickstartCoordinator.Step.welcome.rawValue)
+                .padding(.bottom, 34)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 44)
@@ -1058,7 +1280,7 @@ struct QuickstartView: View {
         let lowMemoryChoices = choices.filter { $0.isLowMemory && !existingAliases.contains($0.alias) }
         let tradeUpChoices = choices.filter { $0.tier == .tradeUp && !existingAliases.contains($0.alias) }
         VStack(alignment: .leading, spacing: 0) {
-            OnboardingTopBar(step: 1).padding(.top, 22)
+            OnboardingTopBar(step: .chooseModel).padding(.top, 22)
 
             Text("Choose your first model")
                 .scaledSystemFont(24, relativeTo: .title, weight: .bold)
@@ -1264,6 +1486,63 @@ struct QuickstartView: View {
             .font(.callout)
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
+    }
+
+    /// The Ready confirmation screen — the end of Step 4 and the only
+    /// thing that ends onboarding.
+    ///
+    /// Deliberately minimal: this PR carries the BEHAVIOUR change (Ready is
+    /// persistent, completion is confirmed) and reuses the surrounding
+    /// wizard's existing components and styling so the contract can be
+    /// exercised and tested. The Direction D treatment of this screen —
+    /// the ready indicator, the amber primary sitting in the content
+    /// column, the type scale — belongs to the Onboarding visual PR, which
+    /// consumes this state rather than redefining it.
+    ///
+    /// No spinner, no progress, no countdown: the model IS ready, and
+    /// dressing the wait for a click as work would be a lie about what the
+    /// app is doing.
+    @ViewBuilder
+    private var readyCard: some View {
+        VStack(spacing: 16) {
+            Text("SETUP COMPLETE")
+                .scaledSystemFont(10, weight: .semibold)
+                .tracking(1.4)
+                .foregroundStyle(.tertiary)
+
+            Text("\(coordinator.selection.displayName) is ready.")
+                .font(.title3.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+                completeOnboarding()
+            } label: {
+                Text("Start chatting")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 2)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            // The native default action, not custom key handling: Return
+            // activates it and Space activates it while focused, both via
+            // AppKit's ordinary button semantics.
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("Quickstart.Ready.StartChatting")
+            .accessibilityLabel("Start chatting with \(coordinator.selection.displayName)")
+        }
+        .accessibilityIdentifier("Quickstart.Ready")
+    }
+
+    /// Run the Start chatting transaction.
+    ///
+    /// The coordinator half is authoritative and idempotent — it decides
+    /// whether this activation is the one that completes setup. The parent
+    /// half (route to Chat, announce, focus the composer) runs only on that
+    /// verdict, so a double activation cannot fire a second transition.
+    private func completeOnboarding() {
+        guard coordinator.confirmStartChatting(seedWelcome: onSeedWelcome) else { return }
+        onCompleted()
     }
 
     /// In-sheet twin of ContentView's memory-warning ``.alert`` (#1503).
@@ -1698,9 +1977,15 @@ struct QuickstartView: View {
                 )
             }
         case .cancelled:
-            coordinator.enterFailed(message: "Download was cancelled.")
+            coordinator.enterFailed(
+                message: "Download was cancelled.",
+                origin: .download
+            )
         case .failed(let message):
-            coordinator.enterFailed(message: QuickstartView.friendlyFailureMessage(raw: message))
+            coordinator.enterFailed(
+                message: QuickstartView.friendlyFailureMessage(raw: message),
+                origin: .download
+            )
         }
     }
 
@@ -1709,22 +1994,27 @@ struct QuickstartView: View {
         // user could click Get started, downloads finishes mid-flight,
         // ``server.start`` lands at ``.ready`` BEFORE the
         // download-status observer fired. Guard on the live state so
-        // both ordering paths converge on ``markReady``.
+        // both ordering paths converge on ``enterReady``.
         if case .ready(let alias) = server.state,
            alias == coordinator.selection.alias {
-            // Codex r3 MINOR + r4 MINOR: the completed Quickstart
-            // download job is dismissed inside the parent's
-            // ``seedQuickstartWelcome`` closure on the seed-landed
-            // branch. Centralising the dismiss inside the seed
-            // closure (rather than here on the seeded==true path)
-            // also covers the deferred-seed retry path: a later
-            // ``markReady(seed: seedQuickstartWelcome)`` invocation
-            // from the parent's ``store.activeID`` / ``server.state``
-            // observers lands the welcome AFTER this view has
-            // unmounted, so the view-site dismiss wouldn't fire.
-            _ = coordinator.markReady {
-                onSeedWelcome()
-            }
+            // Onboarding V3: this is the WHOLE readiness effect. Nothing is
+            // seeded, nothing is persisted and nothing is dismissed here —
+            // the user does that from the Ready screen. Repeat notifications
+            // (auto-respawn, residency tick) land on an idempotent no-op.
+            coordinator.enterReady()
+            return
+        }
+        // Relaunch into an unconfirmed Ready flow: the launch auto-start is
+        // bringing up the very model that flow was waiting on. Report Step 4
+        // truthfully while it loads instead of either fabricating Ready from
+        // the stored alias or leaving the user parked on the chooser while
+        // the app visibly works. If the load never lands, the crashed branch
+        // below and the ordinary chooser both remain reachable.
+        if case .starting(let alias) = server.state,
+           alias == coordinator.selection.alias,
+           coordinator.hasPendingReady,
+           case .idle = coordinator.phase {
+            coordinator.enterStarting()
             return
         }
         // Codex r2 BLOCKING: server moved on to a DIFFERENT alias
@@ -1748,7 +2038,13 @@ struct QuickstartView: View {
         if case .crashed(let alias, let message) = server.state,
            alias == coordinator.selection.alias,
            case .starting = coordinator.phase {
-            coordinator.enterFailed(message: QuickstartView.friendlyFailureMessage(raw: message))
+            // The weights are on disk; it is the load that failed. Keeping
+            // the origin means the rail still reads Step 4 rather than
+            // sending the user back through the download.
+            coordinator.enterFailed(
+                message: QuickstartView.friendlyFailureMessage(raw: message),
+                origin: .start
+            )
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -438,7 +438,6 @@ struct AccessibilityIdentifierInventoryTests {
                 #""Quickstart.Memory.SwitchToLowMemory""#,
                 #""Quickstart.Memory.LoadAnyway""#,
                 #""Quickstart.Memory.Cancel""#,
-                #""Quickstart.Ready""#,
                 #""Quickstart.Ready.StartChatting""#,
             ],
             in: "Sources/Rapid/UI/QuickstartView.swift",

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -417,6 +417,44 @@ struct AccessibilityIdentifierInventoryTests {
         )
     }
 
+    // MARK: - Onboarding
+
+    /// Onboarding's addressable controls, including the Ready surface added
+    /// with Onboarding V3.
+    ///
+    /// Ready matters more than the rest here: it is the one screen a golden
+    /// flow can now be *stuck* on. Readiness no longer dismisses setup, so a
+    /// harness that cannot find and press Start chatting never reaches the
+    /// app at all — it hangs on a screen that looks finished.
+    @Test("Onboarding names every step control, including the Ready confirmation")
+    func onboardingIdentifiers() throws {
+        try assertDeclared(
+            [
+                #""Quickstart.GetStarted""#,
+                #""Quickstart.Skip""#,
+                #""Quickstart.BrowseAll""#,
+                #""Quickstart.LowDisk.Continue""#,
+                #""Quickstart.LowDisk.Cancel""#,
+                #""Quickstart.Memory.SwitchToLowMemory""#,
+                #""Quickstart.Memory.LoadAnyway""#,
+                #""Quickstart.Memory.Cancel""#,
+                #""Quickstart.Ready""#,
+                #""Quickstart.Ready.StartChatting""#,
+            ],
+            in: "Sources/Rapid/UI/QuickstartView.swift",
+            surface: "Onboarding"
+        )
+        try assertDeclared(
+            [
+                #""Quickstart.Progress""#,
+                #""Quickstart.Footer.Back""#,
+                #""Quickstart.Footer.Primary""#,
+            ],
+            in: "Sources/Rapid/UI/OnboardingComponents.swift",
+            surface: "Onboarding components"
+        )
+    }
+
     /// The positive test above would still pass if someone re-added the
     /// container identifier, bringing the propagation bug back with it. Naming
     /// the wrapper is the mistake, so the absence has to be asserted directly.

--- a/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPickerBarSectionOrderTests.swift
@@ -281,11 +281,21 @@ struct ModelPickerBarSectionOrderTests {
         #expect(!ModelPickerBar.isQuickstartInFlight(phase: nil))
     }
 
-    @Test("isQuickstartInFlight: idle / ready / failed phases → off (CTA released)")
+    @Test("isQuickstartInFlight: idle / dismissed / failed phases → off (CTA released)")
     func inFlightTerminalPhasesOff() {
         #expect(!ModelPickerBar.isQuickstartInFlight(phase: .idle))
-        #expect(!ModelPickerBar.isQuickstartInFlight(phase: .ready))
-        #expect(!ModelPickerBar.isQuickstartInFlight(phase: .failed(message: "boom")))
+        #expect(!ModelPickerBar.isQuickstartInFlight(phase: .dismissed))
+        #expect(!ModelPickerBar.isQuickstartInFlight(
+            phase: .failed(message: "boom", origin: .download)
+        ))
+    }
+
+    @Test("isQuickstartInFlight: ready is in-flight — onboarding still owns the window")
+    func inFlightReadyAwaitsConfirmation() {
+        // Onboarding V3: ``.ready`` no longer means "handed off to chat".
+        // The setup surface is still up, full-window, waiting for Start
+        // chatting — so the picker's CTA stays gated.
+        #expect(ModelPickerBar.isQuickstartInFlight(phase: .ready))
     }
 
     @Test("isQuickstartInFlight: lowDisk / downloading / starting → on (CTA disabled)")
@@ -382,14 +392,14 @@ struct ModelPickerBarSectionOrderTests {
         }
     }
 
-    @Test("quickstartPhaseGateKey: ready / failed / idle all map to off half")
+    @Test("quickstartPhaseGateKey: dismissed / failed / idle all map to off half")
     func gateKeyOffAcrossInactivePhases() {
         let cat = makeCatalog()
         let keys = [
             ModelPickerBar.quickstartPhaseGateKey(phase: .idle, catalog: cat),
-            ModelPickerBar.quickstartPhaseGateKey(phase: .ready, catalog: cat),
+            ModelPickerBar.quickstartPhaseGateKey(phase: .dismissed, catalog: cat),
             ModelPickerBar.quickstartPhaseGateKey(
-                phase: .failed(message: "boom"),
+                phase: .failed(message: "boom", origin: .download),
                 catalog: cat
             ),
             ModelPickerBar.quickstartPhaseGateKey(phase: nil, catalog: cat),

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
@@ -1,0 +1,602 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Contract for the Onboarding V3 prerequisite behaviour change
+/// (Paper §05.1.G — "Four public steps, and Ready is confirmed",
+/// "Readiness does not dismiss setup", "Completion is what persists,
+/// not readiness").
+///
+/// Three things changed, and each of them is a way the app could quietly
+/// regress back to the ending this PR retires:
+///
+///   1. **Four public steps.** The progress model reports Welcome /
+///      Choose a model / Download / Start. Micro-states collapse into
+///      their macro step and a failure keeps the step that owns it, so
+///      nothing can quietly become a fifth step.
+///   2. **Ready is a destination.** Readiness parks onboarding on a
+///      stable screen. It writes no completion flag and dismisses
+///      nothing. The superseded behaviour — dismiss the moment a
+///      subprocess reports a listening port — is pinned as forbidden
+///      rather than merely unimplemented.
+///   3. **Completion is confirmed and idempotent.** Start chatting runs
+///      one transaction: seed once, persist once, retire the pending
+///      record, release the surface. Repeated readiness notifications
+///      and repeated activations are both no-ops.
+///
+/// The persistence half is deliberately paranoid: a stored alias is a
+/// claim about a previous launch, never evidence about this one.
+@MainActor
+@Suite("Onboarding V3 — four steps, persistent Ready, confirmed completion")
+struct OnboardingCompletionBehaviorTests {
+
+    /// A coordinator with every persisted key cleared, so a case never
+    /// inherits another case's flags through ``UserDefaults``.
+    private func makeCoordinator() -> QuickstartCoordinator {
+        let coord = QuickstartCoordinator()
+        coord._testingReset()
+        return coord
+    }
+
+    /// Drop every key this suite can write, including the ones a
+    /// deliberately "relaunched" coordinator leaves behind.
+    private func clearPersistedState() {
+        let coord = QuickstartCoordinator()
+        coord._testingReset()
+    }
+
+    // MARK: - 1. Four public steps
+
+    @Test("There are exactly four public steps, in order")
+    func fourPublicSteps() {
+        #expect(QuickstartCoordinator.Step.total == 4)
+        #expect(QuickstartCoordinator.Step.allCases == [
+            .welcome, .chooseModel, .download, .start
+        ])
+        #expect(QuickstartCoordinator.Step.welcome.displayNumber == 1)
+        #expect(QuickstartCoordinator.Step.chooseModel.displayNumber == 2)
+        #expect(QuickstartCoordinator.Step.download.displayNumber == 3)
+        #expect(QuickstartCoordinator.Step.start.displayNumber == 4)
+    }
+
+    @Test("Welcome is Step 1 of 4; the chooser is Step 2 of 4")
+    func welcomeAndChooserSteps() {
+        let coord = makeCoordinator()
+        #expect(coord.step == .welcome)
+        #expect(coord.step.displayNumber == 1)
+
+        coord.advanceToChooseModel()
+        #expect(coord.step == .chooseModel)
+        #expect(coord.step.displayNumber == 2)
+
+        coord.backToWelcome()
+        #expect(coord.step == .welcome)
+    }
+
+    @Test("Download is Step 3 — including its low-disk and failure micro-states")
+    func downloadIsStepThree() {
+        let coord = makeCoordinator()
+        coord.enterDownloading()
+        #expect(coord.step == .download)
+        #expect(coord.step.displayNumber == 3)
+
+        // Insufficient disk is a question about the pull the user just
+        // authorised, not a step of its own.
+        coord.cancelLowDiskWarning()
+        coord.enterLowDiskWarning(freeBytes: 1_000, requiredBytes: 5_000)
+        #expect(coord.step == .download)
+
+        // A broken pull must not move the rail — the user is still in
+        // Download, which is exactly where Retry puts them back.
+        coord.enterFailed(message: "network unreachable", origin: .download)
+        #expect(coord.step == .download)
+        #expect(coord.step.displayNumber == 3)
+    }
+
+    @Test("Starting and Ready are both Step 4 — including a load failure")
+    func startingAndReadyAreStepFour() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        #expect(coord.step == .start)
+        #expect(coord.step.displayNumber == 4)
+
+        coord.enterReady()
+        #expect(coord.step == .start)
+        #expect(coord.step.displayNumber == 4)
+
+        // The weights are on disk; only the load failed. Sending the user
+        // back to Step 3 would imply the download needs redoing.
+        coord.enterFailed(message: "could not load", origin: .start)
+        #expect(coord.step == .start)
+        #expect(coord.step.displayNumber == 4)
+    }
+
+    @Test("Every phase maps into the four steps — no failure becomes a fifth")
+    func noPhaseEscapesTheFourSteps() {
+        let phases: [QuickstartCoordinator.Phase] = [
+            .idle,
+            .lowDiskWarning(freeBytes: 1, requiredBytes: 2),
+            .downloading,
+            .starting,
+            .ready,
+            .dismissed,
+            .failed(message: "x", origin: .download),
+            .failed(message: "x", origin: .start),
+        ]
+        for phase in phases {
+            for stage in [QuickstartCoordinator.Stage.welcome, .chooseModel] {
+                let step = QuickstartCoordinator.step(phase: phase, stage: stage)
+                #expect(
+                    QuickstartCoordinator.Step.allCases.contains(step),
+                    "phase \(phase) escaped the four-step model"
+                )
+                #expect(step.displayNumber >= 1 && step.displayNumber <= 4)
+            }
+        }
+    }
+
+    @Test("No production surface still says 'of 3'")
+    func noThreeStepLanguageSurvives() throws {
+        // The step count now lives in exactly one constant, so a
+        // regression would have to reintroduce a literal. Grep for the
+        // shapes that could: an explicit `total: 3` argument, or a
+        // hard-coded three-step progress row.
+        for file in ["Sources/Rapid/UI/OnboardingComponents.swift",
+                     "Sources/Rapid/UI/QuickstartView.swift"] {
+            let body = try Self.strippedSource(file)
+            #expect(
+                !body.contains("total:3"),
+                "\(file) hard-codes a step total; it must read QuickstartCoordinator.Step.total"
+            )
+        }
+    }
+
+    // MARK: - 2. Readiness parks; it does not complete or dismiss
+
+    @Test("Readiness alone does NOT mark onboarding complete")
+    func readinessDoesNotComplete() {
+        let coord = makeCoordinator()
+        coord.enterDownloading()
+        coord.enterStarting()
+        coord.enterReady()
+
+        #expect(coord.phase == .ready)
+        #expect(!coord.done, "readiness must not write the completion flag")
+        #expect(
+            !UserDefaults.standard.bool(forKey: QuickstartCoordinator.storageKey),
+            "readiness must not persist completion"
+        )
+        #expect(!coord.hasSeededWelcome, "readiness must not seed the welcome message")
+    }
+
+    @Test("Readiness alone does NOT dismiss the onboarding surface")
+    func readinessDoesNotDismiss() {
+        // The superseded ending (Paper: "must not be re-introduced") let
+        // readiness release the window. The surface-retention rule is the
+        // single gate that decides, so pin it across every phase.
+        #expect(ContentView.quickstartRetainsSurface(phase: .ready),
+                "Ready must keep the full-window onboarding surface up")
+        #expect(ContentView.quickstartRetainsSurface(phase: .downloading))
+        #expect(ContentView.quickstartRetainsSurface(phase: .starting))
+        #expect(ContentView.quickstartRetainsSurface(
+            phase: .failed(message: "x", origin: .download)
+        ))
+        #expect(ContentView.quickstartRetainsSurface(
+            phase: .lowDiskWarning(freeBytes: 1, requiredBytes: 2)
+        ))
+        // Only the terminal states hand the window back.
+        #expect(!ContentView.quickstartRetainsSurface(phase: .dismissed))
+        #expect(!ContentView.quickstartRetainsSurface(phase: .idle))
+    }
+
+    @Test("Repeated readiness notifications are harmless")
+    func repeatedReadinessIsIdempotent() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+
+        // Auto-respawn cycle, residency tick, scheduler re-publish: the
+        // same serve can announce itself many times.
+        for _ in 0..<5 { coord.enterReady() }
+
+        #expect(coord.phase == .ready)
+        #expect(!coord.done)
+        #expect(coord.pendingReadyAlias == coord.selection.alias)
+
+        // And a late notification after the user has already finished must
+        // not drag them back onto a screen they dismissed.
+        var seeds = 0
+        _ = coord.confirmStartChatting { seeds += 1; return true }
+        #expect(coord.phase == .dismissed)
+        coord.enterReady()
+        #expect(coord.phase == .dismissed, "a late readiness tick must not resurrect Ready")
+        #expect(seeds == 1)
+    }
+
+    // MARK: - 3. Start chatting is one idempotent transaction
+
+    @Test("Start chatting completes exactly once and seeds exactly once")
+    func startChattingCompletesOnce() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        coord.enterReady()
+
+        var seeds = 0
+        var transitions = 0
+        func activate() {
+            if coord.confirmStartChatting(seedWelcome: { seeds += 1; return true }) {
+                transitions += 1
+            }
+        }
+
+        // A double-click, a Return that repeats, an accessibility
+        // double-activation: all reach the same entry point.
+        activate()
+        activate()
+        activate()
+
+        #expect(transitions == 1, "only the first activation may run the transition")
+        #expect(seeds == 1, "the welcome message must be seeded exactly once")
+        #expect(coord.done)
+        #expect(coord.hasSeededWelcome)
+        #expect(coord.phase == .dismissed)
+    }
+
+    @Test("Start chatting before Ready is a no-op")
+    func startChattingRequiresReady() {
+        let coord = makeCoordinator()
+        var seeds = 0
+        for phase in ["idle", "downloading", "starting"] {
+            switch phase {
+            case "downloading": coord.enterDownloading()
+            case "starting":    coord.enterStarting()
+            default:            break
+            }
+            #expect(!coord.confirmStartChatting { seeds += 1; return true })
+        }
+        #expect(seeds == 0)
+        #expect(!coord.done, "nothing outside Ready may complete onboarding")
+    }
+
+    @Test("Completion writes the persistent flag and clears pending provenance")
+    func completionClearsPendingProvenance() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        coord.enterReady()
+        #expect(coord.hasPendingReady, "Ready must record that a confirmation is owed")
+
+        _ = coord.confirmStartChatting { true }
+
+        #expect(coord.done)
+        #expect(UserDefaults.standard.bool(forKey: QuickstartCoordinator.storageKey))
+        #expect(!coord.hasPendingReady, "a confirmed flow owes no confirmation")
+        #expect(
+            UserDefaults.standard.string(forKey: QuickstartCoordinator.pendingReadyAliasKey) == nil,
+            "the pending record must be erased from disk, not just from memory"
+        )
+        clearPersistedState()
+    }
+
+    // MARK: - 4. Relaunch and persistence
+
+    @Test("Pending Ready survives a coordinator reconstruction")
+    func pendingReadySurvivesReconstruction() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        coord.enterReady()
+        #expect(coord.hasPendingReady)
+
+        // Same shape as a relaunch, and also as a SwiftUI re-mount that
+        // rebuilds the coordinator: the record must come from disk.
+        let next = QuickstartCoordinator()
+        #expect(next.hasPendingReady, "an unconfirmed Ready flow must survive")
+        #expect(next.pendingReadyAlias == coord.selection.alias)
+        #expect(next.selection.alias == coord.selection.alias,
+                "the restored flow must be about the same model")
+        #expect(!next.done, "an unconfirmed flow is not a completed one")
+        clearPersistedState()
+    }
+
+    @Test("Relaunch does NOT fabricate Ready from the stored alias alone")
+    func relaunchDoesNotFabricateReady() {
+        let coord = makeCoordinator()
+        let alias = coord.selection.alias
+        coord.enterStarting()
+        coord.enterReady()
+
+        let next = QuickstartCoordinator()
+        // The claim survived; the STATE did not. Nothing on this launch has
+        // yet said the model is up, so claiming Ready here would be the
+        // app inventing a readiness it has not observed.
+        #expect(next.phase == .idle, "a restored flow must not start in Ready")
+        #expect(next.phase != .ready)
+        #expect(next.hasPendingReady)
+        // It lands on the chooser with the pick restored — the ordinary
+        // setup path — rather than re-asking "would you like to begin?".
+        #expect(next.stage == .chooseModel)
+        #expect(next.selection.alias == alias)
+        clearPersistedState()
+    }
+
+    @Test("Relaunch with a genuinely ready model returns to the Ready screen")
+    func relaunchWithReadyModelReturnsToReady() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        coord.enterReady()
+        let alias = coord.selection.alias
+
+        let next = QuickstartCoordinator()
+        #expect(next.phase == .idle)
+        // This is the step the live server observer performs once
+        // ``ServerManager`` genuinely reports ``.ready`` for this alias on
+        // THIS launch — the evidence the stored record deliberately lacks.
+        next.enterReady()
+        #expect(next.phase == .ready, "a genuinely ready model returns to the confirmation screen")
+        #expect(next.selection.alias == alias)
+        #expect(!next.done, "returning to Ready must still not complete anything")
+        clearPersistedState()
+    }
+
+    @Test("Re-entering Ready is gated on the SERVED alias, not the stored one")
+    func readyReEntryIsGatedOnServedAlias() throws {
+        // The guard that stops a stored alias becoming a fabricated ready
+        // state lives in the view's server observer. Pin its shape: the
+        // ready branch must compare the served alias against the live
+        // selection before calling ``enterReady``.
+        let body = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
+        #expect(
+            body.contains("ifcase.ready(letalias)=server.state,alias==coordinator.selection.alias{coordinator.enterReady()"),
+            """
+            QuickstartView no longer enters Ready by comparing the SERVED \
+            alias against the current selection. Re-entering Ready from a \
+            stored alias alone would let onboarding claim a model is up \
+            without this launch ever observing it.
+            """
+        )
+    }
+
+    @Test("Changing to another model clears stale pending provenance")
+    func changingModelClearsPendingProvenance() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        coord.enterReady()
+        #expect(coord.hasPendingReady)
+
+        // Back out to the chooser and pick something else. The Ready record
+        // was about the OLD model; keeping it would offer to confirm a flow
+        // the user has walked away from.
+        coord.returnToChooser()
+        let other = QuickstartCoordinator.onboardingChoices.first {
+            $0.alias != coord.selection.alias
+        }
+        #expect(other != nil)
+        guard let other else { return }
+        coord.select(other)
+
+        #expect(coord.selection.alias == other.alias)
+        #expect(!coord.hasPendingReady, "a different model retires the old Ready record")
+        #expect(
+            UserDefaults.standard.string(forKey: QuickstartCoordinator.pendingReadyAliasKey) == nil
+        )
+        clearPersistedState()
+    }
+
+    @Test("Re-selecting the SAME model keeps the pending record")
+    func reselectingSameModelKeepsProvenance() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        coord.enterReady()
+        let same = coord.selection
+        coord.returnToChooser()
+        coord.select(same)
+        #expect(coord.hasPendingReady, "re-affirming the same pick is not a change of mind")
+        clearPersistedState()
+    }
+
+    @Test("Skip retires the pending record without claiming completion")
+    func skipClearsPendingWithoutCompleting() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        coord.enterReady()
+        #expect(coord.hasPendingReady)
+
+        coord.skipForNow()
+
+        #expect(!coord.hasPendingReady, "walking away answers the question Ready was asking")
+        #expect(!coord.done, "Skip must keep its existing meaning — onboarding is still owed")
+        #expect(
+            !UserDefaults.standard.bool(forKey: QuickstartCoordinator.storageKey)
+        )
+        clearPersistedState()
+    }
+
+    @Test("A fresh download retires a stale pending record")
+    func freshDownloadClearsPendingProvenance() {
+        let coord = makeCoordinator()
+        coord.enterStarting()
+        coord.enterReady()
+        #expect(coord.hasPendingReady)
+        coord.returnToChooser()
+        coord.enterDownloading()
+        #expect(!coord.hasPendingReady, "a fresh pull is a fresh flow")
+        clearPersistedState()
+    }
+
+    // MARK: - 5. Welcome seeding
+
+    @Test("The welcome message lands in the transcript exactly once")
+    func welcomeSeedsExactlyOnce() {
+        let chat = ChatViewModel(persistsConversations: false)
+        #expect(chat.messages.isEmpty)
+
+        #expect(chat.seedAssistantWelcome("Welcome aboard."))
+        #expect(chat.messages.count == 1)
+        #expect(chat.messages.first?.role == .assistant)
+        #expect(chat.messages.first?.content == "Welcome aboard.")
+        #expect(chat.messages.first?.status == .complete,
+                "a locally authored welcome must never render as a live stream")
+
+        // A second attempt must not append. In production the coordinator
+        // already guarantees one call; this is the defence in depth that
+        // makes a stray second call harmless rather than duplicating.
+        #expect(!chat.seedAssistantWelcome("Welcome aboard."))
+        #expect(chat.messages.count == 1)
+    }
+
+    @Test("Seeding never interrupts a conversation that already has content")
+    func welcomeNeverInterruptsAnExistingChat() {
+        let chat = ChatViewModel(persistsConversations: false)
+        chat.devSeedMessages([ChatMessage(role: .user, content: "hello")])
+        #expect(!chat.seedAssistantWelcome("Welcome aboard."))
+        #expect(chat.messages.count == 1, "no intro may be injected into somebody's chat")
+    }
+
+    @Test("Empty welcome copy is refused rather than appended blank")
+    func emptyWelcomeIsRefused() {
+        let chat = ChatViewModel(persistsConversations: false)
+        #expect(!chat.seedAssistantWelcome("   \n  "))
+        #expect(chat.messages.isEmpty)
+    }
+
+    // MARK: - 6. The completion transaction's wiring
+
+    @Test("Ready renders a Start chatting action with stable identifiers")
+    func readyRendersConfirmationAction() throws {
+        let body = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
+        #expect(body.contains(#".accessibilityIdentifier("Quickstart.Ready")"#),
+                "the Ready surface must be addressable by the golden-flow harness")
+        #expect(body.contains(#".accessibilityIdentifier("Quickstart.Ready.StartChatting")"#),
+                "the completion action must be addressable by the golden-flow harness")
+        #expect(body.contains(#"Text("Startchatting")"#),
+                "the Ready screen must offer the Start chatting action")
+        // The confirmation must run the coordinator transaction, not a
+        // local shortcut that bypasses seeding / persistence.
+        #expect(body.contains("coordinator.confirmStartChatting(seedWelcome:onSeedWelcome)"))
+        // No fake work between the click and the app.
+        #expect(!body.contains("case.ready:centeredCard(progressStep:.start){ProgressView"),
+                "Ready must not render a spinner — the model is already up")
+    }
+
+    @Test("Completion announces before it moves focus, and routes to Chat")
+    func completionAnnouncesThenFocuses() throws {
+        let body = try Self.strippedSource("Sources/Rapid/UI/ContentView.swift")
+        // Routing, announcement and focus all belong to the parent half of
+        // the transaction, in that order.
+        let handoff = "privatefuncfinishOnboardingHandoff(){section=.chat" +
+            #"VoiceOverAnnouncer.announce("Setupcomplete.Openingyourfirstchat.")"# +
+            "composerFocusRequest&+=1}"
+        #expect(
+            body.contains(handoff),
+            """
+            The onboarding completion handoff no longer routes to Chat, \
+            announces completion, and requests composer focus in that order. \
+            A VoiceOver user who hears the composer described before they \
+            hear that setup finished never learns their action worked.
+            """
+        )
+        // The parent half must be gated on the coordinator's verdict so a
+        // repeated activation cannot re-run the transition.
+        let view = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
+        #expect(
+            view.contains("guardcoordinator.confirmStartChatting(seedWelcome:onSeedWelcome)else{return}onCompleted()"),
+            "the parent transition must run only when the coordinator says it completed"
+        )
+    }
+
+    @Test("The composer focus request is plumbed from ContentView into ChatView")
+    func composerFocusIsPlumbed() throws {
+        let content = try Self.strippedSource("Sources/Rapid/UI/ContentView.swift")
+        #expect(content.contains("composerFocusRequest:composerFocusRequest"),
+                "ChatView must receive the focus request")
+        let chat = try Self.strippedSource("Sources/Rapid/UI/ChatView.swift")
+        #expect(chat.contains("varcomposerFocusRequest:Int=0"))
+        #expect(
+            chat.contains(".onChange(of:composerFocusRequest){_,requestinguardrequest!=0else{return}composeFocusToken&+=1}"),
+            "an external focus request must reach the composer's own focus token"
+        )
+    }
+
+    @Test("Skip clears pending provenance at the call site, not just in theory")
+    func skipIsWiredAtTheCallSite() throws {
+        let body = try Self.strippedSource("Sources/Rapid/UI/ContentView.swift")
+        #expect(body.contains("quickstart.skipForNow()"),
+                "the Skip callback must retire any pending Ready record")
+    }
+
+    // MARK: - 7. Behaviour outside this contract is untouched
+
+    @Test("Skip, cached-model, low-disk, memory-warning and browse paths still hold")
+    func adjacentBehaviourUnchanged() throws {
+        let body = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
+        // Skip is still the one genuine dismiss control, and still does not
+        // write the completion flag.
+        #expect(body.contains(#".accessibilityIdentifier("Quickstart.Skip")"#))
+        // Browse all models still routes to the Settings catalogue.
+        #expect(body.contains(#".accessibilityIdentifier("Quickstart.BrowseAll")"#))
+        #expect(body.contains("settingsRouter.beginQuickstartCatalogRoundTrip()"))
+        // The low-disk warning is still non-blocking with both exits.
+        #expect(body.contains(#".accessibilityIdentifier("Quickstart.LowDisk.Continue")"#))
+        #expect(body.contains(#".accessibilityIdentifier("Quickstart.LowDisk.Cancel")"#))
+        // The in-sheet memory decision (#1503) still exists in all three arms.
+        #expect(body.contains(#".accessibilityIdentifier("Quickstart.Memory.LoadAnyway")"#))
+        #expect(body.contains(#".accessibilityIdentifier("Quickstart.Memory.Cancel")"#))
+        #expect(body.contains(#".accessibilityIdentifier("Quickstart.Memory.SwitchToLowMemory")"#))
+        // A cached model still skips the download and goes straight to serve.
+        #expect(body.contains("privatefuncstartCachedModel(_cached:ModelEntry){coordinator.enterStarting()"))
+    }
+
+    @Test("A cached-model start still lands on Ready rather than completing itself")
+    func cachedModelStartStillRequiresConfirmation() {
+        // The cached path is a shorter route into the SAME serving
+        // lifecycle, so it must inherit the same ending: park on Ready,
+        // wait for the user.
+        let coord = makeCoordinator()
+        coord.enterStarting()          // startCachedModel's transition
+        coord.enterReady()             // server reports ready
+        #expect(coord.phase == .ready)
+        #expect(!coord.done, "a cached model must not complete onboarding on its own")
+        clearPersistedState()
+    }
+
+    @Test("The memory-warning decision is still owned by the sheet only while starting")
+    func memoryWarningOwnershipUnchanged() {
+        let alias = QuickstartCoordinator.defaultChoice.alias
+        let warning = ModelSizing.MemoryWarning(
+            alias: alias,
+            hfPath: nil,
+            isAutoRespawn: false,
+            severity: .unsafe,
+            footprintGB: 3.25,
+            freeGB: 0.7,
+            totalGB: 18
+        )
+        #expect(QuickstartView.memoryWarningToPresent(
+            phase: .starting, pending: warning, selectionAlias: alias
+        ) != nil)
+        // Ready is past the load — there is no parked decision to resolve,
+        // and the Ready screen must not be replaced by a stale warning.
+        #expect(QuickstartView.memoryWarningToPresent(
+            phase: .ready, pending: warning, selectionAlias: alias
+        ) == nil)
+        #expect(QuickstartView.memoryWarningToPresent(
+            phase: .dismissed, pending: warning, selectionAlias: alias
+        ) == nil)
+    }
+
+    // MARK: - Source helpers
+
+    private static var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // package root
+    }
+
+    /// Comment- and whitespace-stripped source, matching the canonical form
+    /// the rest of the suite's source-grep guards use. ViewInspector is not
+    /// in this target (#1492), so view wiring is pinned this way.
+    private static func strippedSource(_ relativePath: String) throws -> String {
+        let url = packageRoot.appendingPathComponent(relativePath)
+        let body = try String(contentsOf: url, encoding: .utf8)
+        return CapabilityChipRenderGateSourceGuardTests.stripCommentsAndWhitespace(body)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
@@ -462,10 +462,10 @@ struct OnboardingCompletionBehaviorTests {
     @Test("Ready renders a Start chatting action with stable identifiers")
     func readyRendersConfirmationAction() throws {
         let body = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
-        #expect(body.contains(#".accessibilityIdentifier("Quickstart.Ready")"#),
-                "the Ready surface must be addressable by the golden-flow harness")
         #expect(body.contains(#".accessibilityIdentifier("Quickstart.Ready.StartChatting")"#),
                 "the completion action must be addressable by the golden-flow harness")
+        #expect(!body.contains(#".accessibilityIdentifier("Quickstart.Ready")"#),
+                "a container identifier would overwrite the child button's AX identifier")
         #expect(body.contains(#"Text("Startchatting")"#),
                 "the Ready screen must offer the Start chatting action")
         // The confirmation must run the coordinator transaction, not a

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartViewTests.swift
@@ -155,7 +155,7 @@ struct QuickstartViewTests {
 
     // MARK: - State machine
 
-    @Test("State machine: idle → downloading → starting → ready seeds welcome once")
+    @Test("State machine: idle → downloading → starting → ready parks, confirm completes")
     func stateMachineHappyPath() {
         let coord = makeCoordinator()
         #expect(coord.phase == .idle)
@@ -169,54 +169,44 @@ struct QuickstartViewTests {
         #expect(coord.phase == .starting)
         #expect(!coord.done)
 
-        var seedCount = 0
-        let landed = coord.markReady { seedCount += 1; return true }
-        #expect(landed)
+        // Onboarding V3: readiness parks the flow, it does not finish it.
+        coord.enterReady()
         #expect(coord.phase == .ready)
-        #expect(coord.done, "markReady must flip the persistent done flag on success")
+        #expect(!coord.done, "readiness alone must NOT flip the persistent done flag")
+
+        var seedCount = 0
+        let completed = coord.confirmStartChatting { seedCount += 1; return true }
+        #expect(completed)
+        #expect(coord.phase == .dismissed)
+        #expect(coord.done, "Start chatting must flip the persistent done flag")
         #expect(seedCount == 1, "seed closure must fire exactly once")
 
-        // A second .ready notification (auto-respawn cycle, scheduler
-        // tick, etc.) must NOT re-seed the welcome message.
-        let landedAgain = coord.markReady { seedCount += 1; return true }
-        #expect(!landedAgain)
+        // A second activation (double click, repeated key) must not
+        // re-seed, re-write, or re-run the parent's transition.
+        let completedAgain = coord.confirmStartChatting { seedCount += 1; return true }
+        #expect(!completedAgain)
         #expect(seedCount == 1, "seed closure must not double-fire")
         #expect(coord.done)
     }
 
-    @Test("Codex r2 MAJOR: seed-returns-false must NOT flip done or hasSeededWelcome")
-    func seedFailureKeepsRetryDoorOpen() {
+    @Test("Seed that cannot land must not block the completion the user asked for")
+    func seedFailureStillCompletes() {
         let coord = makeCoordinator()
         coord.enterStarting()
-        // Simulate "no active session yet" — onSeedWelcome returns
-        // false; markReady must respect that and leave both gates
-        // open so a later .ready tick (after the user creates a
-        // session, or auto-restart finishes) can finish the seed.
-        let landed = coord.markReady { false }
-        #expect(!landed, "markReady must report failure when seed returned false")
-        #expect(!coord.done, "done must NOT flip when seed reported failure")
-        #expect(!coord.hasSeededWelcome, "hasSeededWelcome must NOT flip when seed reported failure")
-        #expect(coord.awaitingWelcomeSeed, "awaitingWelcomeSeed must flip so the parent's retry observer can fire")
-        // Phase still progresses so the visibility predicate's
-        // in-flight gate releases — the alternative (keep .starting)
-        // would lock the user out of chat indefinitely.
-        #expect(coord.phase == .ready)
-
-        // A later retry tick with a seed that succeeds completes the
-        // flow properly. Codex r3 MAJOR closure: ContentView's
-        // ``.onChange(of: store.activeID)`` observer fires this re-try
-        // when an active session finally lands — without that observer
-        // the user would be permanently denied the welcome message.
-        var retrySeedCount = 0
-        let retried = coord.markReady { retrySeedCount += 1; return true }
-        #expect(retried)
-        #expect(retrySeedCount == 1)
+        coord.enterReady()
+        // Simulate "the welcome could not be appended". The user pressed
+        // Start chatting; stranding them on a screen they just dismissed
+        // because a courtesy message failed would be strictly worse than
+        // starting without it.
+        let completed = coord.confirmStartChatting { false }
+        #expect(completed, "completion must not be gated on the welcome landing")
         #expect(coord.done)
-        #expect(coord.hasSeededWelcome)
-        #expect(!coord.awaitingWelcomeSeed, "awaitingWelcomeSeed must clear on successful seed")
+        #expect(coord.phase == .dismissed)
+        #expect(!coord.hasSeededWelcome, "hasSeededWelcome must NOT flip when the seed reported failure")
+        #expect(coord.awaitingWelcomeSeed, "a welcome that never landed is still owed")
     }
 
-    @Test("Codex r4 MAJOR: awaitingWelcomeSeed clears on revoke / fresh-Quickstart click")
+    @Test("awaitingWelcomeSeed clears on revoke / fresh-Quickstart click")
     func awaitingWelcomeSeedClearsOnIntentChange() {
         // Provenance scenario codex flagged: without the flag, a user
         // who dismissed Quickstart and later manually started
@@ -227,7 +217,8 @@ struct QuickstartViewTests {
         //      stale flag from a prior aborted flow
         let coord = makeCoordinator()
         coord.enterStarting()
-        _ = coord.markReady { false }
+        coord.enterReady()
+        _ = coord.confirmStartChatting { false }
         #expect(coord.awaitingWelcomeSeed)
 
         // Scenario 1: user clicks "or browse all models" or picks
@@ -238,7 +229,8 @@ struct QuickstartViewTests {
         // Reset and set it again to test the other clear path.
         coord._testingReset()
         coord.enterStarting()
-        _ = coord.markReady { false }
+        coord.enterReady()
+        _ = coord.confirmStartChatting { false }
         #expect(coord.awaitingWelcomeSeed)
 
         // Scenario 2: user clicks Get started AGAIN (kicks a fresh
@@ -250,15 +242,13 @@ struct QuickstartViewTests {
 
     @Test("Codex r5 MAJOR: awaitingWelcomeSeed persists across coordinator init")
     func awaitingSeedSurvivesRelaunch() {
-        // Quit-mid-flow scenario codex flagged: server reaches .ready,
-        // ServerManager persists lastServedAlias; user quits before
-        // activeID lands. Without persistence of awaitingWelcomeSeed,
-        // the next launch sees Quickstart ineligible (lastServedAlias
-        // == quickstart-alias) AND the in-memory flag is lost, so the
-        // welcome is permanently skipped. Persistence closes that gap.
+        // Quit-mid-flow scenario codex flagged: the welcome was owed but
+        // never landed, and the in-memory flag dies with the process.
+        // Persistence is what stops the message being skipped forever.
         let coord = makeCoordinator()
         coord.enterStarting()
-        _ = coord.markReady { false }
+        coord.enterReady()
+        _ = coord.confirmStartChatting { false }
         #expect(coord.awaitingWelcomeSeed)
 
         // Simulate process restart by constructing a fresh coordinator
@@ -273,12 +263,10 @@ struct QuickstartViewTests {
     func awaitingSeedRestoresNonDefaultSelectionAcrossRelaunch() {
         // #1524 regression: the deferred-seed path persists a flag but
         // ``selection`` is NOT persisted — a fresh coordinator re-inits it
-        // to ``defaultChoice`` (0.6B). Before the alias-persist fix, a
-        // user who picked a BIGGER model, reached ``.ready``, then quit
-        // before ``activeID`` landed would relaunch with ``selection`` at
-        // 0.6B; ContentView's seed observers compare the served alias
-        // (the bigger model) against ``selection.alias`` (0.6B), mismatch,
-        // and CLEAR the pending seed → welcome message permanently lost.
+        // to ``defaultChoice``. Before the alias-persist fix, a user who
+        // picked a BIGGER model and quit with the welcome still owed would
+        // relaunch with ``selection`` reset, and the welcome copy would
+        // name the wrong model.
         let bigger = QuickstartCoordinator.onboardingChoices.first { !$0.isStarter }
         #expect(bigger != nil, "onboarding ladder must offer a non-starter trade-up")
         guard let bigger else { return }
@@ -287,20 +275,20 @@ struct QuickstartViewTests {
         coord.select(bigger)
         #expect(coord.selection == bigger, "select() must retarget while idle")
         coord.enterStarting()
-        _ = coord.markReady { false }
+        coord.enterReady()
+        _ = coord.confirmStartChatting { false }
         #expect(coord.awaitingWelcomeSeed)
 
         // Simulate process restart: the fresh coordinator must restore
         // ``selection`` to the bigger pick (from the persisted alias), not
-        // fall back to the 0.6B default — otherwise the seed observers
-        // would drop the welcome for exactly this non-default flow.
+        // fall back to the default.
         let next = QuickstartCoordinator()
         #expect(next.awaitingWelcomeSeed, "flag must survive relaunch")
         #expect(next.selection.alias == bigger.alias,
                 "selection must be restored to the in-flight non-default pick, not reset to defaultChoice")
         #expect(next.selection == bigger, "the full restored choice must round-trip (name + isStarter drive the seed copy)")
         #expect(!next.seedMessage.contains(QuickstartCoordinator.defaultChoice.displayName),
-                "the welcome copy must name the restored model, not the 0.6B default")
+                "the welcome copy must name the restored model, not the default")
         next._testingReset()
     }
 
@@ -312,7 +300,8 @@ struct QuickstartViewTests {
         // deferred-seed state. Pin the public surface.
         let coord = makeCoordinator()
         coord.enterStarting()
-        _ = coord.markReady { false }
+        coord.enterReady()
+        _ = coord.confirmStartChatting { false }
         #expect(coord.awaitingWelcomeSeed)
         coord.clearPendingSeed()
         #expect(!coord.awaitingWelcomeSeed)
@@ -324,20 +313,18 @@ struct QuickstartViewTests {
     @Test("Codex r4 MAJOR: successful seed does NOT set awaitingWelcomeSeed (steady-state)")
     func successfulSeedNeverSetsAwaiting() {
         // The flag is supposed to be a provenance signal for the
-        // DEFERRED path only. A happy-path Quickstart whose seed lands
-        // on the first call must never raise the flag — otherwise the
-        // observer in ContentView would fire spuriously on the next
-        // activeID change (e.g. user creates a new chat after the
-        // flow completes).
+        // DEFERRED path only. A completion whose seed lands on the first
+        // call must never raise it.
         let coord = makeCoordinator()
         coord.enterStarting()
-        _ = coord.markReady { true }
+        coord.enterReady()
+        _ = coord.confirmStartChatting { true }
         #expect(coord.done)
         #expect(coord.hasSeededWelcome)
         #expect(!coord.awaitingWelcomeSeed)
     }
 
-    @Test("releaseInFlight: phase flips to ready WITHOUT seed or done")
+    @Test("releaseInFlight: phase dismisses WITHOUT seed or done")
     func releaseInFlightDoesNotCommit() {
         // Codex r2 BLOCKING: user clicks Get started, then picks a
         // DIFFERENT model from the still-visible picker. The
@@ -350,9 +337,10 @@ struct QuickstartViewTests {
         let coord = makeCoordinator()
         coord.enterStarting()
         coord.releaseInFlight()
-        #expect(coord.phase == .ready)
+        #expect(coord.phase == .dismissed)
         #expect(!coord.done, "releaseInFlight must NOT flip the persistent done flag")
         #expect(!coord.hasSeededWelcome)
+        #expect(!coord.hasPendingReady, "a revoked flow leaves no Ready confirmation owed")
     }
 
     @Test("serverEngagedWithDifferentAlias predicate truth table")
@@ -389,9 +377,10 @@ struct QuickstartViewTests {
     func failurePathPreservesEligibility() {
         let coord = makeCoordinator()
         coord.enterDownloading()
-        coord.enterFailed(message: "network unreachable")
-        if case .failed(let message) = coord.phase {
+        coord.enterFailed(message: "network unreachable", origin: .download)
+        if case .failed(let message, let origin) = coord.phase {
             #expect(message == "network unreachable")
+            #expect(origin == .download)
         } else {
             Issue.record("Expected .failed phase, got \(coord.phase)")
         }
@@ -423,11 +412,12 @@ struct QuickstartViewTests {
     func resetClearsEverything() {
         let coord = makeCoordinator()
         coord.markDone()
-        coord.enterFailed(message: "boom")
+        coord.enterFailed(message: "boom", origin: .download)
         coord._testingReset()
         #expect(!coord.done)
         #expect(coord.phase == .idle)
         #expect(!coord.hasSeededWelcome)
+        #expect(!coord.hasPendingReady)
     }
 
     // MARK: - Failure classifier (friendlyFailureMessage)
@@ -498,20 +488,21 @@ struct QuickstartViewTests {
 
     // MARK: - Regression: post-success handoff to ChatView
 
-    @Test("Codex r1 BLOCKING regression: .ready phase + done flag → eligibility predicate returns false")
+    @Test("Codex r1 BLOCKING regression: dismissed phase + done flag → eligibility predicate returns false")
     func readyPhaseAfterSuccessReportsNotEligible() {
-        // The integration bug codex flagged: after ``markReady`` fires
-        // ``done = true``, the parent view must stop rendering the
-        // Quickstart card and hand the frame off to ChatView. The
-        // eligibility predicate is the single gate the parent consults,
-        // so pin it: ``done == true`` immediately makes the predicate
-        // return ``false`` regardless of phase or other inputs.
+        // The integration bug codex flagged: once the flow is complete the
+        // parent view must stop rendering the Quickstart card and hand the
+        // frame off to ChatView. The eligibility predicate is the single
+        // gate the parent consults, so pin it: ``done == true`` immediately
+        // makes the predicate return ``false`` regardless of phase or other
+        // inputs.
         let coord = makeCoordinator()
         coord.enterDownloading()
-        _ = coord.markReady { true }
+        coord.enterReady()
+        _ = coord.confirmStartChatting { true }
         #expect(coord.done)
-        #expect(coord.phase == .ready)
-        // Even with ``.ready`` phase still set, an isEligible read on
+        #expect(coord.phase == .dismissed)
+        // Even with the terminal phase still set, an isEligible read on
         // a freshly idle server must report not-eligible — proving the
         // persistent done flag short-circuits ``isEligible`` and that
         // the ``.ready`` phase is NOT relied on as a sticky "keep card

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1072,13 +1072,13 @@ flow_cached_quickstart() {
     wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
     jq -e '.data.ui_elements[]?
             | select(.identifier == "Quickstart.Progress")
-            | select(.description == "Setup progress, step 1 of 3")' "$OUT/welcome.json" >/dev/null \
+            | select(.description == "Setup progress, step 1 of 4")' "$OUT/welcome.json" >/dev/null \
         || die "Quickstart welcome does not expose honest step progress"
     press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
     wait_identifier "Quickstart.CachedModel.$FAKE_ALIAS" "$OUT/chooser.json"
     jq -e '.data.ui_elements[]?
             | select(.identifier == "Quickstart.Progress")
-            | select(.description == "Setup progress, step 2 of 3")' "$OUT/chooser.json" >/dev/null \
+            | select(.description == "Setup progress, step 2 of 4")' "$OUT/chooser.json" >/dev/null \
         || die "Quickstart chooser does not advance its honest step progress"
     press "$OUT/chooser.json" "Quickstart.CachedModel.$FAKE_ALIAS" "$OUT/select-cached.json"
     see_main "$OUT/selected.json"
@@ -1096,7 +1096,26 @@ flow_cached_quickstart() {
         || die "dogfood launch terminated the operator-owned :8000 server (#1618)"
     curl -fsS http://127.0.0.1:8000/healthz >/dev/null \
         || die "operator-owned :8000 server stopped responding after dogfood launch"
+
+    # Ready is no longer completion: onboarding must hold the window until
+    # the user explicitly confirms the final step. Pin both halves so a
+    # future regression cannot silently restore the old auto-dismiss path.
+    wait_identifier Quickstart.Ready.StartChatting "$OUT/ready-confirmation.json"
+    jq -e '.data.ui_elements[]?
+            | select(.identifier == "Quickstart.Progress")
+            | select(.description == "Setup progress, step 4 of 4")' \
+        "$OUT/ready-confirmation.json" >/dev/null \
+        || die "Quickstart Ready does not report the final onboarding step"
+    # SwiftUI sheets expose the covered window's AX descendants as well, so
+    # the background composer may still be present in this tree. The Ready
+    # action itself is the reliable contract: old auto-dismiss builds never
+    # expose it, and this press is the only route that completes onboarding.
+    press "$OUT/ready-confirmation.json" Quickstart.Ready.StartChatting \
+        "$OUT/start-chatting.json"
     wait_identifier rapid.chat.compose "$OUT/ready.json"
+    assert_tree_text "$OUT/ready.json" "chatting with fake-alias, running entirely on your Mac."
+    [[ "$(jq '[.data.ui_elements[]? | select(.value? | strings | startswith("You’re chatting with fake-alias, running entirely on your Mac."))] | length' "$OUT/ready.json")" == 1 ]] \
+        || die "Quickstart welcome was not seeded exactly once after confirmation"
     if jq -e -s 'any(.[]; .event == "command" and .subcommand == "pull")' \
         "$OUT/fake-events.jsonl" >/dev/null; then
         die "cached Quickstart invoked rapid-mlx pull instead of the start-only path"


### PR DESCRIPTION
Behavior PR 1 of the Phase UI-2 Onboarding work. Implements the prerequisite contract from Paper §05.1.G so the later Onboarding V3 visual PR has something truthful to render. **No visual refresh is included** — see Scope.

## The problem

Readiness used to end onboarding by itself. The moment the sidecar reported a listening port, the app seeded a welcome message, wrote the completion flag, and dismissed the setup surface. The user was never asked and never confirmed.

Paper §05.1.G retires that ending explicitly — *"Kept for the record, not for build. This ending dismissed setup the moment the model reported ready, gave the user no control and left nothing to confirm … must not be re-introduced."* Readiness is something to **state**; completion is something to **confirm**.

## Four-step state model

The public progress model moves from three steps to four: **Welcome → Choose a model → Download → Start**.

Micro-states collapse into their macro step rather than becoming steps of their own:

| Step | Owns |
|---|---|
| 1 · Welcome | the hero |
| 2 · Choose a model | hardware detection, recommendation loading, recommended / cached / alternative choice, model review |
| 3 · Download | preparing, offline, insufficient disk, interrupted download, download failure, retry |
| 4 · Start | starting, memory confirmation while starting, Ready |

A failure keeps the macro step that owns it. `Phase.failed` carries a new `FailureOrigin`, so a broken pull still reports Step 3 and a load failure still reports Step 4 — a failure never becomes a fifth step, and the rail does not jump when something goes wrong.

The step count now lives in one constant (`QuickstartCoordinator.Step.total`) that every rail reads, and `OnboardingTopBar` takes a `Step` rather than a raw ordinal, so no screen can drift by miscounting. No `Step N of 3` language survives in production.

## Why Ready is now persistent

`Phase.ready` changes meaning: it **parks** onboarding and holds the full-window surface. It writes nothing and dismisses nothing. A new terminal `Phase.dismissed` absorbs the old release semantics (used by `releaseInFlight` when the user revises intent mid-flow).

`markReady(seed:)` is split in two:

- `enterReady()` — park only. Idempotent, and refuses to resurrect a flow already confirmed or released, so repeated readiness notifications (auto-respawn cycle, residency tick, scheduler re-publish) are no-ops.
- `confirmStartChatting(seedWelcome:)` — the completion transaction.

`ModelPickerBar.isQuickstartInFlight` follows the new meaning: `.ready` moved from *released* to *in-flight*, because the onboarding surface is still holding the whole window. Releasing the picker CTA there would claim ownership of a control the user cannot see.

## Exact `Start chatting` transaction order

Guarded on `Phase.ready`, so a double click, a repeated key activation, or a stray re-entry after completion returns `false` without seeding twice, re-writing the flag, or re-running the transition.

**Coordinator half** (authoritative, idempotent):
1. Ensure the intended chat session is the one on screen.
2. Seed the welcome message — exactly once.
3. Persist the completion flag.
4. Retire the pending-Ready record.
5. Release the surface (`phase = .dismissed`).

**Parent half** — runs only on a `true` verdict, so a repeated activation cannot re-fire it:

6. Restore the normal shell (same window, same size — no resize, no flash, no second window).
7. Route to Chat.
8. **Announce completion** via the existing `VoiceOverAnnouncer`.
9. **Request composer focus.**

The announcement is posted **before** the focus request: a VoiceOver user who hears the field described first never learns that the thing they just activated actually worked. No delay, no fake progress, no intermediate loading state after the click.

Return and Space activate the button through ordinary AppKit semantics; no custom key handling was added.

## Relaunch and persistence

A new key, `rapid.quickstart.v1.pendingReadyAlias`, records a flow that reached Ready without being confirmed. The existing completion key keeps its meaning but with a **narrowed writer** — it is now written only by the user's confirmation.

The stored alias is a claim about a previous launch, never evidence about this one:

- `init` restores the model and the chooser stage, but **never** `Phase.ready`.
- Ready is re-entered only when `ServerManager` genuinely reports `.ready` for that alias **on this launch**.
- If the model is no longer ready, the user lands on the ordinary chooser with their pick preselected. Nothing claims a download or a selection was "resumed", and no cross-relaunch byte-level download resume is promised.
- A relaunch auto-start of that same alias reports `.starting` truthfully as Step 4 rather than fabricating Ready.

The record is retired on confirmation, skip (including Esc / swipe-down, which the existing code already documents as the same intent), revoke, a fresh download, selecting another alias, and when the app serves a different model.

## Welcome-message deduplication

Seeding is **wired for the first time** — the closure was previously a stub that returned `true` and seeded nothing, so the welcome never actually reached production users.

Three independent guards: the coordinator calls the seed closure only from the confirmation transaction and only when `!hasSeededWelcome`; `ChatViewModel.seedAssistantWelcome` refuses to append into a transcript that already holds messages; and the message is written as a finished assistant turn, so it can never wedge the typing indicator or the streaming gate.

If the seed genuinely cannot land, completion still proceeds — the user asked to start chatting and must not be stranded on a screen they already dismissed — and `awaitingWelcomeSeed` records that a welcome is still owed.

## Focus and VoiceOver

`ChatView` gains a `composerFocusRequest` counter that routes through the existing `composeFocusToken`, so every focus request in that view (Send, ⌘L, onboarding completion) reaches the editor by one path. A counter rather than a Bool, so a second request is distinguishable and nothing needs resetting; `0` means "never asked", so a plain mount never steals focus.

## Automated tests

From the final rebased commit `960c69e7`:

- **Focused onboarding + affected suites: 203/203 pass** (`OnboardingCompletionBehaviorTests`, `QuickstartViewTests`, `AccessibilityIdentifierInventoryTests`, `ModelPickerBarSectionOrderTests`, `DiskSpaceProbeTests`, `QuickstartCachedModelTests`, `LaunchOnboardingOrderingTests`, `QuickstartBrowseAllDestinationTests`, `ChatComposeAccessibilityTests`, `ModelSwitchHistoryTests`, …).
- **Full suite: 2209 tests / 199 suites.** All pass except one pre-existing failure — see below.
- Clean release build; app bundle assembled and ad-hoc signed; `codesign --verify --deep --strict` passes.

30 new regression tests cover: four-step mapping; Download is Step 3; Starting and Ready are Step 4; every phase maps inside the four steps; no `of 3` language survives; readiness alone does not complete; readiness alone does not dismiss; repeated readiness is harmless; `Start chatting` completes exactly once; welcome seeded exactly once; repeated activation is harmless; activation outside Ready is a no-op; pending Ready survives reconstruction; relaunch with a genuinely ready model returns to Ready; relaunch without one does not fabricate Ready; Ready re-entry is gated on the served alias; completion clears provenance; changing alias clears stale provenance; skip clears provenance without completing; composer focus is requested after completion; announcement precedes focus; and that Skip, cached-model, low-disk, memory-warning, failure, and Browse-all behaviour are intact.

No test was weakened, skipped, deleted, or renamed to obtain a pass. Existing tests that asserted the *old* automatic-completion contract were rewritten to the new one, since that contract is what this PR deliberately changes.

### Pre-existing failing test — not a regression, and not a clean run

`ThroughputCaptionIntegrationTests` → *"The persisted stats separate prefill from decode on a real stream"* fails on this machine.

I verified it against clean `upstream/main` at the **identical base commit** (`3913de76`) in a separate worktree: it fails **3/3 there too**, with the same wall-clock ratio assertion. On this branch it also fails 3/3. It is a machine-speed-dependent throughput ratio assertion, unrelated to this change.

`DownloadCatalogHardeningTests` → *"ModelCatalog terminates catalog subprocesses when the async task is cancelled"* is intermittent (1 of 4 runs here), also pre-existing — a 1-second subprocess-teardown timeout.

Stating this plainly: **the final full-suite run is not clean.** The failures are pre-existing and reproduce on unmodified upstream, but I am not presenting the run as green.

## Manual verification

Verified end to end in a fresh, fully isolated installation — throwaway bundle identifier and preferences domain, throwaway `HOME` and Application Support, cold model cache, pinned high port with the launch port-sweep disabled — against a real bundled engine:

1. Welcome renders as **Step 1 of 4**.
2. Model selection renders as **Step 2 of 4**.
3. A real cold-cache download renders as **Step 3 of 4**.
4. Starting and Ready render as **Step 4 of 4**.
5. Ready stays visible and does not auto-dismiss.
6. `Start chatting` enters Chat in the same window.
7. The welcome message appears exactly once.
8. The composer receives focus.
9. **Quitting while on Ready and relaunching the same isolated install does not mark setup complete and does not jump to Chat.** The model starts truthfully and the app returns to Ready; `Start chatting` is still required.
10. After confirming, relaunching no longer shows onboarding.

## Scope

Deliberately **not** in this PR. Two were found while verifying it and are confirmed pre-existing on `upstream/main`:

- **Phantom `No` model row in an empty cache.** With no models downloaded, the engine prints `No models cached yet. Run 'rapid-mlx pull <alias>' …`, and `ModelCatalog.parseCached` splits it on single whitespace into `alias="No"`, `hfRepo="models"`, `size="cached yet."`. `parseAvailable` already guards against exactly this class (it rejects the same line); `parseCached` uses single-whitespace splitting by design and only has a banner guard that never anticipated this notice. Reproduced at parser level; producer and consumer are byte-identical to `upstream/main`. Affects every genuinely new user, so it matters — but it belongs to the next **model-selection/catalog Behavior PR**, in `ModelCatalog.parseCached` where the value is minted, not in an onboarding view.
- **Disappearing button labels on hover.** `RapidButtonStyles` paints the hover wash in an `.overlay` (above the label) while `RapidTheme.hoverFill` is fully opaque, so the text is erased on hover. Affects every `.rapidPrimary` / `.rapidSecondary` button app-wide. Untouched by this branch; belongs to the later **Visual PR**.

Also excluded: in-window `Browse all models`; model detail / storage confirmation; catalog & loading redesign; download cancellation / recovery changes; missing-engine routing; memory-compatibility recovery; Quickstart redesign; Settings and other unrelated surfaces.

**No Direction D / Onboarding V3 visual refresh is included.** The Ready view is deliberately minimal and built from existing components and styling, present only so the new behaviour can be exercised and tested. No Direction D tokens, colours, typography, spacing, rail, cards, animation, or responsive layout work. The visual PR consumes this contract and must not redefine it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
