### PR TITLE
fix(mac): restart text resident for connectors

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -121,6 +121,19 @@ struct ModelResidencySnapshot: Codable, Sendable, Equatable {
     func contains(_ alias: String) -> Bool {
         models.contains { $0.matches(alias) && $0.state != "evicting" }
     }
+
+    /// Pick the resident text model that can host chat-only subsystems such
+    /// as MCP. The process-owning alias may be an audio model after a user
+    /// visits Speech, even while a text engine is resident in that process.
+    func preferredTextAlias(fallback: String?) -> String? {
+        let textModels = models.filter {
+            $0.modality == "text" && $0.state != "evicting"
+        }
+        guard let model = textModels.first(where: { $0.primary }) ?? textModels.first else {
+            return fallback
+        }
+        return model.displayName(preferredAlias: fallback)
+    }
 }
 
 enum ResidentModelLoadResult: Sendable, Equatable {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
@@ -323,7 +323,14 @@ struct SettingsConnectorsPanel: View {
     /// Stop-then-start the current alias so the child is respawned WITH
     /// ``--mcp-config``. Mirrors the model-switch path in ``ContentView``.
     private func restartModel() {
-        guard let alias = server.launchedChildAlias else { return }
+        // Audio is intentionally non-resident and can own the sidecar after a
+        // trip through Speech. Restarting that launch alias cannot initialize
+        // MCP, even when a ready text model is resident beside it. Prefer the
+        // resident text engine; retain the launch alias for legacy engines
+        // that do not publish residency data.
+        guard let alias = server.residency.preferredTextAlias(
+            fallback: server.launchedChildAlias
+        ) else { return }
         isRestarting = true
         Task {
             await server.stop()

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -78,6 +78,35 @@ struct ModelResidencyTests {
         #expect(status.displayName(preferredAlias: "qwen3.5-4b-4bit") == "qwen3.5-4b-4bit")
     }
 
+    @Test("Connector restart prefers a resident text model over the process-owning audio alias")
+    func connectorRestartTextAlias() {
+        let text = ResidentModelStatus(
+            id: "qwen3.5-4b-4bit",
+            modelPath: "mlx-community/Qwen3.5-4B-MLX-4bit",
+            aliases: [],
+            modality: "text",
+            state: "resident",
+            pinned: false,
+            primary: false,
+            activeRequests: 0,
+            estimatedBytes: 1,
+            measuredBytes: nil,
+            idleSeconds: 0
+        )
+        let snapshot = ModelResidencySnapshot(
+            memoryLimitBytes: 1,
+            memoryUsedBytes: 1,
+            memoryAvailableBytes: 0,
+            idleTTLSeconds: 1,
+            loadsTotal: 1,
+            evictionsTotal: 0,
+            models: [text]
+        )
+
+        #expect(snapshot.preferredTextAlias(fallback: "qwen3-tts-4bit") == "qwen3.5-4b-4bit")
+        #expect(ModelResidencySnapshot.empty.preferredTextAlias(fallback: "legacy-chat") == "legacy-chat")
+    }
+
     @Test("Server readiness is resolved for every resident alias")
     func aliasSpecificReadiness() {
         let image = ResidentModelStatus(


### PR DESCRIPTION
## Summary
- restart a resident text model when enabling MCP connectors
- avoid restarting the process-owning Audio alias, which cannot initialize chat connectors
- retain the launched-alias fallback for legacy engines without residency data

## Reproduction
On Mini main HEAD: start Chat, use Speech (so TTS owns the sidecar), return to Chat, enable Connectors, press Restart. Before this change the app respawned `qwen3-tts-4bit --mcp-config ...`; `/v1/mcp/servers` remained `{configured:false}` and the UI stayed at `Not applied yet`.

## Verification
- Mini `swift test --filter ModelResidencyTests`: 9 tests pass
- new regression pins TTS owner + resident text selection
- real GUI verification on rebuilt Release app follows