### PR TITLE
fix(mac): show resident image download activity

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -248,6 +248,18 @@ final class ServerManager {
     /// instead of a silent no-op (#1838).
     private(set) var residentLoadFailures: [String: ResidentLoadFailure] = [:]
 
+    /// Aliases currently being admitted through the in-process residency
+    /// endpoint. Unlike a cold process start, this work does not change the
+    /// global ``state`` to `.starting`, so surfaces need this alias-scoped
+    /// signal to acknowledge a Download & start tap immediately.
+    private(set) var residentLoadsInFlight: [String: Int] = [:]
+
+    func isResidentLoadInFlight(_ alias: String) -> Bool {
+        residentLoadsInFlight[
+            alias.trimmingCharacters(in: .whitespacesAndNewlines)
+        ] != nil
+    }
+
     /// The most recent rejection for `alias`, or `nil` if the last attempt
     /// for that model succeeded or no rejection has been recorded. Read by
     /// the surface that initiated the load so it can present the engine's
@@ -890,6 +902,19 @@ final class ServerManager {
         // need — audio runs as its own ``serve <alias>`` (audio-mode) process.
         let readyWithChild: Bool = { if case .ready = state, child != nil { return true }; return false }()
         if Self.residencyLoadApplies(residencyEligible: residencyEligible, readyWithChild: readyWithChild) {
+            // Publish before crossing the network await so SwiftUI replaces
+            // the still-pressable CTA with an honest working state in the
+            // same run-loop turn. Count rather than coalescing here: callers
+            // outside the GUI retain latest-attempt-wins concurrency semantics.
+            residentLoadsInFlight[trimmed, default: 0] += 1
+            defer {
+                let remaining = (residentLoadsInFlight[trimmed] ?? 1) - 1
+                if remaining == 0 {
+                    residentLoadsInFlight[trimmed] = nil
+                } else {
+                    residentLoadsInFlight[trimmed] = remaining
+                }
+            }
             let estimate = estimatedMemoryGB ?? ModelSizing.estimate(alias: trimmed).totalGB
             let result = await residencyClient.load(
                 alias: trimmed,

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -193,7 +193,18 @@ struct ImagesView: View {
     /// engine resident beside the chat engine; otherwise the shared resolver
     /// presents the same on-demand load guidance used by Chat.
     private var readiness: ModelReadiness {
-        ModelReadiness.resolve(
+        // In-process image admission leaves the chat sidecar globally
+        // `.ready`, so the generic resolver cannot infer that this alias is
+        // downloading/loading. Use ServerManager's alias-scoped SSOT; without
+        // it the CTA appears dead and remains repeatedly pressable while HF is
+        // already writing gigabytes to disk.
+        if server.isResidentLoadInFlight(viewModel.selectedAlias) {
+            return .starting(
+                alias: viewModel.selectedAlias,
+                detail: "Downloading or loading the image model…"
+            )
+        }
+        return ModelReadiness.resolve(
             serverState: server.readinessState(for: viewModel.selectedAlias),
             alias: viewModel.selectedAlias,
             cacheState: imageCacheState,
@@ -272,6 +283,10 @@ struct ImagesView: View {
             ),
             imageMode: viewModel.isEditing ? .editing : .generation
         )
+        // A cold resident load can change the cache while the sidecar stays
+        // globally ready. Refresh this surface so its cached/downloaded copy
+        // cannot remain stale after the request settles.
+        await viewModel.refreshCatalog()
     }
 
     private var sendEnabled: Bool {

--- a/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ResidentLoadFeedbackTests.swift
@@ -252,6 +252,24 @@ final class ResidentLoadRejectProtocol: URLProtocol, @unchecked Sendable {
 @MainActor
 @Suite("Resident-load rejection feedback", .serialized)
 struct ResidentLoadFeedbackTests {
+    @Test("Resident admission publishes alias-scoped working state immediately")
+    func publishesResidentLoadInFlightState() async {
+        defer { ResidentLoadRejectProtocol.reset() }
+        let server = makeServer()
+        let alias = "flux2-klein-4b"
+        ResidentLoadRejectProtocol.gateAlias = alias
+
+        let load = Task { @MainActor in
+            await server.ensureServing(alias: alias, hfPath: nil)
+        }
+        #expect(await pollUntil { ResidentLoadRejectProtocol.gateHasHeldOne })
+        #expect(server.isResidentLoadInFlight(alias))
+
+        ResidentLoadRejectProtocol.releaseGate()
+        _ = await load.value
+        #expect(!server.isResidentLoadInFlight(alias))
+    }
+
     /// The core defect (#1838): the engine returns an actionable reason, the
     /// ``ServerResidencyClient`` maps it to ``.rejected(detail)``, but the
     /// GUI layer previously dropped that result — the failure reached only the

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -614,6 +614,9 @@ class Handler(BaseHTTPRequestHandler):
                 body = {}
         target = body.get("model") if isinstance(body.get("model"), str) else ""
         _event("model_load", alias=target)
+        delay_ms = int(_setting("FAKE_RESIDENT_LOAD_DELAY_MS", "0") or "0")
+        if delay_ms > 0:
+            time.sleep(delay_ms / 1000)
         if _setting("FAKE_REJECT_IMAGE_LOAD") == "1" and target == FAKE_IMAGE_ALIAS:
             # The engine refuses to admit this model (missing Python extra).
             # Mirror the real server's rejection envelope so

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2681,7 +2681,8 @@ flow_image_generation() {
     log "  image-generation OK"
 }
 flow_resident_load_rejected() {
-    start_persona resident-load-rejected FAKE_REJECT_IMAGE_LOAD=1
+    start_persona resident-load-rejected FAKE_REJECT_IMAGE_LOAD=1 \
+        FAKE_RESIDENT_LOAD_DELAY_MS=1500
 
     dismiss_first_run
 
@@ -2751,6 +2752,19 @@ flow_resident_load_rejected() {
     # 4. The wire must show the load was ATTEMPTED in-process and REJECTED.
     wait_fake_event '.event == "model_load"' \
         "the Images action never issued an in-process /v1/models/load"
+
+    # The request is deliberately held open: the tap must immediately replace
+    # the CTA with a working state. Before this regression fix HF was already
+    # writing the checkpoint while the UI still said "isn't downloaded yet"
+    # and kept showing a pressable Download & start button.
+    see_main "$OUT/rlr-in-flight.json"
+    jq -e '[.data.ui_elements[]? | .value? | strings] | any(contains("Downloading or loading the image model"))' \
+        "$OUT/rlr-in-flight.json" >/dev/null \
+        || die "resident image download started without visible working feedback"
+    if jq -e '.data.ui_elements[]? | select(.identifier == "Readiness.Action")' \
+        "$OUT/rlr-in-flight.json" >/dev/null; then
+        die "Download & start remained pressable while its resident load was in flight"
+    fi
     wait_fake_event '.event == "model_load_rejected"' \
         "the fake did not reject the in-process image load (FAKE_REJECT_IMAGE_LOAD not applied)"
 


### PR DESCRIPTION
## Why

Clicking **Download & start** for an uncached image model already started the HF download, but the Images surface continued to say the model was not downloaded and kept the CTA visible. Users reasonably read the tap as a no-op and could press it again.

The root cause is that in-process residency admission leaves the global chat sidecar state `.ready`; Images only derived progress from global `.starting`, so it could not observe its own alias's load.

## What changed

- publish alias-scoped resident-load in-flight counts from `ServerManager`, preserving existing concurrent latest-attempt-wins behavior;
- render an immediate working state on Images while its selected alias is being downloaded or loaded, removing the repeated CTA;
- refresh the image catalog after the request settles so cached state does not remain stale;
- extend the real resident-load GUI golden flow with a delayed endpoint and assert the working message appears before the response, while `Readiness.Action` is absent.

## Validation

- `swift test --filter ResidentLoadFeedbackTests` — 6 passed
- `swift test --filter ModelReadinessTests` — 57 passed
- `bash -n scripts/fake-rapid-mlx.sh scripts/gui-golden-flows.sh`
- On Mac mini GUI session: `scripts/gui-golden-flows.sh --flow resident-load-rejected` — PASS
- `git diff --check`
