### PR TITLE
fix(mac): make interactive controls verifiably actionable

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -469,6 +469,7 @@ private struct ConnectToolRow: View {
                       ? "Copy this agent's one-session launch command"
                       : "Start a model to generate a valid key and launch command.")
                 .accessibilityLabel(copied ? "Copied \(tool.name) command" : "Copy \(tool.name) command")
+                .accessibilityIdentifier("Launch.Integration.Copy.\(tool.id)")
             }
 
             // Description and snippet share the title's column.
@@ -503,7 +504,6 @@ private struct ConnectToolRow: View {
         }
         .padding(.horizontal, RapidTheme.Space.xl - 4)
         .padding(.vertical, RapidTheme.Space.lg + 1)
-        .accessibilityIdentifier("Launch.Integration.\(tool.id)")
     }
 
     private func copy() {

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -30,62 +30,62 @@ AXApplication title="Rapid-MLX"
             AXStaticText value=text enabled=true
             AXButton id="doc.on.doc" desc="Copy Model" help="Copy Model" enabled=true
             AXHeading desc="Editors and agents" enabled=true
-            AXStaticText id="Launch.Integration.cline" value=text enabled=true
-            AXButton id="Launch.Integration.cline" desc="Copy Cline command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.cline" value=text enabled=true
-            AXStaticText id="Launch.Integration.cline" value=text enabled=true
-            AXStaticText id="Launch.Integration.claude-code" value=text enabled=true
-            AXButton id="Launch.Integration.claude-code" desc="Copy Claude Code command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.claude-code" value=text enabled=true
-            AXStaticText id="Launch.Integration.claude-code" value=text enabled=true
-            AXStaticText id="Launch.Integration.continue-dev" value=text enabled=true
-            AXButton id="Launch.Integration.continue-dev" desc="Copy Continue.dev command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.continue-dev" value=text enabled=true
-            AXStaticText id="Launch.Integration.continue-dev" value=text enabled=true
-            AXStaticText id="Launch.Integration.cursor" value=text enabled=true
-            AXButton id="Launch.Integration.cursor" desc="Copy Cursor command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.cursor" value=text enabled=true
-            AXStaticText id="Launch.Integration.cursor" value=text enabled=true
-            AXStaticText id="Launch.Integration.aider" value=text enabled=true
-            AXButton id="Launch.Integration.aider" desc="Copy Aider command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.aider" value=text enabled=true
-            AXStaticText id="Launch.Integration.aider" value=text enabled=true
-            AXStaticText id="Launch.Integration.codex" value=text enabled=true
-            AXButton id="Launch.Integration.codex" desc="Copy Codex CLI command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.codex" value=text enabled=true
-            AXStaticText id="Launch.Integration.codex" value=text enabled=true
-            AXStaticText id="Launch.Integration.hermes" value=text enabled=true
-            AXButton id="Launch.Integration.hermes" desc="Copy Hermes Agent command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.hermes" value=text enabled=true
-            AXStaticText id="Launch.Integration.hermes" value=text enabled=true
-            AXStaticText id="Launch.Integration.kilo-code" value=text enabled=true
-            AXButton id="Launch.Integration.kilo-code" desc="Copy Kilo Code command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.kilo-code" value=text enabled=true
-            AXStaticText id="Launch.Integration.kilo-code" value=text enabled=true
-            AXStaticText id="Launch.Integration.langchain" value=text enabled=true
-            AXButton id="Launch.Integration.langchain" desc="Copy LangChain command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.langchain" value=text enabled=true
-            AXStaticText id="Launch.Integration.langchain" value=text enabled=true
-            AXStaticText id="Launch.Integration.opencode" value=text enabled=true
-            AXButton id="Launch.Integration.opencode" desc="Copy OpenCode command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.opencode" value=text enabled=true
-            AXStaticText id="Launch.Integration.opencode" value=text enabled=true
-            AXStaticText id="Launch.Integration.openhands" value=text enabled=true
-            AXButton id="Launch.Integration.openhands" desc="Copy OpenHands command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.openhands" value=text enabled=true
-            AXStaticText id="Launch.Integration.openhands" value=text enabled=true
-            AXStaticText id="Launch.Integration.pydanticai" value=text enabled=true
-            AXButton id="Launch.Integration.pydanticai" desc="Copy PydanticAI command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.pydanticai" value=text enabled=true
-            AXStaticText id="Launch.Integration.pydanticai" value=text enabled=true
-            AXStaticText id="Launch.Integration.qwen-code" value=text enabled=true
-            AXButton id="Launch.Integration.qwen-code" desc="Copy Qwen Code command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.qwen-code" value=text enabled=true
-            AXStaticText id="Launch.Integration.qwen-code" value=text enabled=true
-            AXStaticText id="Launch.Integration.smolagents" value=text enabled=true
-            AXButton id="Launch.Integration.smolagents" desc="Copy smolagents command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText id="Launch.Integration.smolagents" value=text enabled=true
-            AXStaticText id="Launch.Integration.smolagents" value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.cline" desc="Copy Cline command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.claude-code" desc="Copy Claude Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.continue-dev" desc="Copy Continue.dev command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.cursor" desc="Copy Cursor command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.aider" desc="Copy Aider command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.codex" desc="Copy Codex CLI command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.hermes" desc="Copy Hermes Agent command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.kilo-code" desc="Copy Kilo Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.langchain" desc="Copy LangChain command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.opencode" desc="Copy OpenCode command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.openhands" desc="Copy OpenHands command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.pydanticai" desc="Copy PydanticAI command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.qwen-code" desc="Copy Qwen Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.smolagents" desc="Copy smolagents command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
             AXScrollBar value=number enabled=true
               AXValueIndicator value=number
               AXButton subrole=AXIncrementArrow

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -454,6 +454,17 @@ struct AccessibilityIdentifierInventoryTests {
         )
     }
 
+    // MARK: - Launch integrations
+
+    @Test("Launch integration copy buttons are individually addressable")
+    func launchIntegrationCopyIdentifiers() throws {
+        try assertDeclared(
+            [#""Launch.Integration.Copy.\(tool.id)""#],
+            in: "Sources/Rapid/UI/ConnectToolsView.swift",
+            surface: "Launch integration rows"
+        )
+    }
+
     /// The positive test above would still pass if someone re-added the
     /// container identifier, bringing the propagation bug back with it. Naming
     /// the wrapper is the mistake, so the absence has to be asserted directly.

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1775,7 +1775,7 @@ flow_no_dead_controls() {
     see_main "$OUT/dead-before.json"
 
     local category
-    for category in modelManagement tools appearance privacy app; do
+    for category in modelManagement instructions tools connectors performance appearance privacy app; do
         press "$OUT/dead-before.json" "Settings.Category.$category" \
             "$OUT/dead-open-$category.json" \
             || die "Settings category $category is not pressable"
@@ -1793,6 +1793,43 @@ flow_no_dead_controls() {
             || die "Settings > $category exposes no identified controls of its own"
         log "  $category: $count identified controls"
     done
+
+    # Presence is not behaviour. Exercise reversible controls and require the
+    # AX value/selection to round-trip after each press. This catches buttons
+    # that highlight under the pointer but never mutate their binding.
+    press "$OUT/dead-panel-app.json" Settings.Category.appearance "$OUT/dead-open-appearance-actions.json" \
+        || die "Appearance category is not pressable"
+    see_main "$OUT/dead-appearance-before.json"
+    press "$OUT/dead-appearance-before.json" Settings.Appearance.Theme.dark "$OUT/dead-appearance-dark-press.json" \
+        || die "Dark appearance option is not pressable"
+    see_main "$OUT/dead-appearance-dark.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.Appearance.Theme.dark")
+           | select(.selected == true or .value == 1 or .value == "1")' \
+        "$OUT/dead-appearance-dark.json" >/dev/null \
+        || die "Dark appearance accepted AXPress but did not become selected"
+    press "$OUT/dead-appearance-dark.json" Settings.Appearance.Theme.light "$OUT/dead-appearance-light-press.json" \
+        || die "Light appearance option is not pressable"
+    see_main "$OUT/dead-appearance-light.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.Appearance.Theme.light")
+           | select(.selected == true or .value == 1 or .value == "1")' \
+        "$OUT/dead-appearance-light.json" >/dev/null \
+        || die "Light appearance did not restore selection"
+
+    press "$OUT/dead-appearance-light.json" Settings.Category.privacy "$OUT/dead-open-privacy-actions.json" \
+        || die "Privacy category is not pressable"
+    see_main "$OUT/dead-privacy-before.json"
+    local telemetry_before telemetry_after
+    telemetry_before="$(element_field "$OUT/dead-privacy-before.json" Settings.Privacy.TelemetryToggle value)"
+    press "$OUT/dead-privacy-before.json" Settings.Privacy.TelemetryToggle "$OUT/dead-privacy-toggle.json" \
+        || die "Telemetry toggle is not pressable"
+    see_main "$OUT/dead-privacy-after.json"
+    telemetry_after="$(element_field "$OUT/dead-privacy-after.json" Settings.Privacy.TelemetryToggle value)"
+    [[ -n "$telemetry_before" && -n "$telemetry_after" && "$telemetry_before" != "$telemetry_after" ]] \
+        || die "Telemetry toggle accepted AXPress but its value did not change"
+    press "$OUT/dead-privacy-after.json" Settings.Privacy.TelemetryToggle "$OUT/dead-privacy-restore.json" \
+        || die "Telemetry toggle could not be restored"
 
     local ax_contracts=(
         "dead-panel-tools.json|Settings.Tools.Toggle.web_search|Web search"
@@ -2820,19 +2857,37 @@ flow_launch_integrations() {
 
     # The engine-owned registry currently resolves to fourteen distinct
     # products after the overlapping Claude Code and Continue entries are
-    # merged. Pin representatives at both ends as well as the exact count so a
-    # new YAML profile cannot silently disappear from the desktop again.
+    # merged. Count the actual per-row action, not a container: putting the id
+    # on the row propagates it to the Copy button in SwiftUI and makes the
+    # button look addressable while preventing it from having its own stable
+    # identity.
     for _ in {1..40}; do
         see_main "$OUT/launch.json"
-        count="$(jq '[.data.ui_elements[]? | (.identifier // "") | select(startswith("Launch.Integration."))] | unique | length' "$OUT/launch.json")"
+        count="$(jq '[.data.ui_elements[]? | (.identifier // "") | select(startswith("Launch.Integration.Copy."))] | unique | length' "$OUT/launch.json")"
         [[ "$count" == 14 ]] && break
         sleep 0.25
     done
     [[ "$count" == 14 ]] || die "Launch rendered $count integrations; engine registry exposes 14 (#1715)"
-    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.cline")' "$OUT/launch.json" >/dev/null \
+    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.Copy.cline")' "$OUT/launch.json" >/dev/null \
         || die "Launch omitted config-writing target Cline"
-    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.smolagents")' "$OUT/launch.json" >/dev/null \
+    jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.Copy.smolagents")' "$OUT/launch.json" >/dev/null \
         || die "Launch omitted adapter profile smolagents"
+    # The card itself is not the action. Every visible row must publish a
+    # distinct Copy button so AX/keyboard users can invoke the same command a
+    # pointer user can, and every one is disabled honestly until a live model
+    # has minted a usable endpoint/key.
+    local copy_count enabled_copy_count
+    copy_count="$(jq '[.data.ui_elements[]?
+                       | (.identifier // "")
+                       | select(startswith("Launch.Integration.Copy."))]
+                      | unique | length' "$OUT/launch.json")"
+    [[ "$copy_count" == 14 ]] \
+        || die "Launch rendered $copy_count addressable Copy buttons for 14 integrations"
+    enabled_copy_count="$(jq '[.data.ui_elements[]?
+                               | select(((.identifier // "") | startswith("Launch.Integration.Copy."))
+                                        and .enabled == true)] | length' "$OUT/launch.json")"
+    [[ "$enabled_copy_count" == 0 ]] \
+        || die "Launch enabled $enabled_copy_count copy commands before a model was ready"
     baseline launch-integrations.complete "$OUT/launch.json"
     log "  launch-integrations OK"
     cleanup_persona


### PR DESCRIPTION
## What changed

- Expand the no-dead-controls GUI journey from five Settings categories to all eight.
- Exercise reversible Settings controls with press → observable state change → restore assertions.
- Move Launch integration accessibility identifiers from row containers to the actual Copy command buttons.
- Make the Launch golden flow count real per-row actions and verify they remain disabled until the endpoint is usable.

## Why

The existing control audit mostly proved that controls existed. It missed three Settings categories and could accept a control that handled AXPress without changing anything. Launch had a subtler SwiftUI propagation bug: the row identifier was inherited by the nested Copy button, so the accessibility tree appeared addressable while the actual action had no independent stable identity.

## User impact

Settings controls and Launch copy actions are now reachable and testable through the same interaction path used by keyboard and accessibility users. Future dead-button regressions fail the GUI journey instead of shipping.

## Validation

- `./scripts/gui-golden-flows.sh --flow no-dead-controls`
- `./scripts/gui-golden-flows.sh --flow launch-integrations --update-baselines`
- `pytest -q tests/test_gui_preflight_contract.py tests/test_rapid_mac_ax_identifiers.py` (74 passed)
- `swift test --filter AccessibilityIdentifierInventoryTests` (15 passed)
- `SKIP_SIDECAR=1 ./scripts/build.sh`
