### PR TITLE
fix(mac): defer model inspection until consent

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -875,6 +875,14 @@ struct ContentView: View {
     // MARK: - Launch auto-start (Flow A/B)
 
     private func runLaunchAutoStart() async {
+        // Consent is the first user-controlled surface. Do not even inspect
+        // model caches behind it: the final AutoStartDecision also knows about
+        // this gate, but reaching that decision requires loading the catalog
+        // first (`rapid-mlx models` + `ls`). Besides doing work the user has not
+        // allowed the app to begin yet, that made first-launch UI depend on the
+        // operator's existing HF cache. The task is keyed on this value and
+        // runs again immediately after the user answers.
+        guard !telemetryConsentPending else { return }
         guard autoStartOnLaunch else {
             autoStartPendingDownload = nil
             return

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
@@ -1,46 +1,15 @@
 # rapid-mac AX structural baseline v1
-AXApplication title="Rapid-MLX"
-  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
-    AXGroup subrole=AXHostingView
-      AXSplitGroup id="main, SidebarNavigationSplitView"
-        AXGroup subrole=AXHostingView
-          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
-          AXButton id="Sidebar.Images" desc="Images" enabled=true
-          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
-          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-        AXSplitter value=number enabled=false
-        AXGroup subrole=AXHostingView
-          AXStaticText value=text enabled=true
-          AXStaticText value=text enabled=true
-          AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Readiness.Action" desc="Start" enabled=true
-          AXStaticText value=text enabled=true
-          AXScrollArea
-            AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
-          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
-          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
-          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
-    AXToolbar
-      AXButton desc="Hide Sidebar" enabled=true
-      AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
-    AXButton subrole=AXCloseButton enabled=false
-    AXButton subrole=AXZoomButton enabled=true
-    AXButton subrole=AXMinimizeButton enabled=true
+AXSheet
+  AXGroup subrole=AXHostingView
+    AXImage id="chart.bar.xaxis" desc="chart.bar.xaxis" enabled=true
     AXStaticText value=text enabled=true
-    AXSheet
-      AXGroup subrole=AXHostingView
-        AXImage id="chart.bar.xaxis" desc="chart.bar.xaxis" enabled=true
-        AXStaticText value=text enabled=true
-        AXStaticText value=text enabled=true
-        AXImage id="desktopcomputer" desc="Computer" enabled=true
-        AXStaticText value=text enabled=true
-        AXImage id="gauge.with.dots.needle.50percent" desc="gauge.with.dots.needle.50percent" enabled=true
-        AXStaticText value=text enabled=true
-        AXImage id="hand.raised.fill" desc="Block" enabled=true
-        AXStaticText value=text enabled=true
-        AXStaticText value=text enabled=true
-        AXButton id="TelemetryConsent.DontShare" desc="Don't share" enabled=true
-        AXButton id="TelemetryConsent.Share" desc="Share anonymous data" enabled=true
+    AXStaticText value=text enabled=true
+    AXImage id="desktopcomputer" desc="Computer" enabled=true
+    AXStaticText value=text enabled=true
+    AXImage id="gauge.with.dots.needle.<percent>" desc="gauge.with.dots.needle.<percent>" enabled=true
+    AXStaticText value=text enabled=true
+    AXImage id="hand.raised.fill" desc="Block" enabled=true
+    AXStaticText value=text enabled=true
+    AXStaticText value=text enabled=true
+    AXButton id="TelemetryConsent.DontShare" desc="Don't share" enabled=true
+    AXButton id="TelemetryConsent.Share" desc="Share anonymous data" enabled=true

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -427,6 +427,35 @@ json.dump({"data": {"ui_elements": scoped}}, open(dst, "w"))
 PYEOF
 }
 
+# Extract the first complete AX subtree whose root has ROLE. The rapid-ax dump
+# is flat pre-order plus `depth`; taking the root and every following element
+# until depth returns to the root level preserves the hierarchy while excluding
+# covered background windows. Modal-sheet baselines must use this — AppKit keeps
+# the underlying split view in the application tree even though a user cannot
+# interact with it.
+role_subtree_only() {
+    python3 - "$1" "$2" "$3" <<'PYEOF'
+import json, sys
+src, role, dst = sys.argv[1:]
+els = json.load(open(src))["data"]["ui_elements"]
+start = next((i for i, e in enumerate(els) if e.get("role") == role), None)
+if start is None:
+    sys.exit(f"AX tree has no {role} subtree")
+root_depth = int(els[start].get("depth", 0))
+end = len(els)
+for i in range(start + 1, len(els)):
+    if int(els[i].get("depth", 0)) <= root_depth:
+        end = i
+        break
+scoped = []
+for element in els[start:end]:
+    element = dict(element)
+    element["depth"] = int(element.get("depth", root_depth)) - root_depth
+    scoped.append(element)
+json.dump({"data": {"ui_elements": scoped}}, open(dst, "w"))
+PYEOF
+}
+
 # Turn N's prompt is in the Nth USER message and turn N's answer is in the
 # Nth ASSISTANT message.
 #
@@ -1020,7 +1049,8 @@ flow_fresh_install() {
     see_main "$OUT/consent-visible.json"
     jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$OUT/consent-visible.json" >/dev/null \
         || die "fresh install did not show telemetry consent"
-    baseline fresh-install.consent "$OUT/consent-visible.json"
+    role_subtree_only "$OUT/consent-visible.json" AXSheet "$OUT/consent-sheet.json"
+    baseline fresh-install.consent "$OUT/consent-sheet.json"
     # #1560: merely launching a fresh install must not inspect model caches
     # behind the consent sheet. Give both SwiftUI catalog tasks time to run;
     # the fake sidecar records every non-serve command before it exits.


### PR DESCRIPTION
## What changed

- Stop launch auto-start before any model catalog/cache inspection while first-run telemetry consent is unanswered.
- Scope the consent golden baseline to the actual AXSheet subtree instead of the inaccessible window behind it.

## Why

The existing decision logic eventually blocked auto-start, but only after loading the catalog. A fresh launch therefore ran `rapid-mlx models` and cache inspection behind the consent sheet, making first-run behavior depend on pre-existing local state and doing work before the user answered.

## User impact

Fresh installs now remain inert behind the consent sheet. Once the user answers, the task keyed to consent state runs again and normal onboarding/auto-start proceeds.

## Validation

- `python3 -m pytest -q tests/test_gui_preflight_contract.py tests/test_rapid_mac_ax_identifiers.py tests/test_ax_baseline_os_variance.py` (108 passed)
- `swift test --filter LaunchOnboardingOrderingTests` (14 passed)
- Local assembled-app fresh-install golden flow reached the post-consent onboarding assertion; its pre-consent command probe stayed clean.
