### PR TITLE
test(mac): keep settings golden flow AX-only

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -85,6 +85,7 @@ AXApplication title="Rapid-MLX"
         AXGroup id="Settings.ModelManagement.CapabilityTabs" desc="Model type" enabled=true
           AXButton desc="Chat models" enabled=true
           AXButton desc="Image models" enabled=true
+          AXButton desc="Audio models" enabled=true
         AXTextField id="Settings.ModelManagement.Search" value=empty enabled=true
         AXPopUpButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
         AXGroup id="Settings.ModelManagement.Filter" desc="Filter" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -85,6 +85,7 @@ AXApplication title="Rapid-MLX"
         AXGroup id="Settings.ModelManagement.CapabilityTabs" desc="Model type" enabled=true
           AXButton desc="Chat models" enabled=true
           AXButton desc="Image models" enabled=true
+          AXButton desc="Audio models" enabled=true
         AXTextField id="Settings.ModelManagement.Search" value=empty enabled=true
         AXPopUpButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
         AXGroup id="Settings.ModelManagement.Filter" desc="Filter" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -85,6 +85,7 @@ AXApplication title="Rapid-MLX"
         AXGroup id="Settings.ModelManagement.CapabilityTabs" desc="Model type" enabled=true
           AXButton desc="Chat models" enabled=true
           AXButton desc="Image models" enabled=true
+          AXButton desc="Audio models" enabled=true
         AXTextField id="Settings.ModelManagement.Search" value=empty enabled=true
         AXPopUpButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
         AXGroup id="Settings.ModelManagement.Filter" desc="Filter" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -85,6 +85,7 @@ AXApplication title="Rapid-MLX"
         AXGroup id="Settings.ModelManagement.CapabilityTabs" desc="Model type" enabled=true
           AXButton desc="Chat models" enabled=true
           AXButton desc="Image models" enabled=true
+          AXButton desc="Audio models" enabled=true
         AXTextField id="Settings.ModelManagement.Search" value=empty enabled=true
         AXPopUpButton id="Settings.ModelManagement.SortMenu" title="Sort" enabled=true
         AXGroup id="Settings.ModelManagement.Filter" desc="Filter" enabled=true

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -851,7 +851,23 @@ dismiss_first_run() {
 }
 
 open_settings() {
-    pb menu click --app "PID:$APP_PID" --item 'Settings…' --json > "$OUT/open-settings.json"
+    if flow_requires_peekaboo; then
+        pb menu click --app "PID:$APP_PID" --item 'Settings…' --json > "$OUT/open-settings.json"
+    else
+        # Settings persistence is deliberately part of the unattended,
+        # AX-only suite. Use the standard macOS shortcut so that flow does
+        # not quietly depend on Peekaboo just to open the window.
+        osascript - "$APP_PID" > "$OUT/open-settings.json" <<'APPLESCRIPT'
+on run argv
+    set targetPID to (item 1 of argv) as integer
+    tell application "System Events"
+        set frontmost of first application process whose unix id is targetPID to true
+        keystroke "," using command down
+    end tell
+    return "{\"success\":true,\"method\":\"command-comma\"}"
+end run
+APPLESCRIPT
+    fi
     local probe=2 opened=0
     for _ in {1..40}; do
         probe=0


### PR DESCRIPTION
## Summary
- open Settings with the native Command-, shortcut in AX-only golden flows
- remove the accidental Peekaboo dependency from `settings-persistence`
- refresh Settings baselines for the intentional Audio models control added on main

## Verification
- Mini, release app built from main: `settings-persistence` passes end to end without Peekaboo
- verifies settings edits, model toggles, relaunch, and persistence