### PR TITLE
test(mac): make every native control AX-reachable

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
@@ -199,7 +199,9 @@ private struct AboutView: View {
     private func aboutLink(_ label: String, _ urlString: String) -> some View {
         Group {
             if let url = URL(string: urlString) {
-                Link(label, destination: url).tint(RapidTheme.brand)
+                Link(label, destination: url)
+                    .tint(RapidTheme.brand)
+                    .accessibilityIdentifier("About.Link.\(label)")
             } else {
                 Text(label)
             }

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -1091,7 +1091,9 @@ private struct SettingsControlProofSheet: View {
                         .accessibilityIdentifier("DevSnapshot.Specimen.DestructiveCompact")
                     QuietIconButton(symbol: "trash", label: "Delete",
                                     tint: RapidTheme.statusError) {}
+                        .accessibilityIdentifier("DevSnapshot.Specimen.Icon.Delete")
                     QuietIconButton(symbol: "arrow.down.circle", label: "Download") {}
+                        .accessibilityIdentifier("DevSnapshot.Specimen.Icon.Download")
                 }
                 HStack(spacing: RapidTheme.Space.sm) {
                     Button("Disabled primary") {}.buttonStyle(.rapidPrimary).disabled(true)

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1028,6 +1028,7 @@ private struct MessageRow: View {
             .foregroundStyle(RapidTheme.userBubbleText)
             .scrollContentBackground(.hidden)
             .focused($editFieldFocused)
+            .accessibilityIdentifier(actionIdentifier("EditField"))
             .task {
                 await Task.yield()
                 guard !Task.isCancelled else { return }
@@ -1321,6 +1322,7 @@ private struct MessageRow: View {
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel(reasoningAccessibilityLabel)
         }
+        .accessibilityIdentifier(actionIdentifier("ReasoningDisclosure"))
         .onAppear {
             // Auto-expand a truncated reasoning-only turn so the user
             // sees the partial trace instead of an empty bubble.
@@ -1555,6 +1557,7 @@ private struct ToolCallChip: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Tool call \(call.function.name)")
+            .accessibilityIdentifier("ToolCallChip.Toggle.\(call.id)")
 
             if expanded {
                 VStack(alignment: .leading, spacing: 6) {
@@ -2384,6 +2387,9 @@ private struct CodeBlockWithCopy: View {
         }
         .buttonStyle(.plain)
         .help("Copy code")
+        .accessibilityIdentifier(
+            "ChatView.CodeBlock.Copy.\(config.content.utf8.count)"
+        )
         .task(id: copiedRecently) {
             guard copiedRecently else { return }
             // 1.2 s feels like ChatGPT Desktop's flash; long enough

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/InlineNotice.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/InlineNotice.swift
@@ -69,6 +69,7 @@ struct InlineNotice: View {
     let message: String
     var tone: Tone = .warning
     var actionTitle: String? = nil
+    var actionIdentifier: String? = nil
     var action: (() -> Void)? = nil
 
     var body: some View {
@@ -91,6 +92,7 @@ struct InlineNotice: View {
                         height: RapidTheme.ControlHeight.mini
                     ))
                     .fixedSize()
+                    .accessibilityIdentifier(actionIdentifier ?? "InlineNotice.Action")
             }
         }
         .padding(.horizontal, RapidTheme.Space.md)

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/QuietIconButton.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/QuietIconButton.swift
@@ -41,6 +41,7 @@ struct QuietIconButton: View {
     private var resolvedOpacity: Double { isEnabled ? 1.0 : 0.55 }
 
     var body: some View {
+        // ax-exempt: callers attach action/entity-specific identifiers to this wrapper
         Button(action: action) {
             Image(systemName: symbol)
                 .font(.system(size: symbolSize, weight: .medium))
@@ -75,5 +76,6 @@ struct SheetCloseButton: View {
             help: "Close — Esc",
             action: action
         )
+        .accessibilityIdentifier("Sheet.Close")
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/RapidTextField.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/RapidTextField.swift
@@ -29,6 +29,7 @@ struct RapidTextField: View {
     @FocusState private var focused: Bool
 
     var body: some View {
+        // ax-exempt: the caller owns the surface-specific identifier on this wrapper
         TextField(placeholder, text: $text)
             .textFieldStyle(.plain)
             .font(RapidFont.body)

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -192,6 +192,7 @@ struct ConnectToolsView: View {
             Spacer()
             if showsCloseButton {
                 SheetCloseButton(action: onClose)
+                    .accessibilityIdentifier("ConnectTools.Close")
             }
         }
         .frame(maxWidth: RapidTheme.Layout.pageMaxWidth, alignment: .leading)
@@ -602,6 +603,7 @@ private struct CopyableRow: View {
                 ) {
                     reveal.toggle()
                 }
+                .accessibilityIdentifier("ConnectTools.Reveal.\(label)")
             }
             QuietIconButton(
                 symbol: copied ? "checkmark" : "doc.on.doc",
@@ -621,6 +623,7 @@ private struct CopyableRow: View {
                 }
             }
             .disabled(!hasValue)
+            .accessibilityIdentifier("ConnectTools.Copy.\(label)")
         }
         .padding(.horizontal, RapidTheme.Space.md)
         .frame(height: RapidTheme.ControlHeight.medium)

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -210,9 +210,11 @@ struct ContentView: View {
                 if let running = runningAlias { alias = running }
                 server.cancelPendingMemoryLoad(warning)
             }
+            .accessibilityIdentifier("MemoryWarning.Cancel")
             Button(warning.confirmTitle, role: .destructive) {
                 server.confirmPendingMemoryLoad(warning)
             }
+            .accessibilityIdentifier("MemoryWarning.Confirm")
         } message: { warning in
             Text(warning.message)
         }
@@ -801,19 +803,24 @@ struct ContentView: View {
                             NSWorkspace.shared.open(downloadURL)
                         }
                         .buttonStyle(.rapidPrimaryWide)
+                        .accessibilityIdentifier("MissingRuntime.DownloadUpdate")
                         HStack(spacing: RapidTheme.Space.sm) {
                             Button("Recheck") { server.refreshBinary() }
                                 .buttonStyle(.rapidSecondary)
+                                .accessibilityIdentifier("MissingRuntime.Recheck")
                             Button("Quit Rapid-MLX") { NSApp.terminate(nil) }
                                 .buttonStyle(.rapidSecondary)
+                                .accessibilityIdentifier("MissingRuntime.Quit")
                         }
                     }
                 } else {
                     HStack(spacing: RapidTheme.Space.sm) {
                         Button("Recheck") { server.refreshBinary() }
                             .buttonStyle(.rapidPrimary)
+                            .accessibilityIdentifier("MissingRuntime.Recheck")
                         Button("Quit Rapid-MLX") { NSApp.terminate(nil) }
                             .buttonStyle(.rapidSecondary)
+                            .accessibilityIdentifier("MissingRuntime.Quit")
                     }
                 }
                 Text("Rapid-MLX runs AI models on your Mac. Your chats stay on this computer — no messages are sent to the cloud.")
@@ -1266,6 +1273,7 @@ struct SettingsGearButton: View {
         .buttonStyle(.borderless)
         .help("Settings — ⌘,")
         .accessibilityLabel("Settings")
+        .accessibilityIdentifier("ContentView.Settings")
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DownloadStrip.swift
@@ -233,6 +233,7 @@ struct DownloadStrip: View {
             .buttonStyle(.plain)
             .help("Cancel download (partial files stay in the HuggingFace cache and can resume on retry).")
             .accessibilityLabel("Cancel download of \(job.alias)")
+            .accessibilityIdentifier("DownloadStrip.Cancel.\(job.alias)")
         case .completed, .cancelled, .failed:
             Button {
                 downloads.dismissJob(alias: job.alias)
@@ -244,6 +245,7 @@ struct DownloadStrip: View {
             .buttonStyle(.plain)
             .help("Dismiss")
             .accessibilityLabel("Dismiss \(job.alias) status")
+            .accessibilityIdentifier("DownloadStrip.Dismiss.\(job.alias)")
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/FailedReplaceBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/FailedReplaceBanner.swift
@@ -66,11 +66,13 @@ struct FailedReplaceBanner: View {
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
+                        .accessibilityIdentifier("FailedReplace.OpenUpdate")
                         Button("Dismiss") {
                             installTracker.dismiss()
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                        .accessibilityIdentifier("FailedReplace.Dismiss")
                     }
                     .padding(.top, 2)
                 }

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -349,9 +349,11 @@ struct ModelPickerBar: View {
                 Task { await runDeletion(of: entry) }
                 pendingDeletion = nil
             }
+            .accessibilityIdentifier("ModelPickerBar.Delete.Confirm")
             Button("Keep on disk", role: .cancel) {
                 pendingDeletion = nil
             }
+            .accessibilityIdentifier("ModelPickerBar.Delete.Cancel")
         } message: { entry in
             Text("Removes this model from your Mac. You can download it again later by selecting it.\(entry.sizeOnDisk.map { " Frees \($0)." } ?? "")")
         }
@@ -399,6 +401,7 @@ struct ModelPickerBar: View {
                 Text("Fetching models…")
                 Divider()
                 Button("Type a model name…") { showCustom = true }
+                    .accessibilityIdentifier("ModelPickerBar.CustomAlias.Open")
             } else if !hasSelectableRows {
                 // v0.4.29: previously this state was a dead end — a
                 // failed first-load (bootstrapper still installing
@@ -423,7 +426,9 @@ struct ModelPickerBar: View {
                 Button("Refresh catalog") {
                     Task { await refreshCatalog(force: true) }
                 }
+                .accessibilityIdentifier("ModelPickerBar.RefreshCatalog")
                 Button("Type a model name…") { showCustom = true }
+                    .accessibilityIdentifier("ModelPickerBar.CustomAlias.Open")
             } else {
                 // v0.6.9: dropped the separate "Cached" section. Users
                 // skim the picker by alias name, not by cache-state —
@@ -610,6 +615,7 @@ struct ModelPickerBar: View {
             Image(systemName: "info.circle")
                 .font(.system(size: 14))
         }
+        .accessibilityIdentifier("ModelPickerBar.ModelInfo")
         .buttonStyle(.plain)
         .disabled(alias.isEmpty)
         .help("Show model details")
@@ -714,6 +720,7 @@ struct ModelPickerBar: View {
                 systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
             )
         }
+        .accessibilityIdentifier("ModelPickerBar.Quickstart.\(entry.alias)")
         .disabled(deleting == entry.alias)
         .help(ModelPickerBar.quickstartSubtitle)
         .accessibilityLabel(ModelPickerBar.quickstartRowAccessibilityLabel(
@@ -958,6 +965,7 @@ struct ModelPickerBar: View {
             // section where that matters most.
             Label(title, systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached))
         }
+        .accessibilityIdentifier("ModelPickerBar.Recommended.\(entry.alias)")
         .disabled(deleting == entry.alias)
         // The recommendation shows only the curated capability / speed
         // tagline — the single source of truth for a pick. The per-axis
@@ -1082,6 +1090,7 @@ struct ModelPickerBar: View {
                 systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
             )
         }
+        .accessibilityIdentifier("ModelPickerBar.Alias.\(entry.alias)")
         .disabled(deleting == entry.alias)
         // cycle-10: rows in the .tiny (< 1B) and .small (>= 1B,
         // cycle-11 < 3B) buckets get a richer hover tooltip surfacing
@@ -1128,6 +1137,7 @@ struct ModelPickerBar: View {
                         Text("Delete from disk")
                     }
                 }
+                .accessibilityIdentifier("ModelPickerBar.Context.Delete.\(entry.alias)")
             }
             // v0.5.7: side-car download affordance. Only offered when
             // the alias isn't cached and isn't already being pulled.
@@ -1141,6 +1151,7 @@ struct ModelPickerBar: View {
                 } label: {
                     Text("Download in background")
                 }
+                .accessibilityIdentifier("ModelPickerBar.Context.Download.\(entry.alias)")
             }
         }
     }
@@ -1625,17 +1636,20 @@ struct ModelPickerBar: View {
                 text: $customDraft,
                 onSubmit: commitCustomAlias
             )
+            .accessibilityIdentifier("ModelPickerBar.CustomAlias.Field")
 
             HStack(spacing: RapidTheme.Space.sm) {
                 Spacer()
                 Button("Cancel") { showCustom = false }
                     .buttonStyle(.rapidSecondary)
                     .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("ModelPickerBar.CustomAlias.Cancel")
                 Button("Use", action: commitCustomAlias)
                     .buttonStyle(RapidPrimaryButtonStyle(
                         height: RapidTheme.ControlHeight.medium
                     ))
                     .keyboardShortcut(.return, modifiers: [])
+                    .accessibilityIdentifier("ModelPickerBar.CustomAlias.Use")
             }
             .padding(.top, RapidTheme.Space.xs)
         }
@@ -2039,6 +2053,7 @@ struct ModelInfoPopover: View {
                 }
                 .help("Open on Hugging Face")
                 .accessibilityLabel("Open Hugging Face page")
+                .accessibilityIdentifier("ModelPickerBar.HuggingFace.\(repo)")
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1762,6 +1762,7 @@ struct QuickstartView: View {
                 .font(.callout)
         }
         .buttonStyle(.borderless)
+        .accessibilityIdentifier("Quickstart.Failure.BrowseAll")
     }
 
     /// Open Settings on the model catalogue and restore Quickstart on return.

--- a/apps/rapid-mac/Sources/Rapid/UI/SelectTextSheet.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SelectTextSheet.swift
@@ -44,6 +44,7 @@ struct SelectTextSheet: View {
                 Spacer()
                 Button("Done") { dismiss() }
                     .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("SelectText.Done")
             }
             .padding(16)
             Divider()

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsModelManagementPanel.swift
@@ -143,6 +143,7 @@ struct SettingsModelManagementPanel: View {
                     message: lastError,
                     tone: .error,
                     actionTitle: "Dismiss",
+                    actionIdentifier: "Settings.ModelManagement.DismissError",
                     action: { self.lastError = nil }
                 )
             }
@@ -151,6 +152,7 @@ struct SettingsModelManagementPanel: View {
                     message: lastFreed,
                     tone: .success,
                     actionTitle: "Dismiss",
+                    actionIdentifier: "Settings.ModelManagement.DismissSuccess",
                     action: { self.lastFreed = nil }
                 )
             }
@@ -208,6 +210,7 @@ struct SettingsModelManagementPanel: View {
             Button("Keep on disk", role: .cancel) {
                 pendingDeletion = nil
             }
+            .accessibilityIdentifier("Settings.ModelManagement.KeepOnDisk")
         } message: { entry in
             Text(ModelCacheActions.deletionConfirmation(
                 for: entry,
@@ -472,6 +475,7 @@ struct SettingsModelManagementPanel: View {
                         ) {
                             query = ""
                         }
+                        .accessibilityIdentifier("Settings.ModelManagement.ClearSearch")
                     }
                 }
                 .padding(.horizontal, RapidTheme.Space.sm)
@@ -500,6 +504,7 @@ struct SettingsModelManagementPanel: View {
                                 Text(order.displayLabel)
                             }
                         }
+                        .accessibilityIdentifier("Settings.ModelManagement.Sort.\(order.rawValue)")
                     }
                 } label: {
                     Label("Sort", systemImage: "arrow.up.arrow.down")

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
@@ -166,6 +166,7 @@ struct SettingsPerformancePanel: View {
             message: "Reload \(alias) to apply. Other resident models will stay available.",
             tone: .warning,
             actionTitle: isReloading ? "Reloading…" : "Reload model",
+            actionIdentifier: "Settings.Performance.ReloadModel",
             action: { reload(alias: alias) }
         )
         .disabled(isReloading)

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -536,6 +536,7 @@ struct SettingsView: View {
                 }
                 .pickerStyle(.radioGroup)
                 .labelsHidden()
+                .accessibilityIdentifier("Settings.Appearance.ThemePicker")
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -491,6 +491,7 @@ struct SidebarView: View {
             .padding(.horizontal, RapidTheme.Space.sm)
             .padding(.top, RapidTheme.Space.lg)
             .padding(.bottom, RapidTheme.Space.xs)
+            .accessibilityIdentifier("Sidebar.Archived.Toggle")
 
             if showArchived {
                 ForEach(archived) { conv in
@@ -745,6 +746,7 @@ struct SidebarView: View {
                 endRename()
             }
             .onExitCommand { cancelRename() }
+            .accessibilityIdentifier("Sidebar.Conversation.Rename.\(conv.id.uuidString)")
             .task(id: renameSession) {
                 renameFieldDidFocus = false
                 // Defer the request to the next scheduling point, so it lands
@@ -853,6 +855,7 @@ private struct SidebarRow<Content: View>: View {
     @State private var hovering = false
 
     var body: some View {
+        // ax-exempt: each caller attaches its entity-specific identifier to SidebarRow
         Button(action: action) {
             content
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/rapid-mac/Sources/Rapid/UI/UpdateInstallView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/UpdateInstallView.swift
@@ -154,9 +154,11 @@ struct UpdateInstallView: View {
             HStack {
                 Button("Open release page") { openReleasePage() }
                     .buttonStyle(.bordered)
+                    .accessibilityIdentifier("UpdateInstall.OpenReleasePage")
                 Spacer()
                 Button("Later") { dismissWindow(id: "update-install") }
                     .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("UpdateInstall.Later")
                 Button {
                     startInstall()
                 } label: {
@@ -165,6 +167,7 @@ struct UpdateInstallView: View {
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
                 .disabled(!canInstall)
+                .accessibilityIdentifier("UpdateInstall.InstallAndRestart")
             }
             if !canInstall {
                 Text("This release doesn't ship a DMG yet — use the release page link to download manually.")
@@ -190,6 +193,7 @@ struct UpdateInstallView: View {
                 Spacer()
                 Button("Open release page") { openReleasePage() }
                     .buttonStyle(.link)
+                    .accessibilityIdentifier("UpdateInstall.Progress.OpenReleasePage")
             }
         }
     }
@@ -241,6 +245,7 @@ struct UpdateInstallView: View {
             HStack {
                 Button("Open release page") { openReleasePage() }
                     .buttonStyle(.bordered)
+                    .accessibilityIdentifier("UpdateInstall.Failure.OpenReleasePage")
                 Spacer()
                 Button("Try again") {
                     installer.reset()
@@ -248,6 +253,7 @@ struct UpdateInstallView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .disabled(!canInstall)
+                .accessibilityIdentifier("UpdateInstall.TryAgain")
             }
         }
     }

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.speech.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.speech.txt
@@ -34,7 +34,7 @@ AXApplication title="Rapid-MLX"
               AXStaticText value=text enabled=true
               AXButton id="Readiness.Action" desc="Download & start" enabled=true
             AXButton id="Audio.Speech.Generate" desc="Generate Speech" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.transcription.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.transcription.txt
@@ -25,7 +25,7 @@ AXApplication title="Rapid-MLX"
               AXStaticText value=text enabled=true
               AXButton id="Readiness.Action" desc="Download & start" enabled=true
             AXButton id="Audio.Transcription.Run" desc="Transcribe" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -28,7 +28,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -38,7 +38,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
               AXStaticText value=text enabled=true
@@ -59,7 +59,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXScrollArea
               AXOutline desc="Markdown table" enabled=true
                 AXRow subrole=AXOutlineRow
@@ -100,7 +100,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -110,7 +110,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -128,9 +128,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
@@ -27,7 +27,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -37,7 +37,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
               AXStaticText value=text enabled=true
@@ -58,7 +58,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXScrollArea
               AXOutline desc="Markdown table" enabled=true
                 AXRow subrole=AXOutlineRow
@@ -99,7 +99,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -109,7 +109,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -127,9 +127,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -27,7 +27,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -39,9 +39,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
@@ -27,7 +27,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -50,9 +50,9 @@ AXApplication title="Rapid-MLX"
                 AXButton id="ChatView.ConversationInstructions.Cancel" desc="Cancel" enabled=true
                 AXButton id="ChatView.ConversationInstructions.Save" desc="Save" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
@@ -37,9 +37,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -27,7 +27,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -39,9 +39,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
@@ -31,7 +31,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=true
           AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=true
           AXButton id="Images.Generate" desc="Up" help="Load the model first" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
@@ -30,7 +30,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=false
           AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=false
           AXButton id="Images.Generate" desc="Stop" help="Cancel" enabled=true
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -39,7 +39,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=true
           AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=true
           AXButton id="Images.Generate" desc="Up" help="Generate" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
@@ -31,7 +31,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=false
           AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=false
           AXButton id="Images.Generate" desc="Stop" help="Cancel" enabled=true
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -92,7 +92,7 @@ AXApplication title="Rapid-MLX"
               AXButton subrole=AXDecrementArrow
               AXButton subrole=AXIncrementPage
               AXButton subrole=AXDecrementPage
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -27,7 +27,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -39,9 +39,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -22,9 +22,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -22,9 +22,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -22,9 +22,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -22,9 +22,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -22,9 +22,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -22,9 +22,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -22,9 +22,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/slow-stream-stop.stopped.txt
@@ -27,7 +27,7 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
-            AXDisclosureTriangle desc="Reasoning" value=bool:false enabled=true
+            AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
@@ -39,9 +39,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.txt
@@ -22,9 +22,9 @@ AXApplication title="Rapid-MLX"
           AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
-      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true
       AXUnknown desc="Tokens per second: no data yet" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/SidebarRenameFocusTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarRenameFocusTests.swift
@@ -218,9 +218,9 @@ struct SidebarRenameFocusTests {
         )
         #expect(
             stripped.contains(
-                ".focused($editFieldFocused).task{awaitTask.yield()guard!Task.isCancelledelse{return}editFieldFocused=true}"
+                ".focused($editFieldFocused).accessibilityIdentifier(actionIdentifier(\"EditField\")).task{awaitTask.yield()guard!Task.isCancelledelse{return}editFieldFocused=true}"
             ),
-            "The sent-message editor must request focus from a .task attached to the editor, after a yield — a request made while the bubble is still switching branches is dropped and the editor opens unfocused."
+            "The sent-message editor must stay AX-addressable and request focus from a .task attached to the editor, after a yield — a request made while the bubble is still switching branches is dropped and the editor opens unfocused."
         )
         #expect(
             !stripped.contains(".task(id:isEditing){guardisEditingelse{return}editFieldFocused=true}"),

--- a/tests/test_rapid_mac_ax_identifiers.py
+++ b/tests/test_rapid_mac_ax_identifiers.py
@@ -10,6 +10,7 @@ through the masker to catch a lexer desync on Swift the fixtures do not model.
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -873,7 +874,7 @@ def test_disclosure_group_is_a_control():
 
 
 # --------------------------------------------------------------------------
-# The real tree. Not a coverage assertion — a lexer soak test.
+# The real tree. Lexer soak plus the paid-down backlog contract.
 # --------------------------------------------------------------------------
 
 
@@ -905,3 +906,34 @@ def test_gate_runs_over_the_real_tree_without_exploding():
             assert 1 <= v.line <= len(lines)
             assert v.source == lines[v.line - 1].strip()
             assert ".accessibilityIdentifier" not in v.source
+
+
+def test_shipping_tree_has_no_unlabelled_native_controls():
+    """The diff gate deliberately grandfathered the old backlog. That backlog
+    is now zero, so keep it zero: every shipping native SwiftUI control must be
+    reachable by the assembled-app AX harness, not only controls added by the
+    current PR."""
+    violations = []
+    for path in _real_sources():
+        violations.extend(gate.find_violations(str(path), path.read_text(encoding="utf-8")))
+    assert violations == [], "\n" + "\n".join(str(v) for v in violations)
+
+
+def test_shipping_control_wrappers_are_identified_at_each_call_site():
+    """Native controls inside these wrappers are intentionally identified by
+    the caller, where the surface/entity name is known. Pin that second half of
+    the contract so the wrapper exemptions cannot hide an unreachable use."""
+    wrapper = re.compile(
+        r"(?<![A-Za-z0-9_])(QuietIconButton|SheetCloseButton|RapidTextField)\s*([({])"
+    )
+    missing = []
+    for path in _real_sources():
+        src = path.read_text(encoding="utf-8")
+        masked, _, _ = gate._mask(src)
+        for match in wrapper.finditer(masked):
+            delimiter = match.end() - 1
+            end = gate._expression_end(masked, delimiter)
+            if not gate._has_own_identifier(masked, delimiter, end):
+                line = masked.count("\n", 0, match.start()) + 1
+                missing.append(f"{path}:{line}: {match.group(1)}")
+    assert missing == [], "\n" + "\n".join(missing)

--- a/tests/test_rapid_mac_ax_identifiers.py
+++ b/tests/test_rapid_mac_ax_identifiers.py
@@ -915,7 +915,9 @@ def test_shipping_tree_has_no_unlabelled_native_controls():
     current PR."""
     violations = []
     for path in _real_sources():
-        violations.extend(gate.find_violations(str(path), path.read_text(encoding="utf-8")))
+        violations.extend(
+            gate.find_violations(str(path), path.read_text(encoding="utf-8"))
+        )
     assert violations == [], "\n" + "\n".join(str(v) for v in violations)
 
 


### PR DESCRIPTION
## What changed

- Added stable accessibility identifiers to all 48 previously-unreachable native SwiftUI controls across Chat, model selection, Settings, update/recovery, downloads, sidebar, About, and shared components.
- Added entity-scoped identifiers for repeated rows and separate identifiers for destructive/cancel dialog actions.
- Added a full shipping-tree regression contract: the historical native-control backlog must remain at zero.
- Added a second contract for shared control wrappers, requiring every `QuietIconButton`, `SheetCloseButton`, and `RapidTextField` call site to carry a surface-specific identifier.

## Why

The existing CI gate only rejected newly-added unlabelled controls. Its documented historical backlog still contained 48 controls, so the GUI harness could not reliably press or distinguish them. This pays down that backlog and changes the invariant from “do not add more” to “all shipping controls are reachable.”

## User/developer impact

No visual layout or behavior changes. VoiceOver and assembled-app GUI tests can now address update recovery, download cancellation, model picker menus/dialogs, message editing/reasoning/code copy, sidebar archive/rename, and other existing controls without title- or coordinate-based guesses.

## Validation

- Release Desktop.app build succeeded (`SKIP_SIDECAR=1 ./scripts/build.sh`).
- `python3 scripts/check_rapid_mac_ax_identifiers.py --audit`: 0 unlabelled controls (was 48).
- Harness/parser suite: 110 passed.
- Full Swift suite: 2,217/2,218 on the parallel first run; the sole existing throughput timing assertion passed on 3/3 isolated reruns.
- Local GUI execution was correctly blocked by the locked macOS session preflight; CI assembled-app goldenflows are the authoritative unlocked run for this PR.
