### PR TITLE
test(mac): exercise audio model readiness actions

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -304,7 +304,7 @@ jobs:
       # than "golden flows failed". Each needs its own output directory: the
       # harness refuses to start on a non-empty one.
       #
-      # These six drive the app through `rapid-ax` alone (see
+      # These seven drive the app through `rapid-ax` alone (see
       # `flow_requires_peekaboo` in the harness). Most other flows shell out to
       # peekaboo — a third-party install whose bridge socket comes from the
       # Peekaboo app rather than its CLI, with its own permission surface. The
@@ -339,6 +339,11 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/image-generation
 
+      - name: 'Golden flow: audio-readiness'
+        run: ./scripts/gui-golden-flows.sh --flow audio-readiness
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/audio-readiness
+
       - name: 'Golden flow: window-close-prompt'
         run: ./scripts/gui-golden-flows.sh --flow window-close-prompt
         env:
@@ -371,7 +376,7 @@ jobs:
           set -uo pipefail
           mkdir -p "$SCRATCH/snapshots"
           cp Tests/GUIGoldenFlows/__Snapshots__/*.txt "$SCRATCH/snapshots/"
-          for flow in chat-restore slow-stream-stop model-crash-recovery image-generation; do
+          for flow in chat-restore slow-stream-stop model-crash-recovery image-generation audio-readiness; do
             RAPID_GUI_BASELINE_DIR="$SCRATCH/snapshots" \
             RAPID_GUI_GOLDEN_OUT="$SCRATCH/run/$flow" \
               ./scripts/gui-golden-flows.sh --flow "$flow" --update-baselines || true

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2948,7 +2948,25 @@ flow_audio_readiness() {
         || die "Speech did not expose Chat-equivalent Download & start readiness"
     baseline audio-readiness.speech "$OUT/speech.json"
 
-    press "$OUT/speech.json" Audio.Mode.Transcription "$OUT/transcription.json" \
+    press "$OUT/speech.json" Readiness.Action "$OUT/speech-start.json" \
+        || die "Speech Download & start is not pressable"
+    wait_fake_event \
+        '.event == "server_started" and .alias == "fake-qwen3-tts"' \
+        "Speech Download & start did not start its selected model"
+    local speech_loaded=0
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/speech-loaded.json"
+        if ! jq -e '.data.ui_elements[]?
+                    | select(.identifier == "Readiness.Action")' \
+                   "$OUT/speech-loaded.json" >/dev/null; then
+            speech_loaded=1; break
+        fi
+        sleep 0.25
+    done
+    [[ "$speech_loaded" == 1 ]] \
+        || die "Speech stayed behind Download & start after its model became ready"
+
+    press "$OUT/speech-loaded.json" Audio.Mode.Transcription "$OUT/transcription.json" \
         || die "Audio transcription segment is not pressable"
     local transcription_ready=0
     for ((i=0; i<40; i++)); do
@@ -2967,6 +2985,27 @@ flow_audio_readiness() {
     [[ "$transcription_ready" == 1 ]] \
         || die "Transcription did not expose Chat-equivalent Download & start readiness"
     baseline audio-readiness.transcription "$OUT/transcription.json"
+
+    press "$OUT/transcription.json" Readiness.Action "$OUT/transcription-start.json" \
+        || die "Transcription Download & start is not pressable"
+    wait_fake_event \
+        '.event == "server_started" and .alias == "fake-whisper-small"' \
+        "Transcription Download & start did not switch to its selected model"
+    local transcription_loaded=0
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/transcription-loaded.json"
+        if ! jq -e '.data.ui_elements[]?
+                    | select(.identifier == "Readiness.Action")' \
+                   "$OUT/transcription-loaded.json" >/dev/null; then
+            transcription_loaded=1; break
+        fi
+        sleep 0.25
+    done
+    [[ "$transcription_loaded" == 1 ]] \
+        || die "Transcription stayed behind Download & start after its model became ready"
+    jq -n '{success: true,
+            assertion: "Speech and Transcription each start the selected model and leave readiness"}' \
+        > "$OUT/audio-readiness-actions.json"
     log "  audio-readiness OK"
     cleanup_persona
 }

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source guards for GUI journeys that prove control outcomes, not just presses."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
+WORKFLOW = ROOT / ".github/workflows/rapid-mac-ci.yml"
+
+
+def test_audio_readiness_actions_start_both_selected_models_and_clear_the_gate():
+    source = HARNESS.read_text()
+    flow = source.split("flow_audio_readiness() {", 1)[1].split("\n}", 1)[0]
+
+    assert flow.count('press "$OUT/') >= 3
+    assert '.alias == "fake-qwen3-tts"' in flow
+    assert '.alias == "fake-whisper-small"' in flow
+    assert "Speech stayed behind Download & start" in flow
+    assert "Transcription stayed behind Download & start" in flow
+
+
+def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():
+    workflow = WORKFLOW.read_text()
+
+    assert "Golden flow: audio-readiness" in workflow
+    assert "--flow audio-readiness" in workflow
+    diagnostic = workflow.split("Regenerate baselines on this runner (diagnostic)", 1)[
+        1
+    ]
+    assert "image-generation audio-readiness" in diagnostic


### PR DESCRIPTION
## Why

The Audio goldenflow only proved that Speech and Transcription rendered a `Download & start` button. A dead or miswired action could still pass—the same false-green shape found during media-tab dogfood.

## What

- Press the Speech readiness action and require the selected `fake-qwen3-tts` server to start.
- Require the readiness gate to disappear before switching modes.
- Repeat the full action/outcome contract for Transcription and `fake-whisper-small`.
- Make `audio-readiness` a blocking rapid-mac GUI CI step and include it in failure diagnostics.
- Add source guards so future edits cannot quietly reduce the journey back to presence-only checks.

## Validation

- Local assembled-app `audio-readiness` goldenflow: PASS.
- Observed sequential `server_started` events for both selected aliases on the isolated persona port.
- `pytest tests/test_gui_preflight_contract.py tests/test_gui_control_behavior_contract.py`: 9 passed.
- Ruff, Bash syntax, YAML parse, and `git diff --check`: pass.