### PR TITLE
fix(mac): the Launch page's Codex and Hermes rows never launched anything

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/IntegrationCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/IntegrationCatalog.swift
@@ -22,6 +22,42 @@ enum IntegrationCatalog {
         try JSONDecoder().decode([IntegrationTarget].self, from: data)
     }
 
+    /// Rows the Launch page leads with, in this order.
+    ///
+    /// The registry's own order is "config writers first, then adapter
+    /// profiles", which is an implementation detail of how the sidecar
+    /// assembles the list — it put Cline at the top, a client most users do
+    /// not have, and buried Codex at position six behind LangChain. Neither
+    /// position reflects how likely the row is to work.
+    ///
+    /// These two are pinned because they are the two the page can genuinely
+    /// finish: paste the command and the client is running against the local
+    /// server, nothing written, nothing left behind. Most of the rest either
+    /// only print instructions or leave a config carrying a bearer that stops
+    /// working at the next restart — worth showing, not worth leading with.
+    static let leadingIntegrations = ["claude-code", "codex"]
+
+    /// Applies ``leadingIntegrations`` and disturbs nothing else.
+    ///
+    /// Sorted on the original index as a tiebreaker rather than with a bare
+    /// comparator. `sorted(by:)` is documented as not guaranteed stable, so
+    /// unpinned rows could shuffle between renders of the same list. Today's
+    /// implementation does preserve input order at this size — removing the
+    /// tiebreaker does not change the result — so this is insurance against a
+    /// standard-library change, not a fix for observed behaviour.
+    static func displayOrdered(_ targets: [IntegrationTarget]) -> [IntegrationTarget] {
+        func rank(_ id: String) -> Int {
+            leadingIntegrations.firstIndex(of: id) ?? leadingIntegrations.count
+        }
+        return targets.enumerated()
+            .sorted { lhs, rhs in
+                let left = rank(lhs.element.id)
+                let right = rank(rhs.element.id)
+                return left == right ? lhs.offset < rhs.offset : left < right
+            }
+            .map(\.element)
+    }
+
     static func load(binary: URL? = ServerLocator.find()) async -> [IntegrationTarget] {
         guard let binary else { return [] }
         return await Task.detached(priority: .utility) {

--- a/apps/rapid-mac/Sources/Rapid/UI/Components/QuietIconButton.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/QuietIconButton.swift
@@ -46,6 +46,15 @@ struct QuietIconButton: View {
             Image(systemName: symbol)
                 .font(.system(size: symbolSize, weight: .medium))
                 .foregroundStyle(foreground)
+                // These buttons are overwhelmingly toggles — copy/checkmark,
+                // show/hide, play/pause — and a hard glyph swap gave no signal
+                // that the press registered. `.replace` cross-fades the old
+                // symbol out and the new one in, which is what carries "copied"
+                // once the word "Copied" is gone. Animating on the symbol name
+                // keeps it to genuine changes: a button whose glyph is constant
+                // never animates, and Reduce Motion drops it entirely (see
+                // ``rapidAnimation``).
+                .contentTransition(.symbolEffect(.replace))
                 .frame(width: size, height: size)
                 .background(
                     RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
@@ -59,6 +68,7 @@ struct QuietIconButton: View {
         .buttonStyle(.plain)
         .onHover { hovering = $0 }
         .rapidAnimation(RapidMotion.quick, value: hovering)
+        .rapidAnimation(RapidMotion.quick, value: symbol)
         .help(help ?? label)
         .accessibilityLabel(label)
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -346,9 +346,56 @@ struct ConnectToolsView: View {
 /// has no top-level `--ignore-user-config` flag (that flag belongs only to the
 /// non-interactive `exec` subcommand in Codex 0.146). The temporary home keeps
 /// the Rapid provider isolated without rewriting `~/.codex/config.toml`.
+///
+/// `CODEX_HOME` isolates the config Codex *writes and reads by that name*, not
+/// everything it loads. `open -a Terminal` starts the script in the user's home
+/// directory, and Codex then treats `~/.codex/` as a PROJECT-local config dir —
+/// so hooks and MCP servers defined there still start, and their failures print
+/// before the prompt. Observed on a real machine: two broken MCP servers dumped
+/// tracebacks into a freshly launched session. Nothing is written and the
+/// provider override still wins (Codex refuses `model_provider` from a
+/// project-local config, so ours is the only one in play), but the session is
+/// not the clean room the name suggests. There is no cwd Rapid could pick that
+/// would be better — an agent CLI opened away from the user's code is worse
+/// than a noisy one.
 enum AgentLaunchCommand {
+    /// One-session Claude Code launch that leaves `~/.claude/settings.json`
+    /// alone.
+    ///
+    /// The alternative — `rapid-mlx launch claude-code` — patches the user's
+    /// GLOBAL settings file. Even done carefully (it merges and takes a
+    /// backup) that is the wrong default for a "try this now" button: it
+    /// changes the endpoint for every future Claude Code session, including
+    /// ones the user starts long after Rapid has quit and the local server is
+    /// gone. A bearer that rotates on each start is then baked into a config
+    /// that outlives it.
+    ///
+    /// `--settings <file>` is the escape hatch Claude Code provides for
+    /// exactly this. amux (`src/provider.rs:resolve_claude_settings`) drives
+    /// it the same way: render the blob, write it to a temp file, pass the
+    /// path. Scope ends with the process.
+    ///
+    /// Env vars alone would be simpler still, but `settings.json` beats the
+    /// shell environment when both set `ANTHROPIC_BASE_URL` — a user who
+    /// already routes Claude Code somewhere else (a proxy, another local
+    /// server) would see this command silently do nothing. The temp settings
+    /// file wins that precedence fight without touching their file.
+    /// `ANTHROPIC_AUTH_TOKEN` is blanked deliberately. A settings `env` entry
+    /// is applied OVER the inherited shell environment, and Claude Code
+    /// refuses to choose when both credentials are non-empty ("Both
+    /// ANTHROPIC_AUTH_TOKEN and ANTHROPIC_API_KEY set · auth may not work").
+    /// Proxy front-ends such as CC Switch export both as stubs, so a user of
+    /// one would hit that warning through no fault of their own. amux carries
+    /// the same workaround (`neutralize_conflicting_auth_token`) for the same
+    /// reason. Blanking is scoped to this launch like everything else here.
     static func claude(baseURL: String, key: String, model: String) -> String {
-        "env ANTHROPIC_BASE_URL=\(baseURL) ANTHROPIC_API_KEY=\(key) ANTHROPIC_MODEL=\(model) claude"
+        let settings = """
+        {"env":{"ANTHROPIC_BASE_URL":"\(baseURL)","ANTHROPIC_API_KEY":"\(key)","ANTHROPIC_AUTH_TOKEN":"","ANTHROPIC_MODEL":"\(model)"}}
+        """
+        // `mktemp -d` keeps the key out of a predictable path, and the trap
+        // removes it when the session ends however it ends.
+        return "d=$(mktemp -d) && printf '%s' '\(settings)' > \"$d/settings.json\" && "
+            + "trap 'rm -rf \"$d\"' EXIT && claude --settings \"$d/settings.json\""
     }
 
     static func codex(baseURL: String, key: String, model: String) -> String {

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -440,7 +440,8 @@ enum AgentLaunchCommand {
     }
 
     static func codex(baseURL: String, key: String, model: String) -> String {
-        "env CODEX_HOME=\"$(mktemp -d)\" OPENAI_API_KEY=\(key) codex -m \(model) "
+        "d=$(mktemp -d) && trap 'rm -rf \"$d\"' EXIT && "
+            + "env CODEX_HOME=\"$d\" OPENAI_API_KEY=\(key) codex -m \(model) "
             + "-c 'model_provider=\"rapid-mlx\"' "
             + "-c 'model_providers.rapid-mlx={name=\"Rapid-MLX\",base_url=\"\(baseURL)\",env_key=\"OPENAI_API_KEY\",wire_api=\"responses\"}'"
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -586,23 +586,22 @@ private struct ConnectToolRow: View {
 
                 Spacer(minLength: RapidTheme.Space.md)
 
-                Button(action: copy) {
-                    Label(copied ? "Copied" : "Copy command",
-                          systemImage: copied ? "checkmark" : "doc.on.doc")
-                }
-                .buttonStyle(RapidSecondaryButtonStyle(
-                    utility: true,
-                    height: RapidTheme.ControlHeight.small,
-                    foreground: copied ? RapidTheme.utilityActionSuccess : nil
-                ))
+                // Icon only, and the same ``QuietIconButton`` the endpoint
+                // rows above use. The labelled variant did not fit: pinned to
+                // 132pt it rendered "Copy comm…" — the fixed width was chosen
+                // to stop the row reflowing when the label flips to "Copied",
+                // and it truncated the resting label to buy that. It also put
+                // the button's hit area and its drawn pill at different sizes,
+                // since the frame sat outside the button style. An icon has
+                // one width in both states, so none of that arises.
+                QuietIconButton(
+                    symbol: copied ? "checkmark" : "doc.on.doc",
+                    label: copied ? "Copied \(tool.name) command" : "Copy \(tool.name) command",
+                    help: copyHelp,
+                    tint: copied ? RapidTheme.utilityActionSuccess : nil,
+                    action: copy
+                )
                 .disabled(!isReady)
-                // Fixed width so all three buttons form a clean right
-                // column instead of each sizing to its own label (the
-                // "Copied" flip would otherwise resize the button and
-                // shift the row).
-                .frame(width: 132)
-                .help(copyHelp)
-                .accessibilityLabel(copied ? "Copied \(tool.name) command" : "Copy \(tool.name) command")
                 .accessibilityIdentifier("Launch.Integration.Copy.\(tool.id)")
 
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -259,38 +259,79 @@ struct ConnectToolsView: View {
 
     // MARK: - Tool definitions
 
+    /// A one-session launch command for the clients Rapid can drive directly,
+    /// or ``nil`` for the rest.
+    ///
+    /// The sidecar registry classifies every target as either a config writer
+    /// or an adapter profile, and neither classification carries the thing
+    /// this page most wants to offer: a command that connects the client for
+    /// one session and leaves nothing behind. Three clients accept one —
+    /// Claude Code via `--settings`, Codex via `CODEX_HOME`, Hermes via
+    /// `--ignore-user-config` — so those rows take it in preference to
+    /// whatever the registry would have generated.
+    ///
+    /// This is a deliberate override, not a gap in the registry: the registry
+    /// entries stay valid for `rapid-mlx launch` / `rapid-mlx agents`, which
+    /// are still the right answer for a persistent setup.
+    private func sessionLaunchCommand(id: String, key: String) -> String? {
+        switch id {
+        case "claude-code":
+            return AgentLaunchCommand.claude(baseURL: anthropicBaseURL, key: key, model: snippetModel)
+        case "codex":
+            return AgentLaunchCommand.codex(baseURL: openAIBaseURL, key: key, model: snippetModel)
+        case "hermes":
+            return AgentLaunchCommand.hermes(baseURL: openAIBaseURL, key: key, model: snippetModel)
+        default:
+            return nil
+        }
+    }
+
     private var tools: [ConnectTool] {
         guard !integrationTargets.isEmpty else { return legacyTools }
-        return integrationTargets.map { target in
-            let isWriter = target.kind == .configWriter
-            let command: String
-            let displayCommand: String
-            if isWriter {
-                command = IntegrationLaunchCommand.configWriter(
-                    id: target.id, serverURL: serverOrigin, key: snippetKey, model: snippetModel, cli: cliCommand
+        return IntegrationCatalog.displayOrdered(integrationTargets).map { target in
+            if let command = sessionLaunchCommand(id: target.id, key: snippetKey) {
+                return ConnectTool(
+                    id: target.id,
+                    name: target.name,
+                    symbol: "terminal",
+                    blurb: "Launch with this connection for one session. Your configuration files and shell environment stay unchanged.",
+                    snippet: command,
+                    displaySnippet: sessionLaunchCommand(id: target.id, key: snippetKeyMasked) ?? command,
+                    action: .launch
                 )
-                displayCommand = IntegrationLaunchCommand.configWriter(
-                    id: target.id, serverURL: serverOrigin, key: snippetKeyMasked, model: snippetModel, cli: cliCommand
-                )
-            } else {
-                command = IntegrationLaunchCommand.adapterGuide(
-                    id: target.id, baseURL: openAIBaseURL, model: snippetModel, cli: cliCommand
-                )
-                displayCommand = command
             }
-            let destination = target.configPath.map { " It writes \($0)." } ?? ""
-            let cursorCaveat = target.id == "cursor"
-                ? " Cursor requires a public HTTPS endpoint; localhost cannot be reached by Cursor's backend."
-                : ""
+            if target.kind == .configWriter {
+                let destination = target.configPath.map { " It writes \($0)." } ?? ""
+                let cursorCaveat = target.id == "cursor"
+                    ? " Cursor requires a public HTTPS endpoint; localhost cannot be reached by Cursor's backend."
+                    : ""
+                return ConnectTool(
+                    id: target.id,
+                    name: target.name,
+                    symbol: "slider.horizontal.3",
+                    blurb: "Configure this client to use Rapid-MLX.\(destination)\(cursorCaveat)",
+                    snippet: IntegrationLaunchCommand.configWriter(
+                        id: target.id, serverURL: serverOrigin, key: snippetKey, model: snippetModel, cli: cliCommand
+                    ),
+                    displaySnippet: IntegrationLaunchCommand.configWriter(
+                        id: target.id, serverURL: serverOrigin, key: snippetKeyMasked, model: snippetModel, cli: cliCommand
+                    ),
+                    action: .rewriteConfig
+                )
+            }
+            // Everything else prints setup instructions. The command carries no
+            // key because it contacts nothing — see ``ConnectTool.Action.guide``.
+            let command = IntegrationLaunchCommand.adapterGuide(
+                id: target.id, baseURL: openAIBaseURL, model: snippetModel, cli: cliCommand
+            )
             return ConnectTool(
                 id: target.id,
                 name: target.name,
-                symbol: isWriter ? "slider.horizontal.3" : "point.3.connected.trianglepath.dotted",
-                blurb: isWriter
-                    ? "Configure this client to use Rapid-MLX.\(destination)\(cursorCaveat)"
-                    : "View this adapter's setup guide for the local endpoint.",
+                symbol: "point.3.connected.trianglepath.dotted",
+                blurb: "Print this adapter's setup guide for the local endpoint — Rapid can't launch this client for you.",
                 snippet: command,
-                displaySnippet: displayCommand
+                displaySnippet: command,
+                action: .guide
             )
         }
     }
@@ -475,6 +516,22 @@ private struct ConnectTool: Identifiable {
     /// The same command with the key masked — the ONLY form painted on screen,
     /// so a screenshot can't leak the bearer.
     let displaySnippet: String
+    /// What the row's command actually does when the user runs it. The three
+    /// cases are not interchangeable — one starts a client, one rewrites a
+    /// file the user owns, one only prints documentation — and the row's icon
+    /// and Copy tooltip both say which.
+    enum Action: Equatable {
+        /// Connects the client for one session and leaves nothing behind.
+        case launch
+        /// Edits a config file the user owns. The edit outlives both the
+        /// session and the bearer it records, which is why this is something
+        /// the user pastes deliberately rather than something a button fires.
+        case rewriteConfig
+        /// Prints setup instructions rather than starting anything.
+        case guide
+    }
+
+    var action: Action = .launch
 }
 
 /// One agent row: icon, name, description, a Copy action, and its launch
@@ -544,11 +601,10 @@ private struct ConnectToolRow: View {
                 // "Copied" flip would otherwise resize the button and
                 // shift the row).
                 .frame(width: 132)
-                .help(isReady
-                      ? "Copy this agent's one-session launch command"
-                      : "Start a model to generate a valid key and launch command.")
+                .help(copyHelp)
                 .accessibilityLabel(copied ? "Copied \(tool.name) command" : "Copy \(tool.name) command")
                 .accessibilityIdentifier("Launch.Integration.Copy.\(tool.id)")
+
             }
 
             // Description and snippet share the title's column.
@@ -585,6 +641,17 @@ private struct ConnectToolRow: View {
         .padding(.vertical, RapidTheme.Space.lg + 1)
     }
 
+    private var copyHelp: String {
+        guard isReady else {
+            return "Start a model to generate a valid key and launch command."
+        }
+        switch tool.action {
+        case .launch:        return "Copy this agent's one-session launch command"
+        case .rewriteConfig: return "Copy the command that configures \(tool.name)"
+        case .guide:         return "Copy the command that prints \(tool.name)'s setup guide"
+        }
+    }
+
     private func copy() {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(tool.snippet, forType: .string)
@@ -594,6 +661,7 @@ private struct ConnectToolRow: View {
             withAnimation { copied = false }
         }
     }
+
 }
 
 /// A labelled value with a trailing copy button; masks secrets by default.

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -19,23 +19,27 @@ AXApplication title="Rapid-MLX"
             AXHeading desc="Endpoint" enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
-            AXButton id="doc.on.doc" desc="Copy OpenAI base URL" help="Copy OpenAI base URL" enabled=true
+            AXButton id="ConnectTools.Copy.OpenAI base URL" desc="Copy OpenAI base URL" help="Copy OpenAI base URL" enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
-            AXButton id="doc.on.doc" desc="Copy Anthropic base URL" help="Copy Anthropic base URL" enabled=true
+            AXButton id="ConnectTools.Copy.Anthropic base URL" desc="Copy Anthropic base URL" help="Copy Anthropic base URL" enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
-            AXButton id="doc.on.doc" desc="Copy API key" help="Start a model to generate a valid key and configuration." enabled=false
+            AXButton id="ConnectTools.Copy.API key" desc="Copy API key" help="Start a model to generate a valid key and configuration." enabled=false
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
-            AXButton id="doc.on.doc" desc="Copy Model" help="Copy Model" enabled=true
+            AXButton id="ConnectTools.Copy.Model" desc="Copy Model" help="Copy Model" enabled=true
             AXHeading desc="Editors and agents" enabled=true
             AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.cline" desc="Copy Cline command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
             AXButton id="Launch.Integration.Copy.claude-code" desc="Copy Claude Code command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.codex" desc="Copy Codex CLI command" help="Start a model to generate a valid key and launch command." enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Launch.Integration.Copy.cline" desc="Copy Cline command" help="Start a model to generate a valid key and launch command." enabled=false
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
@@ -48,10 +52,6 @@ AXApplication title="Rapid-MLX"
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="Launch.Integration.Copy.aider" desc="Copy Aider command" help="Start a model to generate a valid key and launch command." enabled=false
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXStaticText value=text enabled=true
-            AXButton id="Launch.Integration.Copy.codex" desc="Copy Codex CLI command" help="Start a model to generate a valid key and launch command." enabled=false
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
@@ -83,11 +83,29 @@ struct AgentLaunchCommandTests {
         ]
 
         for command in commands {
-            #expect(command.hasPrefix("env "))
             #expect(!command.contains("export "))
             #expect(!command.contains("\n"))
             #expect(command.contains(key))
             #expect(command.contains(model))
+        }
+    }
+
+    /// The rule these commands exist to honour: nothing they touch survives
+    /// the process. `env` prefixes and `mktemp` scratch dirs both satisfy it;
+    /// a path under the user's home does not. This is the assertion that
+    /// actually distinguishes the two, so it names the home directories rather
+    /// than matching on a command prefix.
+    @Test("No command writes anywhere under the user's home")
+    func commandsStayOutOfTheUserHome() {
+        let commands = [
+            AgentLaunchCommand.claude(baseURL: base, key: key, model: model),
+            AgentLaunchCommand.codex(baseURL: base, key: key, model: model),
+            AgentLaunchCommand.hermes(baseURL: base, key: key, model: model),
+        ]
+
+        for command in commands {
+            #expect(!command.contains("~/"))
+            #expect(!command.contains("$HOME"))
         }
     }
 
@@ -101,13 +119,59 @@ struct AgentLaunchCommandTests {
         #expect(command.contains(#"wire_api="responses""#))
     }
 
-    @Test("Claude and Hermes retain their native provider variables")
-    func providerSpecificVariablesRemainComplete() {
+    /// Claude Code reads `settings.json` in preference to the environment for
+    /// `ANTHROPIC_BASE_URL`, so an `env`-only command is silently ignored for
+    /// any user who already routes Claude Code elsewhere. `--settings <file>`
+    /// is the supported way to win that precedence fight without editing the
+    /// file they own — the same mechanism amux uses.
+    @Test("Claude routes through a throwaway settings file, not the user's")
+    func claudeUsesTemporarySettingsFile() {
         let claude = AgentLaunchCommand.claude(baseURL: base, key: key, model: model)
-        #expect(claude.contains("ANTHROPIC_BASE_URL=\(base)"))
-        #expect(claude.contains("ANTHROPIC_API_KEY=\(key)"))
-        #expect(claude.hasSuffix("ANTHROPIC_MODEL=\(model) claude"))
 
+        #expect(claude.contains("mktemp -d"))
+        #expect(claude.contains("claude --settings "))
+        // The blob is JSON under `env`, which is where Claude Code reads these.
+        #expect(claude.contains("\"ANTHROPIC_BASE_URL\":\"\(base)\""))
+        #expect(claude.contains("\"ANTHROPIC_API_KEY\":\"\(key)\""))
+        #expect(claude.contains("\"ANTHROPIC_MODEL\":\"\(model)\""))
+        // Exactly one non-empty credential, so a shell that exports the other
+        // (CC Switch and friends do) cannot make Claude Code refuse to choose.
+        #expect(claude.contains("\"ANTHROPIC_AUTH_TOKEN\":\"\""))
+        // Cleaned up however the session ends, so the key does not outlive it.
+        #expect(claude.contains("trap "))
+        // The whole point: the user's own settings file is never named.
+        #expect(!claude.contains(".claude/settings.json"))
+    }
+
+    /// Codex and Hermes each accept a one-session connection, and the Launch
+    /// page must offer it rather than the registry's documentation printer.
+    ///
+    /// This is the regression the test exists for: the sidecar registry
+    /// classifies both as `adapter_profile`, so the page generated `rapid-mlx
+    /// agents codex ...` — a command that prints a setup guide. The button
+    /// said "run" and what ran was a page of Markdown; Codex never started,
+    /// even though the command that starts it was already written and sitting
+    /// unreachable in the fallback list.
+    @Test("Codex and Hermes launch the client, not a setup guide")
+    func sessionLaunchCommandsStartTheClient() {
+        let codex = AgentLaunchCommand.codex(baseURL: base, key: key, model: model)
+        #expect(codex.contains(" codex "))
+        #expect(!codex.contains(" agents "))
+
+        let hermes = AgentLaunchCommand.hermes(baseURL: base, key: key, model: model)
+        #expect(hermes.contains(" hermes "))
+        #expect(!hermes.contains(" agents "))
+
+        // The guide generator is what these must NOT be.
+        let guide = IntegrationLaunchCommand.adapterGuide(
+            id: "codex", baseURL: base, model: model, cli: "rapid-mlx"
+        )
+        #expect(guide.contains(" agents codex "))
+        #expect(codex != guide)
+    }
+
+    @Test("Hermes retains its native provider variables")
+    func providerSpecificVariablesRemainComplete() {
         let hermes = AgentLaunchCommand.hermes(baseURL: base, key: key, model: model)
         #expect(hermes.contains("OPENAI_BASE_URL=\(base)"))
         #expect(hermes.contains("HERMES_INFERENCE_MODEL=\(model)"))

--- a/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AgentLaunchCommandTests.swift
@@ -113,7 +113,9 @@ struct AgentLaunchCommandTests {
     func codexInteractiveCommandUsesSupportedIsolation() {
         let command = AgentLaunchCommand.codex(baseURL: base, key: key, model: model)
 
-        #expect(command.contains(#"CODEX_HOME="$(mktemp -d)""#))
+        #expect(command.contains("d=$(mktemp -d)"))
+        #expect(command.contains(#"CODEX_HOME="$d""#))
+        #expect(command.contains(#"trap 'rm -rf "$d"' EXIT"#))
         #expect(command.contains(" codex -m qwen-test "))
         #expect(!command.contains("codex --ignore-user-config"))
         #expect(command.contains(#"wire_api="responses""#))

--- a/apps/rapid-mac/Tests/RapidTests/IntegrationOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/IntegrationOrderingTests.swift
@@ -1,0 +1,62 @@
+import Testing
+@testable import Rapid
+
+/// The Launch page leads with the rows that work.
+///
+/// The sidecar assembles its list as "config writers first, then adapter
+/// profiles" — an artefact of how the registry is built, not a judgement about
+/// the rows. It put Cline first, a VS Code extension most users do not have,
+/// and Codex sixth behind LangChain.
+@Suite("Launch page integration ordering")
+struct IntegrationOrderingTests {
+
+    private func target(_ id: String, _ kind: IntegrationTarget.Kind) -> IntegrationTarget {
+        IntegrationTarget(id: id, name: id, kind: kind, configPath: nil)
+    }
+
+    /// The registry order observed on a real install, trimmed to the head.
+    private var registryOrder: [IntegrationTarget] {
+        [
+            target("cline", .configWriter),
+            target("claude-code", .configWriter),
+            target("continue-dev", .configWriter),
+            target("cursor", .configWriter),
+            target("langchain", .adapterProfile),
+            target("codex", .adapterProfile),
+            target("hermes", .adapterProfile),
+        ]
+    }
+
+    @Test("Claude Code leads, Codex follows")
+    func leadingRowsArePinned() {
+        let ordered = IntegrationCatalog.displayOrdered(registryOrder).map(\.id)
+        #expect(ordered.first == "claude-code")
+        #expect(ordered.dropFirst().first == "codex")
+    }
+
+    /// Pinning must not become a reshuffle. Everything the pin does not name
+    /// keeps the order the registry gave it — that order encodes the sidecar's
+    /// own grouping, and rearranging it silently would be a second change
+    /// nobody asked for.
+    ///
+    /// This does NOT prove the sort is stable: Swift's `sorted(by:)` happens
+    /// to preserve input order for equal elements at these sizes even without
+    /// an explicit tiebreaker (verified by removing ours — this test still
+    /// passed). The tiebreaker in `displayOrdered` guards a documented
+    /// non-guarantee, and no test can demonstrate that today.
+    @Test("Unpinned rows keep the registry's order")
+    func unpinnedRowsAreUndisturbed() {
+        let ordered = IntegrationCatalog.displayOrdered(registryOrder).map(\.id)
+        let rest = ordered.filter { !IntegrationCatalog.leadingIntegrations.contains($0) }
+        #expect(rest == ["cline", "continue-dev", "cursor", "langchain", "hermes"])
+    }
+
+    @Test("A missing pinned row is skipped, not faked")
+    func absentPinnedRowIsSkipped() {
+        let withoutCodex = registryOrder.filter { $0.id != "codex" }
+        let ordered = IntegrationCatalog.displayOrdered(withoutCodex).map(\.id)
+        #expect(ordered.first == "claude-code")
+        #expect(!ordered.contains("codex"))
+        #expect(ordered.count == withoutCodex.count)
+    }
+}

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2902,6 +2902,18 @@ flow_launch_integrations() {
         || die "Launch omitted config-writing target Cline"
     jq -e '.data.ui_elements[]? | select(.identifier == "Launch.Integration.Copy.smolagents")' "$OUT/launch.json" >/dev/null \
         || die "Launch omitted adapter profile smolagents"
+    # The two one-session launch commands are the useful fast path, not an
+    # implementation-detail registry order. Keep them first and in the product
+    # order promised by the Launch page.
+    local first_two
+    first_two="$(jq -r '[.data.ui_elements[]?
+                         | select((.identifier // "")
+                                  | startswith("Launch.Integration.Copy."))
+                         | .identifier]
+                        | .[0:2]
+                        | join(",")' "$OUT/launch.json")"
+    [[ "$first_two" == "Launch.Integration.Copy.claude-code,Launch.Integration.Copy.codex" ]] \
+        || die "Launch did not lead with Claude Code then Codex (got: $first_two)"
     # The card itself is not the action. Every visible row must publish a
     # distinct Copy button so AX/keyboard users can invoke the same command a
     # pointer user can, and every one is disabled honestly until a live model

--- a/tests/test_agent_profile_model_aliases.py
+++ b/tests/test_agent_profile_model_aliases.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Every model an agent profile recommends must be a real alias.
+
+``rapid-mlx agents <id>`` prints a setup guide, and the desktop Launch page
+prints the same guide. The guide's "Recommended models" list is the one part a
+reader is meant to copy straight into a ``pull`` command, so an alias that does
+not exist fails at the first thing the guide asks the user to do.
+
+That is what ``hermes.yaml`` shipped: it recommended ``qwen3.5-35b-a3b``, taking
+the name from the upstream model card (``Qwen3.5-35B-A3B``) rather than from
+``aliases.json``, where the same weights are registered as
+``qwen3.5-35b-4bit``. Nothing failed at build time — the profile is data, and
+nothing cross-checked it against the alias registry until a user ran it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1] / "vllm_mlx"
+_PROFILES = sorted((_ROOT / "agents" / "profiles").glob("*.yaml"))
+
+
+def _valid_aliases() -> set[str]:
+    return set(json.loads((_ROOT / "aliases.json").read_text()).keys())
+
+
+def _recommended(profile: Path) -> list[str]:
+    """The ``models.recommended`` list, read without a YAML dependency.
+
+    Deliberately a narrow regex rather than a YAML parse: the block is a flat
+    list of quoted scalars in every profile, and the test exists to be run in
+    the minimal environment that `tests/test_adapters_import_without_mlx.py`
+    also targets.
+    """
+    text = profile.read_text()
+    block = re.search(r"^\s*recommended:\n((?:\s*- \"[^\"]+\"\n)+)", text, re.M)
+    if block is None:
+        return []
+    return re.findall(r'- "([^"]+)"', block.group(1))
+
+
+@pytest.mark.parametrize("profile", _PROFILES, ids=lambda p: p.stem)
+def test_recommended_models_resolve(profile: Path) -> None:
+    valid = _valid_aliases()
+    unknown = [
+        model
+        for model in _recommended(profile)
+        # A full HuggingFace path needs no alias entry.
+        if "/" not in model and model not in valid
+    ]
+    assert not unknown, (
+        f"{profile.name} recommends {unknown}, which `rapid-mlx pull` cannot "
+        f"resolve. Check aliases.json for the registered name — the alias "
+        f"often differs from the upstream model card."
+    )
+
+
+def test_at_least_one_profile_recommends_something() -> None:
+    """Guards the regex above.
+
+    If the profile format changes, ``_recommended`` starts returning ``[]`` for
+    every file and the parametrized test passes while checking nothing.
+    """
+    assert any(_recommended(profile) for profile in _PROFILES)

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -60,7 +60,7 @@ def fake_home(tmp_path, monkeypatch) -> Path:
 
     # claude_code: replace the two module constants.
     monkeypatch.setattr(claude_code, "_CLAUDE_STATE_DIR", tmp_path / ".claude")
-    monkeypatch.setattr(claude_code, "_CONFIG_DIR", tmp_path / ".config/claude")
+    monkeypatch.setattr(claude_code, "_CONFIG_DIR", tmp_path / ".claude")
 
     # continue_dev: replace the config dir.
     monkeypatch.setattr(continue_dev, "_CONFIG_DIR", tmp_path / ".continue")
@@ -191,7 +191,11 @@ class TestClaudeCode:
             json.dumps(
                 {
                     "permissions": {"allow": ["Bash(git:*)"]},
-                    "env": {"OTHER_VAR": "preserved", "ANTHROPIC_BASE_URL": "old"},
+                    "env": {
+                        "OTHER_VAR": "preserved",
+                        "ANTHROPIC_BASE_URL": "old",
+                        "ANTHROPIC_AUTH_TOKEN": "proxy-token",
+                    },
                 }
             )
         )
@@ -202,6 +206,7 @@ class TestClaudeCode:
         assert data["env"]["OTHER_VAR"] == "preserved"
         # Overwritten.
         assert data["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8000"
+        assert data["env"]["ANTHROPIC_AUTH_TOKEN"] == ""
 
     def test_backup_created(self, fake_home):
         cfg = claude_code.current_config_path()

--- a/vllm_mlx/agents/profiles/codex.yaml
+++ b/vllm_mlx/agents/profiles/codex.yaml
@@ -31,11 +31,22 @@ config:
     [model_providers.rapid-mlx]
     name = "Rapid-MLX (local)"
     base_url = "{base_url}"
-    # No auth field — rapid-mlx is unauthed by default and Codex
-    # `--strict-config` rejects an inline literal like `api_key = "..."`.
-    # If you start the server with `--api-key`, add:
+    # Auth: rapid-mlx requires a bearer whenever it was started with
+    # `--api-key` or with `RAPID_MLX_API_KEY` set. That is ALWAYS true of
+    # the Rapid-MLX desktop app, which mints a fresh key per launch — an
+    # unauthenticated request there gets 401, not a response. In that
+    # case add:
     #     env_key = "RAPID_MLX_API_KEY"
-    # and `export RAPID_MLX_API_KEY=<your-key>` in your shell.
+    # and `export RAPID_MLX_API_KEY=<your-key>` in the shell you run
+    # Codex from.
+    #
+    # Leave `env_key` out ONLY for a bare `rapid-mlx serve` with no key
+    # set. Codex hard-errors — "Missing environment variable: `NAME`" —
+    # when `env_key` names a variable that is not exported, so this is
+    # not a safe thing to leave in unconditionally.
+    #
+    # Codex `--strict-config` rejects an inline literal like
+    # `api_key = "..."`, so the env var is the only route.
     # The /v1/responses path is the hot path Codex uses; rapid-mlx
     # exposes it directly. No wire_api override needed.
 

--- a/vllm_mlx/agents/profiles/hermes.yaml
+++ b/vllm_mlx/agents/profiles/hermes.yaml
@@ -23,7 +23,7 @@ models:
     - "qwen3.5-4b-4bit"
     - "qwen3.5-9b-4bit"
     - "gemma-4-26b-4bit"
-    - "qwen3.5-35b-a3b"
+    - "qwen3.5-35b-4bit"
     - "qwen3.6-35b-4bit"
 
 streaming:

--- a/vllm_mlx/launch/claude_code.py
+++ b/vllm_mlx/launch/claude_code.py
@@ -3,7 +3,7 @@
 
 Unlike the VS Code-extension clients (Cline, Continue), the Claude Code
 CLI ships as a Node-based command-line tool (``claude``) that reads its
-config from ``~/.config/claude/settings.json`` and also honours a small
+config from ``~/.claude/settings.json`` and also honours a small
 set of environment variables — most importantly
 ``ANTHROPIC_BASE_URL`` and ``ANTHROPIC_API_KEY``.
 
@@ -35,9 +35,21 @@ from . import _common
 # Volta or asdf shim that's not in the parent shell's PATH).
 _CLAUDE_STATE_DIR = Path.home() / ".claude"
 
-# Canonical settings location. Anthropic's docs document this path on
-# both macOS and Linux; the CLI mkdir's it on first launch.
-_CONFIG_DIR = Path.home() / ".config" / "claude"
+# Canonical settings location: ``~/.claude/settings.json``.
+#
+# This used to point at ``~/.config/claude/``. That directory is not what
+# the CLI reads — on a machine with a real Claude Code install, ``~/.claude``
+# holds ``settings.json`` alongside ``CLAUDE.md``, ``agents/`` and
+# ``commands/``, while ``~/.config/claude/`` did not exist at all until this
+# adapter created it. The write therefore succeeded and changed nothing the
+# CLI would ever load, and — because the target was a fresh file — the
+# "merge into the user's existing settings" logic below had nothing to merge
+# with, so the result looked like an overwrite of a config that was in fact
+# untouched somewhere else.
+#
+# ``integrations.py`` already advertises ``~/.claude/settings.json`` to the
+# desktop UI, so the adapter was also contradicting its own catalogue entry.
+_CONFIG_DIR = Path.home() / ".claude"
 _CONFIG_FILENAME = "settings.json"
 
 
@@ -48,8 +60,7 @@ def detect() -> bool:
 
     * The ``claude`` executable resolves on PATH.
     * ``~/.claude`` exists (the CLI's state dir from a previous run).
-    * ``~/.config/claude/`` exists (the config dir, mkdir'd on first
-      launch on freshly installed boxes).
+    * ``~/.claude/`` exists (the CLI's state + config dir).
 
     Multiple signals exist because users install the CLI through wildly
     different package managers (npm-global, brew, official installer)
@@ -67,7 +78,7 @@ def detect() -> bool:
 
 
 def current_config_path() -> Path | None:
-    """Return ``~/.config/claude/settings.json``.
+    """Return ``~/.claude/settings.json``.
 
     Unlike Cline (where we *might* refuse to write when the extension
     isn't installed), Claude Code's settings file is safe to create
@@ -87,7 +98,7 @@ def write_or_patch_config(
     api_key: str = "sk-noop",
     config_path: Path | None = None,
 ) -> Path:
-    """Patch ``~/.config/claude/settings.json`` to route at the local
+    """Patch ``~/.claude/settings.json`` to route at the local
     rapid-mlx Anthropic-compatible endpoint.
 
     Keys we own (all under the top-level ``env`` object, which Anthropic

--- a/vllm_mlx/launch/claude_code.py
+++ b/vllm_mlx/launch/claude_code.py
@@ -110,6 +110,8 @@ def write_or_patch_config(
       correct, ``http://127.0.0.1:8000/v1`` produces 404 on
       ``/v1/v1/messages``).
     * ``env.ANTHROPIC_API_KEY`` → ``<api_key>``
+    * ``env.ANTHROPIC_AUTH_TOKEN`` → ``""`` so a token inherited from a
+      proxy/switcher cannot conflict with the API key above.
     * ``env.ANTHROPIC_MODEL`` → ``<model>`` (Claude Code reads this as
       the default model id; the rapid-mlx server accepts any
       ``claude-*`` model name and routes to the actually-loaded engine,
@@ -151,6 +153,7 @@ def patched_config(
     env = dict(existing.get("env", {}))
     env["ANTHROPIC_BASE_URL"] = base_url
     env["ANTHROPIC_API_KEY"] = api_key
+    env["ANTHROPIC_AUTH_TOKEN"] = ""
     env["ANTHROPIC_MODEL"] = model
     existing["env"] = env
 


### PR DESCRIPTION
## What this is

Six fixes to the Launch page and the setup guides behind it, found by driving
the shipped app rather than by reading it: every claim below was checked
against a real install with a real local server.

The page's job is "connect your agent to this server". Four of the fixes are
cases where it appeared to do that and did not.

## The fixes

**The Codex and Hermes rows printed documentation instead of launching.**
Copying the Codex CLI row's command and running it produced a page of Markdown
— `# Codex CLI + Rapid-MLX Setup` — ending in instructions to go write
`~/.codex/config.toml` by hand. Codex never started. The command that starts it
was already written and correct, sitting in `legacyTools`, which is unreachable
whenever the sidecar registry loads — that is, always, in a real install.

The cause is that the registry's two kinds don't include the one this page most
wants to offer. `config_writer` means "edits a file you own"; `adapter_profile`
means "prints instructions". A one-session connection is neither. The three
clients that accept one now take it explicitly, and the distinction lives in
`ConnectTool.Action` rather than in a chain of id comparisons — nine of the
fourteen rows only print, and nothing on the page had been saying so.

The page now also leads with Claude Code and Codex. The registry's order is an
artefact of how the list is assembled: it put Cline first (a VS Code extension
most users don't have) and Codex sixth, behind LangChain.

**Claude Code's command silently did nothing for some users.** The page offered
`env ANTHROPIC_BASE_URL=... claude`. Claude Code reads `settings.json` in
preference to the environment for that variable, so anyone already routing it
elsewhere — a proxy, another local server — saw the command do nothing at all.

`rapid-mlx launch claude-code` has the opposite problem: it patches the user's
global `settings.json`. Carefully, with a merge and a backup, but it repoints
every future session at an endpoint that is gone once Rapid quits, and bakes in
a bearer that rotates on the next start. `--settings <file>` is the escape hatch
for exactly this, and the one [amux](https://github.com/kesor/amux) drives.
`ANTHROPIC_AUTH_TOKEN` is blanked in the blob for the reason amux blanks it:
proxy front-ends such as CC Switch export both credentials as stubs, and Claude
Code refuses to choose when both are set.

**The Claude Code adapter wrote a path the CLI never reads.** It targeted
`~/.config/claude/settings.json`. The CLI keeps settings in `~/.claude`, and
`integrations.py` had been advertising that path to the desktop UI all along.
The write succeeded, created a directory nobody reads, and reported success.

**The Codex setup guide told users auth was off.** It emitted `# No auth field
— rapid-mlx is unauthed by default`. Measured against a desktop-app server:
`/v1/models` without a bearer returns 401, with one returns 200. The desktop app
mints a fresh key on every launch, so for anyone arriving from the Launch page —
who is exactly who reads this guide — that default has never been the case.

**The Hermes guide recommended a model that doesn't exist.** `qwen3.5-35b-a3b`,
taken from the upstream model card rather than from `aliases.json`, where the
same weights are `qwen3.5-35b-4bit`. Profiles are data and nothing cross-checked
them against the alias registry, so now a test does.

**The Copy button rendered as "Copy comm…".** Pinned to 132pt, narrower than its
own label, so `lineLimit(1)` truncated it. The fixed width existed to stop the
row reflowing when the label flips to "Copied" — it bought that by truncating
the resting state, and left the hit area and the drawn pill at different sizes
because the frame sat outside the button style. Now icon-only, using the
`QuietIconButton` the endpoint rows in the same card already use.

## Verification

Driven against a real install, not asserted from source:

| Claim | How it was checked |
|---|---|
| Codex now launches | Row's command opens the Codex TUI, resolves `provider: rapid-mlx`, completes a turn |
| Claude Code doesn't touch user config | `~/.claude/settings.json` checksum identical before and after; Claude Code reports the bearer Rapid minted for that run, so the temp settings won over a populated user file |
| Guide's auth claim was false | `GET /v1/models` → 401 without bearer, 200 with |
| `env_key` can't be unconditional | Codex aborts with `Missing environment variable: NAME` when it points at an unexported variable — which is why the corrected comment keeps both cases |
| Hermes model missing | `rapid-mlx info qwen3.5-35b-a3b` → `not a known alias`; sweep of all 13 profiles found this one and no others |
| Copy works | Clipboard carries the command; accessibility label flips to `Copied Claude Code command` and back |
| Row order | Accessibility tree reads `claude-code, codex,` then the registry's order unchanged |

## Tests

- `AgentLaunchCommandTests` — 10 tests; new coverage that Codex and Hermes
  produce launch commands rather than `agents` guide commands, and that the
  Claude blob routes through a temp settings file naming no user path
- `IntegrationOrderingTests` — 3 tests, each break-verified by emptying
  `leadingIntegrations`
- `test_agent_profile_model_aliases.py` — 13 tests, break-verified by restoring
  the bad alias

One test was written and then deleted: a "list with no pinned rows is returned
unchanged" case meant to guard the sort's stability tiebreaker. Removing the
tiebreaker did not make it fail — Swift's `sorted(by:)` preserves input order at
this size even though it does not promise to — so it proved nothing it claimed.
The tiebreaker stays as insurance against a standard-library change, and the
comment now says that rather than implying it fixes observed behaviour.

Full suite: 2224 Swift tests. The three failing suites (`Web tools hardening`,
`Download/catalog hardening`, `Throughput caption integration`) fail identically
on unmodified `main` on this machine — DNS NXDOMAIN hijacking by the local ISP,
and two timing-sensitive cases.

## Not fixed here

Found while investigating, left alone because each needs a product decision or
is a separate change:

- **The four `config_writer` rows write a bearer that dies on restart.** Proven:
  configure, request succeeds (200), restart Rapid, same config now returns 401.
  The written key is a snapshot of a value that rotates every launch. Fixing it
  means choosing between a persistent bearer, an env-var indirection, or framing
  those rows as single-session.
- **The Cursor row cannot ever succeed.** `cursor.py` rejects local URLs by
  design, and the page can only supply `http://127.0.0.1:<port>`. Running the
  exact command it offers leaves `settings.json` untouched.
- **No install detection.** Every adapter has `detect()`; `IntegrationTarget`
  doesn't carry the result, so all fourteen rows render regardless. On the test
  machine, three of eight checked clients were installed.
- **`IntegrationCatalog.load()` has no timeout**, and its failure path falls back
  to `legacyTools` silently — a user would never learn the other integrations
  exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
