### PR TITLE
fix(server): correct rejected CORS preflight length

### DIFF
--- a/tests/test_cors_lockdown_response_shape.py
+++ b/tests/test_cors_lockdown_response_shape.py
@@ -102,6 +102,11 @@ def test_disallowed_origin_preflight_is_200_not_400(
         f"got {r.text!r}. If the body is intentionally being changed, "
         f"update the comment in ``_SpecAlignedCORSMiddleware.preflight_response``."
     )
+    assert r.headers.get("content-length") == str(len(r.content)), (
+        "The replacement response must describe its own body length; carrying "
+        "Starlette's rejected-preflight Content-Length truncates the response "
+        "on the wire for curl and strict HTTP clients."
+    )
 
 
 def test_disallowed_origin_preflight_omits_acao(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1063,6 +1063,13 @@ class _SpecAlignedCORSMiddleware(CORSMiddleware):
             lk = k.lower()
             if lk == "access-control-allow-origin":
                 continue
+            # The upstream 400 body is longer than our constant ``"OK"``.
+            # Carrying its Content-Length into PlainTextResponse makes the
+            # wire response claim bytes that never arrive: curl exits 18 and
+            # strict HTTP clients raise IncompleteRead. Let PlainTextResponse
+            # calculate the length of the replacement body instead.
+            if lk == "content-length":
+                continue
             if lk == "vary":
                 continue  # canonicalized below
             headers[k] = v


### PR DESCRIPTION
## What changed

- discard Starlette’s stale `Content-Length` when replacing a rejected CORS preflight body with `OK`
- let `PlainTextResponse` emit the correct two-byte length
- pin header/body byte-length parity in the rejection regression test

## Why

A denied preflight returned HTTP 200 and the two-byte body `OK`, but advertised `Content-Length: 22` inherited from Starlette’s original 400 response. curl exited 18 with “transfer closed with 20 bytes remaining,” and strict HTTP clients raised `IncompleteRead`.

## Validation

- real Mini server before fix: curl exit 18, header 22, body 2 bytes
- real Mini server after fix: curl exit 0, header 2, body 2 bytes; strict `http.client` succeeds
- 65 CORS/auth/body-limit/probe middleware tests pass
- Ruff and `git diff --check` pass

Found during deep main-HEAD GUI/server dogfood on Apple Silicon.