### PR TITLE
chore: bump version to 0.12.13

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,12 +13,34 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.13] — 2026-08-14
+
+Adds Qwen's newest 27B model and document attachments in chat, plus a round of
+Mac app reliability and polish fixes.
+
 ### Added
 
+- **Qwen3.8-27B** — Qwen's latest 27B model is now one click/command away
+  (`rapid-mlx chat qwen3.8-27b-4bit`). It's a strong general-purpose and
+  tool-using model, and it can also describe images when you start it with the
+  vision option turned on.
 - Normal chats now accept PDF, CSV, and TXT attachments. Rapid extracts document
   text locally, keeps it with the conversation for follow-up questions, and
   clearly marks large partial extracts. Scanned PDFs without selectable text
   report that OCR is required instead of sending an empty prompt.
+
+### Fixed
+
+- The model list no longer shows a phantom "No" model on a machine that has
+  nothing downloaded yet.
+- The Launch page's Codex and Hermes buttons, which did nothing when clicked,
+  now start the right thing.
+- Hovering a button no longer covers its label with a grey block.
+- Long answers no longer slow the app down as their links pile up.
+- The message-box placeholder text now stays out of the way while you type in
+  another language.
+- Audio models are downloaded and checked before the app tries to use them, so
+  they no longer fail at the moment you press play.
 
 ## [0.12.12] — 2026-08-13
 

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.12</string>
+	<string>0.12.13</string>
 	<key>CFBundleVersion</key>
-	<string>156</string>
+	<string>157</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.12.13.md
+++ b/docs/release-notes/v0.12.13.md
@@ -1,0 +1,25 @@
+## Highlights
+
+**New model — Qwen3.8-27B.** Qwen's newest 27B is one command away:
+`rapid-mlx chat qwen3.8-27b-4bit`. It's a hybrid (GatedDeltaNet) model that
+serves as a strong general-purpose and tool-using text model on the default
+lane with full batched throughput. It's also a vision-language checkpoint:
+start it with `--mllm` to answer questions about images through the serialized
+single-stream lane (#1798) — verified describing a real photo end-to-end. The
+stale routing notice that told users `--mllm` "will error" for a hybrid backbone
+was corrected: `--mllm` now correctly advertises the working serialized vision
+lane. (#1939)
+
+## Also in this release
+
+- **Model list:** a machine with an empty cache no longer shows a phantom "No"
+  entry parsed out of the CLI's "no models cached yet" notice. (#1920)
+- **Onboarding:** completing macOS onboarding now requires explicit
+  confirmation, and model inspection is deferred until consent. (#1917, #1926)
+- Rapid Mac reliability & UX: Launch-page Codex/Hermes rows now actually launch
+  (#1933); hovering a button no longer masks its label (#1934); long answers no
+  longer degrade as link cursor rects grew O(n²) (#1930); the composer
+  placeholder stays clear of IME text (#1935); audio models are downloaded and
+  verified before serving (#1928, #1923, #1929); resident image-download
+  activity is shown (#1922); zero-token stopped turns are dropped from wire
+  history (#1914).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.12"
+version = "0.12.13"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Cuts release **0.12.13** to ship the just-merged **Qwen3.8-27B** onboarding (#1939) — Qwen's newest 27B, available day-one — **because** we want it live for users now. Per `RELEASE.md`, merging this `chore: bump version to 0.12.13` commit to `main` is what triggers the tagged release (auto tag → tier1-agent-gate → PyPI/Homebrew).

## What ships in 0.12.13

- **Qwen3.8-27B** (#1939) — hybrid GatedDeltaNet model; text lane by default, `--mllm` serves the serialized vision lane.
- Empty-cache phantom "No" model fix (#1920); explicit macOS onboarding confirmation (#1917); PDF/CSV/TXT chat attachments (#1932).
- A round of rapid-mac reliability/UX fixes (#1930, #1935, #1933, #1934, #1928, #1922, …).

## Bump contents (4 changes)

- `pyproject.toml` `0.12.12` → `0.12.13`
- `apps/rapid-mac/Resources/Info.plist` — `CFBundleShortVersionString` → `0.12.13`, `CFBundleVersion` `156` → `157`
- `apps/rapid-mac/CHANGELOG.md` — new `## [0.12.13]` section (accumulated `[Unreleased]` entries folded in)
- `docs/release-notes/v0.12.13.md` — curated GitHub Release notes (`git mv` from `unreleased.md`)

Offline release-notes builder test: `tests/release/test_build_release_notes.sh` → 45 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)