### PR TITLE
fix(mac): unify media model readiness and finalization

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -48,9 +48,18 @@ final class ImageGenViewModel {
         var longEdge: Int { rawValue }
     }
 
-    /// The two phases of a render, shown very differently: a reassuring
-    /// (indeterminate) cold-load, then a determinate denoise.
-    enum Phase: Equatable { case preparing, denoising }
+    /// User-visible phases of a render. A completed denoise is not a completed
+    /// request: VAE decode, image encoding, transport, and client decode still
+    /// happen after the final sampling step.
+    enum Phase: Equatable { case preparing, denoising, finalizing }
+
+    static func nextPhase(from current: Phase, progress: ImageClient.ImageProgress) -> Phase {
+        if progress.total > 0, progress.step >= progress.total {
+            return .finalizing
+        }
+        if progress.running { return .denoising }
+        return .preparing
+    }
 
     /// A few one-tap prompt starters to beat the blank page.
     static let starters: [String] = [
@@ -309,10 +318,11 @@ final class ImageGenViewModel {
                     port: port,
                     bearer: bearer
                 ) {
-                    self?.progress = snap
-                    self?.phase = snap.running ? .denoising : .preparing
-                    if snap.running, self?.denoiseStartedAt == nil {
-                        self?.denoiseStartedAt = Date()
+                    guard let self else { return }
+                    self.progress = snap
+                    self.phase = Self.nextPhase(from: self.phase, progress: snap)
+                    if snap.running, self.denoiseStartedAt == nil {
+                        self.denoiseStartedAt = Date()
                     }
                 }
                 try? await Task.sleep(for: .milliseconds(300))

--- a/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
@@ -26,6 +26,49 @@ struct AudioView: View {
     private let controlLabelWidth: CGFloat = 80
     private let controlFieldWidth: CGFloat = 320
 
+    private var selectedAlias: String {
+        viewModel.mode == .speech
+            ? viewModel.selectedSpeechAlias
+            : viewModel.selectedTranscriptionAlias
+    }
+
+    private var selectedEntry: ModelEntry? {
+        viewModel.audioModels.first { $0.alias == selectedAlias }
+    }
+
+    /// Audio uses the same lifecycle SSOT and CTA semantics as Chat and
+    /// Images: choose → Download & start / Start → ready.
+    private var readiness: ModelReadiness {
+        if server.isResidentLoadInFlight(selectedAlias) {
+            return .starting(alias: selectedAlias, detail: "Downloading or loading the audio model…")
+        }
+        let cacheState: ModelReadiness.CacheState
+        if selectedAlias.isEmpty || !viewModel.catalogLoaded {
+            cacheState = .catalogPending
+        } else if let selectedEntry {
+            cacheState = selectedEntry.cached ? .onDisk : .notOnDisk
+        } else {
+            cacheState = .notInCatalog
+        }
+        let progress: ModelReadiness.ProgressSnapshot? = if case .starting = server.state {
+            .init(
+                activity: server.downloadProgress.startupActivity,
+                subtitle: server.downloadProgress.progressSubtitle,
+                fraction: server.downloadProgress.progressFraction
+            )
+        } else { nil }
+        return ModelReadiness.resolve(
+            serverState: server.readinessState(for: selectedAlias),
+            alias: selectedAlias,
+            cacheState: cacheState,
+            sizeText: selectedEntry?.sizeOnDisk,
+            progress: progress,
+            failure: server.residentLoadFailure(for: selectedAlias).map {
+                .init(message: $0.message, alias: $0.alias)
+            }
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -55,7 +98,11 @@ struct AudioView: View {
             RapidSegmentedControl(
                 selection: $viewModel.mode,
                 options: AudioViewModel.Mode.allCases.map {
-                    .init(value: $0, title: $0.label)
+                    .init(
+                        value: $0,
+                        title: $0.label,
+                        identifier: "Audio.Mode.\($0.label)"
+                    )
                 },
                 accessibilityLabel: "Audio mode"
             )
@@ -119,6 +166,7 @@ struct AudioView: View {
                     entries: viewModel.transcriptionModels,
                     identifier: "Audio.Transcription.ModelPicker"
                 )
+                ReadinessBanner(readiness: readiness, onAction: handleReadinessAction)
                 swapNotice(alias: viewModel.selectedTranscriptionAlias)
                 operationNotice
                 HStack(spacing: RapidTheme.Space.md) {
@@ -138,6 +186,7 @@ struct AudioView: View {
                     .disabled(
                         viewModel.selectedFileURL == nil
                             || viewModel.selectedTranscriptionAlias.isEmpty
+                            || !readiness.sendAllowed
                             || viewModel.isBusy
                     )
                     .accessibilityIdentifier("Audio.Transcription.Run")
@@ -285,6 +334,7 @@ struct AudioView: View {
                 }
 
                 speechControls
+                ReadinessBanner(readiness: readiness, onAction: handleReadinessAction)
                 swapNotice(alias: viewModel.selectedSpeechAlias)
                 operationNotice
 
@@ -304,6 +354,7 @@ struct AudioView: View {
                     .disabled(
                         viewModel.speechText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             || viewModel.selectedSpeechAlias.isEmpty
+                            || !readiness.sendAllowed
                             || viewModel.isBusy
                     )
                     .accessibilityIdentifier("Audio.Speech.Generate")
@@ -348,7 +399,11 @@ struct AudioView: View {
                         Task { _ = await viewModel.loadVoices() }
                     }
                     .buttonStyle(.rapidSecondaryCompactUtility)
-                    .disabled(viewModel.selectedSpeechAlias.isEmpty || viewModel.isBusy)
+                    .disabled(
+                        viewModel.selectedSpeechAlias.isEmpty
+                            || !readiness.sendAllowed
+                            || viewModel.isBusy
+                    )
                     .accessibilityIdentifier("Audio.Speech.LoadVoices")
                     if viewModel.isLoadingVoices {
                         ProgressView().controlSize(.small)
@@ -549,6 +604,36 @@ struct AudioView: View {
     private func modelTitle(_ entry: ModelEntry) -> String {
         let status = entry.cached ? "Downloaded" : "Not downloaded"
         return "\(entry.alias) - \(status)"
+    }
+
+    private func handleReadinessAction(_ action: ModelReadiness.Action) {
+        switch action {
+        case .chooseModel:
+            break
+        case .downloadAndStart(let alias), .start(let alias), .retry(let alias):
+            Task { await loadAudioModel(alias) }
+        case .restart(let alias):
+            Task {
+                await server.stop()
+                await loadAudioModel(alias)
+            }
+        case .openModelManagement:
+            openModelManagement()
+        }
+    }
+
+    private func loadAudioModel(_ alias: String) async {
+        let entry = viewModel.audioModels.first { $0.alias == alias }
+        _ = await server.ensureServing(
+            alias: alias,
+            hfPath: entry?.hfRepo,
+            estimatedMemoryGB: ModelSizing.residentEstimateGB(
+                alias: alias,
+                sizeText: entry?.sizeOnDisk
+            ),
+            residencyEligible: false
+        )
+        await viewModel.refreshCatalog()
     }
 
     @ViewBuilder

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -303,6 +303,7 @@ struct ImagesView: View {
             let phase = (context.date.timeIntervalSinceReferenceDate
                 .truncatingRemainder(dividingBy: 1.6)) / 1.6
             let denoising = viewModel.phase == .denoising && viewModel.progress != nil
+            let finalizing = viewModel.phase == .finalizing
             let total = max(viewModel.progress?.total ?? 0, viewModel.estimatedSteps)
             let step = max(1, viewModel.progress?.step ?? 0)
             let fraction = (denoising && total > 0) ? min(1, Double(step) / Double(total)) : 0
@@ -315,7 +316,7 @@ struct ImagesView: View {
 
                 VStack(spacing: 14) {
                     HStack(spacing: 10) {
-                        if denoising {
+                        if denoising || finalizing {
                             // Breathing, and only when Reduce Motion is
                             // off: this is a perpetual loop, so it is
                             // fully suppressed rather than merely slowed.
@@ -335,7 +336,9 @@ struct ImagesView: View {
                                         ? 0.65 + 0.35 * (0.5 + 0.5 * sin(phase * .pi * 2))
                                         : 1
                                 )
-                            Text(viewModel.cancelling ? "Stopping…" : "Generating")
+                            Text(viewModel.cancelling
+                                 ? "Stopping…"
+                                 : (finalizing ? "Finalizing image…" : "Generating"))
                                 .font(.system(size: 14, weight: .semibold))
                                 .foregroundStyle(RapidTheme.bandInk)
                         } else {
@@ -368,7 +371,11 @@ struct ImagesView: View {
                         .accessibilityIdentifier("Images.Cancel")
                     }
 
-                    ShimmerProgressBar(fraction: fraction, indeterminate: !denoising, phase: phase)
+                    ShimmerProgressBar(
+                        fraction: fraction,
+                        indeterminate: !denoising || finalizing,
+                        phase: phase
+                    )
                         .frame(height: 10)
 
                     HStack {
@@ -381,9 +388,12 @@ struct ImagesView: View {
                         // otherwise cold-load time inflates the per-step estimate.
                         let denoiseElapsed = viewModel.denoiseStartedAt
                             .map { context.date.timeIntervalSince($0) } ?? elapsed
-                        Text(denoising
-                             ? (etaText(step: step, total: total, elapsed: denoiseElapsed) ?? "finishing…")
-                             : "First run — only happens once")
+                        Text(finalizing
+                             ? "Decoding and saving…"
+                             : (denoising
+                                ? (etaText(step: step, total: total, elapsed: denoiseElapsed)
+                                   ?? "Finalizing next…")
+                                : "First run — only happens once"))
                             .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(RapidTheme.bandInkSecondary)
                     }

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.speech.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.speech.txt
@@ -1,0 +1,51 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXGroup id="Audio.Mode" desc="Audio mode" enabled=true
+            AXButton id="Audio.Mode.Speech" desc="Speech" enabled=true
+            AXButton id="Audio.Mode.Transcription" desc="Transcription" enabled=true
+          AXScrollArea
+            AXHeading desc="Speech, Create spoken audio with a model and one of its built-in voices." enabled=true
+            AXHeading desc="Text" enabled=true
+            AXScrollArea
+              AXTextArea id="Audio.Speech.Text" desc="Text to speak" value=empty
+              AXScrollBar value=number enabled=false
+            AXStaticText value=text enabled=true
+            AXPopUpButton id="Audio.Speech.ModelPicker" desc="Model" value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Audio.Speech.VoicePicker" desc="Voice" value=empty enabled=false
+            AXButton id="Audio.Speech.LoadVoices" desc="Load Voices" enabled=false
+            AXStaticText value=text enabled=true
+            AXGroup enabled=true
+              AXSlider id="Audio.Speech.Speed" value=number enabled=true
+                AXValueIndicator value=number
+              AXStaticText value=text enabled=true
+            AXGroup desc="fake-qwen3-tts isn't downloaded yet, It downloads once (<size>), then starts in seconds." enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="Readiness.Action" desc="Download & start" enabled=true
+            AXButton id="Audio.Speech.Generate" desc="Generate Speech" enabled=false
+      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+      AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.transcription.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.transcription.txt
@@ -1,0 +1,42 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXGroup id="Audio.Mode" desc="Audio mode" enabled=true
+            AXButton id="Audio.Mode.Speech" desc="Speech" enabled=true
+            AXButton id="Audio.Mode.Transcription" desc="Transcription" enabled=true
+          AXScrollArea
+            AXHeading desc="Transcription, Turn a local recording into text without uploading it." enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Audio.Transcription.FilePicker" desc="Choose File" enabled=true
+            AXStaticText value=text enabled=true
+            AXPopUpButton id="Audio.Transcription.ModelPicker" desc="Model" value=text enabled=true
+            AXGroup desc="fake-whisper-small isn't downloaded yet, It downloads once (<size>), then starts in seconds." enabled=true
+              AXStaticText value=text enabled=true
+              AXStaticText value=text enabled=true
+              AXButton id="Readiness.Action" desc="Download & start" enabled=true
+            AXButton id="Audio.Transcription.Run" desc="Transcribe" enabled=false
+      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+      AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
@@ -1,0 +1,47 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
+          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXStaticText value=text enabled=true
+          AXButton id="Images.Cancel" desc="Close" help="Cancel" enabled=true
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXScrollArea id="Images.Prompt"
+            AXTextArea id="rapid.images.compose" desc="Image prompt field" value=text
+          AXButton id="Images.Aspect" desc="1:1" enabled=true
+          AXButton id="Images.Aspect" desc="3:4" enabled=true
+          AXButton id="Images.Aspect" desc="4:3" enabled=true
+          AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 1024 × 1024" value=text enabled=true
+          AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=false
+          AXPopUpButton id="Images.ModelPicker" desc="fake-image-alias" help="Model: fake-image-alias" enabled=false
+          AXButton id="Images.Generate" desc="Stop" help="Cancel" enabled=true
+      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+      AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
@@ -28,7 +28,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect" desc="4:3" enabled=true
           AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 1024 × 1024" value=text enabled=true
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=false
-          AXPopUpButton id="Images.ModelPicker" desc="fake-image-alias" help="Model: fake-image-alias" enabled=false
+          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=false
           AXButton id="Images.Generate" desc="Stop" help="Cancel" enabled=true
       AXButton desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
@@ -17,7 +17,7 @@ AXApplication title="Rapid-MLX"
           AXStaticText id="Sidebar.Residency" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
-          AXBusyIndicator value=number enabled=true
+          AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
           AXButton id="Images.Cancel" desc="Close" help="Cancel" enabled=true
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import Rapid
+
+@Suite("Image generation phase semantics")
+@MainActor
+struct ImageGenerationPhaseTests {
+    @Test("The final denoise step becomes finalizing until the response lands")
+    func completedDenoiseFinalizes() {
+        let final = ImageClient.ImageProgress(
+            running: false, step: 4, total: 4, elapsedMs: 1_000
+        )
+        #expect(ImageGenViewModel.nextPhase(from: .denoising, progress: final) == .finalizing)
+        #expect(ImageGenViewModel.nextPhase(from: .finalizing, progress: final) == .finalizing)
+        #expect(ImageGenViewModel.nextPhase(from: .preparing, progress: final) == .finalizing)
+        let finalStillRunning = ImageClient.ImageProgress(
+            running: true, step: 4, total: 4, elapsedMs: 1_000
+        )
+        #expect(
+            ImageGenViewModel.nextPhase(from: .denoising, progress: finalStillRunning)
+                == .finalizing
+        )
+    }
+
+    @Test("Idle progress before sampling remains preparation")
+    func idleProgressPrepares() {
+        let idle = ImageClient.ImageProgress(
+            running: false, step: 0, total: 0, elapsedMs: 0
+        )
+        #expect(ImageGenViewModel.nextPhase(from: .preparing, progress: idle) == .preparing)
+    }
+}

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -543,7 +543,7 @@ class Handler(BaseHTTPRequestHandler):
         if self.path == "/v1/models/residency":
             self._json(200, self._residency_snapshot())
             return
-        if self.path == "/v1/images/progress":
+        if self.path.partition("?")[0] == "/v1/images/progress":
             # Polled every few hundred ms while a render is in flight. Answer
             # it even when nothing is running: the client treats a transport
             # failure and "idle" identically, so a 404 here would be
@@ -697,6 +697,10 @@ class Handler(BaseHTTPRequestHandler):
             if RENDERS.advance():
                 cancelled = True
                 break
+        # Real image engines still perform VAE decode / PNG encoding after the
+        # last denoise step. Keep that tail observable for GUI phase coverage.
+        finish_ms = max(0, int(_setting("FAKE_IMAGE_FINISH_MS", 0)))
+        time.sleep(finish_ms / 1000)
         RENDERS.end()
         png = _one_pixel_png(((index * 70) % 256, (index * 130) % 256, (index * 190) % 256))
         encoded = base64.b64encode(png).decode("ascii")
@@ -901,6 +905,12 @@ def _emit_catalog(subcommand, alias):
         print("Alias                  Size       Kind        HF id")
         print("---------------------  ---------  ----------  ------")
         print(f"{FAKE_IMAGE_ALIAS}       4.6 GiB    [image:both] {FAKE_IMAGE_REPO}")
+        print()
+        print("Audio models (2 aliases)")
+        print("Alias                  Size       Kind        Family      HF id")
+        print("---------------------  ---------  ----------  ----------  ------")
+        print("fake-qwen3-tts         1.1 GiB    [audio:tts] qwen3_tts   fake/qwen3-tts")
+        print("fake-whisper-small     461 MiB    [audio:stt] whisper     fake/whisper-small")
         return True
     if subcommand == "ls":
         if _setting("FAKE_EMPTY_CACHE_NOTICE") == "1":
@@ -923,6 +933,8 @@ def _emit_catalog(subcommand, alias):
         repo = {
             FAKE_IMAGE_ALIAS: FAKE_IMAGE_REPO,
             "fake-video-alias": "fake/video-mlx",
+            "fake-qwen3-tts": "fake/qwen3-tts",
+            "fake-whisper-small": "fake/whisper-small",
         }.get(alias, FAKE_REPO)
         print(f"Alias: {alias} -> {repo}")
         return True

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -40,7 +40,7 @@ Flows: fresh-install, cached-quickstart, download-progress, settings-persistence
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, window-close-prompt, no-dead-controls, catalog-integrity,
-       browse-all-destination, image-generation, all
+       browse-all-destination, image-generation, audio-readiness, all
 
 download-progress, chat-restore, chat-depth, slow-stream-stop, model-crash-recovery,
 restored-tools, tool-loop-budget and image-generation drive the app through
@@ -100,7 +100,7 @@ flow_requires_screen_recording() {
 flow_requires_peekaboo() {
     case "$FLOW" in
         cached-quickstart|download-progress|settings-persistence|chat-restore|restored-tools|tool-loop-budget|chat-depth|math-rendering) return 1 ;;
-        slow-stream-stop|model-crash-recovery|image-generation|window-close-prompt|resident-load-rejected) return 1 ;;
+        slow-stream-stop|model-crash-recovery|image-generation|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
         *) return 0 ;;
     esac
 }
@@ -2254,7 +2254,10 @@ flow_image_generation() {
     # key events on an unattended CI runner. The golden-mode gate means a real
     # user's launch — which never sets it — always gets the picker even if an
     # unrelated process leaked an import path into the environment.
+    # AX baseline normalization itself takes several seconds on a busy mini;
+    # keep the synthetic decode tail long enough to observe after it.
     start_persona image-generation FAKE_IMAGE_STEPS=8 FAKE_IMAGE_STEP_MS=300 \
+        FAKE_IMAGE_FINISH_MS=15000 \
         RAPID_GUI_GOLDEN_MODE=1 \
         RAPID_SIMULATED_IMPORT_PATH="$ROOT/Tests/RapidTests/__Snapshots__/cheetah-logo-96.png"
 
@@ -2342,6 +2345,22 @@ flow_image_generation() {
     [[ "$inflight" == 1 ]] \
         || die "no in-flight progress card: Images.Cancel never appeared during a render"
     baseline image-generation.inflight "$OUT/ig-inflight.json"
+
+    # Sampling completion is followed by VAE decode / encoding. That tail must
+    # be a named indeterminate phase, not a full 8/8 bar that appears stuck.
+    local finalizing=0
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/ig-finalizing.json"
+        if jq -e '.data.ui_elements[]?
+                  | select((.value // .label // "") == "Finalizing image…")' \
+               "$OUT/ig-finalizing.json" >/dev/null; then
+            finalizing=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$finalizing" == 1 ]] \
+        || die "the post-denoise tail never showed Finalizing image…"
+    baseline image-generation.finalizing "$OUT/ig-finalizing.json"
 
     wait_fake_event '.event == "image_request"' \
         "no image_request reached the sidecar — the prompt was never sent"
@@ -2819,6 +2838,54 @@ flow_launch_integrations() {
     cleanup_persona
 }
 
+flow_audio_readiness() {
+    log "flow: audio-readiness"
+    start_persona audio-readiness
+    dismiss_first_run
+    see_main "$OUT/chat.json"
+    press "$OUT/chat.json" Sidebar.Audio "$OUT/speech.json" \
+        || die "Sidebar.Audio is not pressable"
+
+    local i speech_ready=0
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/speech.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "Audio.Speech.ModelPicker")' "$OUT/speech.json" >/dev/null \
+           && jq -e '.data.ui_elements[]?
+                     | select(.identifier == "Readiness.Action"
+                              and (.description // .value // .label // "") == "Download & start")' \
+                    "$OUT/speech.json" >/dev/null; then
+            speech_ready=1; break
+        fi
+        sleep 0.25
+    done
+    [[ "$speech_ready" == 1 ]] \
+        || die "Speech did not expose Chat-equivalent Download & start readiness"
+    baseline audio-readiness.speech "$OUT/speech.json"
+
+    press "$OUT/speech.json" Audio.Mode.Transcription "$OUT/transcription.json" \
+        || die "Audio transcription segment is not pressable"
+    local transcription_ready=0
+    for ((i=0; i<40; i++)); do
+        see_main "$OUT/transcription.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "Audio.Transcription.ModelPicker")' \
+                 "$OUT/transcription.json" >/dev/null \
+           && jq -e '.data.ui_elements[]?
+                     | select(.identifier == "Readiness.Action"
+                              and (.description // .value // .label // "") == "Download & start")' \
+                    "$OUT/transcription.json" >/dev/null; then
+            transcription_ready=1; break
+        fi
+        sleep 0.25
+    done
+    [[ "$transcription_ready" == 1 ]] \
+        || die "Transcription did not expose Chat-equivalent Download & start readiness"
+    baseline audio-readiness.transcription "$OUT/transcription.json"
+    log "  audio-readiness OK"
+    cleanup_persona
+}
+
 
 if [[ -d "$OUT_ROOT" && -n "$(ls -A "$OUT_ROOT" 2>/dev/null)" ]]; then
     RESULT_WRITTEN=1
@@ -2845,6 +2912,7 @@ case "$FLOW" in
     catalog-integrity) flow_catalog_integrity ;;
     browse-all-destination) flow_browse_all_destination ;;
     image-generation) flow_image_generation ;;
+    audio-readiness) flow_audio_readiness ;;
     resident-load-rejected) flow_resident_load_rejected ;;
     launch-integrations) flow_launch_integrations ;;
     all)
@@ -2866,6 +2934,7 @@ case "$FLOW" in
         flow_catalog_integrity
         flow_browse_all_destination
         flow_image_generation
+        flow_audio_readiness
         flow_resident_load_rejected
         flow_launch_integrations
         ;;

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -99,6 +99,7 @@ def test_peekaboo_requirement_is_default_deny():
         "slow-stream-stop",
         "model-crash-recovery",
         "image-generation",
+        "audio-readiness",
         "window-close-prompt",
         "resident-load-rejected",
     }


### PR DESCRIPTION
## What changed

- Give Speech and Transcription the same shared ModelReadiness lifecycle and Download & start / Start actions as Chat and Images.
- Gate audio operations on actual model readiness and refresh the catalog after a load.
- Add an explicit image finalization phase after the last diffusion step, with indeterminate progress and decoding copy.
- Fix the fake image progress endpoint to accept the real query-string request and add GUI golden coverage for image finalization plus both audio modes.

## Why

These surfaces must share one lifecycle contract because diverging cache and readiness semantics leave users unable to start cold media models and make completed sampling look stuck.

## Root cause

Audio exposed cache status in its picker but never rendered the shared readiness action, leaving cold models unreachable. Image progress treated the last diffusion step as request completion even though VAE decode, encoding, transport, and client decode were still running.

## Validation

- `swift test --filter ImageGenerationPhaseTests`
- Full Swift suite: 2,213/2,214 passed; one unrelated Throughput timing test flaked and is unchanged by this diff.
- mac-mini release build with `SKIP_SIDECAR=1`
- mac-mini GUI golden: `image-generation` PASS
- mac-mini GUI golden: `audio-readiness` PASS for Speech and Transcription

