### PR TITLE
fix(server): suppress false missing-finish on disconnect

### DIFF
--- a/tests/test_chat_streaming_spec.py
+++ b/tests/test_chat_streaming_spec.py
@@ -40,6 +40,7 @@ already supports.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Sequence
 from typing import Any
@@ -48,9 +49,11 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from vllm_mlx.api.models import ChatCompletionRequest
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.routes.chat import router as chat_router
+from vllm_mlx.routes.chat import stream_chat_completion
 from vllm_mlx.service.postprocessor import StreamingPostProcessor
 from vllm_mlx.tool_parsers.abstract_tool_parser import (
     ExtractedToolCallInformation,
@@ -1378,6 +1381,60 @@ def test_r11a_v2_synthetic_finish_fires_when_no_inline_finish():
         f"R11-V2 regression: expected synthetic finish_reason=stop "
         f"when engine never emitted a finished chunk; got {finish_chunks!r}"
     )
+
+
+def test_confirmed_disconnect_does_not_synthesize_missing_finish(caplog):
+    """Expected client cancellation must not masquerade as a broken SSE stream.
+
+    The disconnect guard cancels the in-flight engine iteration. Batched engines
+    deliberately turn that cancellation into clean iterator exhaustion after
+    aborting the scheduler request, which previously made the route emit the
+    R11-V2 warning and construct a terminal chunk for an already-dead socket.
+    """
+
+    class _CancelledEngine:
+        preserve_native_tool_format = False
+        is_mllm = False
+        supports_guided_generation = False
+        tokenizer = None
+
+        async def stream_chat(self, messages, **kwargs):
+            yield GenerationOutput(
+                text="partial",
+                new_text="partial",
+                prompt_tokens=4,
+                completion_tokens=1,
+                finished=False,
+                finish_reason=None,
+                channel=None,
+            )
+
+    cfg = reset_config()
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = True
+    state = [True]
+    request = ChatCompletionRequest(
+        model="test-model",
+        stream=True,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    async def _collect():
+        return [
+            chunk
+            async for chunk in stream_chat_completion(
+                _CancelledEngine(),
+                request.messages,
+                request,
+                _client_disconnect_state=state,
+            )
+        ]
+
+    chunks = asyncio.run(_collect())
+    assert not any("finish_reason" in chunk for chunk in chunks)
+    assert not any("[DONE]" in chunk for chunk in chunks)
+    assert "SSE-MISSING-FINISH-R11V2" not in caplog.text
 
 
 if __name__ == "__main__":

--- a/tests/test_disconnect_guard_aborts_scheduler.py
+++ b/tests/test_disconnect_guard_aborts_scheduler.py
@@ -101,7 +101,9 @@ async def test_response_task_cancellation_publishes_disconnect_state():
     orphaned_task_errors: list[dict] = []
     loop = asyncio.get_running_loop()
     previous_handler = loop.get_exception_handler()
-    loop.set_exception_handler(lambda _loop, context: orphaned_task_errors.append(context))
+    loop.set_exception_handler(
+        lambda _loop, context: orphaned_task_errors.append(context)
+    )
 
     async def _blocked_stream():
         yield "data: first\n\n"

--- a/tests/test_disconnect_guard_aborts_scheduler.py
+++ b/tests/test_disconnect_guard_aborts_scheduler.py
@@ -85,6 +85,42 @@ class _NeverDisconnectsRequest:
         return False
 
 
+@pytest.mark.asyncio
+async def test_response_task_cancellation_publishes_disconnect_state():
+    """Uvicorn commonly reports a dead socket by cancelling Starlette's
+    response-body task before ``Request.is_disconnected()`` observes it.
+
+    The route-level stream finalizer must see that signal before the guard
+    closes it; otherwise it synthesizes a misleading missing-finish warning
+    and terminal frame for a connection that no longer exists.
+    """
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    disconnect_state = [False]
+
+    async def _blocked_stream():
+        yield "data: first\n\n"
+        await asyncio.sleep(60.0)
+
+    async def _consume():
+        async for _ in _disconnect_guard(
+            _blocked_stream(),
+            _NeverDisconnectsRequest(),
+            poll_interval=0.05,
+            keepalive_seconds=0.0,
+            disconnect_state=disconnect_state,
+        ):
+            pass
+
+    task = asyncio.create_task(_consume())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert disconnect_state == [True]
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------

--- a/tests/test_disconnect_guard_aborts_scheduler.py
+++ b/tests/test_disconnect_guard_aborts_scheduler.py
@@ -25,6 +25,7 @@ remains as belt-and-suspenders but is no longer the primary signal.
 from __future__ import annotations
 
 import asyncio
+import gc
 import time
 
 import pytest
@@ -97,6 +98,10 @@ async def test_response_task_cancellation_publishes_disconnect_state():
     from vllm_mlx.service.helpers import _disconnect_guard
 
     disconnect_state = [False]
+    orphaned_task_errors: list[dict] = []
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: orphaned_task_errors.append(context))
 
     async def _blocked_stream():
         yield "data: first\n\n"
@@ -112,13 +117,20 @@ async def test_response_task_cancellation_publishes_disconnect_state():
         ):
             pass
 
-    task = asyncio.create_task(_consume())
-    await asyncio.sleep(0.05)
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    try:
+        task = asyncio.create_task(_consume())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        del task
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
 
     assert disconnect_state == [True]
+    assert orphaned_task_errors == []
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5020,11 +5020,16 @@ async def _create_chat_completion_impl(
                 media_type="text/event-stream",
                 headers=_sse_headers,
             )
+        # Shared route/guard latch: an engine may translate cancellation into
+        # clean iterator exhaustion after the client disconnects.  The route
+        # needs to distinguish that from a genuinely malformed stream ending.
+        _client_disconnect_state = [False]
         _chat_stream = stream_chat_completion(
             engine,
             messages,
             request,
             caller_agent=_caller_ua,
+            _client_disconnect_state=_client_disconnect_state,
             **chat_kwargs,
         )
         if engine.is_mllm:
@@ -5055,6 +5060,7 @@ async def _create_chat_completion_impl(
                 raw_request,
                 engine=engine,
                 request_id_holder=request_id_holder,
+                disconnect_state=_client_disconnect_state,
             ),
             media_type="text/event-stream",
             headers=_sse_headers,
@@ -6174,6 +6180,7 @@ async def stream_chat_completion(
     response_id: str | None = None,
     created: int | None = None,
     caller_agent: str | None = None,
+    _client_disconnect_state: list[bool] | None = None,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion response.
@@ -6194,6 +6201,9 @@ async def stream_chat_completion(
             unbucketed — ``emit.request`` funnels it through
             ``normalize_caller_agent`` (never stored raw). ``None`` when
             the header is absent or telemetry is off.
+        _client_disconnect_state: Private route/guard coordination latch.
+            True means the consumer disappeared and post-stream recovery must
+            not synthesize terminal frames for the dead connection.
     """
     from ..service.postprocessor import StreamingPostProcessor
 
@@ -6692,6 +6702,14 @@ async def stream_chat_completion(
                     # finish_reason as "tool_calls" — not emit two
                     # contradictory finish chunks.
                     buffered_finish = (event, output)
+
+        # A confirmed disconnect needs scheduler cleanup, not a synthetic
+        # terminal frame for a socket that no longer exists.  Some engines
+        # intentionally swallow the cancellation used by the guard and expose
+        # it here as ordinary exhaustion, so cancellation alone is not enough
+        # to distinguish this path.
+        if _client_disconnect_state and _client_disconnect_state[0]:
+            return
 
         # Fallback tool call detection (post-stream). Collect ALL fallback
         # tool_call events before emitting; they get merged into the

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -4120,8 +4120,24 @@ async def _disconnect_guard(
     finally:
         if disconnect_task and not disconnect_task.done():
             disconnect_task.cancel()
-        if anext_task and not anext_task.done():
-            anext_task.cancel()
+        if anext_task:
+            if not anext_task.done():
+                anext_task.cancel()
+            # Cancellation of the response task races the upstream async
+            # generator's own cancellation-to-exhaustion cleanup.  Always
+            # retrieve the terminal result: it may be CancelledError *or*
+            # StopAsyncIteration.  Leaving the latter on the task produces
+            # asyncio's noisy "Task exception was never retrieved" warning
+            # on the next GC cycle even though the request was handled.
+            try:
+                await anext_task
+            except (asyncio.CancelledError, StopAsyncIteration):
+                pass
+            except Exception:
+                # The streaming loop owns client-facing error translation.
+                # During teardown there is no live consumer, but retrieving
+                # the exception still prevents an orphan-task warning.
+                pass
         # Drive the cascade first: ``generator.aclose()`` propagates
         # ``GeneratorExit`` into the upstream so its ``finally`` runs
         # (calls ``stream_generate.finally`` → ``scheduler.abort_request``).

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3777,6 +3777,7 @@ async def _disconnect_guard(
     keepalive_seconds: float | None = None,
     request_id_holder: list | None = None,
     keepalive_factory=None,
+    disconnect_state: list[bool] | None = None,
 ) -> AsyncIterator[str]:
     """Wrap streaming generator to abort on client disconnect.
 
@@ -3913,6 +3914,8 @@ async def _disconnect_guard(
                 **wait_kwargs,
             )
             if disconnect_task in done:
+                if disconnect_state is not None:
+                    disconnect_state[0] = True
                 logger.info(
                     f"[disconnect_guard] CLIENT DISCONNECTED after "
                     f"{chunk_count} chunks ({keepalive_count} keepalives), "
@@ -4075,7 +4078,27 @@ async def _disconnect_guard(
             # consumer has pulled this chunk. Do NOT eagerly schedule
             # the next ``__anext__`` here — see the docstring at loop
             # entry for the rationale (codex r3 BLOCKING).
+    except asyncio.CancelledError:
+        # Starlette cancels the StreamingResponse body task when the socket
+        # disappears.  On current uvicorn/anyio this is the common disconnect
+        # signal; neither ``Request.is_disconnected()`` nor ``GeneratorExit``
+        # is guaranteed to win the race first.  Publish the state before the
+        # finally block closes the upstream generator so route-level
+        # finalizers do not manufacture a terminal SSE frame for a dead
+        # connection.
+        if disconnect_state is not None:
+            disconnect_state[0] = True
+        logger.info(
+            f"[disconnect_guard] CancelledError after {chunk_count} chunks, "
+            f"elapsed={_elapsed()}"
+        )
+        if anext_task is not None and not anext_task.done():
+            anext_task.cancel()
+        _force_abort_request(engine, request_id_holder)
+        raise
     except GeneratorExit:
+        if disconnect_state is not None:
+            disconnect_state[0] = True
         logger.info(
             f"[disconnect_guard] GeneratorExit after {chunk_count} chunks, elapsed={_elapsed()}"
         )


### PR DESCRIPTION
## What changed

- propagate confirmed client-disconnect state from the shared SSE guard into the chat stream finalizer
- handle the uvicorn/Starlette response-task cancellation path in addition to request polling and generator close
- skip post-stream recovery and synthetic terminal frames only after a confirmed disconnect
- add focused coverage for ASGI task cancellation and missing-finish suppression

## Why

On a real abrupt client disconnect, the scheduler correctly aborted the request and released resources, but the chat generator then observed ordinary iterator exhaustion and logged `SSE-MISSING-FINISH-R11V2`. It also constructed an unsendable terminal frame for the already-closed socket. This was a false operator warning, not a malformed engine stream.

## Validation

- Mini, real LFM2.5-1.2B model: abrupt streaming disconnect immediately aborts the scheduler, server remains healthy, and no missing-finish warning is logged
- Mini normal SSE: exactly one `finish_reason=stop` and one `[DONE]`
- `pytest -q tests/test_chat_streaming_spec.py tests/test_sse_keepalive.py tests/test_disconnect_guard_aborts_scheduler.py` (46 passed)
- `ruff check` on all changed Python files
- `git diff --check`
