### PR TITLE
fix(mac): hovering any button covered its label with a grey block

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/Components/RapidButtonStyles.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Components/RapidButtonStyles.swift
@@ -221,9 +221,13 @@ private struct RapidButtonSurface: View {
                 // Hover and pressed are drawn as a wash ON TOP of the
                 // tier's own fill, so one pair of values reads correctly
                 // over amber, over white, and over nothing.
+                //
+                // Both values must therefore be translucent. ``hoverFill`` is
+                // not — it is the opaque plane colour rows paint behind their
+                // content — so this position takes ``hoverWash``.
                 if isEnabled, configuration.isPressed || hovering {
                     RoundedRectangle(cornerRadius: RapidTheme.Radius.button, style: .continuous)
-                        .fill(configuration.isPressed ? RapidTheme.pressedFill : RapidTheme.hoverFill)
+                        .fill(configuration.isPressed ? RapidTheme.pressedFill : RapidTheme.hoverWash)
                 }
             }
             .overlay {

--- a/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/RapidTheme.swift
@@ -631,7 +631,26 @@ enum RapidTheme {
         appearance.isDark ? NSColor(deviceRed: 0x21/255.0, green: 0x24/255.0, blue: 0x29/255.0, alpha: 1.0)
                           : NSColor(deviceRed: 0xF0/255.0, green: 0xF0/255.0, blue: 0xED/255.0, alpha: 1.0)
     }))
-    /// Pressed wash — one step firmer than hover.
+    /// Hover wash for controls that draw it ON TOP of their own fill.
+    ///
+    /// ``hoverFill`` is an opaque plane colour, which is right for the rows
+    /// and chips that paint it BEHIND their content — that is what Phase UI-2
+    /// made it, so the same hover lands the same colour on all four surfaces.
+    /// A button cannot use it: ``RapidButtonSurface`` composites hover over an
+    /// amber or white fill it must not replace, so an opaque value there
+    /// covers the label instead of shading it. The button surface hovered to a
+    /// solid grey block with no text, and pressing it brought the text back —
+    /// ``pressedFill`` beside this is still translucent, so the same overlay
+    /// read as a wash on press and as a lid on hover.
+    ///
+    /// This is the value ``hoverFill`` carried before it became a plane, kept
+    /// here for the over-content case only. It composites differently across
+    /// surfaces — the reason Phase UI-2 moved off it — but a wash sitting on
+    /// the control's own fill is exactly where that behaviour is wanted.
+    static let hoverWash = Color.primary.opacity(0.055)
+    /// Pressed wash — one step firmer than ``hoverWash``, and drawn in the
+    /// same over-content position, which is why it is an opacity rather than
+    /// a plane colour.
     static let pressedFill = Color.primary.opacity(0.10)
     /// Multiplier applied to a control's opacity when disabled.
     ///

--- a/apps/rapid-mac/Tests/RapidTests/ControlWashTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ControlWashTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Rapid
+
+/// Washes drawn OVER a control's own fill have to let it through.
+///
+/// ``RapidButtonSurface`` paints hover and pressed as an overlay, so that one
+/// pair of values reads correctly over an amber primary, a white secondary,
+/// and a borderless tertiary. That only works while both values are
+/// translucent.
+///
+/// Phase UI-2 recast ``hoverFill`` as an opaque plane colour — correct for the
+/// twelve rows and chips that paint it BEHIND their content, and silently
+/// wrong for the one place that paints it in front. It did not touch the
+/// button surface; nothing connected the two. Every button in the app then
+/// hovered to a solid block with no label, and pressing it brought the label
+/// back, because ``pressedFill`` in the same overlay was still a wash.
+@Suite("Control washes")
+@MainActor
+struct ControlWashTests {
+
+    private func alpha(_ color: Color, in appearance: NSAppearance.Name) -> CGFloat {
+        var resolved: CGFloat = -1
+        NSAppearance(named: appearance)!.performAsCurrentDrawingAppearance {
+            resolved = NSColor(color).usingColorSpace(.sRGB)?.alphaComponent ?? -1
+        }
+        return resolved
+    }
+
+    private let appearances: [NSAppearance.Name] = [.aqua, .darkAqua]
+
+    @Test("Over-content washes are translucent in both appearances")
+    func washesLetTheControlThrough() {
+        for appearance in appearances {
+            let hover = alpha(RapidTheme.hoverWash, in: appearance)
+            let pressed = alpha(RapidTheme.pressedFill, in: appearance)
+            #expect(
+                hover > 0 && hover < 1,
+                "hoverWash is \(hover) in \(appearance.rawValue) — an opaque overlay hides the label it should be shading"
+            )
+            #expect(
+                pressed > 0 && pressed < 1,
+                "pressedFill is \(pressed) in \(appearance.rawValue)"
+            )
+        }
+    }
+
+    /// The pair has an order: pressed reads firmer than hover. Inverting it
+    /// makes a button look like it lifts when you press it.
+    @Test("Pressed is firmer than hover")
+    func pressedIsFirmerThanHover() {
+        for appearance in appearances {
+            #expect(
+                alpha(RapidTheme.pressedFill, in: appearance)
+                    > alpha(RapidTheme.hoverWash, in: appearance)
+            )
+        }
+    }
+
+    /// ``hoverFill`` is deliberately opaque and stays that way — this pins the
+    /// distinction so the two tokens are not "cleaned up" back into one.
+    @Test("The row hover plane stays opaque")
+    func rowHoverPlaneIsOpaque() {
+        for appearance in appearances {
+            #expect(alpha(RapidTheme.hoverFill, in: appearance) == 1)
+        }
+    }
+}


### PR DESCRIPTION
## The bug

Every button in the app turned into a solid grey block on hover, hiding
its own label. Pressing it brought the label back.

`RapidButtonSurface` paints hover and pressed as an **overlay**, so one pair
of values reads correctly over an amber primary, a white secondary and a
borderless tertiary. Its comment has said so since #1460:

```swift
// Hover and pressed are drawn as a wash ON TOP of the
// tier's own fill, so one pair of values reads correctly
// over amber, over white, and over nothing.
```

That contract requires both values to be translucent.

Phase UI-2 (#1905) recast `hoverFill` from `Color.primary.opacity(0.055)` to
an opaque mineral plane — `#F0F0ED` light, `#212429` dark. **That change is
correct** for what it was made for: the twelve rows, chips and pickers that
paint it *behind* their content, so one hover colour lands the same on all
four surface planes. It is wrong only for the single consumer that paints it
*in front*, and #1905 never touched that file — nothing connected the two.

Measured on the built app, both appearances:

| token | alpha |
|---|---|
| `hoverFill` | **1.0** |
| `pressedFill` | 0.085 |

Same overlay. Hence: hover covers the label, press reveals it.

Forty-seven call sites route through this surface — `.rapidPrimary` 12,
`.rapidSecondary` 26, `.rapidTertiary` 3, `.rapidDestructive` 3, plus 3
explicit.

## The fix

`hoverWash` restores the pre-#1905 value for the over-content position only.
`hoverFill` keeps its plane semantics and all twelve of its consumers, which
I checked one at a time — every one of them draws it as a background.

This is deliberately *not* a revert of #1905. The plane colour is the right
answer for rows; a button compositing over its own amber fill needs a wash.
Two positions, two tokens.

## Verification

Rendered a `.rapidSecondaryCompact` button through `ImageRenderer` with the
surface's hover state temporarily forced on, then counted pixels:

| | before | after |
|---|---|---|
| label pixels (`#313131`) | 0 | **409** |
| stroke pixels (`#DDDCD9`) | 0 | **696** |
| button interior | one flat colour | wash over fill, label and border intact |

The forced-hover edit was reverted; what ships is the token split and the
tests.

## Tests

`ControlWashTests` pins the invariants that make the two tokens different,
rather than their values:

- an over-content wash is translucent in both appearances
- pressed reads firmer than hover
- the row plane stays opaque, so the pair is not later merged back into one

Break-verified by pointing `hoverWash` at `hoverFill`: the first two fail in
both appearances.

Full suite: 2221 Swift tests. The three failing suites (`Web tools
hardening`, `Download/catalog hardening`, `Throughput caption integration`)
fail identically on unmodified `main` on this machine — DNS NXDOMAIN
hijacking by the local ISP, and two timing-sensitive cases.

## Not fixed here

Measured while investigating, left for a separate change because both are
design calls rather than defects:

- **Hover is faint.** With the wash restored, hover contrast ratio is 1.10
  in light and **1.036** for dark-mode amber — close to imperceptible.
  `utility: false` tiers also leave the label colour unchanged on hover, so
  the wash is their only signal.
- **36 `.buttonStyle(.plain)` buttons have no hover feedback at all** —
  concentrated in `ChatView` (7), `AudioView`, `DownloadStrip`,
  `ContentView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
