### PR TITLE
fix(mac): link cursor rects are O(n²) on long answers

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
@@ -218,9 +218,17 @@ final class MarkdownTextBlockView: NSView {
 
     public override func resetCursorRects() {
         super.resetCursorRects()
-        for offset in 0..<renderer.proseLength {
-            guard let rect = renderer.rect(forCharacterAt: offset),
-                  renderer.link(at: CGPoint(x: rect.midX, y: rect.midY)) != nil else { continue }
+        // Ask the storage where the links ARE, rather than asking every
+        // character whether it is one.
+        //
+        // The previous shape walked all `proseLength` offsets and called
+        // `renderer.link(at:)` on each, and that call is itself a linear scan
+        // over the same offsets — O(n²) with an `ensureLayout` inside the inner
+        // loop. AppKit re-runs `resetCursorRects` after every layout and every
+        // scroll, so opening a 6 000-character answer put 86% of the main
+        // thread in this one method (sampled). Enumerating the `.link`
+        // attribute visits only the ranges that actually carry a link.
+        for rect in renderer.linkRects() {
             addCursorRect(rect, cursor: .pointingHand)
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
@@ -118,27 +118,7 @@ final class MarkdownTextRenderer {
     /// Resolve a rendered link at a view-local point. TextKit's drawing-only
     /// host has no NSTextView delegate to do this on our behalf.
     func link(at point: CGPoint) -> URL? {
-        guard let storage = textContentStorage.textStorage else { return nil }
-        textLayoutManager.ensureLayout(for: textContentStorage.documentRange)
-        // Enumerate link runs, not characters: a document with no links costs
-        // one pass and zero rect calculations, and one with links only measures
-        // the runs themselves. Scanning every offset made this O(n) per hit
-        // test, which `resetCursorRects` then called O(n) times.
-        var found: URL?
-        storage.enumerateAttribute(
-            .link,
-            in: NSRange(location: 0, length: min(proseLength, storage.length))
-        ) { value, range, stop in
-            guard let url = value as? URL else { return }
-            for offset in range.location..<NSMaxRange(range) {
-                if let rect = rect(forCharacterAt: offset), rect.contains(point) {
-                    found = url
-                    stop.pointee = true
-                    return
-                }
-            }
-        }
-        return found
+        linkRegions().first { $0.rect.contains(point) }?.url
     }
 
     /// Bounding rects of every link run, for cursor tracking.
@@ -147,28 +127,39 @@ final class MarkdownTextRenderer {
     /// the same line are merged, so a link is a single tracking area instead of
     /// dozens.
     func linkRects() -> [CGRect] {
+        linkRegions().map(\.rect)
+    }
+
+    /// Geometry for each laid-out line segment carrying a link.
+    ///
+    /// TextKit already splits an attributed range at line boundaries. Asking
+    /// it for those segments avoids both per-character geometry calls and the
+    /// fragile `minY` tolerance previously used to merge character rects.
+    private func linkRegions() -> [(url: URL, rect: CGRect)] {
         guard let storage = textContentStorage.textStorage else { return [] }
         textLayoutManager.ensureLayout(for: textContentStorage.documentRange)
-        var rects: [CGRect] = []
+        var regions: [(url: URL, rect: CGRect)] = []
         storage.enumerateAttribute(
             .link,
             in: NSRange(location: 0, length: min(proseLength, storage.length))
         ) { value, range, _ in
-            guard value is URL else { return }
-            var line: CGRect?
-            for offset in range.location..<NSMaxRange(range) {
-                guard let rect = rect(forCharacterAt: offset) else { continue }
-                if var current = line, abs(current.minY - rect.minY) < 1 {
-                    current = current.union(rect)
-                    line = current
-                } else {
-                    if let current = line { rects.append(current) }
-                    line = rect
-                }
+            guard let url = value as? URL,
+                  let start = textContentStorage.location(
+                    textContentStorage.documentRange.location,
+                    offsetBy: range.location
+                  ),
+                  let end = textContentStorage.location(start, offsetBy: range.length),
+                  let textRange = NSTextRange(location: start, end: end)
+            else { return }
+
+            textLayoutManager.enumerateTextSegments(
+                in: textRange, type: .standard, options: []
+            ) { _, frame, _, _ in
+                regions.append((url, frame))
+                return true
             }
-            if let current = line { rects.append(current) }
         }
-        return rects
+        return regions
     }
 
     /// Lay out at a given width and report the height the text needs.

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
@@ -120,13 +120,55 @@ final class MarkdownTextRenderer {
     func link(at point: CGPoint) -> URL? {
         guard let storage = textContentStorage.textStorage else { return nil }
         textLayoutManager.ensureLayout(for: textContentStorage.documentRange)
-        for offset in 0..<min(proseLength, storage.length) {
-            guard let rect = rect(forCharacterAt: offset), rect.contains(point),
-                  let url = storage.attribute(.link, at: offset, effectiveRange: nil) as? URL
-            else { continue }
-            return url
+        // Enumerate link runs, not characters: a document with no links costs
+        // one pass and zero rect calculations, and one with links only measures
+        // the runs themselves. Scanning every offset made this O(n) per hit
+        // test, which `resetCursorRects` then called O(n) times.
+        var found: URL?
+        storage.enumerateAttribute(
+            .link,
+            in: NSRange(location: 0, length: min(proseLength, storage.length))
+        ) { value, range, stop in
+            guard let url = value as? URL else { return }
+            for offset in range.location..<NSMaxRange(range) {
+                if let rect = rect(forCharacterAt: offset), rect.contains(point) {
+                    found = url
+                    stop.pointee = true
+                    return
+                }
+            }
         }
-        return nil
+        return found
+    }
+
+    /// Bounding rects of every link run, for cursor tracking.
+    ///
+    /// One rect per run rather than per character: adjacent character rects on
+    /// the same line are merged, so a link is a single tracking area instead of
+    /// dozens.
+    func linkRects() -> [CGRect] {
+        guard let storage = textContentStorage.textStorage else { return [] }
+        textLayoutManager.ensureLayout(for: textContentStorage.documentRange)
+        var rects: [CGRect] = []
+        storage.enumerateAttribute(
+            .link,
+            in: NSRange(location: 0, length: min(proseLength, storage.length))
+        ) { value, range, _ in
+            guard value is URL else { return }
+            var line: CGRect?
+            for offset in range.location..<NSMaxRange(range) {
+                guard let rect = rect(forCharacterAt: offset) else { continue }
+                if var current = line, abs(current.minY - rect.minY) < 1 {
+                    current = current.union(rect)
+                    line = current
+                } else {
+                    if let current = line { rects.append(current) }
+                    line = rect
+                }
+            }
+            if let current = line { rects.append(current) }
+        }
+        return rects
     }
 
     /// Lay out at a given width and report the height the text needs.

--- a/apps/rapid-mac/Tests/RapidTests/MarkdownLinkPerformanceTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MarkdownLinkPerformanceTests.swift
@@ -1,0 +1,75 @@
+import AppKit
+import Testing
+@testable import Rapid
+
+/// Link lookup must scale with the number of LINKS, not the number of
+/// characters.
+///
+/// The shape this pins: `resetCursorRects` used to walk every character and
+/// ask `link(at:)` whether it was a link, and that call was itself a linear
+/// scan over the same characters with an `ensureLayout` inside. Opening a
+/// 6 000-character answer put 86% of the main thread in those two methods
+/// (sampled on a real transcript) — the chat surface was unusable before a
+/// single token streamed.
+@Suite("Markdown link hit-testing cost")
+@MainActor
+struct MarkdownLinkPerformanceTests {
+
+    private func renderer(_ blocks: [MarkdownItem.TextBlock]) -> MarkdownTextRenderer {
+        var options = MarkdownOptions.assistantTranscript()
+        options.textColor = .black
+        let renderer = MarkdownTextRenderer(options: options)
+        renderer.setBlocks(blocks)
+        renderer.measureHeight(width: 600)
+        return renderer
+    }
+
+    @Test("A long link-free answer reports no link rects")
+    func longProseHasNoLinkRects() {
+        let paragraph = String(repeating: "这是一段没有任何链接的长文本。", count: 200)
+        let renderer = renderer([.init(runs: [InlineRun(text: paragraph)], kind: .paragraph)])
+
+        #expect(renderer.proseLength > 2_000, "fixture must be long enough to matter")
+        #expect(renderer.linkRects().isEmpty)
+    }
+
+    @Test("Link rects are per run, not per character")
+    func linkRectsAreMerged() {
+        // One link inside ordinary prose. A per-character implementation would
+        // return one rect per character of the link text.
+        var linked = InlineRun(text: "Rapid MLX")
+        linked.link = URL(string: "https://example.com")
+        let renderer = renderer([
+            .init(
+                runs: [InlineRun(text: "See "), linked, InlineRun(text: " for details.")],
+                kind: .paragraph
+            )
+        ])
+
+        let rects = renderer.linkRects()
+        #expect(!rects.isEmpty, "the link must still be tracked")
+        #expect(
+            rects.count <= 2,
+            "\(rects.count) rects for a 9-character link — merging by line regressed"
+        )
+    }
+
+    @Test("Hit testing a link-free document is cheap")
+    func hitTestingSkipsUnlinkedRuns() {
+        let paragraph = String(repeating: "纯文本内容，没有链接。", count: 300)
+        let renderer = renderer([.init(runs: [InlineRun(text: paragraph)], kind: .paragraph)])
+
+        let started = Date()
+        for _ in 0..<50 {
+            _ = renderer.link(at: CGPoint(x: 100, y: 100))
+        }
+        let elapsed = Date().timeIntervalSince(started)
+
+        // Generous by design: this is a complexity guard, not a benchmark. The
+        // O(n²) shape took multiple seconds for a single pass at this length.
+        #expect(
+            elapsed < 1.0,
+            "50 hit tests took \(String(format: "%.2f", elapsed))s — link lookup is scanning characters again"
+        )
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/MarkdownLinkPerformanceTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MarkdownLinkPerformanceTests.swift
@@ -20,7 +20,7 @@ struct MarkdownLinkPerformanceTests {
         options.textColor = .black
         let renderer = MarkdownTextRenderer(options: options)
         renderer.setBlocks(blocks)
-        renderer.measureHeight(width: 600)
+        _ = renderer.measureHeight(width: 600)
         return renderer
     }
 
@@ -52,6 +52,36 @@ struct MarkdownLinkPerformanceTests {
             rects.count <= 2,
             "\(rects.count) rects for a 9-character link — merging by line regressed"
         )
+    }
+
+    @Test("A wrapped link exposes one clickable rect per rendered line")
+    func wrappedLinkSegmentsRemainClickable() throws {
+        let url = try #require(URL(string: "https://example.com/wrapped"))
+        var linked = InlineRun(text: String(repeating: "wrapped link ", count: 20))
+        linked.link = url
+        let renderer = renderer([.init(runs: [linked], kind: .paragraph)])
+
+        let rects = renderer.linkRects()
+        #expect(rects.count > 1, "fixture must wrap across lines")
+        for rect in rects {
+            #expect(renderer.link(at: CGPoint(x: rect.midX, y: rect.midY)) == url)
+        }
+    }
+
+    @Test("Adjacent links keep their own hit targets")
+    func adjacentLinksDoNotMerge() throws {
+        let firstURL = try #require(URL(string: "https://one.example"))
+        let secondURL = try #require(URL(string: "https://two.example"))
+        var first = InlineRun(text: "one")
+        first.link = firstURL
+        var second = InlineRun(text: "two")
+        second.link = secondURL
+        let renderer = renderer([.init(runs: [first, second], kind: .paragraph)])
+
+        let rects = renderer.linkRects()
+        #expect(rects.count == 2)
+        #expect(renderer.link(at: CGPoint(x: rects[0].midX, y: rects[0].midY)) == firstURL)
+        #expect(renderer.link(at: CGPoint(x: rects[1].midX, y: rects[1].midY)) == secondURL)
     }
 
     @Test("Hit testing a link-free document is cheap")


### PR DESCRIPTION
## Summary

- replace `resetCursorRects`' all-character scan with direct `.link` attribute enumeration
- ask TextKit 2 for the laid-out line segments of each entire link range, avoiding per-character rect queries and hand-merged geometry
- reuse the same link regions for click hit-testing and pointing-hand cursor rects

This removes the O(n²) path on long link-free answers. Work now scales with link runs and their rendered line segments rather than total answer characters; even a very long URL no longer falls back to per-character layout calls.

## Validation

- `swift test --no-parallel --filter 'MarkdownLinkPerformanceTests|TextKitMarkdownParityTests.customTextKitLinkHitTesting'`
- long 2,000+ character link-free answer yields no cursor rects
- wrapped links expose a clickable rect on every rendered line
- adjacent distinct links retain distinct URL hit targets
- existing compiled-markdown click behavior remains green

No dependencies, scripts, network calls, or process-launch behavior are added.
