### PR TITLE
test(mac): align release dogfood with current onboarding and scroll

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -22,7 +22,6 @@ AXApplication title="Rapid-MLX"
           AXStaticText id="Sidebar.Residency" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
-          AXButton id="Transcript.JumpToBottom" desc="Jump to latest" enabled=true
           AXScrollArea
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1175,7 +1175,10 @@ flow_download_progress() {
     press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
     wait_identifier Quickstart.Footer.Primary "$OUT/chooser.json"
     assert_tree_text "$OUT/chooser.json" "~633 MB"
-    press "$OUT/chooser.json" Quickstart.Footer.Primary "$OUT/download-start.json"
+    press "$OUT/chooser.json" Quickstart.Footer.Primary "$OUT/review-open.json"
+    wait_identifier Quickstart.Review.Alias "$OUT/review.json"
+    assert_tree_text "$OUT/review.json" "Download & start"
+    press "$OUT/review.json" Quickstart.Footer.Primary "$OUT/download-start.json"
 
     local observed=0
     for _ in {1..40}; do


### PR DESCRIPTION
## What changed

- Update the `download-progress` GUI GoldenFlow to follow the Step 2 Review Download micro-stage introduced by #1931 before asserting live download progress.
- Refresh the five-turn live-chat baseline: current streaming correctly remains pinned to the latest response, so `Jump to latest` is absent. The restored-conversation baseline is unchanged.

## Why

The release harness lagged two already-landed UX changes. It pressed the shortlist primary once and waited for bytes even though that press now opens Review; it also expected a jump-to-bottom affordance while live streaming was already at the bottom. Aligning the harness restores trustworthy release gating without changing production behavior.

## Validation

- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `pytest tests/test_gui_preflight_contract.py -q`
- Mini main-HEAD `download-progress` GoldenFlow: PASS
- Mini main-HEAD `chat-depth --update-baselines`: PASS; exactly one baseline element removed; restored baseline unchanged.