### PR TITLE
feat(mllm): add opt-in vision pixel bounds

### DIFF
--- a/docs/guides/multimodal.md
+++ b/docs/guides/multimodal.md
@@ -310,5 +310,17 @@ compatible web UI (Open WebUI, LibreChat, etc.) pointed at it:
 rapid-mlx serve qwen3-vl-4b-4bit --mllm --port 8000
 ```
 
+Dynamic-resolution VLMs such as Qwen2.5-VL and Qwen3-VL can turn a large
+photo into thousands of vision tokens. To trade some fine image detail for
+lower first-token latency and memory use, set an explicit server-side cap:
+
+```bash
+rapid-mlx serve qwen3-vl-4b-4bit --mllm --vision-max-pixels 1048576
+```
+
+The cap is opt-in. A value of `0` (the default) leaves the model processor's
+resolution policy unchanged. `--vision-min-pixels` is available for operators
+who also need to preserve a minimum amount of visual detail.
+
 The shipped `rapid-mlx chat` REPL is text-only. The optional Gradio web UI
 (`pip install 'rapid-mlx[chat]'`) supports image / video uploads.

--- a/tests/test_cli_config_fidelity.py
+++ b/tests/test_cli_config_fidelity.py
@@ -87,6 +87,24 @@ def test_prefill_step_size_is_plumbed_in_server_main():
     )
 
 
+def test_vision_pixel_bounds_are_plumbed_in_both_server_entrypoints():
+    for source, function in (
+        (CLI_SOURCE, "serve_command"),
+        (SERVER_SOURCE, "main"),
+    ):
+        kwargs = _function_scheduler_config_kwargs(source, function)
+        assert {"vision_min_pixels", "vision_max_pixels"} <= kwargs
+
+
+def test_vision_pixel_bounds_cross_validation():
+    from vllm_mlx.cli import _vision_pixel_bounds_error
+
+    assert _vision_pixel_bounds_error(0, 0) is None
+    assert _vision_pixel_bounds_error(65_536, 1_048_576) is None
+    error = _vision_pixel_bounds_error(1_048_576, 65_536)
+    assert error is not None and "must not exceed" in error
+
+
 # ---------------------------------------------------------------------------
 # Layer 2: the audit script behavior
 # ---------------------------------------------------------------------------

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -237,6 +237,16 @@ class TestMLLMBatchStats:
 class TestMLLMSchedulerConfig:
     """Tests for MLLMSchedulerConfig."""
 
+    def test_vision_pixel_bounds_default_off_and_validate(self):
+        from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig
+
+        config = MLLMSchedulerConfig()
+        assert config.vision_min_pixels == 0
+        assert config.vision_max_pixels == 0
+
+        with pytest.raises(ValueError, match="must not exceed"):
+            MLLMSchedulerConfig(vision_min_pixels=200, vision_max_pixels=100)
+
     def test_default_config(self):
         """Test default configuration."""
         from vllm_mlx.mllm_scheduler import MLLMSchedulerConfig

--- a/tests/test_mllm_corrupt_image.py
+++ b/tests/test_mllm_corrupt_image.py
@@ -43,7 +43,11 @@ from __future__ import annotations
 
 import pytest
 
-from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator, MLLMBatchRequest
+from vllm_mlx.mllm_batch_generator import (
+    MLLMBatchGenerator,
+    MLLMBatchRequest,
+    _temporary_vision_pixel_bounds,
+)
 
 
 class _StubModel:
@@ -58,12 +62,19 @@ class _StubModel:
         self.config = _Cfg()
 
 
-def _make_generator() -> MLLMBatchGenerator:
+def _make_generator(
+    *,
+    vision_min_pixels: int = 0,
+    vision_max_pixels: int = 0,
+    processor=None,
+) -> MLLMBatchGenerator:
     return MLLMBatchGenerator(
         model=_StubModel(),
-        processor=object(),
+        processor=processor or object(),
         mm_processor=None,
         enable_vision_cache=False,
+        vision_min_pixels=vision_min_pixels,
+        vision_max_pixels=vision_max_pixels,
     )
 
 
@@ -107,6 +118,73 @@ def _install_prepare_inputs_stub(monkeypatch, raiser):
     monkeypatch.setattr(mlx_vlm_utils, "prepare_inputs", raiser)
     if hasattr(gen_mod, "prepare_inputs"):
         monkeypatch.setattr(gen_mod, "prepare_inputs", raiser)
+
+
+def test_preprocess_forwards_opt_in_dynamic_resolution_bounds(monkeypatch):
+    _bypass_process_image(monkeypatch)
+    captured = {}
+
+    class _ImageProcessor:
+        size = {"shortest_edge": 65_536, "longest_edge": 16_777_216}
+
+    class _Processor:
+        image_processor = _ImageProcessor()
+
+    def _prepare(*args, **kwargs):
+        captured.update(args[0].image_processor.size)
+        return {"input_ids": None, "pixel_values": None, "attention_mask": None}
+
+    _install_prepare_inputs_stub(monkeypatch, _prepare)
+    processor = _Processor()
+    original_size = processor.image_processor.size
+    gen = _make_generator(
+        processor=processor,
+        vision_min_pixels=65_536,
+        vision_max_pixels=1_048_576,
+    )
+    gen._preprocess_request(_make_request(images=["image.png"]))
+
+    assert captured["shortest_edge"] == 65_536
+    assert captured["longest_edge"] == 1_048_576
+    assert processor.image_processor.size is original_size
+
+
+def test_pixel_cap_rejects_fixed_resolution_processor():
+    with pytest.raises(ValueError, match="dynamic-resolution image processor"):
+        _make_generator(vision_max_pixels=1_048_576)
+
+
+def test_native_mlx_vlm_pixel_attributes_are_bounded_and_restored():
+    class _ImageProcessor:
+        min_pixels = 3_136
+        max_pixels = 1_003_520
+
+    class _Processor:
+        image_processor = _ImageProcessor()
+
+    processor = _Processor()
+    with _temporary_vision_pixel_bounds(processor, 0, 262_144) as applied:
+        assert applied
+        assert processor.image_processor.min_pixels == 3_136
+        assert processor.image_processor.max_pixels == 262_144
+
+    assert processor.image_processor.min_pixels == 3_136
+    assert processor.image_processor.max_pixels == 1_003_520
+
+
+def test_preprocess_default_does_not_override_processor_resolution(monkeypatch):
+    _bypass_process_image(monkeypatch)
+    captured = {}
+
+    def _prepare(*args, **kwargs):
+        captured.update(kwargs)
+        return {"input_ids": None, "pixel_values": None, "attention_mask": None}
+
+    _install_prepare_inputs_stub(monkeypatch, _prepare)
+    _make_generator()._preprocess_request(_make_request(images=["image.png"]))
+
+    assert "min_pixels" not in captured
+    assert "max_pixels" not in captured
 
 
 def test_preprocess_wraps_pil_oserror_as_failed_to_process_image(monkeypatch):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -146,6 +146,12 @@ def non_negative_int(value: str) -> int:
     return n
 
 
+def _vision_pixel_bounds_error(min_pixels: int, max_pixels: int) -> str | None:
+    if min_pixels and max_pixels and min_pixels > max_pixels:
+        return "--vision-min-pixels must not exceed --vision-max-pixels"
+    return None
+
+
 def positive_finite_float(value: str) -> float:
     """Argparse type for positive, finite resource-budget values."""
     import math
@@ -2520,6 +2526,13 @@ def serve_command(args):
     import os
     import sys
 
+    if bounds_error := _vision_pixel_bounds_error(
+        getattr(args, "vision_min_pixels", 0),
+        getattr(args, "vision_max_pixels", 0),
+    ):
+        print(f"error: {bounds_error}", file=sys.stderr)
+        raise SystemExit(2)
+
     if os.environ.get("RAPID_PYSAMPLE"):
         from ._pysample import install as _pysample_install
 
@@ -3607,6 +3620,8 @@ def serve_command(args):
         # accepted but never used. See #400 and the CLI ↔ Config fidelity
         # audit at scripts/audit_cli_config_fidelity.py.
         prefill_step_size=args.prefill_step_size,
+        vision_min_pixels=getattr(args, "vision_min_pixels", 0),
+        vision_max_pixels=getattr(args, "vision_max_pixels", 0),
         # Speculative decoding selection.
         enable_mtp=getattr(args, "enable_mtp", False),
         mtp_num_draft_tokens=getattr(args, "mtp_num_draft_tokens", 1),
@@ -9051,6 +9066,25 @@ Examples:
         default=2048,
         help="Chunk size for prompt prefill processing. Larger values use more memory "
         "but can improve prefill throughput. (default: 2048)",
+    )
+    serve_parser.add_argument(
+        "--vision-min-pixels",
+        type=non_negative_int,
+        default=0,
+        help=(
+            "Minimum pixels used by dynamic-resolution VLM image processors. "
+            "0 keeps the model default (default: 0)."
+        ),
+    )
+    serve_parser.add_argument(
+        "--vision-max-pixels",
+        type=non_negative_int,
+        default=0,
+        help=(
+            "Maximum pixels used by dynamic-resolution VLM image processors. "
+            "Lower values trade image detail for lower TTFT and memory. "
+            "0 keeps the model default (default: 0)."
+        ),
     )
     # MCP options
     serve_parser.add_argument(

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1183,6 +1183,18 @@ class BatchedEngine(BaseEngine):
         self._model = self._mllm_instance.model
         self._processor = self._mllm_instance.processor
 
+        vision_min_pixels = getattr(self._scheduler_config, "vision_min_pixels", 0)
+        vision_max_pixels = getattr(self._scheduler_config, "vision_max_pixels", 0)
+        if vision_min_pixels or vision_max_pixels:
+            from ..mllm_batch_generator import _supports_dynamic_vision_bounds
+
+            if not _supports_dynamic_vision_bounds(self._processor):
+                raise RuntimeError(
+                    "--vision-min-pixels/--vision-max-pixels require a "
+                    "dynamic-resolution image processor (for example, "
+                    "Qwen2.5-VL or Qwen3-VL)"
+                )
+
         # Probe the language-backbone cache before the port reports ready.
         # ArraysCache has the merge/filter/extract primitives needed for a
         # correctness-first serialized lane (#1796), but concurrent hybrid
@@ -1258,7 +1270,6 @@ class BatchedEngine(BaseEngine):
         max_concurrent_requests = getattr(
             self._scheduler_config, "max_concurrent_requests", 256
         )
-
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,
             prefill_batch_size=prefill_batch_size,
@@ -1268,6 +1279,8 @@ class BatchedEngine(BaseEngine):
             vision_cache_size=100,
             max_concurrent_requests=max_concurrent_requests,
             allow_arrays_cache=arrays_cache_compat,
+            vision_min_pixels=vision_min_pixels,
+            vision_max_pixels=vision_max_pixels,
         )
 
         # Create and start MLLM scheduler — pass the model-owning executor so
@@ -1283,7 +1296,9 @@ class BatchedEngine(BaseEngine):
         logger.info(
             f"MLLM Scheduler started with continuous batching: "
             f"max_num_seqs={max_num_seqs}, prefill_batch={prefill_batch_size}, "
-            f"completion_batch={completion_batch_size}"
+            f"completion_batch={completion_batch_size}, vision_min_pixels="
+            f"{vision_min_pixels or 'model-default'}, vision_max_pixels="
+            f"{vision_max_pixels or 'model-default'}"
         )
 
     async def _start_llm(self) -> None:

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -20,6 +20,7 @@ import inspect
 import logging
 import time
 from collections.abc import Callable
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -46,6 +47,94 @@ from .vision_embedding_cache import (  # noqa: E402
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _dynamic_vision_size_values(processor: Any) -> dict[str, int] | None:
+    image_processor = getattr(processor, "image_processor", None)
+    size = getattr(image_processor, "size", None)
+    if size is None:
+        return None
+    try:
+        values = dict(size)
+    except (TypeError, ValueError):
+        return None
+    if "shortest_edge" not in values or "longest_edge" not in values:
+        return None
+    return values
+
+
+def _supports_dynamic_vision_bounds(processor: Any) -> bool:
+    image_processor = getattr(processor, "image_processor", None)
+    native_min = getattr(image_processor, "min_pixels", None)
+    native_max = getattr(image_processor, "max_pixels", None)
+    return (
+        isinstance(native_min, int)
+        and isinstance(native_max, int)
+        and native_min > 0
+        and native_max > 0
+    ) or _dynamic_vision_size_values(processor) is not None
+
+
+@contextmanager
+def _temporary_vision_pixel_bounds(processor: Any, min_pixels: int, max_pixels: int):
+    """Apply native dynamic-resolution bounds for one serialized preprocess.
+
+    ``mlx_vlm.prepare_inputs`` filters arbitrary kwargs against the processor's
+    explicit signature, so Qwen's ``max_pixels``/``size`` kwargs do not reach
+    its image processor. Replace its size descriptor while its own
+    ``smart_resize`` runs, then restore the exact object even on failure.
+    MLLM preprocessing is serialized on the scheduler worker.
+    """
+    image_processor = getattr(processor, "image_processor", None)
+    native_min = getattr(image_processor, "min_pixels", None)
+    native_max = getattr(image_processor, "max_pixels", None)
+    if (
+        isinstance(native_min, int)
+        and isinstance(native_max, int)
+        and native_min > 0
+        and native_max > 0
+    ):
+        effective_min = min_pixels or native_min
+        effective_max = max_pixels or native_max
+        if max_pixels and not min_pixels:
+            effective_min = min(effective_min, effective_max)
+        if min_pixels and not max_pixels:
+            effective_max = max(effective_max, effective_min)
+        image_processor.min_pixels = effective_min
+        image_processor.max_pixels = effective_max
+        try:
+            yield True
+        finally:
+            image_processor.min_pixels = native_min
+            image_processor.max_pixels = native_max
+        return
+
+    original = getattr(image_processor, "size", None)
+    if not (min_pixels or max_pixels) or original is None:
+        yield False
+        return
+
+    values = _dynamic_vision_size_values(processor)
+    if values is None:
+        yield False
+        return
+
+    effective_min = min_pixels or values["shortest_edge"]
+    effective_max = max_pixels or values["longest_edge"]
+    if max_pixels and not min_pixels:
+        effective_min = min(effective_min, effective_max)
+    if min_pixels and not max_pixels:
+        effective_max = max(effective_max, effective_min)
+    values["shortest_edge"] = effective_min
+    values["longest_edge"] = effective_max
+
+    replacement = values if isinstance(original, dict) else type(original)(**values)
+    image_processor.size = replacement
+    try:
+        yield True
+    finally:
+        image_processor.size = original
+
 
 # Upper bound on the per-forward chunk size used when prefilling a long
 # text-only prompt on the MLLM path (issue #1187, Problem B). The actual
@@ -536,6 +625,8 @@ class MLLMBatchGenerator:
         prefill_step_size: int = 1024,
         enable_vision_cache: bool = True,
         vision_cache_size: int = 100,
+        vision_min_pixels: int = 0,
+        vision_max_pixels: int = 0,
     ):
         """
         Initialize MLLM batch generator.
@@ -553,6 +644,8 @@ class MLLMBatchGenerator:
             prefill_step_size: Tokens to process per prefill step
             enable_vision_cache: Enable vision embedding caching
             vision_cache_size: Max entries in vision cache
+            vision_min_pixels: Optional processor-side minimum image pixels
+            vision_max_pixels: Optional processor-side maximum image pixels
         """
         self.model = model
         self.processor = processor
@@ -611,6 +704,14 @@ class MLLMBatchGenerator:
                 "batch sizes of 1"
             )
         self.prefill_step_size = prefill_step_size
+        if (vision_min_pixels or vision_max_pixels) and not (
+            _supports_dynamic_vision_bounds(processor)
+        ):
+            raise ValueError(
+                "vision pixel bounds require a dynamic-resolution image processor"
+            )
+        self.vision_min_pixels = vision_min_pixels
+        self.vision_max_pixels = vision_max_pixels
 
         # Request management
         self.unprocessed_requests: list[MLLMBatchRequest] = []
@@ -982,12 +1083,17 @@ class MLLMBatchGenerator:
         # propagating as server errors so the caller sees HTTP 500
         # instead of a misleading HTTP 400 "Failed to process image".
         try:
-            inputs = prepare_inputs(
+            with _temporary_vision_pixel_bounds(
                 self.processor,
-                images=all_images if all_images else None,
-                prompts=request.prompt,
-                image_token_index=image_token_index,
-            )
+                self.vision_min_pixels,
+                self.vision_max_pixels,
+            ):
+                inputs = prepare_inputs(
+                    self.processor,
+                    images=all_images if all_images else None,
+                    prompts=request.prompt,
+                    image_token_index=image_token_index,
+                )
         except (OSError, ValueError) as e:
             # Do not reflect decoder text: PIL / mlx-vlm messages can contain
             # server-side temporary paths. Keep the public diagnostic useful

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -77,6 +77,10 @@ class MLLMSchedulerConfig:
     # carrying the text-LLM default (2048) gets bumped to 8192, while
     # any explicit operator-set value is honored as-is (#682, codex r2).
     prefill_step_size: int = 8192
+    # Optional image-resolution bounds forwarded to dynamic-resolution
+    # processors (Qwen2.5/3-VL). Zero leaves model defaults unchanged.
+    vision_min_pixels: int = 0
+    vision_max_pixels: int = 0
     # Enable vision embedding cache
     enable_vision_cache: bool = True
     # Maximum cache entries
@@ -96,6 +100,14 @@ class MLLMSchedulerConfig:
     allow_arrays_cache: bool = False
 
     def __post_init__(self) -> None:
+        if self.vision_min_pixels < 0 or self.vision_max_pixels < 0:
+            raise ValueError("vision pixel bounds must be non-negative")
+        if (
+            self.vision_min_pixels
+            and self.vision_max_pixels
+            and self.vision_min_pixels > self.vision_max_pixels
+        ):
+            raise ValueError("vision_min_pixels must not exceed vision_max_pixels")
         if self.allow_arrays_cache and (
             self.max_num_seqs != 1
             or self.prefill_batch_size != 1
@@ -465,6 +477,8 @@ class MLLMScheduler:
                 completion_batch_size=self.config.completion_batch_size,
                 allow_arrays_cache=self.config.allow_arrays_cache,
                 prefill_step_size=self.config.prefill_step_size,
+                vision_min_pixels=self.config.vision_min_pixels,
+                vision_max_pixels=self.config.vision_max_pixels,
             )
 
     # ========== Sync API (step-based) ==========

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -418,10 +418,9 @@ class SchedulerConfig:
     adaptive_prefill_min_tokens: int = 32_768
     adaptive_prefill_min_chunk_size: int = 256
 
-    # APPENDED AT THE END DELIBERATELY: this dataclass is constructed
-    # positionally by external callers, so a field inserted mid-list
-    # silently rebinds every argument after it (see the note above
-    # ``mtp_sidecar``).
+    # APPEND-ONLY TAIL: this dataclass is constructed positionally by
+    # external callers, so every new field from here onward must stay at
+    # the end (see the note above ``mtp_sidecar``).
     #
     # Checkpoint identity for the MTP depth-controller registry, which is
     # process-global and survives a model swap. Without it the key falls
@@ -433,7 +432,21 @@ class SchedulerConfig:
     # ``rapid_mlx_spec_decode_k_cost_ms``.
     model_name: str | None = None
 
+    # Opt-in dynamic-resolution bounds for MLLM image preprocessing.
+    # Appended to preserve positional SchedulerConfig compatibility.
+    # Zero preserves the processor/model defaults exactly.
+    vision_min_pixels: int = 0
+    vision_max_pixels: int = 0
+
     def __post_init__(self) -> None:
+        if self.vision_min_pixels < 0 or self.vision_max_pixels < 0:
+            raise ValueError("vision pixel bounds must be non-negative")
+        if (
+            self.vision_min_pixels
+            and self.vision_max_pixels
+            and self.vision_min_pixels > self.vision_max_pixels
+        ):
+            raise ValueError("vision_min_pixels must not exceed vision_max_pixels")
         if self.response_cache_entries < 0:
             raise ValueError("response_cache_entries must be >= 0")
         if self.enable_mtp:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2832,6 +2832,18 @@ Examples:
         help="Tokens to process per prefill chunk (default: 2048). "
         "Larger values may improve TTFT on Apple Silicon with sufficient memory.",
     )
+    parser.add_argument(
+        "--vision-min-pixels",
+        type=int,
+        default=0,
+        help="Minimum pixels for dynamic-resolution VLM inputs (0: model default).",
+    )
+    parser.add_argument(
+        "--vision-max-pixels",
+        type=int,
+        default=0,
+        help="Maximum pixels for dynamic-resolution VLM inputs (0: model default).",
+    )
     # Task #292: mirror the ``rapid-mlx serve`` ``--enable-audio`` flag
     # on the legacy ``python -m vllm_mlx.server`` entrypoint so the same
     # text-mode-with-audio escape hatch is available to operators who
@@ -3091,8 +3103,19 @@ Examples:
         args, model_name=args.model
     )
 
+    if args.vision_min_pixels < 0 or args.vision_max_pixels < 0:
+        parser.error("vision pixel bounds must be non-negative")
+    if (
+        args.vision_min_pixels
+        and args.vision_max_pixels
+        and args.vision_min_pixels > args.vision_max_pixels
+    ):
+        parser.error("--vision-min-pixels must not exceed --vision-max-pixels")
+
     scheduler_config = SchedulerConfig(
         prefill_step_size=args.prefill_step_size,
+        vision_min_pixels=args.vision_min_pixels,
+        vision_max_pixels=args.vision_max_pixels,
         pflash_config=server_pflash_config,
         **_server_turboquant_scheduler_kwargs(args),
     )


### PR DESCRIPTION
Closes #1911.

## What changed

- adds opt-in `--vision-min-pixels` and `--vision-max-pixels` flags to both server entrypoints
- applies bounds through the native dynamic-resolution processor state and restores the exact defaults after each serialized preprocess
- rejects unsupported fixed-resolution processors during server startup
- keeps the default (`0`) behavior byte-for-byte compatible with model defaults
- documents the quality/latency tradeoff and adds config/preprocessing coverage

## Why

Large images can expand to thousands of visual tokens on Qwen2.5/3-VL-family processors. Operators need a deliberate quality-for-TTFT/memory control without changing behavior for existing users.

## Validation

- `ruff format --check` and `ruff check` on all touched Python files
- CLI/config fidelity audit passes
- 67 dependency-independent related tests pass locally
- Mini end-to-end with Qwen3.5-9B MLLM and the same 1481x874 image: TTFT 13.109s default vs 3.064s at 262,144 pixels; both returned 32 streamed tokens without errors
- processor-only checks confirmed 4,968 patches default vs 960 patches at 262,144 pixels and exact restoration of processor defaults