### PR TITLE
test(mac): cover empty-cache onboarding regression

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -770,10 +770,13 @@ enum ModelCatalog {
         return entries
     }
 
-    /// Log/banner lines the engine or its HTTP server can interleave
-    /// with table output. None of these are catalog rows, and every one
-    /// of them would otherwise yield a phantom alias from its first
-    /// token ("Loading", "INFO:", "Uvicorn", …).
+    /// Log/banner and catalog-notice lines the engine or its HTTP server
+    /// can share stdout with the table. None of these are catalog rows, and
+    /// every one of them would otherwise yield a phantom alias from its
+    /// first token ("Loading", "INFO:", "Uvicorn", "No", …).
+    ///
+    /// Shared by `parseCached` and `parseAvailable`, so a single entry here
+    /// fixes every consumer of the catalog (picker, Onboarding, Settings).
     ///
     /// Pure + `static` so the set is one list rather than a chain of
     /// `hasPrefix` calls buried in the parse loop.
@@ -793,6 +796,16 @@ enum ModelCatalog {
             "ERROR:",
             "Uvicorn running",
             "Traceback (",
+            // The empty-cache notice `rapid-mlx ls` prints in place of a
+            // "Cached models" table when the disk is cold:
+            //   "No models cached yet. Run 'rapid-mlx pull …' …"
+            // Its single-space prose tokenizes (parseCached splits on ANY
+            // whitespace) into alias "No", repo "models", size "cached yet." —
+            // a selectable phantom that dead-ends model start
+            // (raullenchai/Rapid-MLX#1918). Matching the full "No models
+            // cached yet" prefix (not the bare word "No") keeps a genuine
+            // alias named "No" — whose row is "No" + 2+ spaces + repo — safe.
+            "No models cached yet",
         ]
         return bannerPrefixes.contains { line.hasPrefix($0) }
     }

--- a/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadCatalogHardeningTests.swift
@@ -219,6 +219,48 @@ struct DownloadCatalogHardeningTests {
         #expect(!available.contains(where: { $0.0 == "Size" }))
     }
 
+    @Test("empty-cache notice never parses as a phantom \"No\" model (#1918)")
+    func emptyCacheNoticeIsNotAModel() {
+        // `rapid-mlx ls` prints this in place of a "Cached models" table when
+        // the disk is cold. Its single-space prose used to tokenize (parseCached
+        // splits on any whitespace) into a selectable phantom — alias "No",
+        // repo "models", size "cached yet." — that dead-ended model start.
+        let notice = """
+
+              No models cached yet. Run 'rapid-mlx pull <alias>' or 'rapid-mlx chat <alias>' to download one.
+
+            """
+        #expect(ModelCatalog.parseCached(notice).isEmpty)
+        #expect(ModelCatalog.parseAvailable(notice).isEmpty)
+    }
+
+    @Test("a genuine alias literally named \"No\" is not blacklisted (#1918)")
+    func genuineNoAliasIsNotBlacklisted() {
+        // The fix matches the full "No models cached yet" notice, never the
+        // bare word "No", so a real model whose alias happens to be "No"
+        // (row = "No" + 2+ spaces + repo) must still reach the catalog.
+        let cached = ModelCatalog.parseCached(
+            """
+              Cached models (1 on disk)
+              ────────────────────────────────────────
+              Alias                 HuggingFace repo                         Size
+              No                    mlx-community/No-Model-4bit               2 GB
+            """
+        )
+        #expect(cached.map { $0.0 } == ["No"])
+        #expect(cached.first?.1 == "mlx-community/No-Model-4bit")
+
+        let available = ModelCatalog.parseAvailable(
+            """
+              Available models (1 aliases)
+              ────────────────────────────────────────
+              Alias                 Family
+              No                    experimental
+            """
+        )
+        #expect(available.map { $0.0 } == ["No"])
+    }
+
     @Test("ModelInfoCatalog sanitizes repo ids before UI link construction")
     func modelInfoSanitizesHuggingFaceRepo() {
         let safe = ModelInfoCatalog.info(for: "qwen3-8b", hfRepo: "mlx-community/Qwen3-8B-4bit")

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -900,6 +900,8 @@ def _emit_catalog(subcommand, alias):
         print(f"{FAKE_IMAGE_ALIAS}       4.6 GiB    [image:both] {FAKE_IMAGE_REPO}")
         return True
     if subcommand == "ls":
+        if _setting("FAKE_EMPTY_CACHE_NOTICE") == "1":
+            print("No models cached yet. Run 'rapid-mlx pull <alias>' or 'rapid-mlx chat <alias>' to download one.")
         print("Cached models")
         print("Alias                  Repo                   Size")
         print("---------------------  ---------------------  ------")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1062,7 +1062,10 @@ flow_cached_quickstart() {
     kill -0 "$OPERATOR_SERVER_PID" 2>/dev/null \
         || die ":8000 was already occupied; cannot establish the owned-server isolation repro"
 
-    start_persona cached-quickstart
+    # Include the real cold-cache notice alongside the deterministic cached
+    # fixture. Catalog output can be interleaved with prose; the chooser must
+    # never promote that notice into a selectable model named "No" (#1918).
+    start_persona cached-quickstart FAKE_EMPTY_CACHE_NOTICE=1
 
     see_main "$OUT/consent.json"
     if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
@@ -1076,6 +1079,11 @@ flow_cached_quickstart() {
         || die "Quickstart welcome does not expose honest step progress"
     press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
     wait_identifier "Quickstart.CachedModel.$FAKE_ALIAS" "$OUT/chooser.json"
+    if jq -e '.data.ui_elements[]?
+              | select(.identifier == "Quickstart.CachedModel.No")' \
+        "$OUT/chooser.json" >/dev/null; then
+        die "empty-cache notice surfaced as a selectable model named No (#1918)"
+    fi
     jq -e '.data.ui_elements[]?
             | select(.identifier == "Quickstart.Progress")
             | select(.description == "Setup progress, step 2 of 4")' "$OUT/chooser.json" >/dev/null \


### PR DESCRIPTION
## Why\n\nBecause #1920 fixed the user-visible #1918 onboarding dead end, the GUI harness should prove that the real cold-cache notice never returns as a selectable model while a valid cached row remains usable.\n\nFollow-up GUI regression coverage for #1918 / #1920.

#1920 merged while this review was in progress, before this coverage commit reached its branch. This adds no product behavior and no dependencies:

- teach the existing fake sidecar to optionally interleave the real empty-cache notice with its deterministic cached rows;
- exercise that mode in the cached Quickstart golden flow;
- assert the notice never becomes `Quickstart.CachedModel.No`, while the real cached model remains selectable and completes onboarding.

Local verification:

- `bash -n scripts/fake-rapid-mlx.sh scripts/gui-golden-flows.sh`
- `RAPID_GUI_GOLDEN_OUT=<fresh-dir> scripts/gui-golden-flows.sh --flow cached-quickstart` — PASS

Supply-chain review: test harness only; no dependency, workflow, installer, network endpoint, binary, or executable-mode changes.