### PR TITLE
feat(models): onboard Qwen3.8-27B (text default, serialized vision via --mllm) [skip-version-bump]

### DIFF
--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -305,6 +305,13 @@
     "supports_spec_decode": false,
     "is_moe": true
   },
+  "qwen3.8-27b-4bit": {
+    "hf_path": "mlx-community/Qwen3.8-27B-4bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false
+  },
   "qwen3.6-35b-nvfp4": {
     "hf_path": "mlx-community/Qwen3.6-35B-A3B-nvfp4",
     "tool_call_parser": "qwen3_coder_xml",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1810,14 +1810,16 @@ def load_model(
                 "(alias pins is_text_only=True but --mllm was also given)"
             )
 
-    # Hybrid/linear-attention VLM checkpoints (e.g. Qwen3.5/3.6 GatedDeltaNet
-    # with a vision tower) auto-route to the MLLM lane on their vision weights,
-    # but the MLLM continuous-batching engine cannot build a BatchKVCache over
-    # an ArraysCache backbone (GitHub #352). Left alone, the naive
-    # ``rapid-mlx serve <flagship>`` command boots into the MLLM lane and then
-    # raises a RuntimeError telling the user to "Drop --mllm" — a flag they
-    # never set. Auto-fall-back to the text-only mlx-lm lane HERE, at the
-    # routing layer, with one clear INFO line. The dense text lane serves the
+    # Hybrid/linear-attention VLM checkpoints (e.g. Qwen3.5/3.6/3.8 GatedDeltaNet
+    # with a vision tower) auto-route to the MLLM lane on their vision weights.
+    # Post-#1798 the MLLM engine CAN serve an ArraysCache backbone, but only in
+    # a serialized one-request-at-a-time lane (a BatchKVCache cannot be built
+    # over ArraysCache, so concurrent batching stays off — GitHub #352). Left
+    # alone, the naive ``rapid-mlx serve <flagship>`` command would boot the
+    # whole model into that B=1 lane, capping text throughput for every request.
+    # Auto-fall-back to the text-only mlx-lm lane HERE, at the routing layer,
+    # with one clear INFO line, so the common text path keeps full batching and
+    # --mllm opts into the serialized vision lane. The dense text lane serves the
     # GatedDeltaNet backbone coherently and keeps ``is_hybrid=False`` (avoiding
     # the metal::malloc throttle wedge the 4B/9B/27B dense variants hit under
     # the hybrid scheduler path — see model_auto_config r6-A R6-C1).
@@ -1827,11 +1829,13 @@ def load_model(
     # "auto-downgraded" and never falsely claim the user passed ``--no-mllm``
     # (codex #2 on #1178). The materialize-then-probe order is load-bearing:
     # ``_ensure_routing_config`` must run BEFORE ``resolve_serving_lane`` so a
-    # first-time uncached hybrid VLM has real config evidence and is not routed
-    # into the crashing MLLM engine (codex BLOCKING on #1178). Only fires in
+    # first-time uncached hybrid VLM has real config evidence and is routed on
+    # fact, not on a missing config (codex BLOCKING on #1178). Only fires in
     # auto mode: an explicit ``--mllm`` (force_mllm) is respected so the
-    # operator who insists on the multimodal path gets the engine's own #352
-    # error rather than a silent override. #352 dogfood P1-② (0.10.16).
+    # operator who wants vision gets the serialized MLLM lane (#1798) — for a
+    # hybrid backbone that serves vision at B=1; for an arch mlx-vlm cannot
+    # drive it still errors — rather than a silent override. #352 dogfood
+    # P1-② (0.10.16).
     #
     # The generative-media lanes are exempt. An ``image-gen`` / ``video-gen``
     # alias never reaches ``resolve_serving_lane``'s question at all — it
@@ -1856,14 +1860,16 @@ def load_model(
         )
         if _auto_text_fallback:
             logger.info(
-                "Model %r auto-downgraded to the text-only mlx-lm lane: it is "
-                "a multimodal checkpoint the MLLM continuous-batching engine "
-                "cannot serve — either a hybrid/linear-attention language "
-                "backbone (GitHub #352) or an architecture the installed "
-                "mlx-vlm does not support yet (e.g. muse_glimmer, served via "
-                "the vendored text backbone). The vision path is unavailable "
-                "for this checkpoint. Pass --mllm to force the multimodal "
-                "engine (it will error), or --no-mllm to silence this notice.",
+                "Model %r auto-downgraded to the text-only mlx-lm lane for "
+                "full batched throughput: it is a multimodal checkpoint whose "
+                "language backbone the MLLM continuous-batching engine cannot "
+                "batch — either hybrid/linear-attention (GatedDeltaNet: "
+                "Qwen3.5/3.6/3.8) or a vision architecture the installed "
+                "mlx-vlm cannot drive yet (e.g. muse_glimmer, served via the "
+                "vendored text backbone). Pass --mllm to serve vision: a "
+                "hybrid backbone runs a serialized one-request-at-a-time lane "
+                "(#1798); an unsupported arch errors instead. Pass --no-mllm "
+                "to silence this notice.",
                 model_name,
             )
 


### PR DESCRIPTION
## Why

Qwen3.8 is Qwen's newest 27B release and we want it live in Rapid-MLX day-one. It is a hybrid (GatedDeltaNet) vision-language model, so it needs an explicit alias (correct parsers + `is_hybrid`) rather than relying on family-regex inference. And **because** the pre-existing auto-downgrade notice wrongly told users `--mllm` *"will error"* for hybrid backbones, its working serialized vision path (#1798) was effectively hidden — this PR makes it discoverable.

## What

Onboards **Qwen3.8-27B** — a hybrid (GatedDeltaNet linear-attention) **vision-language** model — to the engine.

- Add the `qwen3.8-27b-4bit` alias → `mlx-community/Qwen3.8-27B-4bit`
  - `tool_call_parser: hermes`, `reasoning_parser: qwen3` (matches the Qwen3.5 family)
  - `is_hybrid: true`, `supports_spec_decode: false` (linear-attention backbone — config `text_config.layer_types` is 3/4 `linear_attention`)
- Correct a now-stale user-facing log message + adjacent routing comment in `server.py`.

## The vision story

Qwen3.8-27B is a VLM (config has `vision_config`, `image_token_id`, `video_token_id`; mlx-vlm 0.6.3 ships a `qwen3_5` vision module that drives it). Its text backbone is hybrid, so the MLLM continuous-batching engine can only serve it in the **serialized (B=1) ArraysCache lane added in #1798**.

- **Default `serve qwen3.8-27b-4bit`** → text lane, full batched throughput.
- **`serve qwen3.8-27b-4bit --mllm`** → serialized one-request-at-a-time **vision** lane. Verified: on a real photo it returned *"An orange cat is sleeping on the gray sofa."*

The pre-existing auto-downgrade notice still said `--mllm` *"(it will error)"* and the vision path was *"unavailable"* — both untrue post-#1798 for a hybrid backbone. Reworded to say `--mllm` serves serialized vision for hybrid backbones; only a vision arch mlx-vlm cannot drive still errors. The adjacent routing comment was updated for consistency (no logic change).

## Verification (M3 Ultra 256GB)

| Check | Result |
|---|---|
| Text chat | ✅ coherent, no `<think>`/control-token leak |
| Tool call (hermes) | ✅ `finish=tool_calls`, valid JSON args, empty content |
| Vision via `--mllm` | ✅ accurate photo description, 4.7s, serialized lane (`max_num_seqs=1`) |
| `ruff check` + `format` | ✅ clean |
| `pytest` alias contract + hybrid probe | ✅ 2862 passed (2848 + 14) |
| codex review | ✅ no blocking or major issues |

## Not in scope

Making serialized vision the **default** would drop text throughput to B=1 for all hybrid VLMs — deliberately left out; the correct default is text batching with `--mllm` opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)