### PR TITLE
fix(mac): download and verify audio models before serving

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
@@ -21,6 +21,7 @@ struct AudioView: View {
     @State private var playingPreviewVoice: String?
     @State private var voicePreviewTask: Task<Void, Never>?
     @State private var voicePreviewRequestID: UUID?
+    @State private var modelLoadsInFlight: Set<String> = []
 
     private let contentMaxWidth = RapidTheme.Layout.contentMaxWidth
     private let controlLabelWidth: CGFloat = 80
@@ -39,6 +40,21 @@ struct AudioView: View {
     /// Audio uses the same lifecycle SSOT and CTA semantics as Chat and
     /// Images: choose → Download & start / Start → ready.
     private var readiness: ModelReadiness {
+        // Audio-only `serve` processes intentionally report healthy before
+        // loading their lazy STT/TTS engine. For an uncached model that
+        // process-level signal is not readiness: the first audio request would
+        // still begin the weight download. The explicit DownloadManager job is
+        // authoritative until the catalog confirms the weights are on disk.
+        if let selectedEntry,
+           let downloadReadiness = Self.audioDownloadReadiness(
+               alias: selectedAlias,
+               cached: selectedEntry.cached,
+               sizeText: selectedEntry.sizeOnDisk,
+               job: downloads.job(for: selectedAlias),
+               activationInFlight: modelLoadsInFlight.contains(selectedAlias)
+           ) {
+            return downloadReadiness
+        }
         if server.isResidentLoadInFlight(selectedAlias) {
             return .starting(alias: selectedAlias, detail: "Downloading or loading the audio model…")
         }
@@ -67,6 +83,39 @@ struct AudioView: View {
                 .init(message: $0.message, alias: $0.alias)
             }
         )
+    }
+
+    @MainActor
+    static func audioDownloadReadiness(
+        alias: String,
+        cached: Bool,
+        sizeText: String?,
+        job: DownloadManager.Job?,
+        activationInFlight: Bool
+    ) -> ModelReadiness? {
+        guard !alias.isEmpty, !cached else { return nil }
+        if let job {
+            switch job.status {
+            case .running:
+                return .downloading(
+                    alias: alias,
+                    detail: job.progress.progressSubtitle,
+                    fraction: job.progress.progressFraction
+                )
+            case .failed(let message):
+                return .failed(alias: alias, message: message, action: .retry(alias: alias))
+            case .completed:
+                if activationInFlight {
+                    return .starting(alias: alias, detail: "Finishing the download…")
+                }
+            case .cancelled:
+                break
+            }
+        }
+        if activationInFlight {
+            return .downloading(alias: alias, detail: "Starting the download…", fraction: nil)
+        }
+        return .needsDownload(alias: alias, sizeText: sizeText)
     }
 
     var body: some View {
@@ -501,18 +550,23 @@ struct AudioView: View {
                 Button {
                     selection.wrappedValue = entry.alias
                 } label: {
-                    if selection.wrappedValue == entry.alias {
-                        Label(modelTitle(entry), systemImage: "checkmark")
-                    } else {
-                        Text(modelTitle(entry))
-                    }
+                    Label(
+                        entry.alias,
+                        systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
+                    )
                 }
                 .accessibilityIdentifier("\(identifier).\(entry.alias)")
+                .accessibilityLabel(
+                    "\(entry.alias), \(entry.cached ? "Downloaded" : "Not downloaded")"
+                )
+                .accessibilityAddTraits(
+                    selection.wrappedValue == entry.alias ? .isSelected : []
+                )
             }
         } label: {
             popupControlLabel(
                 entries.first(where: { $0.alias == selection.wrappedValue })
-                    .map(modelTitle) ?? "Choose a model"
+                    .map(\.alias) ?? "Choose a model"
             )
         }
         .menuStyle(.button)
@@ -601,11 +655,6 @@ struct AudioView: View {
             .frame(width: controlLabelWidth, alignment: .leading)
     }
 
-    private func modelTitle(_ entry: ModelEntry) -> String {
-        let status = entry.cached ? "Downloaded" : "Not downloaded"
-        return "\(entry.alias) - \(status)"
-    }
-
     private func handleReadinessAction(_ action: ModelReadiness.Action) {
         switch action {
         case .chooseModel:
@@ -623,6 +672,64 @@ struct AudioView: View {
     }
 
     private func loadAudioModel(_ alias: String) async {
+        guard !modelLoadsInFlight.contains(alias),
+              let initialEntry = viewModel.audioModels.first(where: { $0.alias == alias }) else {
+            return
+        }
+        modelLoadsInFlight.insert(alias)
+        defer { modelLoadsInFlight.remove(alias) }
+        viewModel.errorMessage = nil
+
+        // `Start` may have been rendered from a catalog snapshot taken before
+        // an interrupted pull left only some numbered weight shards behind.
+        // Re-probe before trusting cached=true; the engine's cache listing
+        // validates that every shard is present and turns a partial back into
+        // Download & start.
+        if initialEntry.cached {
+            await viewModel.refreshCatalog()
+            guard !Task.isCancelled else { return }
+        }
+        guard let currentEntry = viewModel.audioModels.first(where: { $0.alias == alias }) else {
+            return
+        }
+
+        if !currentEntry.cached {
+            // A completed job may have landed while this view's catalog
+            // snapshot was stale. Refresh before deciding to pull it again.
+            if downloads.job(for: alias)?.status == .completed {
+                await viewModel.refreshCatalog()
+            }
+
+            if viewModel.audioModels.first(where: { $0.alias == alias })?.cached != true {
+                if let job = downloads.job(for: alias), job.status != .running {
+                    downloads.dismissJob(alias: alias)
+                }
+                if !downloads.isDownloading(alias) {
+                    _ = downloads.startDownload(
+                        alias: alias,
+                        hfPath: currentEntry.hfRepo,
+                        totalBytes: ModelCacheActions.parseSizeBytes(currentEntry.sizeOnDisk)
+                    )
+                }
+                await downloads.awaitDownloadSettlement(alias: alias)
+                guard !Task.isCancelled else { return }
+                guard downloads.job(for: alias)?.status == .completed else { return }
+                await viewModel.refreshCatalog()
+            }
+
+            // `rapid-mlx pull` exiting successfully is necessary, but the
+            // catalog is the final proof that the concrete HF snapshot is
+            // usable. Never turn the audio server's lazy health response into
+            // a false Ready state when that proof is absent.
+            guard viewModel.audioModels.first(where: { $0.alias == alias })?.cached == true else {
+                viewModel.errorMessage = "The download finished, but Rapid couldn't find the model on disk. Try downloading it again."
+                return
+            }
+        }
+
+        // A download may finish after the user selects a different audio
+        // model. Keep the completed cache, but do not start the stale choice.
+        guard selectedAlias == alias else { return }
         let entry = viewModel.audioModels.first { $0.alias == alias }
         _ = await server.ensureServing(
             alias: alias,

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.transcription.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.transcription.txt
@@ -25,6 +25,10 @@ AXApplication title="Rapid-MLX"
               AXStaticText value=text enabled=true
               AXButton id="Readiness.Action" desc="Download & start" enabled=true
             AXButton id="Audio.Transcription.Run" desc="Transcribe" enabled=false
+      AXImage id="checkmark.circle.fill" desc="Selected" enabled=true
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXButton id="DownloadStrip.Dismiss.fake-qwen3-tts" desc="Dismiss fake-qwen3-tts status" help="Dismiss" enabled=true
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -119,6 +119,87 @@ struct AudioCatalogTests {
                 "The desktop sidecar does not bundle ffmpeg for these formats.")
     }
 
+    @Test("audio model rows use the shared cache icons instead of status suffixes")
+    func pickerUsesCacheIcons() throws {
+        let source = try String(contentsOf: Self.audioViewURL, encoding: .utf8)
+
+        #expect(source.contains("ModelPickerBar.cacheGlyph(cached: entry.cached)"))
+        #expect(source.contains(".map(\\.alias) ?? \"Choose a model\""))
+        #expect(!source.contains("private func modelTitle(_ entry: ModelEntry)"),
+                "Keep visible audio model labels to the alias; the icon owns cache state.")
+    }
+
+    @Test("uncached audio ignores the lazy server's early ready signal")
+    @MainActor
+    func uncachedAudioNeedsARealDownload() {
+        let readiness = AudioView.audioDownloadReadiness(
+            alias: "qwen3-tts-4bit",
+            cached: false,
+            sizeText: "1.1 GiB",
+            job: nil,
+            activationInFlight: false
+        )
+
+        #expect(readiness == .needsDownload(alias: "qwen3-tts-4bit", sizeText: "1.1 GiB"))
+        #expect(readiness?.sendAllowed == false)
+    }
+
+    @Test("audio download job drives progress and failure instead of false ready")
+    @MainActor
+    func audioDownloadJobDrivesReadiness() throws {
+        let downloads = DownloadManager()
+        let alias = "whisper-medium"
+        let job = downloads._testingSeedJob(alias: alias)
+        downloads._testingIngestStderr(
+            alias: alias,
+            line: "Fetching 10 files:  30%|███       | 3/10 [00:03<00:07, 1.00it/s]"
+        )
+
+        let downloading = AudioView.audioDownloadReadiness(
+            alias: alias,
+            cached: false,
+            sizeText: "1.5 GiB",
+            job: job,
+            activationInFlight: true
+        )
+        guard case .downloading(let model, _, let fraction) = downloading else {
+            Issue.record("Expected the live pull to own audio readiness")
+            return
+        }
+        #expect(model == alias)
+        #expect(fraction == 0.3)
+
+        downloads._testingFinish(alias: alias, status: 1, reason: .exit)
+        let failed = AudioView.audioDownloadReadiness(
+            alias: alias,
+            cached: false,
+            sizeText: "1.5 GiB",
+            job: job,
+            activationInFlight: false
+        )
+        guard case .failed(let model, _, let action) = failed else {
+            Issue.record("Expected a failed pull to offer retry")
+            return
+        }
+        #expect(model == alias)
+        #expect(action == .retry(alias: alias))
+    }
+
+    @Test("audio activation pulls and verifies the cache before serving")
+    func activationOrdersDownloadBeforeServe() throws {
+        let source = try String(contentsOf: Self.audioViewURL, encoding: .utf8)
+        let pull = try #require(source.range(of: "downloads.startDownload("))
+        let wait = try #require(source.range(of: "downloads.awaitDownloadSettlement(alias: alias)"))
+        let cacheProof = try #require(source.range(
+            of: "guard viewModel.audioModels.first(where: { $0.alias == alias })?.cached == true"
+        ))
+        let serve = try #require(source.range(of: "_ = await server.ensureServing(", options: .backwards))
+
+        #expect(pull.lowerBound < wait.lowerBound)
+        #expect(wait.lowerBound < cacheProof.lowerBound)
+        #expect(cacheProof.lowerBound < serve.lowerBound)
+    }
+
     @Test("unmapped audio cache rows match their Hugging Face repo")
     func matchesUnmappedAudioCacheByRepo() async throws {
         let directory = FileManager.default.temporaryDirectory
@@ -150,6 +231,41 @@ struct AudioCatalogTests {
 
         #expect(qwen.cached)
         #expect(qwen.sizeOnDisk == "2.2 GiB")
+    }
+
+    @Test("incomplete audio cache rows remain downloadable")
+    @MainActor
+    func incompleteAudioCacheIsNotStartable() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-partial-audio-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let binary = directory.appendingPathComponent("rapid-mlx")
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "models" ]; then
+          cat <<'EOF'
+          Audio models (1 aliases)
+          Alias               Size       Kind        Family      HF id
+          qwen3-tts-4bit      2.2 GiB    [audio:tts] qwen3_tts   mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit
+        EOF
+        else
+          cat <<'EOF'
+          Cached models (1 on disk)
+          Alias          HF repo                                              Size
+          (incomplete)   mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit   611 MiB
+        EOF
+        fi
+        """
+        try script.write(to: binary, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+
+        let entries = await ModelCatalog.audioEntries(binary: binary, hubCacheOverride: nil)
+        let qwen = try #require(entries.first { $0.alias == "qwen3-tts-4bit" })
+
+        #expect(!qwen.cached)
+        #expect(qwen.sizeOnDisk == "2.2 GiB")
+        #expect(ModelPickerBar.cacheGlyph(cached: qwen.cached) == "icloud.and.arrow.down")
     }
 
     private func audioEntry(

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -76,6 +76,17 @@ def _setting(name, default=None):
     return os.environ.get(name, FILE_CONFIG.get(name, default))
 
 
+def _pulled_audio_aliases():
+    state_path = _setting("FAKE_AUDIO_PULL_STATE")
+    if not state_path:
+        return set()
+    try:
+        with open(state_path) as stream:
+            return {line.strip() for line in stream if line.strip()}
+    except OSError:
+        return set()
+
+
 def _parse_args(argv):
     """Match the real rapid-mlx CLI shape closely enough that
     ServerManager's spawn arguments work unmodified.
@@ -923,12 +934,17 @@ def _emit_catalog(subcommand, alias):
         # Cached, so the Images tab resolves to it without a download path —
         # ``ImageGenViewModel.resolveAlias`` prefers a cached entry.
         print(f"{FAKE_IMAGE_ALIAS}       {FAKE_IMAGE_REPO}  4.6 GB")
-        if _setting("FAKE_PARTIAL_AUDIO_CACHE") == "1":
+        pulled_audio = _pulled_audio_aliases()
+        if "fake-qwen3-tts" in pulled_audio:
+            print("fake-qwen3-tts         fake/qwen3-tts        1.1 GiB")
+        elif _setting("FAKE_PARTIAL_AUDIO_CACHE") == "1":
             # A real interrupted multi-shard pull remains visible in `ls` for
             # disk cleanup, but its status alias must never make Audio render
             # Start. The audio-readiness flow clicks through this row and
             # requires a resumptive `pull fake-qwen3-tts`.
             print("(incomplete)           fake/qwen3-tts        633 MB")
+        if "fake-whisper-small" in pulled_audio:
+            print("fake-whisper-small     fake/whisper-small    461 MiB")
         return True
     if subcommand == "info":
         # Per-alias, not a constant: `ls`/`models` map fake-image-alias to its
@@ -999,6 +1015,10 @@ def main():
             # for the AX flow to inspect the in-flight progress card.
             print("[bytes] 663748608/590348288", flush=True)
             time.sleep(5)
+            state_path = _setting("FAKE_AUDIO_PULL_STATE")
+            if state_path and args.alias in {"fake-qwen3-tts", "fake-whisper-small"}:
+                with open(state_path, "a") as stream:
+                    stream.write(f"{args.alias}\n")
             sys.exit(0)
         _emit_catalog(args.subcommand, args.alias)
         sys.exit(0)

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -923,6 +923,12 @@ def _emit_catalog(subcommand, alias):
         # Cached, so the Images tab resolves to it without a download path —
         # ``ImageGenViewModel.resolveAlias`` prefers a cached entry.
         print(f"{FAKE_IMAGE_ALIAS}       {FAKE_IMAGE_REPO}  4.6 GB")
+        if _setting("FAKE_PARTIAL_AUDIO_CACHE") == "1":
+            # A real interrupted multi-shard pull remains visible in `ls` for
+            # disk cleanup, but its status alias must never make Audio render
+            # Start. The audio-readiness flow clicks through this row and
+            # requires a resumptive `pull fake-qwen3-tts`.
+            print("(incomplete)           fake/qwen3-tts        633 MB")
         return True
     if subcommand == "info":
         # Per-alias, not a constant: `ls`/`models` map fake-image-alias to its

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2925,7 +2925,12 @@ flow_launch_integrations() {
 
 flow_audio_readiness() {
     log "flow: audio-readiness"
-    start_persona audio-readiness
+    # Keep `pull` alive long enough to prove Audio owns a real download job.
+    # The audio server reports /healthz before its lazy engine has weights, so
+    # a UI-only Ready assertion would miss the regression this flow guards.
+    start_persona audio-readiness \
+        FAKE_DOWNLOAD_OVERRUN=1 \
+        FAKE_PARTIAL_AUDIO_CACHE=1
     dismiss_first_run
     see_main "$OUT/chat.json"
     press "$OUT/chat.json" Sidebar.Audio "$OUT/speech.json" \
@@ -2948,8 +2953,37 @@ flow_audio_readiness() {
         || die "Speech did not expose Chat-equivalent Download & start readiness"
     baseline audio-readiness.speech "$OUT/speech.json"
 
-    press "$OUT/speech.json" Readiness.Action "$OUT/speech-start.json" \
+    press "$OUT/speech.json" Readiness.Action "$OUT/speech-download-start.json" \
         || die "Speech Download & start is not pressable"
+    wait_fake_event \
+        '.event == "command" and .subcommand == "pull" and .alias == "fake-qwen3-tts"' \
+        "Speech Download & start did not invoke pull for fake-qwen3-tts"
+
+    # Sample several fresh AX trees inside the fake's five-second pull window.
+    # An early healthy audio sidecar must never turn that window into Ready.
+    local speech_downloading=0
+    for ((i=0; i<8; i++)); do
+        see_main "$OUT/speech-downloading.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(((.description // .value // .label // "") | tostring)
+                           | startswith("Downloading fake-qwen3-tts"))' \
+                 "$OUT/speech-downloading.json" >/dev/null; then
+            speech_downloading=1
+        fi
+        if jq -e '(.data.ui_elements | tostring)
+                  | contains("Ready — fake-qwen3-tts")' \
+                 "$OUT/speech-downloading.json" >/dev/null; then
+            die "Speech reported Ready while fake-qwen3-tts was still downloading"
+        fi
+        sleep 0.25
+    done
+    [[ "$speech_downloading" == 1 ]] \
+        || die "Speech never exposed Downloading after Download & start"
+    if jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-qwen3-tts")' \
+        "$OUT/fake-events.jsonl" >/dev/null; then
+        die "Speech started fake-qwen3-tts before its pull completed and cache was verified"
+    fi
+
     wait_fake_event \
         '.event == "server_started" and .alias == "fake-qwen3-tts"' \
         "Speech Download & start did not start its selected model"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2930,7 +2930,8 @@ flow_audio_readiness() {
     # a UI-only Ready assertion would miss the regression this flow guards.
     start_persona audio-readiness \
         FAKE_DOWNLOAD_OVERRUN=1 \
-        FAKE_PARTIAL_AUDIO_CACHE=1
+        FAKE_PARTIAL_AUDIO_CACHE=1 \
+        FAKE_AUDIO_PULL_STATE="$OUT_ROOT/audio-readiness/pulled-audio.txt"
     dismiss_first_run
     see_main "$OUT/chat.json"
     press "$OUT/chat.json" Sidebar.Audio "$OUT/speech.json" \
@@ -2986,7 +2987,7 @@ flow_audio_readiness() {
 
     wait_fake_event \
         '.event == "server_started" and .alias == "fake-qwen3-tts"' \
-        "Speech Download & start did not start its selected model"
+        "Speech did not start after its download completed"
     local speech_loaded=0
     for ((i=0; i<80; i++)); do
         see_main "$OUT/speech-loaded.json"
@@ -3022,6 +3023,26 @@ flow_audio_readiness() {
 
     press "$OUT/transcription.json" Readiness.Action "$OUT/transcription-start.json" \
         || die "Transcription Download & start is not pressable"
+    wait_fake_event \
+        '.event == "command" and .subcommand == "pull" and .alias == "fake-whisper-small"' \
+        "Transcription Download & start did not invoke pull for fake-whisper-small"
+    local transcription_downloading=0
+    for ((i=0; i<8; i++)); do
+        see_main "$OUT/transcription-downloading.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(((.description // .value // .label // "") | tostring)
+                           | startswith("Downloading fake-whisper-small"))' \
+                 "$OUT/transcription-downloading.json" >/dev/null; then
+            transcription_downloading=1
+        fi
+        if jq -e -s 'any(.[]; .event == "server_started" and .alias == "fake-whisper-small")' \
+            "$OUT/fake-events.jsonl" >/dev/null; then
+            die "Transcription started fake-whisper-small before its pull completed"
+        fi
+        sleep 0.25
+    done
+    [[ "$transcription_downloading" == 1 ]] \
+        || die "Transcription never exposed Downloading after Download & start"
     wait_fake_event \
         '.event == "server_started" and .alias == "fake-whisper-small"' \
         "Transcription Download & start did not switch to its selected model"

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -342,16 +342,64 @@ def test_cached_view_renders_alias_for_known_repo(tmp_path, monkeypatch, capsys)
 
 
 def test_cached_view_renders_unmapped_for_unknown_repo(monkeypatch, capsys):
-    """A cached HF repo with no alias entry must show ``(unmapped)``."""
+    """A complete cached HF repo with no alias entry shows ``(unmapped)``."""
     monkeypatch.setattr(
         cli,
         "_scan_hf_cache_models",
         lambda: [("some/totally-unmapped-repo", 1024, 0.0)],
     )
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda _repo: True)
     cli._print_cached_models()
     out = capsys.readouterr().out
     assert "(unmapped)" in out
     assert "totally-unmapped-repo" in out
+
+
+def test_cached_view_marks_unmapped_partial_repo_incomplete(monkeypatch, capsys):
+    """Partial Audio repos are usually unmapped but must not look runnable."""
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [("audio/partial-custom-voice", 611 * 1024 * 1024, 0.0)],
+    )
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda _repo: False)
+
+    cli._print_cached_models()
+    out = capsys.readouterr().out
+
+    assert "(incomplete)" in out
+    assert "(unmapped)" not in out
+    assert "audio/partial-custom-voice" in out
+
+
+def test_cached_view_recognizes_complete_unmapped_whisper_npz(
+    tmp_path, monkeypatch, capsys
+):
+    """A completed Whisper pull must remain usable despite having no safetensors."""
+    repo = "mlx-community/whisper-medium-mlx"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--whisper-medium-mlx"
+    sha = "whisper123"
+    snapshot = repo_root / "snapshots" / sha
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}")
+    (snapshot / "weights.npz").write_bytes(b"weights")
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text(sha)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [(repo, 1_524_925_180, 0.0)],
+    )
+
+    cli._print_cached_models()
+    out = capsys.readouterr().out
+
+    assert "(unmapped)" in out
+    assert "(incomplete)" not in out
+    assert repo in out
 
 
 def test_cached_view_marks_known_partial_repo_incomplete(tmp_path, monkeypatch, capsys):
@@ -1052,7 +1100,7 @@ def test_complete_external_copy_keeps_incomplete_hub_stub_visible_for_cleanup(
 
     assert out.count("mlx-community/Dup") == 2
     assert "(external)" in out
-    assert "(unmapped)" in out
+    assert "(incomplete)" in out
 
 
 def test_external_scan_measures_symlinked_weights_within_trusted_root(tmp_path):

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -437,6 +437,35 @@ def test_whisper_cache_rejects_incomplete_npz_layout(tmp_path, monkeypatch, miss
     )
 
 
+@pytest.mark.parametrize("escaped_name", ["config.json", "weights.npz"])
+def test_whisper_cache_rejects_files_symlinked_outside_repo(
+    tmp_path, monkeypatch, escaped_name
+):
+    """A crafted cache symlink must not borrow proof from an unrelated file."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--whisper-small-mlx"
+    sha = "whisper789"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    files = {"config.json": b"{}", "weights.npz": b"weights"}
+    outside = tmp_path / f"outside-{escaped_name}"
+    outside.write_bytes(files[escaped_name])
+    for name, payload in files.items():
+        path = snap / name
+        if name == escaped_name:
+            path.symlink_to(outside)
+        else:
+            path.write_bytes(payload)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert (
+        gate._snapshot_is_complete_whisper_model("mlx-community/whisper-small-mlx")
+        is False
+    )
+
+
 def test_is_repo_cached_false_when_no_snapshot(tmp_path, monkeypatch):
     """Empty HF cache directory → False."""
     empty_cache = tmp_path / "hf-cache"

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -353,6 +353,90 @@ def test_is_repo_cached_true_when_weight_file_present(tmp_path, monkeypatch):
     assert gate.is_repo_cached("foo/cached") is True
 
 
+def test_is_repo_cached_rejects_partial_numbered_shards_without_index(
+    tmp_path, monkeypatch
+):
+    """An interrupted pull may land shard 1 before the index manifest.
+
+    The numbered filename already proves this is a multi-file checkpoint, so
+    one non-empty shard cannot fall through to the single-file cache check.
+    """
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--audio--partial-tts"
+    sha = "audio123"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "model-00001-of-00004.safetensors").write_bytes(b"x" * 2048)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("audio/partial-tts") is False
+
+
+def test_is_repo_cached_accepts_complete_numbered_shards_without_index(
+    tmp_path, monkeypatch
+):
+    """A complete inferred shard set stays usable if a repo omits the index."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--audio--complete-tts"
+    sha = "audio456"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    for index in range(1, 4):
+        name = f"model-{index:05d}-of-00003.safetensors"
+        (snap / name).write_bytes(b"x" * 2048)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("audio/complete-tts") is True
+
+
+def test_whisper_cache_accepts_its_npz_checkpoint_layout(tmp_path, monkeypatch):
+    """mlx-audio Whisper uses config.json + weights.npz, not safetensors."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--whisper-medium-mlx"
+    sha = "whisper123"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_text("{}")
+    (snap / "weights.npz").write_bytes(b"x" * 2048)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert (
+        gate._snapshot_is_complete_whisper_model("mlx-community/whisper-medium-mlx")
+        is True
+    )
+    # The generic text-model probe stays strict about NPZ-only repositories.
+    assert gate.is_repo_cached("mlx-community/whisper-medium-mlx") is False
+
+
+@pytest.mark.parametrize("missing", ["config.json", "weights.npz"])
+def test_whisper_cache_rejects_incomplete_npz_layout(tmp_path, monkeypatch, missing):
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--whisper-small-mlx"
+    sha = "whisper456"
+    snap = repo_root / "snapshots" / sha
+    snap.mkdir(parents=True)
+    files = {"config.json": b"{}", "weights.npz": b"weights"}
+    for name, payload in files.items():
+        if name != missing:
+            (snap / name).write_bytes(payload)
+    _seed_refs_main(repo_root, sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert (
+        gate._snapshot_is_complete_whisper_model("mlx-community/whisper-small-mlx")
+        is False
+    )
+
+
 def test_is_repo_cached_false_when_no_snapshot(tmp_path, monkeypatch):
     """Empty HF cache directory → False."""
     empty_cache = tmp_path / "hf-cache"

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -13,8 +13,10 @@ def test_audio_readiness_actions_start_both_selected_models_and_clear_the_gate()
     flow = source.split("flow_audio_readiness() {", 1)[1].split("\n}", 1)[0]
 
     assert flow.count('press "$OUT/') >= 3
+    assert flow.count('.subcommand == "pull"') == 2
     assert '.alias == "fake-qwen3-tts"' in flow
     assert '.alias == "fake-whisper-small"' in flow
+    assert "before its pull completed" in flow
     assert "Speech stayed behind Download & start" in flow
     assert "Transcription stayed behind Download & start" in flow
 

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -41,6 +41,7 @@ Design choices:
 from __future__ import annotations
 
 import os
+import re
 import sys
 import threading
 
@@ -416,6 +417,52 @@ def _is_model_weight_filename(name: str) -> bool:
     return name.startswith("model")
 
 
+_NUMBERED_MODEL_SHARD_RE = re.compile(r"^model-(\d+)-of-(\d+)\.safetensors$")
+
+
+def _numbered_shards_are_complete(snap_dir: str) -> bool | None:
+    """Validate an index-less ``model-N-of-M`` shard set.
+
+    ``snapshot_download`` does not promise that
+    ``model.safetensors.index.json`` lands before the weight files. If a pull
+    is interrupted after shard 1 arrives but before the index, the generic
+    ``model*.safetensors`` fallback must not mistake that one shard for a
+    complete single-file checkpoint.
+
+    Returns ``None`` when the snapshot has no numbered shard names, preserving
+    the ordinary ``model.safetensors`` / ``model-q4.safetensors`` path. When
+    numbered shards are present, every name must agree on one positive total
+    and cover the indices 1...total exactly once. File type and non-zero size
+    remain the responsibility of ``_root_model_files_all_non_empty`` below.
+    """
+    try:
+        names = os.listdir(snap_dir)
+    except OSError:
+        return False
+
+    numbered: list[tuple[int, int]] = []
+    for name in names:
+        match = _NUMBERED_MODEL_SHARD_RE.fullmatch(name)
+        if match is None:
+            continue
+        numbered.append((int(match.group(1)), int(match.group(2))))
+    if not numbered:
+        return None
+
+    totals = {total for _, total in numbered}
+    if len(totals) != 1:
+        return False
+    total = totals.pop()
+    indices = {index for index, _ in numbered}
+    return (
+        total > 0
+        and len(numbered) == total
+        and len(indices) == total
+        and min(indices) == 1
+        and max(indices) == total
+    )
+
+
 def _snapshot_is_complete(snap_dir: str) -> bool:
     """True if ``snap_dir`` looks like a fully-downloaded model snapshot.
 
@@ -434,8 +481,11 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
       1. ``model.safetensors.index.json`` present → parse ``weight_map``
          and require every referenced shard to exist with non-zero
          size. Codex round-4 BLOCKING #1.
-      2. Otherwise, a single non-empty ``model*.safetensors`` is
-         sufficient (covers single-file non-sharded models).
+      2. Without an index, numbered ``model-N-of-M`` files must form the
+         complete 1...M set. This covers an interrupted pull where one shard
+         lands before the index file.
+      3. Otherwise, a single non-empty ``model*.safetensors`` is sufficient
+         (covers single-file non-sharded models).
 
     Index-but-no-shards (Codex round-5 BLOCKING #1): when an
     ``model.safetensors.index.json`` exists but yields no shard names
@@ -499,7 +549,14 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
             return False
         return True
 
-    # Single-file (non-sharded) model. Match mlx-lm's actual loader
+    # The index can arrive after the first weight shard. Infer completeness
+    # from the standard shard filenames in that window instead of treating
+    # shard 1/N as an ordinary single-file checkpoint.
+    numbered_complete = _numbered_shards_are_complete(snap_dir)
+    if numbered_complete is False:
+        return False
+
+    # Single-file (or complete index-less sharded) model. Match mlx-lm's actual loader
     # glob — ``adapter.safetensors`` / ``embeddings.safetensors`` and
     # other sidecars don't count; only ``model*.safetensors`` at the
     # snapshot root (Codex round-7 BLOCKING #2: the glob is NOT
@@ -644,6 +701,35 @@ def is_repo_cached(repo_id: str) -> bool:
     except Exception:
         pass
     return False
+
+
+def _snapshot_is_complete_whisper_model(repo_id: str) -> bool:
+    """True when a pinned mlx-audio Whisper snapshot can be loaded locally.
+
+    mlx-community Whisper checkpoints intentionally use ``weights.npz`` plus
+    ``config.json`` and contain no ``model*.safetensors``. The text-model
+    completeness probe therefore rejects a fully downloaded Whisper model.
+    Keep this family-specific so an arbitrary NPZ file cannot make a text or
+    unknown repository look runnable.
+    """
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        repo_root = os.path.join(
+            HF_HUB_CACHE,
+            f"models--{repo_id.replace('/', '--')}",
+        )
+        resolved_sha = _resolved_snapshot_sha(repo_root)
+        if resolved_sha is None:
+            return False
+        snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
+        for name in ("config.json", "weights.npz"):
+            path = os.path.join(snap_dir, name)
+            if not os.path.isfile(path) or os.path.getsize(path) <= 0:
+                return False
+        return True
+    except Exception:
+        return False
 
 
 def _snapshot_is_complete_split_model(repo_id: str) -> bool:

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -723,9 +723,18 @@ def _snapshot_is_complete_whisper_model(repo_id: str) -> bool:
         if resolved_sha is None:
             return False
         snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
+        repo_root_real = os.path.realpath(repo_root)
         for name in ("config.json", "weights.npz"):
             path = os.path.join(snap_dir, name)
-            if not os.path.isfile(path) or os.path.getsize(path) <= 0:
+            if not os.path.isfile(path):
+                return False
+            # HF snapshot files normally point into this repo's own ``blobs``
+            # directory. Do not let an unrelated local file satisfy the cache
+            # gate through a crafted symlink.
+            real = os.path.realpath(path)
+            if real != repo_root_real and not real.startswith(repo_root_real + os.sep):
+                return False
+            if os.path.getsize(path) <= 0:
                 return False
         return True
     except Exception:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5253,9 +5253,14 @@ def _cache_entry_is_runnable(repo: str) -> bool:
         from vllm_mlx._download_gate import (
             _snapshot_is_complete_mflux_model,
             _snapshot_is_complete_split_model,
+            _snapshot_is_complete_whisper_model,
             is_repo_cached,
         )
+        from vllm_mlx.audio.registry import resolve_audio_alias
 
+        audio_entry = resolve_audio_alias(repo)
+        if audio_entry is not None and audio_entry.family == "whisper":
+            return _snapshot_is_complete_whisper_model(repo)
         return (
             is_repo_cached(repo)
             or _snapshot_is_complete_split_model(repo)
@@ -5344,10 +5349,11 @@ def _print_cached_models() -> None:
         if is_external_row:
             alias = "(external)"
         # Keep partial directories visible for disk cleanup, but never label
-        # a known alias as downloaded/runnable. The desktop parser deliberately
-        # rejects parenthesized status rows, so this also prevents a 61 MiB
-        # metadata stub for a 26B model from receiving a green checkmark.
-        elif alias != "(unmapped)" and not _cache_entry_is_runnable(repo):
+        # one as downloaded/runnable. This includes unmapped audio repos: the
+        # desktop joins those to its audio registry by HF id, so leaving a
+        # partial row as `(unmapped)` gives it a green checkmark and Start.
+        # The desktop deliberately rejects `(incomplete)` status rows.
+        elif not _cache_entry_is_runnable(repo):
             alias = "(incomplete)"
         # Render modified as a human delta: "2 days ago" beats raw epoch.
         if mtime <= 0:


### PR DESCRIPTION
## What does this PR do?

  - Adds downloaded/not-downloaded icons to the Audio model picker.
  - Makes “Download & start” run `rapid-mlx pull`, display download progress, wait for completion, verify the local cache, and only then start the audio server.
  - Keeps partially downloaded models downloadable so clicking the action resumes the pull instead of reporting Start or Ready.
  - Validates index-less numbered safetensor shard sets to prevent partial checkpoints from appearing runnable.
  - Recognizes the `config.json` + `weights.npz` layout used by mlx-community Whisper models.
  - Adds Python, Swift, and GUI regression coverage for audio download readiness.

  ## Why is this needed?

  The Audio page could report Ready immediately because the audio server exposes a healthy `/healthz` response before its lazily loaded model weights are available. Interrupted downloads could also appear as Start/Ready when only part of a sharded checkpoint existed.

  Additionally, fully downloaded mlx-community Whisper models were rejected because they use `weights.npz` instead of safetensors. This caused “Download & start” to finish with “Rapid couldn't find the model on disk” even though the model had downloaded successfully.

  These changes ensure uncached and partial models continue downloading, completed Whisper models are recognized correctly, and Ready is shown only after the selected model has been verified on disk and started.