### PR TITLE
fix(mac): keep the composer placeholder clear of IME text

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1651,6 +1651,11 @@ struct ComposeField: View {
     /// NSTextView balloon to a giant centred textarea).
     @State private var contentHeight: CGFloat = 22
 
+    /// True while an input method is showing pre-edit text. ``text`` is
+    /// empty for that whole phase, so this is what keeps the placeholder
+    /// from rendering underneath a half-typed pinyin / kana run.
+    @State private var isComposing = false
+
     var body: some View {
         // v0.5 (Phase 5b): explicit height. The editor measures its own
         // text and reports it; we clamp and apply it via `.frame(height:)`.
@@ -1673,6 +1678,7 @@ struct ComposeField: View {
                 axIdentifier: axIdentifier,
                 axLabel: axLabel,
                 axRoleDescription: axRoleDescription,
+                onComposingChange: { isComposing = $0 },
                 onMeasuredHeight: { measured in
                     let clamped = min(max(measured, minHeight), maxHeight)
                     if abs(clamped - contentHeight) > 0.5 {
@@ -1680,7 +1686,7 @@ struct ComposeField: View {
                     }
                 }
             )
-            if text.isEmpty {
+            if text.isEmpty, !isComposing {
                 Text(placeholder)
                     // Overlays the 15pt NSTextView — must match its
                     // size or the placeholder visibly shrinks the
@@ -1708,6 +1714,39 @@ final class AutosizingTextView: NSTextView {
     /// view's width changes. The receiver owns the clamping; this only
     /// reports what the layout manager actually used.
     var onMeasuredHeight: ((CGFloat) -> Void)?
+
+    /// Called when input-method pre-edit text (marked text) appears or
+    /// clears.
+    ///
+    /// AppKit does NOT post a text-did-change notification while an IME
+    /// is composing, so ``text`` stays empty through the whole pinyin /
+    /// kana / jamo phase. ``ComposeField`` keyed its placeholder off
+    /// that binding alone, so "Send a message…" kept rendering
+    /// underneath the candidate text the user was typing. Marked text is
+    /// the only signal that the field is non-empty here.
+    var onComposingChange: ((Bool) -> Void)?
+
+    override func setMarkedText(
+        _ string: Any,
+        selectedRange: NSRange,
+        replacementRange: NSRange
+    ) {
+        super.setMarkedText(
+            string,
+            selectedRange: selectedRange,
+            replacementRange: replacementRange
+        )
+        onComposingChange?(hasMarkedText())
+        // Pre-edit text occupies real lines — a long pinyin run wraps
+        // and must grow the field like committed text does.
+        remeasure()
+    }
+
+    override func unmarkText() {
+        super.unmarkText()
+        onComposingChange?(false)
+        remeasure()
+    }
 
     /// Height of the laid-out text plus the editor's vertical insets.
     var measuredHeight: CGFloat {
@@ -1807,6 +1846,10 @@ struct ComposeTextEditor: NSViewRepresentable {
     var axIdentifier: String = AutosizingTextView.composeAccessibilityIdentifier
     var axLabel: String = AutosizingTextView.composeAccessibilityLabel
     var axRoleDescription: String = AutosizingTextView.composeAccessibilityRoleDescription
+    /// Reports whether an input method is currently showing pre-edit
+    /// text, so the placeholder can yield to it. Defaults to a no-op:
+    /// call sites that don't draw a placeholder don't need to care.
+    var onComposingChange: (Bool) -> Void = { _ in }
     /// Reports the editor's laid-out content height so ``ComposeField``
     /// can size the field to the draft.
     var onMeasuredHeight: (CGFloat) -> Void
@@ -1842,6 +1885,7 @@ struct ComposeTextEditor: NSViewRepresentable {
             width: 0, height: CGFloat.greatestFiniteMagnitude
         )
         tv.onMeasuredHeight = onMeasuredHeight
+        tv.onComposingChange = onComposingChange
         // Bug 3-A residual P2: NSTextView already advertises role
         // ``.textArea`` by default, but with no label / identifier
         // AppleScript and cliclick can't tell which text area is the
@@ -1869,7 +1913,14 @@ struct ComposeTextEditor: NSViewRepresentable {
 
     func updateNSView(_ scroll: NSScrollView, context: Context) {
         guard let view = scroll.documentView as? AutosizingTextView else { return }
-        if view.string != text {
+        // Never write over an in-flight IME composition. While marked
+        // text is up, ``view.string`` holds the pre-edit run and ``text``
+        // is still empty (AppKit posts no text-did-change until the user
+        // commits), so this branch would look like a stale draft and
+        // assigning ``text`` would erase the pinyin mid-word. Any
+        // unrelated SwiftUI update landing on this view — including the
+        // placeholder's own state change — is enough to trigger it.
+        if !view.hasMarkedText(), view.string != text {
             view.string = text
             // A programmatic assignment does not fire ``didChangeText``,
             // so the parent would keep the height of the previous draft
@@ -1877,6 +1928,7 @@ struct ComposeTextEditor: NSViewRepresentable {
             view.remeasure()
         }
         view.onMeasuredHeight = onMeasuredHeight
+        view.onComposingChange = onComposingChange
         context.coordinator.onSubmit = onSubmit
         context.coordinator.onCancel = onCancel
         context.coordinator.onPasteImages = onPasteImages

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1725,6 +1725,14 @@ final class AutosizingTextView: NSTextView {
     /// underneath the candidate text the user was typing. Marked text is
     /// the only signal that the field is non-empty here.
     var onComposingChange: ((Bool) -> Void)?
+    private var lastReportedCompositionState = false
+
+    private func reportCompositionState() {
+        let isComposing = hasMarkedText()
+        guard isComposing != lastReportedCompositionState else { return }
+        lastReportedCompositionState = isComposing
+        onComposingChange?(isComposing)
+    }
 
     override func setMarkedText(
         _ string: Any,
@@ -1736,7 +1744,7 @@ final class AutosizingTextView: NSTextView {
             selectedRange: selectedRange,
             replacementRange: replacementRange
         )
-        onComposingChange?(hasMarkedText())
+        reportCompositionState()
         // Pre-edit text occupies real lines — a long pinyin run wraps
         // and must grow the field like committed text does.
         remeasure()
@@ -1744,7 +1752,7 @@ final class AutosizingTextView: NSTextView {
 
     override func unmarkText() {
         super.unmarkText()
-        onComposingChange?(false)
+        reportCompositionState()
         remeasure()
     }
 
@@ -1854,6 +1862,18 @@ struct ComposeTextEditor: NSViewRepresentable {
     /// can size the field to the draft.
     var onMeasuredHeight: (CGFloat) -> Void
 
+    /// Keep this decision pure so the IME regression stays testable without
+    /// constructing SwiftUI's private representable context. Marked text is
+    /// owned by AppKit until the input method commits it; the binding must not
+    /// overwrite that temporary editor value.
+    static func shouldApplyBindingText(
+        viewHasMarkedText: Bool,
+        editorText: String,
+        bindingText: String
+    ) -> Bool {
+        !viewHasMarkedText && editorText != bindingText
+    }
+
     func makeNSView(context: Context) -> NSScrollView {
         let tv = AutosizingTextView()
         tv.delegate = context.coordinator
@@ -1920,7 +1940,11 @@ struct ComposeTextEditor: NSViewRepresentable {
         // assigning ``text`` would erase the pinyin mid-word. Any
         // unrelated SwiftUI update landing on this view — including the
         // placeholder's own state change — is enough to trigger it.
-        if !view.hasMarkedText(), view.string != text {
+        if Self.shouldApplyBindingText(
+            viewHasMarkedText: view.hasMarkedText(),
+            editorText: view.string,
+            bindingText: text
+        ) {
             view.string = text
             // A programmatic assignment does not fire ``didChangeText``,
             // so the parent would keep the height of the previous draft

--- a/apps/rapid-mac/Tests/RapidTests/ChatComposeAccessibilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatComposeAccessibilityTests.swift
@@ -14,6 +14,47 @@ import Testing
 @MainActor
 @Suite("ChatCompose accessibility shape")
 struct ChatComposeAccessibilityTests {
+    @Test("Marked text reports composition until AppKit unmarks it")
+    func markedTextReportsCompositionLifecycle() {
+        let tv = AutosizingTextView()
+        var states: [Bool] = []
+        tv.onComposingChange = { states.append($0) }
+
+        tv.setMarkedText(
+            "nihao",
+            selectedRange: NSRange(location: 5, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        #expect(tv.hasMarkedText())
+        #expect(tv.string == "nihao")
+        #expect(states == [true])
+
+        tv.unmarkText()
+
+        #expect(!tv.hasMarkedText())
+        #expect(states == [true, false])
+    }
+
+    @Test("SwiftUI binding never overwrites input-method pre-edit text")
+    func bindingSyncYieldsToMarkedText() {
+        #expect(!ComposeTextEditor.shouldApplyBindingText(
+            viewHasMarkedText: true,
+            editorText: "nihao",
+            bindingText: ""
+        ))
+        #expect(ComposeTextEditor.shouldApplyBindingText(
+            viewHasMarkedText: false,
+            editorText: "stale draft",
+            bindingText: "restored draft"
+        ))
+        #expect(!ComposeTextEditor.shouldApplyBindingText(
+            viewHasMarkedText: false,
+            editorText: "same draft",
+            bindingText: "same draft"
+        ))
+    }
+
     @Test("Compose configurator sets label, identifier, role description")
     func applyComposeAccessibilitySetsAllThreeAttributes() {
         let tv = AutosizingTextView()


### PR DESCRIPTION
## Summary

- hide the composer placeholder while AppKit has input-method pre-edit (marked) text
- preserve marked text across unrelated SwiftUI updates instead of replacing it with the still-empty binding
- remeasure the composer while a long pinyin/kana/jamo pre-edit run wraps
- report composition transitions only once, including AppKit's nested `unmarkText` path

The original hover-label commit has been removed during rebase because #1934 already landed the same root-cause fix with the reviewed `hoverWash` visual treatment and regression coverage. Reintroducing the older opaque-background approach would overwrite the button tier fill.

## Validation

- `swift test --no-parallel --filter ChatComposeAccessibilityTests`
- exercises a real `AutosizingTextView.setMarkedText` → `unmarkText` lifecycle
- pins the binding-sync rule that prevents SwiftUI from erasing in-flight IME text

No dependencies, scripts, network calls, or process-launch behavior are added.
