### PR TITLE
feat(cli): add user-owned model aliases

### DIFF
--- a/tests/test_user_aliases.py
+++ b/tests/test_user_aliases.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.user_aliases import (
+    UserAliasError,
+    config_path,
+    load_user_aliases,
+    remove_user_alias,
+    set_user_alias,
+    validated_user_aliases,
+)
+
+
+@pytest.fixture
+def alias_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "config" / "user-aliases.json"
+    monkeypatch.setenv("RAPID_MLX_USER_ALIASES_FILE", str(path))
+    return path
+
+
+BUILTINS = {
+    "smart": "mlx-community/Qwen3.5-9B-4bit",
+    "fast": "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+}
+
+
+def test_set_list_remove_round_trip_is_atomic_and_private(alias_file: Path) -> None:
+    set_user_alias("daily", "smart", BUILTINS)
+
+    assert validated_user_aliases(BUILTINS) == {"daily": "smart"}
+    payload = json.loads(alias_file.read_text())
+    assert payload == {"version": 1, "aliases": {"daily": "smart"}}
+    assert alias_file.stat().st_mode & 0o777 == 0o600
+    assert alias_file.parent.stat().st_mode & 0o777 == 0o700
+    assert not list(alias_file.parent.glob("*.tmp"))
+
+    assert remove_user_alias("daily", BUILTINS) is True
+    assert load_user_aliases() == {}
+    assert remove_user_alias("daily", BUILTINS) is False
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["-option", "../escape", "two words", "tool\nspoof", "éclair", "a" * 65],
+)
+def test_rejects_unsafe_alias_names(alias_file: Path, name: str) -> None:
+    with pytest.raises(UserAliasError):
+        set_user_alias(name, "smart", BUILTINS)
+    assert not alias_file.exists()
+
+
+@pytest.mark.parametrize(
+    "target", ["-option", "../escape", "org/repo/extra", "two words", "org/répo"]
+)
+def test_rejects_unsafe_targets(alias_file: Path, target: str) -> None:
+    with pytest.raises(UserAliasError):
+        set_user_alias("mine", target, BUILTINS)
+
+
+def test_rejects_builtin_collision_and_alias_chains(alias_file: Path) -> None:
+    with pytest.raises(UserAliasError, match="reserved built-in"):
+        set_user_alias("smart", "fast", BUILTINS)
+
+    set_user_alias("mine", "smart", BUILTINS)
+    with pytest.raises(UserAliasError, match="chains are not allowed"):
+        set_user_alias("second", "mine", BUILTINS)
+
+
+def test_rejects_separately_reserved_retired_name(alias_file: Path) -> None:
+    with pytest.raises(UserAliasError, match="reserved built-in"):
+        set_user_alias("retired", "fast", BUILTINS, frozenset({"retired"}))
+
+
+def test_corrupt_config_fails_closed(alias_file: Path) -> None:
+    alias_file.parent.mkdir(parents=True)
+    alias_file.write_text('{"version": 1, "aliases": ')
+    with pytest.raises(UserAliasError, match="cannot read"):
+        validated_user_aliases(BUILTINS)
+
+
+def test_symlinked_config_is_rejected(alias_file: Path, tmp_path: Path) -> None:
+    alias_file.parent.mkdir(parents=True)
+    victim = tmp_path / "victim.json"
+    victim.write_text("do not replace")
+    alias_file.symlink_to(victim)
+
+    with pytest.raises(UserAliasError, match="symlinked"):
+        set_user_alias("mine", "smart", BUILTINS)
+    assert victim.read_text() == "do not replace"
+
+
+def test_remove_never_touches_target_weights(alias_file: Path, tmp_path: Path) -> None:
+    weights = tmp_path / "models--org--repo" / "weights.safetensors"
+    weights.parent.mkdir()
+    weights.write_bytes(b"weights")
+    set_user_alias("mine", "org/repo", BUILTINS)
+
+    assert remove_user_alias("mine", BUILTINS)
+    assert weights.read_bytes() == b"weights"
+
+
+def test_config_path_override_is_expanded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAPID_MLX_USER_ALIASES_FILE", "~/aliases-test.json")
+    assert config_path() == Path.home() / "aliases-test.json"
+
+
+def test_model_registry_resolves_user_alias_through_shared_choke_point(
+    alias_file: Path,
+) -> None:
+    from vllm_mlx.model_aliases import (
+        list_builtin_aliases,
+        list_profiles,
+        resolve_model,
+        resolve_profile,
+    )
+
+    builtins = list_builtin_aliases()
+    set_user_alias("my-smart", "qwen3.5-9b-4bit", builtins)
+    set_user_alias("my-repo", "example/model", builtins)
+
+    assert resolve_model("my-smart") == builtins["qwen3.5-9b-4bit"]
+    assert resolve_model("my-repo") == "example/model"
+    assert resolve_profile("my-smart") == resolve_profile("qwen3.5-9b-4bit")
+    assert resolve_profile("my-repo").hf_path == "example/model"
+    assert list_profiles()["my-smart"].hf_path == builtins["qwen3.5-9b-4bit"]
+
+
+def test_cli_alias_commands_share_the_same_store(
+    alias_file: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from vllm_mlx.cli import alias_command, build_parser
+
+    parser = build_parser()
+    alias_command(parser.parse_args(["alias", "set", "daily", "qwen3.5-9b-4bit"]))
+    alias_command(parser.parse_args(["alias", "list"]))
+    assert "daily -> qwen3.5-9b-4bit" in capsys.readouterr().out
+
+    alias_command(parser.parse_args(["alias", "remove", "daily"]))
+    assert "cached weights were not changed" in capsys.readouterr().out
+    assert json.loads(alias_file.read_text())["aliases"] == {}

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5667,6 +5667,19 @@ def models_command(args):
     print("       `rapid-mlx serve <alias>` for an OpenAI-compatible server")
     if audio_entries:
         print("       `rapid-mlx serve kokoro|whisper-large-v3|parakeet` for audio")
+    # User mappings are rendered explicitly so support output never makes a
+    # private nickname look like an immutable catalog alias.
+    from vllm_mlx.model_aliases import list_builtin_aliases, user_alias_reserved_names
+    from vllm_mlx.user_aliases import validated_user_aliases
+
+    user_aliases = validated_user_aliases(
+        list_builtin_aliases(), user_alias_reserved_names()
+    )
+    if user_aliases:
+        print()
+        print(f"  User aliases ({len(user_aliases)})")
+        for name, target in sorted(user_aliases.items()):
+            print(f"  {name} -> {target}")
     print()
 
 
@@ -5935,6 +5948,41 @@ def rm_command(args):
     strategy = cache.delete_revisions(*revisions)
     strategy.execute()
     print(f"Freed {size_str}")
+
+
+def alias_command(args) -> None:
+    """Create, remove, or list user-owned model aliases."""
+    from vllm_mlx.model_aliases import list_builtin_aliases, user_alias_reserved_names
+    from vllm_mlx.user_aliases import (
+        UserAliasError,
+        remove_user_alias,
+        set_user_alias,
+        validated_user_aliases,
+    )
+
+    builtins = list_builtin_aliases()
+    reserved = user_alias_reserved_names()
+    try:
+        if args.alias_action == "set":
+            set_user_alias(args.name, args.target, builtins, reserved)
+            print(f"  User alias: {args.name} -> {args.target}")
+        elif args.alias_action == "remove":
+            if not remove_user_alias(args.name, builtins, reserved):
+                print(f"  User alias {args.name!r} does not exist.", file=sys.stderr)
+                raise SystemExit(1)
+            print(
+                f"  Removed user alias {args.name!r}; cached weights were not changed."
+            )
+        else:
+            aliases = validated_user_aliases(builtins, reserved)
+            if not aliases:
+                print("  No user aliases configured.")
+            else:
+                for name, target in sorted(aliases.items()):
+                    print(f"  {name} -> {target}")
+    except UserAliasError as exc:
+        print(f"\n  Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
 
 
 def ps_command(_args):
@@ -9708,6 +9756,18 @@ Examples:
         action="store_true",
         help="Skip the confirmation prompt and remove the model immediately.",
     )
+    alias_parser = subparsers.add_parser(
+        "alias", help="Manage user-owned model aliases"
+    )
+    alias_subparsers = alias_parser.add_subparsers(
+        dest="alias_action", required=True, help="Alias action"
+    )
+    alias_set = alias_subparsers.add_parser("set", help="Create or replace an alias")
+    alias_set.add_argument("name", help="Private alias name")
+    alias_set.add_argument("target", help="Built-in alias or Hugging Face repo id")
+    alias_remove = alias_subparsers.add_parser("remove", help="Remove an alias mapping")
+    alias_remove.add_argument("name", help="Private alias name")
+    alias_subparsers.add_parser("list", help="List user alias mappings")
     subparsers.add_parser("ps", help="List running rapid-mlx servers")
 
     # Upgrade — detect install method and run the right upgrade command
@@ -10356,10 +10416,11 @@ def main():
         and getattr(args, "command", None) != "doctor"
     ):
         from vllm_mlx.model_aliases import RetiredModelAliasError, resolve_model
+        from vllm_mlx.user_aliases import UserAliasError
 
         try:
             resolved = resolve_model(args.model)
-        except RetiredModelAliasError as exc:
+        except (RetiredModelAliasError, UserAliasError) as exc:
             print(f"\n  Error: {exc}", file=sys.stderr)
             raise SystemExit(1) from None
         if resolved != args.model:
@@ -10534,6 +10595,8 @@ def main():
         pull_command(args)
     elif args.command == "rm":
         rm_command(args)
+    elif args.command == "alias":
+        alias_command(args)
     elif args.command == "ps":
         ps_command(args)
     elif args.command in ("upgrade", "update"):

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -645,6 +645,14 @@ def resolve_model(name: str) -> str:
         return name
     if reason := _RETIRED_MODEL_ALIASES.get(name):
         raise RetiredModelAliasError(reason)
+    from .user_aliases import validated_user_aliases
+
+    builtins = {alias: profile.hf_path for alias, profile in _load().items()}
+    if target := validated_user_aliases(builtins, user_alias_reserved_names()).get(
+        name
+    ):
+        profile = _load().get(target)
+        return profile.hf_path if profile is not None else target
     # Preserve the historical resolver hot path exactly unless the external
     # feature is configured. In particular, ordinary chat/serve resolution
     # must not introduce a cache/download-gate probe.
@@ -811,13 +819,43 @@ def _external_model_identifier_parts(name: str) -> list[str] | None:
 
 def list_aliases() -> dict[str, str]:
     """Return all aliases as ``{alias: hf_path}`` (legacy view)."""
+    builtins = {alias: profile.hf_path for alias, profile in _load().items()}
+    from .user_aliases import validated_user_aliases
+
+    users = validated_user_aliases(builtins, user_alias_reserved_names())
+    return builtins | {
+        alias: builtins.get(target, target) for alias, target in users.items()
+    }
+
+
+def list_builtin_aliases() -> dict[str, str]:
+    """Return the immutable catalog aliases, excluding user mappings."""
     return {alias: profile.hf_path for alias, profile in _load().items()}
+
+
+def user_alias_reserved_names() -> frozenset[str]:
+    """Names user aliases may not shadow, including retired catalog names."""
+    return frozenset(_load()) | frozenset(_RETIRED_MODEL_ALIASES)
 
 
 def list_profiles() -> dict[str, AliasProfile]:
     """Return all alias profiles. Use this when you need parser/capability
     info, not just the HF path."""
-    return dict(_load())
+    profiles = dict(_load())
+    from .user_aliases import validated_user_aliases
+
+    users = validated_user_aliases(
+        {alias: profile.hf_path for alias, profile in profiles.items()},
+        user_alias_reserved_names(),
+    )
+    for alias, target in users.items():
+        target_profile = profiles.get(target)
+        if target_profile is None and _hf_to_alias is not None:
+            canonical = _hf_to_alias.get(target)
+            if canonical is not None:
+                target_profile = profiles[canonical]
+        profiles[alias] = target_profile or AliasProfile(hf_path=target)
+    return profiles
 
 
 def resolve_profile(name: str) -> AliasProfile | None:
@@ -835,6 +873,19 @@ def resolve_profile(name: str) -> AliasProfile | None:
     direct = profiles.get(name)
     if direct is not None:
         return direct
+    from .user_aliases import validated_user_aliases
+
+    users = validated_user_aliases(
+        {alias: profile.hf_path for alias, profile in profiles.items()},
+        user_alias_reserved_names(),
+    )
+    if target := users.get(name):
+        target_profile = profiles.get(target)
+        if target_profile is None and _hf_to_alias is not None:
+            canonical = _hf_to_alias.get(target)
+            if canonical is not None:
+                target_profile = profiles[canonical]
+        return target_profile or AliasProfile(hf_path=target)
     if "/" in name and _hf_to_alias is not None:
         canonical = _hf_to_alias.get(name)
         if canonical is not None:

--- a/vllm_mlx/user_aliases.py
+++ b/vllm_mlx/user_aliases.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+"""User-owned model aliases with a small, fail-closed persistence contract."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import stat
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
+_TARGET_PART_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,95}\Z")
+
+
+class UserAliasError(ValueError):
+    """The user alias store or a requested mutation is invalid."""
+
+
+def config_path() -> Path:
+    override = os.environ.get("RAPID_MLX_USER_ALIASES_FILE", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "rapid-mlx" / "user-aliases.json"
+
+
+def _validate_name(name: str) -> None:
+    if not isinstance(name, str) or not _NAME_RE.fullmatch(name):
+        raise UserAliasError(
+            "alias names must be 1-64 ASCII letters, digits, '.', '_' or '-', "
+            "and must start with a letter or digit"
+        )
+
+
+def _is_hf_repo_id(target: str) -> bool:
+    parts = target.split("/")
+    return len(parts) == 2 and all(_TARGET_PART_RE.fullmatch(part) for part in parts)
+
+
+def _read_raw(path: Path) -> object:
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return {"version": SCHEMA_VERSION, "aliases": {}}
+    if stat.S_ISLNK(info.st_mode):
+        raise UserAliasError(f"refusing symlinked user alias config: {path}")
+    if not stat.S_ISREG(info.st_mode):
+        raise UserAliasError(f"user alias config is not a regular file: {path}")
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags)
+        try:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise UserAliasError(f"user alias config is not a regular file: {path}")
+            with os.fdopen(fd, encoding="utf-8") as handle:
+                fd = -1
+                return json.load(handle)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+    except UserAliasError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise UserAliasError(f"cannot read user alias config {path}: {exc}") from exc
+
+
+def load_user_aliases() -> dict[str, str]:
+    path = config_path()
+    raw = _read_raw(path)
+    if not isinstance(raw, dict) or set(raw) != {"version", "aliases"}:
+        raise UserAliasError(
+            f"user alias config {path} must contain only 'version' and 'aliases'"
+        )
+    if raw["version"] != SCHEMA_VERSION:
+        raise UserAliasError(
+            f"unsupported user alias config version {raw['version']!r} in {path}"
+        )
+    aliases = raw["aliases"]
+    if not isinstance(aliases, dict):
+        raise UserAliasError(f"'aliases' in {path} must be an object")
+    parsed: dict[str, str] = {}
+    folded: set[str] = set()
+    for name, target in aliases.items():
+        _validate_name(name)
+        if name.casefold() in folded:
+            raise UserAliasError(f"user alias names collide by case: {name!r}")
+        if not isinstance(target, str) or not target:
+            raise UserAliasError(f"target for user alias {name!r} must be a string")
+        folded.add(name.casefold())
+        parsed[name] = target
+    return parsed
+
+
+def _validated_mapping(
+    aliases: dict[str, str],
+    builtins: dict[str, str],
+    reserved_names: frozenset[str] = frozenset(),
+) -> dict[str, str]:
+    builtin_folded = {name.casefold() for name in builtins}
+    reserved_folded = builtin_folded | {name.casefold() for name in reserved_names}
+    folded_names = [name.casefold() for name in aliases]
+    if len(set(folded_names)) != len(folded_names):
+        raise UserAliasError("user alias names collide by case")
+    user_folded = set(folded_names)
+    for name, target in aliases.items():
+        _validate_name(name)
+        if name.casefold() in reserved_folded:
+            raise UserAliasError(f"{name!r} is a reserved built-in alias")
+        if target.casefold() in user_folded:
+            raise UserAliasError(
+                f"user alias {name!r} targets another user alias; chains are not allowed"
+            )
+        if target not in builtins and not _is_hf_repo_id(target):
+            raise UserAliasError(
+                f"target {target!r} must be a built-in alias or Hugging Face repo id"
+            )
+    return aliases
+
+
+def validated_user_aliases(
+    builtins: dict[str, str], reserved_names: frozenset[str] = frozenset()
+) -> dict[str, str]:
+    return _validated_mapping(load_user_aliases(), builtins, reserved_names)
+
+
+def _ensure_safe_parent(path: Path) -> None:
+    parent = path.parent
+    existed = parent.exists()
+    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if parent.is_symlink() or not parent.is_dir():
+        raise UserAliasError(f"refusing unsafe user alias directory: {parent}")
+    if not existed:
+        try:
+            os.chmod(parent, 0o700)
+        except OSError as exc:
+            raise UserAliasError(
+                f"cannot secure user alias directory {parent}: {exc}"
+            ) from exc
+
+
+def _write_aliases(aliases: dict[str, str]) -> None:
+    path = config_path()
+    _ensure_safe_parent(path)
+    # Never replace through an existing symlink. os.replace would replace the
+    # link rather than its target, but rejecting it makes tampering explicit.
+    try:
+        if stat.S_ISLNK(path.lstat().st_mode):
+            raise UserAliasError(f"refusing symlinked user alias config: {path}")
+    except FileNotFoundError:
+        pass
+    payload = (
+        json.dumps(
+            {"version": SCHEMA_VERSION, "aliases": aliases},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    temporary = path.parent / f".{path.name}.{os.getpid()}.{secrets.token_hex(6)}.tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(temporary, flags, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, path)
+            os.chmod(path, 0o600)
+        except BaseException:
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+            raise
+    except OSError as exc:
+        raise UserAliasError(f"cannot write user alias config {path}: {exc}") from exc
+
+
+def set_user_alias(
+    name: str,
+    target: str,
+    builtins: dict[str, str],
+    reserved_names: frozenset[str] = frozenset(),
+) -> None:
+    aliases = load_user_aliases()
+    aliases[name] = target
+    _validated_mapping(aliases, builtins, reserved_names)
+    _write_aliases(aliases)
+
+
+def remove_user_alias(
+    name: str,
+    builtins: dict[str, str],
+    reserved_names: frozenset[str] = frozenset(),
+) -> bool:
+    aliases = validated_user_aliases(builtins, reserved_names)
+    if name not in aliases:
+        return False
+    del aliases[name]
+    _write_aliases(aliases)
+    return True


### PR DESCRIPTION
Closes #1919.

## What changed

- adds `rapid-mlx alias set/remove/list` for user-owned model aliases
- stores mappings in a versioned, atomic, user-private JSON config
- resolves aliases through the shared model registry used by CLI and server paths
- makes user mappings explicit in `models`, `info`, and server model discovery
- keeps built-in and retired aliases reserved and immutable

## Safety

- accepts only bounded ASCII alias names and built-in aliases or two-part Hugging Face repo IDs
- rejects chains, cycles, case-folded collisions, traversal, control characters, and option-shaped names
- rejects symlinked or malformed config files and uses atomic `0600` writes
- `alias remove` removes only the mapping and never cached weights
- adds no dependencies, remote config, executable downloads, or shell interpolation

## Validation

- `ruff check` and `git diff --check`
- 180 focused alias, model registry, CLI-model, and layout tests
- Mini M2 Pro dogfood with cached LFM2.5 1.2B: set/list/models/info, server startup via user alias, `/v1/models`, chat completion (`ALIAS_OK`), and remove-without-weight-deletion invariant
