### PR TITLE
fix(mac): reference off-PATH sidecar binary in Connect agents launch commands

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -16,6 +16,15 @@ struct ConnectToolsView: View {
     let port: Int
     let bearer: String
     let alias: String
+    /// The absolute path to the `rapid-mlx` sidecar binary this app owns
+    /// (``ServerLocator`` resolution). The Desktop app deliberately does NOT
+    /// install its sidecar onto the user's `PATH` (see ``ServerLocator`` —
+    /// PATH/brew/pipx/uv are intentionally not used), so generated launch
+    /// commands must reference the binary by its absolute path or pasting
+    /// them in a terminal fails with `command not found: rapid-mlx`.
+    /// ``nil`` (the dev snapshot harness) falls back to the bare `rapid-mlx`
+    /// so the page still renders.
+    var binaryPath: URL? = nil
     var onClose: () -> Void
     /// Whether to render the top-right dismiss "✕". True in sheet context
     /// (the caller's ``onClose`` dismisses the sheet). False when embedded
@@ -41,6 +50,24 @@ struct ConnectToolsView: View {
     private var openAIBaseURL: String { "http://\(host):\(port)/v1" }
     private var anthropicBaseURL: String { "http://\(host):\(port)" }
     private var serverOrigin: String { "http://\(host):\(port)" }
+
+    /// The shell command that invokes this app's `rapid-mlx` sidecar.
+    ///
+    /// The sidecar never lands on the user's `PATH` (see ``binaryPath``), so
+    /// the copied launch/agent commands must call it by absolute path. When
+    /// no binary is resolved (dev snapshot) we fall back to the bare command.
+    private var cliCommand: String {
+        guard let binary = binaryPath else { return "rapid-mlx" }
+        return Self.shellQuote(binary.path)
+    }
+
+    /// Single-quote a shell word so spaces / special characters in an
+    /// absolute path (e.g. "Application Support") can't break a pasted
+    /// command. Embedded single quotes are escaped by closing, backslash-
+    /// escaping, and reopening.
+    static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
 
     /// The model id to publish in a config, or ``nil`` when no real
     /// model is resolved yet. Deliberately not defaulted to a
@@ -247,14 +274,14 @@ struct ConnectToolsView: View {
             let displayCommand: String
             if isWriter {
                 command = IntegrationLaunchCommand.configWriter(
-                    id: target.id, serverURL: serverOrigin, key: snippetKey, model: snippetModel
+                    id: target.id, serverURL: serverOrigin, key: snippetKey, model: snippetModel, cli: cliCommand
                 )
                 displayCommand = IntegrationLaunchCommand.configWriter(
-                    id: target.id, serverURL: serverOrigin, key: snippetKeyMasked, model: snippetModel
+                    id: target.id, serverURL: serverOrigin, key: snippetKeyMasked, model: snippetModel, cli: cliCommand
                 )
             } else {
                 command = IntegrationLaunchCommand.adapterGuide(
-                    id: target.id, baseURL: openAIBaseURL, model: snippetModel
+                    id: target.id, baseURL: openAIBaseURL, model: snippetModel, cli: cliCommand
                 )
                 displayCommand = command
             }
@@ -344,12 +371,12 @@ enum AgentLaunchCommand {
 }
 
 enum IntegrationLaunchCommand {
-    static func configWriter(id: String, serverURL: String, key: String, model: String) -> String {
-        "env RAPID_MLX_API_KEY=\(key) rapid-mlx launch \(id) --server-url \(serverURL) --model \(model)"
+    static func configWriter(id: String, serverURL: String, key: String, model: String, cli: String) -> String {
+        "env RAPID_MLX_API_KEY=\(key) \(cli) launch \(id) --server-url \(serverURL) --model \(model)"
     }
 
-    static func adapterGuide(id: String, baseURL: String, model: String) -> String {
-        "rapid-mlx agents \(id) --base-url \(baseURL) --model \(model)"
+    static func adapterGuide(id: String, baseURL: String, model: String, cli: String) -> String {
+        "\(cli) agents \(id) --base-url \(baseURL) --model \(model)"
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -58,15 +58,7 @@ struct ConnectToolsView: View {
     /// no binary is resolved (dev snapshot) we fall back to the bare command.
     private var cliCommand: String {
         guard let binary = binaryPath else { return "rapid-mlx" }
-        return Self.shellQuote(binary.path)
-    }
-
-    /// Single-quote a shell word so spaces / special characters in an
-    /// absolute path (e.g. "Application Support") can't break a pasted
-    /// command. Embedded single quotes are escaped by closing, backslash-
-    /// escaping, and reopening.
-    static func shellQuote(_ value: String) -> String {
-        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        return IntegrationLaunchCommand.shellQuote(binary.path)
     }
 
     /// The model id to publish in a config, or ``nil`` when no real
@@ -370,7 +362,19 @@ enum AgentLaunchCommand {
     }
 }
 
+/// Merges the resolved off-PATH sidecar path into the launch/agent commands
+/// the Connect page hands the user. Kept out of any SwiftUI ``View`` so it is
+/// not inferred ``@MainActor`` — these are pure string functions callable from
+/// synchronous, nonisolated tests.
 enum IntegrationLaunchCommand {
+    /// Single-quote a shell word so spaces / special characters in an
+    /// absolute path (e.g. "Application Support") can't break a pasted
+    /// command. Embedded single quotes are escaped by closing, backslash-
+    /// escaping, and reopening. Pure string logic — deliberately not a UI type.
+    static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\''") + "'"
+    }
+
     static func configWriter(id: String, serverURL: String, key: String, model: String, cli: String) -> String {
         "env RAPID_MLX_API_KEY=\(key) \(cli) launch \(id) --server-url \(serverURL) --model \(model)"
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -372,7 +372,7 @@ enum IntegrationLaunchCommand {
     /// command. Embedded single quotes are escaped by closing, backslash-
     /// escaping, and reopening. Pure string logic — deliberately not a UI type.
     static func shellQuote(_ value: String) -> String {
-        "'" + value.replacingOccurrences(of: "'", with: "'\''") + "'"
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     static func configWriter(id: String, serverURL: String, key: String, model: String, cli: String) -> String {

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -918,6 +918,10 @@ struct LaunchView: View {
             port: server.activePort,
             bearer: server.activeBearer ?? "",
             alias: alias,
+            // The sidecar binary this app owns lives off-PATH (see
+            // ``ServerLocator``); pass its absolute path so the launch/agent
+            // commands this page generates actually run in a terminal.
+            binaryPath: server.binaryPath,
             // Page context: the sidebar owns navigation, so there is no sheet
             // to dismiss. Hide the close ✕ (it used to render as a dead
             // no-op button). A dedicated page-mode header lands with the

--- a/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
@@ -25,10 +25,13 @@ struct AgentLaunchCommandTests {
         #expect(cli == "'/Users/alice/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx'")
         #expect(cli.hasPrefix("'") && cli.hasSuffix("'"))
 
+        // Local key so the generator input and the prefix assertion cannot
+        // drift apart (the suite property is a different value).
+        let key = "secret"
         let writer = IntegrationLaunchCommand.configWriter(
             id: "claude-code",
             serverURL: "http://127.0.0.1:8004",
-            key: "secret",
+            key: key,
             model: "model",
             cli: cli
         )

--- a/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
@@ -19,7 +19,7 @@ struct AgentLaunchCommandTests {
     /// `command not found: rapid-mlx`.
     @Test("registry commands reference the off-PATH sidecar binary by absolute path when resolved")
     func registryCommandsUseResolvedBinaryPath() {
-        let cli = ConnectToolsView.shellQuote(
+        let cli = IntegrationLaunchCommand.shellQuote(
             "/Users/alice/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx"
         )
         #expect(cli == "'/Users/alice/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx'")
@@ -51,12 +51,12 @@ struct AgentLaunchCommandTests {
 
     @Test("shell quoting escapes spaces and embedded single quotes")
     func shellQuoteHandlesSpacesAndApostrophes() {
-        let spaced = ConnectToolsView.shellQuote("/tmp/Rapid App Support/rapid-mlx")
+        let spaced = IntegrationLaunchCommand.shellQuote("/tmp/Rapid App Support/rapid-mlx")
         #expect(spaced == "'/tmp/Rapid App Support/rapid-mlx'")
 
         // A path containing a single quote must be escaped so the pasted
         // command still runs as a single argument.
-        let apostrophe = ConnectToolsView.shellQuote("/tmp/it's/rapid-mlx")
+        let apostrophe = IntegrationLaunchCommand.shellQuote("/tmp/it's/rapid-mlx")
         #expect(apostrophe == "'/tmp/it'\\''s/rapid-mlx'")
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
@@ -6,12 +6,67 @@ struct AgentLaunchCommandTests {
     @Test("registry commands carry authentication only for config writers")
     func registryCommands() {
         #expect(IntegrationLaunchCommand.configWriter(
-            id: "cline", serverURL: "http://127.0.0.1:8000", key: "secret", model: "model"
+            id: "cline", serverURL: "http://127.0.0.1:8000", key: "secret", model: "model", cli: "rapid-mlx"
         ) == "env RAPID_MLX_API_KEY=secret rapid-mlx launch cline --server-url http://127.0.0.1:8000 --model model")
         #expect(IntegrationLaunchCommand.adapterGuide(
-            id: "aider", baseURL: "http://127.0.0.1:8000/v1", model: "model"
+            id: "aider", baseURL: "http://127.0.0.1:8000/v1", model: "model", cli: "rapid-mlx"
         ) == "rapid-mlx agents aider --base-url http://127.0.0.1:8000/v1 --model model")
     }
+
+    /// The Desktop app owns an off-PATH sidecar (see ``ServerLocator``), so
+    /// the launch/agent commands it hands the user must invoke the binary by
+    /// its absolute, shell-quoted path — otherwise pasting them yields
+    /// `command not found: rapid-mlx`.
+    @Test("registry commands reference the off-PATH sidecar binary by absolute path when resolved")
+    func registryCommandsUseResolvedBinaryPath() {
+        let cli = ConnectToolsView.shellQuote(
+            "/Users/alice/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx"
+        )
+        #expect(cli == "'/Users/alice/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx'")
+        #expect(cli.hasPrefix("'") && cli.hasSuffix("'"))
+
+        let writer = IntegrationLaunchCommand.configWriter(
+            id: "claude-code",
+            serverURL: "http://127.0.0.1:8004",
+            key: "secret",
+            model: "model",
+            cli: cli
+        )
+        #expect(writer.contains(cli))
+        #expect(writer.hasPrefix("env RAPID_MLX_API_KEY=\(key) \(cli) launch claude-code"))
+        #expect(!writer.contains(" rapid-mlx "))
+
+        let guide = IntegrationLaunchCommand.adapterGuide(
+            id: "aider",
+            baseURL: "http://127.0.0.1:8004/v1",
+            model: "model",
+            cli: cli
+        )
+        #expect(guide.hasPrefix("\(cli) agents aider"))
+        #expect(!guide.contains(" rapid-mlx "))
+    }
+
+    @Test("shell quoting escapes spaces and embedded single quotes")
+    func shellQuoteHandlesSpacesAndApostrophes() {
+        let spaced = ConnectToolsView.shellQuote("/tmp/Rapid App Support/rapid-mlx")
+        #expect(spaced == "'/tmp/Rapid App Support/rapid-mlx'")
+
+        // A path containing a single quote must be escaped so the pasted
+        // command still runs as a single argument.
+        let apostrophe = ConnectToolsView.shellQuote("/tmp/it's/rapid-mlx")
+        #expect(apostrophe == "'/tmp/it'\\''s/rapid-mlx'")
+    }
+
+    /// A nil binary (dev snapshot) intentionally falls back to the bare
+    /// command so the page still renders.
+    @Test("registry commands fall back to the bare command when no binary is resolved")
+    func registryCommandsFallBackToBareCommand() {
+        let writer = IntegrationLaunchCommand.configWriter(
+            id: "cline", serverURL: "http://127.0.0.1:8000", key: "secret", model: "model", cli: "rapid-mlx"
+        )
+        #expect(writer.contains(" rapid-mlx launch cline "))
+    }
+
     private let base = "http://127.0.0.1:8000/v1"
     private let key = "local-key"
     private let model = "qwen-test"


### PR DESCRIPTION
## Problem

The **Launch → Connect your agents** page generates copyable commands that invoke a bare `rapid-mlx`:

```
rapid-mlx launch claude-code --server-url http://127.0.0.1:8004 --model ...
rapid-mlx agents aider --base-url http://127.0.0.1:8004/v1 --model ...
```

But the Rapid Desktop app **deliberately does not install its sidecar onto the user's PATH** (see `ServerLocator.swift` — the Phase 1 legacy PATH/brew/pipx/uv escape hatch was removed in v0.8.10). The sidecar lives at:

- `~/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx`, **or**
- `Rapid.app/Contents/Resources/rapid-mlx/bin/rapid-mlx`

So when a user copies one of these commands and pastes it into a terminal, they get:

```
zsh: command not found: rapid-mlx
```

This is why "most of the commands on the launch page don't work."

## Fix

- Resolve the sidecar's absolute path via `ServerLocator` (through `server.binaryPath`) and reference it in both the config-writer (`rapid-mlx launch …`) and adapter (`rapid-mlx agents …`) commands.
- **Shell-quote** the path, which is required because "Application Support" contains a space (and to survive embedded single quotes / special characters).
- Dev snapshot harnesses with no resolved binary fall back to the bare `rapid-mlx` command so the page still renders.

### Example output (resolved path)

```
env RAPID_MLX_API_KEY=… '/Users/me/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx' launch claude-code --server-url http://127.0.0.1:8004 --model …
'/Users/me/Library/Application Support/Rapid/runtime-override/rapid-mlx/bin/rapid-mlx' agents aider --base-url http://127.0.0.1:8004/v1 --model …
```

These now run verbatim when pasted.

## Verification

- `swift build` passes (465 targets).
- Shell-quoting semantics independently verified: an absolute path with spaces/embedded quotes round-trips through `shlex.split` as a **single** argument.
- Added `AgentLaunchCommandTests` regression coverage:
  - resolved binary path is single-quoted and referenced in writer/guide commands
  - embedded apostrophes escaped correctly
  - nil binary falls back to the bare command
- GUI GoldenFlow AX baselines are unaffected (they scrub command text to `value=text`).

> Note: local `swift test` is blocked by a pre-existing toolchain issue on this machine (CommandLineTools Swift 6.3.3 can't resolve `import Testing` for **all** test targets). CI runs Xcode 16 / Swift 6.0 where `Testing` resolves; production code compiles cleanly via `swift build`.
