### PR TITLE
fix(desktop): stop parsing the empty-cache notice as a phantom "No" model

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -770,10 +770,13 @@ enum ModelCatalog {
         return entries
     }
 
-    /// Log/banner lines the engine or its HTTP server can interleave
-    /// with table output. None of these are catalog rows, and every one
-    /// of them would otherwise yield a phantom alias from its first
-    /// token ("Loading", "INFO:", "Uvicorn", …).
+    /// Log/banner and catalog-notice lines the engine or its HTTP server
+    /// can share stdout with the table. None of these are catalog rows, and
+    /// every one of them would otherwise yield a phantom alias from its
+    /// first token ("Loading", "INFO:", "Uvicorn", "No", …).
+    ///
+    /// Shared by `parseCached` and `parseAvailable`, so a single entry here
+    /// fixes every consumer of the catalog (picker, Onboarding, Settings).
     ///
     /// Pure + `static` so the set is one list rather than a chain of
     /// `hasPrefix` calls buried in the parse loop.
@@ -793,6 +796,16 @@ enum ModelCatalog {
             "ERROR:",
             "Uvicorn running",
             "Traceback (",
+            // The empty-cache notice `rapid-mlx ls` prints in place of a
+            // "Cached models" table when the disk is cold:
+            //   "No models cached yet. Run 'rapid-mlx pull …' …"
+            // Its single-space prose tokenizes (parseCached splits on ANY
+            // whitespace) into alias "No", repo "models", size "cached yet." —
+            // a selectable phantom that dead-ends model start
+            // (raullenchai/Rapid-MLX#1918). Matching the full "No models
+            // cached yet" prefix (not the bare word "No") keeps a genuine
+            // alias named "No" — whose row is "No" + 2+ spaces + repo — safe.
+            "No models cached yet",
         ]
         return bannerPrefixes.contains { line.hasPrefix($0) }
     }

--- a/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
@@ -219,6 +219,48 @@ struct DownloadCatalogHardeningTests {
         #expect(!available.contains(where: { $0.0 == "Size" }))
     }
 
+    @Test("empty-cache notice never parses as a phantom \"No\" model (#1918)")
+    func emptyCacheNoticeIsNotAModel() {
+        // `rapid-mlx ls` prints this in place of a "Cached models" table when
+        // the disk is cold. Its single-space prose used to tokenize (parseCached
+        // splits on any whitespace) into a selectable phantom — alias "No",
+        // repo "models", size "cached yet." — that dead-ended model start.
+        let notice = """
+
+              No models cached yet. Run 'rapid-mlx pull <alias>' or 'rapid-mlx chat <alias>' to download one.
+
+            """
+        #expect(ModelCatalog.parseCached(notice).isEmpty)
+        #expect(ModelCatalog.parseAvailable(notice).isEmpty)
+    }
+
+    @Test("a genuine alias literally named \"No\" is not blacklisted (#1918)")
+    func genuineNoAliasIsNotBlacklisted() {
+        // The fix matches the full "No models cached yet" notice, never the
+        // bare word "No", so a real model whose alias happens to be "No"
+        // (row = "No" + 2+ spaces + repo) must still reach the catalog.
+        let cached = ModelCatalog.parseCached(
+            """
+              Cached models (1 on disk)
+              ────────────────────────────────────────
+              Alias                 HuggingFace repo                         Size
+              No                    mlx-community/No-Model-4bit               2 GB
+            """
+        )
+        #expect(cached.map { $0.0 } == ["No"])
+        #expect(cached.first?.1 == "mlx-community/No-Model-4bit")
+
+        let available = ModelCatalog.parseAvailable(
+            """
+              Available models (1 aliases)
+              ────────────────────────────────────────
+              Alias                 Family
+              No                    experimental
+            """
+        )
+        #expect(available.map { $0.0 } == ["No"])
+    }
+
     @Test("ModelInfoCatalog sanitizes repo ids before UI link construction")
     func modelInfoSanitizesHuggingFaceRepo() {
         let safe = ModelInfoCatalog.info(for: "qwen3-8b", hfRepo: "mlx-community/Qwen3-8B-4bit")


### PR DESCRIPTION
Closes #1918

## Why

When the model cache is cold, `rapid-mlx ls` prints

```
No models cached yet. Run 'rapid-mlx pull <alias>' or 'rapid-mlx chat <alias>' to download one.
```

in place of the "Cached models" table. `ModelCatalog.parseCached` splits rows on **any** whitespace (Rich leaves only a single space after a wide repo column, so it cannot use the 2+-space column split), so this single-space prose tokenized into a selectable catalog entry — alias `No`, repo `models`, size `cached yet.` — that surfaced in the model picker / Onboarding / Settings and dead-ended model start.

## What

- Add the full `No models cached yet` prefix to the shared `isBannerLine` filter. That filter is consulted by **both** `parseCached` and `parseAvailable`, so one entry fixes every catalog consumer.
- Match the whole notice prefix, **not** the bare word `No`, so a genuine alias literally named `No` — whose row is `No` + 2+ spaces + repo — is still parsed.

## Tests

Two regression tests in `DownloadCatalogHardeningTests`:

- `emptyCacheNoticeIsNotAModel` — the notice yields nothing from `parseCached` **and** `parseAvailable`.
- `genuineNoAliasIsNotBlacklisted` — a real `No` alias still parses (repo preserved) from both.

Prove-the-guard was run on the extracted parse logic (this box has CLT only, no Xcode/`Testing` module): reverting the fix reddens the notice test — `parseCached` emits `["No"]`. `swift build` is green. CI runs the full `swift test --no-parallel` on macos-15.