### PR TITLE
feat(agents): add DeepSeek Harness and harden dogfood isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Also: word-level timestamps on transcription, and local text-to-music at
 |---|---|
 | **Apple-Silicon-native** | Pure MLX kernels — no llama.cpp fallback, no Metal shim. Continuous batching, prompt cache (radix + DeltaNet RNN snapshots), and a quantized live KV cache (int4/int8 on the continuous-batching cache + TurboQuant K8V4 codec) run at native MLX bandwidth on M1 → M4. |
 | **Drop-in OpenAI / Anthropic API** | `/v1/chat/completions`, `/v1/responses` (Codex CLI), `/v1/messages` (Anthropic SDK / Claude Code), `/v1/embeddings`, `/v1/audio/*`, `/v1/videos` — same wire as ChatGPT / Claude, no client adapter. |
-| **First-class ecosystem coverage** | 11 agent CLIs and 3 Python frameworks are wire-verified against real weights every release (4 are Tier-1, re-verified on current binaries) — Codex CLI, Claude Code, OpenCode, Qwen Code, OpenHands, Hermes Agent, Aider, Kilo Code, GitHub Copilot, Factory Droid, Moonshot Kimi Code + LangChain, PydanticAI, smolagents. |
+| **First-class ecosystem coverage** | 12 agent CLIs and 3 Python frameworks are wire-verified against real weights every release (4 are Tier-1, re-verified on current binaries) — Codex CLI, Claude Code, OpenCode, Qwen Code, OpenHands, Hermes Agent, Aider, Kilo Code, DeepSeek Harness, GitHub Copilot, Factory Droid, Moonshot Kimi Code + LangChain, PydanticAI, smolagents. |
 
 → [Full feature breakdown](https://rapidmlx.com/docs/index.html)
 
@@ -222,7 +222,7 @@ All 11 agents below are wire-verified against real weights every release via the
 
 | Agents (11) | Frameworks (3) |
 |---|---|
-| [Codex CLI](https://github.com/openai/codex) · [Claude Code](https://www.anthropic.com/claude-code) · [OpenCode](https://github.com/sst/opencode) · [Qwen Code](https://github.com/QwenLM/qwen-code) · [OpenHands](https://github.com/All-Hands-AI/OpenHands) · [Hermes Agent](https://github.com/NousResearch/hermes-agent) · [Aider](https://aider.chat) · [Kilo Code](https://github.com/Kilo-Org/kilocode) · [GitHub Copilot](https://github.com/features/copilot) · [Factory Droid](https://factory.ai) · [Moonshot Kimi Code](https://github.com/MoonshotAI/kimi-cli) | [LangChain](https://langchain.com) (+ [LangGraph](https://langchain-ai.github.io/langgraph/)) · [PydanticAI](https://ai.pydantic.dev) · [smolagents](https://github.com/huggingface/smolagents) |
+| [Codex CLI](https://github.com/openai/codex) · [Claude Code](https://www.anthropic.com/claude-code) · [OpenCode](https://github.com/sst/opencode) · [Qwen Code](https://github.com/QwenLM/qwen-code) · [OpenHands](https://github.com/All-Hands-AI/OpenHands) · [Hermes Agent](https://github.com/NousResearch/hermes-agent) · [Aider](https://aider.chat) · [Kilo Code](https://github.com/Kilo-Org/kilocode) · [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) · [GitHub Copilot](https://github.com/features/copilot) · [Factory Droid](https://factory.ai) · [Moonshot Kimi Code](https://github.com/MoonshotAI/kimi-cli) | [LangChain](https://langchain.com) (+ [LangGraph](https://langchain-ai.github.io/langgraph/)) · [PydanticAI](https://ai.pydantic.dev) · [smolagents](https://github.com/huggingface/smolagents) |
 
 Also compatible with OpenAI-compatible clients that allow direct local endpoints via `http://localhost:8000/v1` — LibreChat, Open WebUI, and more plug in with a single URL change.
 

--- a/docs/agents/deepseek-harness.md
+++ b/docs/agents/deepseek-harness.md
@@ -1,0 +1,54 @@
+# DeepSeek Harness
+
+Run the official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+against a local Rapid-MLX server. Rapid uses Harness's generic
+`openai-completions` provider; it does not impersonate the DeepSeek cloud API.
+
+> DeepSeek currently labels Harness a developer preview. Rapid pins the
+> configuration contract exercised by `@deepseek-ai/dsh@0.1.0-rc.6`; review
+> release notes before upgrading across incompatible preview releases.
+
+## Setup
+
+```bash
+npm install -g @deepseek-ai/dsh
+rapid-mlx serve qwen3.5-9b-4bit
+
+# In another terminal: preview, then apply.
+rapid-mlx agents dsh --setup --dry-run
+rapid-mlx agents dsh --setup
+
+dsh web
+# or one headless task
+dsh --profile headless "summarize this workspace"
+```
+
+`--setup` discovers the running model and its advertised context window, then
+previews an exact diff before changing `$DSH_HOME/settings.yaml` (default
+`~/.dsh/settings.yaml`). It preserves unrelated providers and settings, makes a
+timestamped backup, writes atomically, and refuses to overwrite a file changed
+after the preview.
+
+Harness's current generic OpenAI transport requires a credential reference even
+for an unauthenticated loopback server. Rapid therefore adds the non-secret
+sentinel `RAPID_MLX_API_KEY: not-needed` to Harness's owner-only managed
+`.credentials.yaml` when that key is absent. An existing value is preserved,
+and credential values are redacted from the setup preview.
+
+## Test
+
+```bash
+rapid-mlx agents dsh --test
+```
+
+The test uses an isolated `DSH_HOME` and workspace. It exercises streaming,
+reasoning/tool-call protocol behavior, a real headless response, file reading,
+and a shell command without loading the operator's Harness sessions or
+credentials.
+
+## Node runtime
+
+The current DSH package imports Node's Zstd stream API but does not declare that
+runtime minimum in its npm manifest. Node 22.15 or newer is known to work. If an
+older/incompatible Node is first on `PATH`, `agents dsh --test` reports the
+runtime mismatch before DSH emits its opaque plugin-loader stack trace.

--- a/docs/agents/qwen-code.md
+++ b/docs/agents/qwen-code.md
@@ -3,7 +3,7 @@
 Point [Qwen Code](https://github.com/QwenLM/qwen-code) at a local rapid-mlx
 server. Qwen Code is Alibaba's `gemini-cli` fork tuned for Qwen tool-calling;
 it speaks the **OpenAI-compatible chat completions API**
-(`POST /v1/chat/completions`) via an `openaiCompatible.baseUrl` config that
+(`POST /v1/chat/completions`) via an OpenAI entry in `modelProviders` that
 maps 1:1 onto rapid-mlx's default endpoint.
 
 Verified via wire smoke against Qwen 3.6, Gemma 4, and gpt-oss in the Tier-1
@@ -23,7 +23,7 @@ the [support matrix](matrix.md) for the current per-family status.
 
 ```bash
 # 1. Install Qwen Code
-npm install -g @qwenlm/qwen-code
+npm install -g @qwen-code/qwen-code
 
 # 2. Start rapid-mlx (Qwen 3.6 is the sweet spot)
 rapid-mlx serve qwen3.6-35b-4bit --port 8000
@@ -38,15 +38,28 @@ qwen -p "explain this repo"   # one-shot
 
 ## Manual config
 
-`~/.qwen/settings.json` — substitute your alias for `{model_id}`:
+`~/.qwen/settings.json` — current Qwen Code releases use the provider catalog
+schema below (the older `openaiCompatible` object is no longer recognized):
 
 ```json
 {
-  "openaiCompatible": {
-    "baseUrl": "http://localhost:8000/v1",
-    "apiKey": "not-needed",
-    "model": "qwen3.6-35b-4bit"
-  }
+  "modelProviders": {
+    "openai": [{
+      "id": "qwen3.6-35b-4bit",
+      "name": "qwen3.6-35b-4bit (Rapid-MLX)",
+      "envKey": "RAPID_MLX_API_KEY",
+      "baseUrl": "http://localhost:8000/v1",
+      "generationConfig": {
+        "timeout": 300000,
+        "maxRetries": 1,
+        "contextWindowSize": 262144,
+        "samplingParams": {"max_tokens": 8192}
+      }
+    }]
+  },
+  "env": {"RAPID_MLX_API_KEY": "not-needed"},
+  "security": {"auth": {"selectedType": "openai"}},
+  "model": {"name": "qwen3.6-35b-4bit"}
 }
 ```
 
@@ -68,10 +81,8 @@ rapid-mlx serve qwen3.6-35b-4bit --port 8000   # ~20 GB
 # smaller: qwen3.6-27b-4bit
 ```
 
-```json
-{ "openaiCompatible": { "baseUrl": "http://localhost:8000/v1",
-  "apiKey": "not-needed", "model": "qwen3.6-35b-4bit" } }
-```
+Then run `rapid-mlx agents qwen-code --setup` to select the served model and
+write its actual advertised context window.
 
 - tool-call parser: `qwen3_coder_xml` · reasoning parser: `qwen3`
 - matrix cell: **PASS** ✅
@@ -83,10 +94,7 @@ rapid-mlx serve gemma-4-12b-4bit --port 8000   # ~7 GB at 4-bit
 # larger: gemma-4-26b-4bit
 ```
 
-```json
-{ "openaiCompatible": { "baseUrl": "http://localhost:8000/v1",
-  "apiKey": "not-needed", "model": "gemma-4-12b-4bit" } }
-```
+Then run `rapid-mlx agents qwen-code --setup`.
 
 - tool-call parser: `gemma4` · reasoning parser: `gemma4`
 - matrix cell: **PASS** ✅ (non-Qwen models run at reduced quality)
@@ -98,10 +106,7 @@ rapid-mlx serve gpt-oss-20b --port 8000        # ~11 GB (MXFP4-Q8)
 # larger: gpt-oss-120b
 ```
 
-```json
-{ "openaiCompatible": { "baseUrl": "http://localhost:8000/v1",
-  "apiKey": "not-needed", "model": "gpt-oss-20b" } }
-```
+Then run `rapid-mlx agents qwen-code --setup`.
 
 - tool-call parser: `harmony` · reasoning parser: `harmony`
 - matrix cell: **PASS** ✅

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ GPU acceleration to local AI workloads by integrating:
 - [Qwen Code](agents/qwen-code.md)
 - [OpenHands](agents/openhands.md)
 - [Hermes Agent](agents/hermes-agent.md)
+- [DeepSeek Harness](agents/deepseek-harness.md)
 
 ### Reference
 - [CLI Commands](reference/cli.md)

--- a/tests/test_agent_test_runner_refresh_config.py
+++ b/tests/test_agent_test_runner_refresh_config.py
@@ -28,7 +28,7 @@ from vllm_mlx.agents.base import (
     AgentStreamingSpec,
     AgentTestingSpec,
 )
-from vllm_mlx.agents.testing import AgentTestRunner
+from vllm_mlx.agents.testing import AgentTestRunner, TestStatus
 
 
 def _make_profile(name: str, config_type: str) -> AgentProfile:
@@ -63,7 +63,9 @@ def test_run_calls_setup_agent_config_before_tests():
 
     calls = []
 
-    def _capture_setup(profile_arg, base_url, model_id, agent_version=None):
+    def _capture_setup(
+        profile_arg, base_url, model_id, agent_version=None, context_length=None
+    ):
         calls.append(
             {
                 "profile_name": profile_arg.name,
@@ -122,7 +124,9 @@ def test_run_refreshes_config_when_server_is_available():
 
     calls = []
 
-    def _capture_setup(profile_arg, base_url, model_id, agent_version=None):
+    def _capture_setup(
+        profile_arg, base_url, model_id, agent_version=None, context_length=None
+    ):
         calls.append(model_id)
         return "ok"
 
@@ -153,6 +157,24 @@ def test_run_refreshes_config_when_server_is_available():
         "with the runner's current model_id — the v0.7.26 bug was that it "
         "wasn't called at all, leaving stale config from the prior bench."
     )
+
+
+def test_specific_python_suite_runs_with_script_semantics():
+    """SDK suites guarded by ``__main__`` must execute, not import as no-ops."""
+    profile = _make_profile("pydanticai", "env")
+    runner = AgentTestRunner(profile, model_id="test-model")
+
+    source = (
+        b"if __name__ == '__main__':\n"
+        b"    results = {'sdk_call': 'PASS'}\n"
+        b"    raise SystemExit(0)\n"
+    )
+    with patch("pathlib.Path.read_bytes", return_value=source):
+        results = runner._run_specific_tests("test_pydantic_ai_full.py")
+
+    assert len(results) == 1
+    assert results[0].name == "sdk_call"
+    assert results[0].status == TestStatus.PASS
 
 
 def test_file_config_agent_uses_an_isolated_home_for_setup_and_e2e(monkeypatch):
@@ -191,3 +213,72 @@ def test_file_config_agent_uses_an_isolated_home_for_setup_and_e2e(monkeypatch):
     assert observed["setup_home"] == observed["child_home"]
     assert "rapid-mlx-codex-home-" in observed["child_home"]
     assert "CODEX_HOME" not in os.environ
+
+
+def test_agent_without_home_env_still_uses_isolated_home(monkeypatch):
+    """Every profile must avoid the operator's HOME, not only Codex/Hermes."""
+    real_home = "/Users/operator"
+    monkeypatch.setenv("HOME", real_home)
+    profile = _make_profile("opencode", "yaml")
+    profile = replace(
+        profile,
+        testing=AgentTestingSpec(binary="opencode", query_cmd="opencode {query}"),
+    )
+    observed: dict[str, str] = {}
+
+    def _capture_setup(*_args, **_kwargs):
+        observed["setup_home"] = os.environ["HOME"]
+        return "ok"
+
+    def _capture_e2e(*_args, env_overrides=None, **_kwargs):
+        observed["child_home"] = env_overrides["HOME"]
+        return TestResult("e2e_chat", TestStatus.PASS)
+
+    from vllm_mlx.agents.testing import TestResult, TestStatus
+
+    with (
+        patch.object(AgentTestRunner, "_server_available", return_value=True),
+        patch.object(AgentTestRunner, "_agent_binary_available", return_value=True),
+        patch("vllm_mlx.agents.adapter.setup_agent_config", side_effect=_capture_setup),
+        patch(
+            "vllm_mlx.agents.testing._test_plain_chat",
+            return_value=TestResult("plain_chat", TestStatus.PASS),
+        ),
+        patch("vllm_mlx.agents.testing._test_e2e_chat", side_effect=_capture_e2e),
+    ):
+        AgentTestRunner(profile, model_id="qwen3.5-9b-4bit").run()
+
+    assert observed["setup_home"] == observed["child_home"]
+    assert "rapid-mlx-opencode-home-" in observed["child_home"]
+    assert os.environ["HOME"] == real_home
+
+
+def test_claude_e2e_sets_documented_config_directory():
+    """Claude must not discover the operator's hooks through its account home."""
+    profile = _make_profile("claude-code", "env")
+    profile = replace(
+        profile,
+        testing=AgentTestingSpec(binary="claude", query_cmd="claude -p {query}"),
+    )
+    observed: dict[str, str] = {}
+
+    def _capture_e2e(*_args, env_overrides=None, **_kwargs):
+        observed.update(env_overrides)
+        return TestResult("e2e_chat", TestStatus.PASS)
+
+    from vllm_mlx.agents.testing import TestResult, TestStatus
+
+    with (
+        patch.object(AgentTestRunner, "_server_available", return_value=True),
+        patch.object(AgentTestRunner, "_agent_binary_available", return_value=True),
+        patch("vllm_mlx.agents.adapter.setup_agent_config", return_value="ok"),
+        patch(
+            "vllm_mlx.agents.testing._test_plain_chat",
+            return_value=TestResult("plain_chat", TestStatus.PASS),
+        ),
+        patch("vllm_mlx.agents.testing._test_e2e_chat", side_effect=_capture_e2e),
+    ):
+        AgentTestRunner(profile, model_id="qwen3.5-9b-4bit").run()
+
+    assert observed["CLAUDE_CONFIG_DIR"].startswith(observed["HOME"])
+    assert observed["CLAUDE_CONFIG_DIR"].endswith("/.claude")

--- a/tests/test_deepseek_harness_profile.py
+++ b/tests/test_deepseek_harness_profile.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+import stat
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import yaml
+
+from vllm_mlx.agents import get_profile, load_profiles
+from vllm_mlx.agents.setup import apply_setup_plan, build_setup_plan
+from vllm_mlx.agents.testing import (
+    AgentTestRunner,
+    TestResult,
+    TestStatus,
+    _agent_query,
+)
+
+
+def test_dsh_alias_resolves_first_class_profile():
+    load_profiles()
+    profile = get_profile("dsh")
+    assert profile is not None
+    assert profile.name == "deepseek-harness"
+    assert profile.config.home_env == "DSH_HOME"
+    assert profile.testing.binary == "dsh"
+    assert profile.testing.query_cmd == "dsh --profile headless '{query}'"
+
+
+def test_hermes_binary_uses_path_instead_of_one_obsolete_install_layout():
+    load_profiles()
+    profile = get_profile("hermes")
+    assert profile is not None
+    assert profile.testing.binary == "hermes"
+
+
+def test_aider_profile_runs_the_real_cli():
+    load_profiles()
+    profile = get_profile("aider")
+    assert profile is not None
+    assert profile.testing.binary == "aider"
+    assert profile.testing.query_cmd is not None
+
+
+def test_qwen_code_profile_matches_current_provider_schema():
+    load_profiles()
+    profile = get_profile("qwen-code")
+    assert profile is not None
+    rendered = json.loads(
+        profile.render_config(
+            "http://127.0.0.1:8153/v1",
+            "qwen3.5-9b-4bit",
+            context_length=262144,
+        )
+    )
+    model = rendered["modelProviders"]["openai"][0]
+    assert model["baseUrl"] == "http://127.0.0.1:8153/v1"
+    assert model["generationConfig"]["contextWindowSize"] == 262144
+    assert rendered["security"]["auth"]["selectedType"] == "openai"
+    assert profile.testing.install_cmd == "npm install -g @qwen-code/qwen-code@latest"
+
+
+def test_kilo_profile_matches_current_cli_path_and_schema():
+    load_profiles()
+    profile = get_profile("kilo-code")
+    assert profile is not None
+    assert profile.config.path == "~/.config/kilo/kilo.json"
+    rendered = json.loads(
+        profile.render_config(
+            "http://127.0.0.1:8153/v1",
+            "qwen3.5-9b-4bit",
+            context_length=262144,
+        )
+    )
+    assert rendered["model"] == "rapid-mlx/qwen3.5-9b-4bit"
+    model = rendered["provider"]["rapid-mlx"]["models"]["qwen3.5-9b-4bit"]
+    assert model["limit"] == {"context": 262144, "output": 8192}
+    assert profile.testing.install_cmd == "npm install -g @kilocode/cli"
+    assert "--dir '{cwd}'" in profile.testing.query_cmd
+    assert "--pure" in profile.testing.query_cmd
+
+
+def test_dsh_setup_plan_is_side_effect_free_and_uses_real_capacity(
+    tmp_path, monkeypatch
+):
+    dsh_home = tmp_path / "dsh"
+    settings = dsh_home / "settings.yaml"
+    dsh_home.mkdir()
+    settings.write_text(
+        "ui-theme:\n  theme: dark\nllm-pi-ai:\n  providers:\n    existing:\n      baseURL: https://example.test/v1\n"
+    )
+    original = settings.read_text()
+    monkeypatch.setenv("DSH_HOME", str(dsh_home))
+
+    plan = build_setup_plan(
+        "deepseek-harness",
+        "http://127.0.0.1:8152/v1",
+        "qwen3.5-9b-4bit",
+        context_length=262144,
+    )
+
+    assert settings.read_text() == original
+    assert plan.after["ui-theme"] == {"theme": "dark"}
+    assert "existing" in plan.after["llm-pi-ai"]["providers"]
+    rapid = plan.after["llm-pi-ai"]["providers"]["rapid-mlx"]
+    assert rapid["baseURL"] == "http://127.0.0.1:8152/v1"
+    assert rapid["apiKeyEnv"] == "RAPID_MLX_API_KEY"
+    assert rapid["models"][0]["contextWindow"] == 262144
+    assert rapid["models"][0]["reasoningEfforts"]["off"] == "none"
+    assert plan.after["agent-default-model"] == {
+        "provider": "rapid-mlx",
+        "model": "qwen3.5-9b-4bit",
+    }
+    assert plan.credentials_after == {"RAPID_MLX_API_KEY": "not-needed"}
+
+
+def test_dsh_setup_apply_is_atomic_and_backed_up(tmp_path, monkeypatch):
+    dsh_home = tmp_path / "dsh"
+    settings = dsh_home / "settings.yaml"
+    dsh_home.mkdir()
+    settings.write_text("ui-theme:\n  theme: dark\n")
+    monkeypatch.setenv("DSH_HOME", str(dsh_home))
+
+    plan = build_setup_plan(
+        "dsh", "http://127.0.0.1:8152/v1", "qwen3.5-9b-4bit", 65536
+    )
+    apply_setup_plan(plan)
+
+    written = yaml.safe_load(settings.read_text())
+    assert written["ui-theme"] == {"theme": "dark"}
+    assert written["agent-default-model"]["provider"] == "rapid-mlx"
+    assert written["llm-pi-ai"]["providers"]["rapid-mlx"]["models"][0][
+        "contextWindow"
+    ] == 65536
+    assert len(list(dsh_home.glob("settings.yaml.bak.*"))) == 1
+    credentials = dsh_home / ".credentials.yaml"
+    assert yaml.safe_load(credentials.read_text()) == {
+        "RAPID_MLX_API_KEY": "not-needed"
+    }
+    assert stat.S_IMODE(credentials.stat().st_mode) == 0o600
+
+
+def test_dsh_setup_repairs_missing_credentials_when_settings_match(
+    tmp_path, monkeypatch
+):
+    """A settings-only prior setup must not make credential repair a no-op."""
+    monkeypatch.setenv("DSH_HOME", str(tmp_path))
+    initial = build_setup_plan(
+        "deepseek-harness",
+        "http://127.0.0.1:8000/v1",
+        "test-model",
+        context_length=65536,
+    )
+    initial.path.write_text(
+        yaml.safe_dump(initial.after, sort_keys=False), encoding="utf-8"
+    )
+
+    repair = build_setup_plan(
+        "deepseek-harness",
+        "http://127.0.0.1:8000/v1",
+        "test-model",
+        context_length=65536,
+    )
+    assert repair.before == repair.after
+    assert repair.changed
+    apply_setup_plan(repair)
+    assert yaml.safe_load((tmp_path / ".credentials.yaml").read_text()) == {
+        "RAPID_MLX_API_KEY": "not-needed"
+    }
+
+
+def test_dsh_setup_preserves_and_redacts_existing_credentials(tmp_path, monkeypatch):
+    monkeypatch.setenv("DSH_HOME", str(tmp_path))
+    secret = "real-local-auth-secret"
+    credentials = tmp_path / ".credentials.yaml"
+    credentials.write_text(
+        yaml.safe_dump(
+            {"RAPID_MLX_API_KEY": secret, "REMOTE_PROVIDER_KEY": "other-secret"}
+        ),
+        encoding="utf-8",
+    )
+
+    plan = build_setup_plan(
+        "dsh", "http://127.0.0.1:8000/v1", "test-model", 65536
+    )
+    assert plan.credentials_after == {
+        "RAPID_MLX_API_KEY": secret,
+        "REMOTE_PROVIDER_KEY": "other-secret",
+    }
+    preview = plan.diff()
+    assert secret not in preview
+    assert "other-secret" not in preview
+    assert "REMOTE_PROVIDER_KEY" not in preview
+    apply_setup_plan(plan)
+    assert yaml.safe_load(credentials.read_text())["RAPID_MLX_API_KEY"] == secret
+
+
+def test_dsh_setup_refuses_concurrent_change(tmp_path, monkeypatch):
+    dsh_home = tmp_path / "dsh"
+    dsh_home.mkdir()
+    settings = dsh_home / "settings.yaml"
+    settings.write_text("ui-theme:\n  theme: dark\n")
+    monkeypatch.setenv("DSH_HOME", str(dsh_home))
+    plan = build_setup_plan("dsh", "http://127.0.0.1:8152/v1", "model")
+    settings.write_text("ui-theme:\n  theme: light\n")
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="changed after preview"):
+        apply_setup_plan(plan)
+    assert yaml.safe_load(settings.read_text()) == {"ui-theme": {"theme": "light"}}
+
+
+def test_dsh_test_runner_supplies_only_dummy_loopback_credential(monkeypatch):
+    load_profiles()
+    profile = get_profile("deepseek-harness")
+    assert profile is not None
+    observed = {}
+
+    def capture(*_args, env_overrides=None, **_kwargs):
+        observed.update(env_overrides)
+        return TestResult("e2e_chat", TestStatus.PASS)
+
+    monkeypatch.setattr(AgentTestRunner, "_server_available", lambda _self: True)
+    monkeypatch.setattr(AgentTestRunner, "_agent_binary_available", lambda _self: True)
+    monkeypatch.setattr(
+        "vllm_mlx.agents.adapter.setup_agent_config", lambda *_args, **_kwargs: "ok"
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_plain_chat",
+        lambda *_args, **_kwargs: TestResult("plain_chat", TestStatus.PASS),
+    )
+    monkeypatch.setattr("vllm_mlx.agents.testing._test_e2e_chat", capture)
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_e2e_file_read", capture
+    )
+    monkeypatch.setattr("vllm_mlx.agents.testing._test_e2e_terminal", capture)
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_single_tool_call",
+        lambda *_args, **_kwargs: TestResult("tool", TestStatus.PASS),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_tool_choice",
+        lambda *_args, **_kwargs: TestResult("tool", TestStatus.PASS),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_multi_turn_tool",
+        lambda *_args, **_kwargs: TestResult("tool", TestStatus.PASS),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_no_tool_leak",
+        lambda *_args, **_kwargs: TestResult("tool", TestStatus.PASS),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_no_tool_needed",
+        lambda *_args, **_kwargs: TestResult("tool", TestStatus.PASS),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_streaming_tool_call",
+        lambda *_args, **_kwargs: TestResult("tool", TestStatus.PASS),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_many_tools",
+        lambda *_args, **_kwargs: TestResult("tool", TestStatus.PASS),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_streaming_basic",
+        lambda *_args, **_kwargs: TestResult("stream", TestStatus.PASS),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._test_stress_no_leak",
+        lambda *_args, **_kwargs: TestResult("stress", TestStatus.PASS),
+    )
+
+    AgentTestRunner(profile, model_id="qwen3.5-9b-4bit").run()
+    assert observed["RAPID_MLX_API_KEY"] == "not-needed"
+    assert observed["DSH_HOME"].startswith("/var/") or "rapid-mlx-" in observed[
+        "DSH_HOME"
+    ]
+
+
+def test_dsh_reports_old_node_before_opaque_plugin_boot_failure():
+    with (
+        patch(
+            "vllm_mlx.agents.testing.shutil.which",
+            side_effect=["/fake/dsh", "/fake/node"],
+        ),
+        patch(
+            "vllm_mlx.agents.testing.subprocess.run",
+            return_value=SimpleNamespace(returncode=1, stdout="", stderr=""),
+        ) as run,
+    ):
+        output, error = _agent_query("dsh", "dsh {query}", "hello")
+
+    assert output is None
+    assert "Node 22.15+" in error
+    assert run.call_count == 1

--- a/tests/test_deepseek_harness_profile.py
+++ b/tests/test_deepseek_harness_profile.py
@@ -121,17 +121,16 @@ def test_dsh_setup_apply_is_atomic_and_backed_up(tmp_path, monkeypatch):
     settings.write_text("ui-theme:\n  theme: dark\n")
     monkeypatch.setenv("DSH_HOME", str(dsh_home))
 
-    plan = build_setup_plan(
-        "dsh", "http://127.0.0.1:8152/v1", "qwen3.5-9b-4bit", 65536
-    )
+    plan = build_setup_plan("dsh", "http://127.0.0.1:8152/v1", "qwen3.5-9b-4bit", 65536)
     apply_setup_plan(plan)
 
     written = yaml.safe_load(settings.read_text())
     assert written["ui-theme"] == {"theme": "dark"}
     assert written["agent-default-model"]["provider"] == "rapid-mlx"
-    assert written["llm-pi-ai"]["providers"]["rapid-mlx"]["models"][0][
-        "contextWindow"
-    ] == 65536
+    assert (
+        written["llm-pi-ai"]["providers"]["rapid-mlx"]["models"][0]["contextWindow"]
+        == 65536
+    )
     assert len(list(dsh_home.glob("settings.yaml.bak.*"))) == 1
     credentials = dsh_home / ".credentials.yaml"
     assert yaml.safe_load(credentials.read_text()) == {
@@ -180,9 +179,7 @@ def test_dsh_setup_preserves_and_redacts_existing_credentials(tmp_path, monkeypa
         encoding="utf-8",
     )
 
-    plan = build_setup_plan(
-        "dsh", "http://127.0.0.1:8000/v1", "test-model", 65536
-    )
+    plan = build_setup_plan("dsh", "http://127.0.0.1:8000/v1", "test-model", 65536)
     assert plan.credentials_after == {
         "RAPID_MLX_API_KEY": secret,
         "REMOTE_PROVIDER_KEY": "other-secret",
@@ -231,9 +228,7 @@ def test_dsh_test_runner_supplies_only_dummy_loopback_credential(monkeypatch):
         lambda *_args, **_kwargs: TestResult("plain_chat", TestStatus.PASS),
     )
     monkeypatch.setattr("vllm_mlx.agents.testing._test_e2e_chat", capture)
-    monkeypatch.setattr(
-        "vllm_mlx.agents.testing._test_e2e_file_read", capture
-    )
+    monkeypatch.setattr("vllm_mlx.agents.testing._test_e2e_file_read", capture)
     monkeypatch.setattr("vllm_mlx.agents.testing._test_e2e_terminal", capture)
     monkeypatch.setattr(
         "vllm_mlx.agents.testing._test_single_tool_call",
@@ -274,9 +269,9 @@ def test_dsh_test_runner_supplies_only_dummy_loopback_credential(monkeypatch):
 
     AgentTestRunner(profile, model_id="qwen3.5-9b-4bit").run()
     assert observed["RAPID_MLX_API_KEY"] == "not-needed"
-    assert observed["DSH_HOME"].startswith("/var/") or "rapid-mlx-" in observed[
-        "DSH_HOME"
-    ]
+    assert (
+        observed["DSH_HOME"].startswith("/var/") or "rapid-mlx-" in observed["DSH_HOME"]
+    )
 
 
 def test_dsh_reports_old_node_before_opaque_plugin_boot_failure():

--- a/vllm_mlx/agents/__init__.py
+++ b/vllm_mlx/agents/__init__.py
@@ -33,7 +33,10 @@ _LOADED = False
 # adding duplicate rows to ``rapid-mlx agents``.  Claude's executable is named
 # ``claude``, while the product and launch adapter use ``claude-code``; users
 # reasonably try either spelling.
-_PROFILE_ALIASES = {"claude": "claude-code"}
+_PROFILE_ALIASES = {
+    "claude": "claude-code",
+    "dsh": "deepseek-harness",
+}
 
 PROFILES_DIR = Path(__file__).parent / "profiles"
 

--- a/vllm_mlx/agents/profiles/aider.yaml
+++ b/vllm_mlx/agents/profiles/aider.yaml
@@ -21,7 +21,10 @@ streaming:
   max_tools: 0  # Aider does NOT use function calling
 
 testing:
-  binary: null  # aider is a pip package
+  # pip/uv installs expose the regular `aider` console script on PATH.
+  # Keeping this null made `agents aider --test` report PASS without ever
+  # launching Aider itself.
+  binary: aider
   query_cmd: "aider --message '{query}' --yes --no-git"
   query_timeout: 180
   install_cmd: "pip install aider-chat"

--- a/vllm_mlx/agents/profiles/claude-code.yaml
+++ b/vllm_mlx/agents/profiles/claude-code.yaml
@@ -30,7 +30,11 @@ testing:
   # explicitly allowed or it refuses the calls non-interactively. Scope each
   # permission to the exact fixture/command; changing cwd is not a sandbox.
   query_cmd: "claude --allowedTools 'Read(pyproject.toml)' 'Bash(echo rapidmlx_claude-code_test)' -p '{query}'"
-  query_timeout: 180
+  # A real Claude Code prompt carries ~25K tokens plus 28 tools. On local
+  # models the first tool call can arrive just before 180s, leaving no budget
+  # for the tool-result turn; 360s covers that full loop without conflating a
+  # slow-but-progressing local prefill with a hung client.
+  query_timeout: 360
   install_cmd: "npm install -g @anthropic-ai/claude-code"
 
 capabilities:

--- a/vllm_mlx/agents/profiles/deepseek-harness.yaml
+++ b/vllm_mlx/agents/profiles/deepseek-harness.yaml
@@ -1,0 +1,62 @@
+name: deepseek-harness
+display_name: "DeepSeek Harness"
+repo: "deepseek-ai/deepseek-harness"
+stars: 1000
+
+# DSH reads machine-local provider configuration from $DSH_HOME/settings.yaml.
+# Its generic pi-ai adapter is the correct route for Rapid-MLX: using the
+# native deepseek-official adapter would require a fake API key and claim the
+# local endpoint has the official service's model/capacity contract.
+config:
+  type: yaml
+  path: "~/.dsh/settings.yaml"
+  home_env: DSH_HOME
+  template: |
+    llm-pi-ai:
+      providers:
+        rapid-mlx:
+          displayName: "Rapid-MLX Local"
+          apiKeyEnv: RAPID_MLX_API_KEY
+          api: openai-completions
+          baseURL: "{base_url}"
+          defaultContextWindow: {context_length}
+          defaultMaxTokens: 8192
+          compat:
+            supportsReasoningEffort: true
+          models:
+            - id: "{model_id}"
+              name: "{model_id} (Rapid-MLX)"
+              contextWindow: {context_length}
+              maxTokens: 8192
+              reasoningEfforts:
+                off: none
+                low: low
+                medium: medium
+                high: high
+    agent-default-model:
+      provider: rapid-mlx
+      model: "{model_id}"
+
+models:
+  recommended:
+    - "qwen3.6-35b-4bit"
+    - "qwen3.5-9b-4bit"
+
+streaming:
+  extra_tool_tags: []
+  max_tools: 64
+
+testing:
+  binary: dsh
+  query_cmd: "dsh --profile headless '{query}'"
+  query_timeout: 240
+  install_cmd: "npm install -g @deepseek-ai/dsh"
+
+capabilities:
+  function_calling: true
+  streaming: true
+
+known_issues:
+  - "DeepSeek Harness is currently a developer preview and may make compatibility-breaking configuration changes."
+  - "The current DSH release requires Node's Zstd stream API (Node 22.15+ works) but does not declare that minimum in its npm manifest."
+  - "Use the generic openai-completions provider, not deepseek-official, for a local Rapid-MLX endpoint."

--- a/vllm_mlx/agents/profiles/hermes.yaml
+++ b/vllm_mlx/agents/profiles/hermes.yaml
@@ -32,7 +32,10 @@ streaming:
   max_tools: 62  # Hermes injects 62 tools per request
 
 testing:
-  binary: "~/.hermes/venv/bin/hermes"
+  # Resolve the installed CLI through PATH.  Current pip/uv installs place it
+  # in ~/.local/bin; older source installs used ~/.hermes/venv/bin.  Hardcoding
+  # the latter made `agents hermes --test` silently skip a valid modern install.
+  binary: "hermes"
   query_cmd: "hermes chat -q '{query}' -Q"
   query_timeout: 120
   install_cmd: "pip install hermes-agent"

--- a/vllm_mlx/agents/profiles/kilo-code.yaml
+++ b/vllm_mlx/agents/profiles/kilo-code.yaml
@@ -14,13 +14,29 @@ stars: 25500
 # file when running as the standalone CLI.
 config:
   type: json
-  path: "~/.config/kilo-code/settings.json"
+  path: "~/.config/kilo/kilo.json"
   template: |
     {
-      "apiProvider": "openai",
-      "openAiBaseUrl": "{base_url}",
-      "openAiApiKey": "not-needed",
-      "openAiModelId": "{model_id}"
+      "$schema": "https://app.kilo.ai/config.json",
+      "model": "rapid-mlx/{model_id}",
+      "provider": {
+        "rapid-mlx": {
+          "npm": "@ai-sdk/openai-compatible",
+          "name": "Rapid-MLX",
+          "options": {
+            "apiKey": "not-needed",
+            "baseURL": "{base_url}"
+          },
+          "models": {
+            "{model_id}": {
+              "name": "{model_id} (Rapid-MLX)",
+              "tool_call": true,
+              "reasoning": true,
+              "limit": {"context": {context_length}, "output": 8192}
+            }
+          }
+        }
+      }
     }
 
 models:
@@ -42,9 +58,13 @@ testing:
   binary: kilo
   # Kilo CLI has a one-shot mode via `kilo run '<prompt>'` on 0.3.0+;
   # older builds are interactive-only.
-  query_cmd: "kilo run '{query}'"
+  # Pin the throwaway test workspace explicitly: Kilo otherwise reuses its
+  # last project root and can read the caller's real checkout despite the
+  # child process cwd. `--pure` also prevents user-installed plugins from
+  # entering a compatibility/supply-chain test.
+  query_cmd: "kilo run --dir '{cwd}' --pure '{query}'"
   query_timeout: 180
-  install_cmd: "brew install kilo-org/kilo/kilo-code  # or: npm install -g kilo-code"
+  install_cmd: "npm install -g @kilocode/cli"
 
 capabilities:
   function_calling: true

--- a/vllm_mlx/agents/profiles/qwen-code.yaml
+++ b/vllm_mlx/agents/profiles/qwen-code.yaml
@@ -17,11 +17,25 @@ config:
   path: "~/.qwen/settings.json"
   template: |
     {
-      "openaiCompatible": {
-        "baseUrl": "{base_url}",
-        "apiKey": "not-needed",
-        "model": "{model_id}"
-      }
+      "modelProviders": {
+        "openai": [
+          {
+            "id": "{model_id}",
+            "name": "{model_id} (Rapid-MLX)",
+            "envKey": "RAPID_MLX_API_KEY",
+            "baseUrl": "{base_url}",
+            "generationConfig": {
+              "timeout": 300000,
+              "maxRetries": 1,
+              "contextWindowSize": {context_length},
+              "samplingParams": {"max_tokens": 8192}
+            }
+          }
+        ]
+      },
+      "env": {"RAPID_MLX_API_KEY": "not-needed"},
+      "security": {"auth": {"selectedType": "openai"}},
+      "model": {"name": "{model_id}"}
     }
 
 models:
@@ -44,14 +58,17 @@ testing:
   # qwen-code has a one-shot mode: `qwen -p "<prompt>"` runs without a
   # REPL. Useful for CI smokes.
   query_cmd: "qwen -p '{query}'"
-  query_timeout: 120
-  install_cmd: "npm install -g @qwenlm/qwen-code"
+  # Current Qwen Code injects ~30K prompt tokens and 59 tools before the user
+  # turn.  A local 9B prefill can legitimately exceed two minutes; allow the
+  # complete tool-result round trip rather than classifying progress as a hang.
+  query_timeout: 360
+  install_cmd: "npm install -g @qwen-code/qwen-code@latest"
 
 capabilities:
   function_calling: true
   streaming: true
 
 known_issues:
-  - "qwen-code hardcodes the OpenAI-compat `/v1` suffix — set `baseUrl` to `http://localhost:8000/v1` not the root URL."
+  - "Set the OpenAI provider baseUrl to the full `http://localhost:8000/v1` endpoint, not the server root."
   - "Older releases (< 1.2) had an issue where `chat_template_kwargs` was stripped before send; upgrade if you see `<think>` traces leaking into `content` on Qwen3.6."
   - "Alibaba banned Claude Code internally over alleged backdoor risks (2026-07-03) — qwen-code + rapid-mlx is the local, source-visible alternative."

--- a/vllm_mlx/agents/setup.py
+++ b/vllm_mlx/agents/setup.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import difflib
 import json
+import os
 import sys
+import tempfile
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -25,15 +27,22 @@ class SetupPlan:
     after: dict[str, Any]
     base_url: str
     model: str
+    format: str = "json"
+    credentials_path: Path | None = None
+    credentials_before: dict[str, Any] | None = None
+    credentials_after: dict[str, Any] | None = None
 
     @property
     def changed(self) -> bool:
-        return self.before != self.after
+        return self.before != self.after or (
+            self.credentials_path is not None
+            and self.credentials_before != self.credentials_after
+        )
 
     def diff(self) -> str:
-        before = json.dumps(self.before, indent=2, ensure_ascii=False, sort_keys=True)
-        after = json.dumps(self.after, indent=2, ensure_ascii=False, sort_keys=True)
-        return "\n".join(
+        before = _serialize(self.before, self.format)
+        after = _serialize(self.after, self.format)
+        primary = "\n".join(
             difflib.unified_diff(
                 before.splitlines(),
                 after.splitlines(),
@@ -42,9 +51,95 @@ class SetupPlan:
                 lineterm="",
             )
         )
+        if self.credentials_path is None or self.credentials_after is None:
+            return primary
+        # DSH's credential store may contain real keys for unrelated remote
+        # providers.  A setup preview must never echo those secrets.  Show
+        # only the presence/absence of the one Rapid-managed key.
+        managed_key = "RAPID_MLX_API_KEY"
+        credentials_before = (
+            {managed_key: "<configured; preserved>"}
+            if managed_key in (self.credentials_before or {})
+            else {}
+        )
+        credentials_after = (
+            {managed_key: "<configured; preserved>"}
+            if managed_key in (self.credentials_before or {})
+            else {managed_key: "not-needed"}
+        )
+        credentials = "\n".join(
+            difflib.unified_diff(
+                _serialize(credentials_before, "yaml").splitlines(),
+                _serialize(credentials_after, "yaml").splitlines(),
+                fromfile=str(self.credentials_path),
+                tofile=str(self.credentials_path) + " (proposed)",
+                lineterm="",
+            )
+        )
+        return "\n".join(part for part in (primary, credentials) if part)
 
 
-def build_setup_plan(agent: str, base_url: str, model: str) -> SetupPlan:
+def _serialize(data: dict[str, Any], format: str) -> str:
+    if format == "yaml":
+        import yaml
+
+        return yaml.safe_dump(data, sort_keys=False, allow_unicode=True).rstrip()
+    return json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    import yaml
+
+    if not path.exists() or not path.read_text(encoding="utf-8").strip():
+        return {}
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return value
+
+
+def _merge_dict(base: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _merge_dict(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _dsh_settings_path() -> Path:
+    configured = os.environ.get("DSH_HOME", "").strip()
+    root = Path(configured).expanduser() if configured else Path.home() / ".dsh"
+    return root / "settings.yaml"
+
+
+def _atomic_write_secure_text(path: Path, text: str) -> None:
+    """Atomically publish owner-only text beside a potentially secret config."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".new", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def build_setup_plan(
+    agent: str,
+    base_url: str,
+    model: str,
+    context_length: int | None = None,
+) -> SetupPlan:
     """Build a side-effect-free setup plan for a supported client."""
     if agent in {"claude", "claude-code"}:
         path = claude_code.current_config_path()
@@ -62,17 +157,90 @@ def build_setup_plan(agent: str, base_url: str, model: str) -> SetupPlan:
         return SetupPlan(
             "continue", "Continue.dev", path, before, after, base_url, model
         )
+    if agent in {"deepseek-harness", "dsh"}:
+        path = _dsh_settings_path()
+        before = _load_yaml_mapping(path)
+        credentials_path = path.parent / ".credentials.yaml"
+        credentials_before = _load_yaml_mapping(credentials_path)
+        context = context_length if context_length and context_length > 0 else 32768
+        patch = {
+            "llm-pi-ai": {
+                "providers": {
+                    "rapid-mlx": {
+                        "displayName": "Rapid-MLX Local",
+                        "apiKeyEnv": "RAPID_MLX_API_KEY",
+                        "api": "openai-completions",
+                        "baseURL": base_url.rstrip("/"),
+                        "defaultContextWindow": context,
+                        "defaultMaxTokens": 8192,
+                        "compat": {"supportsReasoningEffort": True},
+                        "models": [
+                            {
+                                "id": model,
+                                "name": f"{model} (Rapid-MLX)",
+                                "contextWindow": context,
+                                "maxTokens": 8192,
+                                "reasoningEfforts": {
+                                    "off": "none",
+                                    "low": "low",
+                                    "medium": "medium",
+                                    "high": "high",
+                                },
+                            }
+                        ],
+                    }
+                }
+            },
+            "agent-default-model": {"provider": "rapid-mlx", "model": model},
+        }
+        credentials_after = dict(credentials_before)
+        credentials_after.setdefault("RAPID_MLX_API_KEY", "not-needed")
+        return SetupPlan(
+            "deepseek-harness",
+            "DeepSeek Harness",
+            path,
+            before,
+            _merge_dict(before, patch),
+            base_url,
+            model,
+            "yaml",
+            credentials_path,
+            credentials_before,
+            credentials_after,
+        )
     raise ValueError(f"{agent} does not have a first-class safe setup flow")
 
 
 def apply_setup_plan(plan: SetupPlan) -> Path:
     """Back up the existing config and atomically apply an unchanged plan."""
     # Re-read to prevent overwriting an edit made between preview and consent.
-    current = launch_common.load_json_lenient(plan.path)
+    current = (
+        _load_yaml_mapping(plan.path)
+        if plan.format == "yaml"
+        else launch_common.load_json_lenient(plan.path)
+    )
     if current != plan.before:
         raise RuntimeError(f"{plan.path} changed after preview; re-run --setup")
+    if plan.credentials_path is not None:
+        credentials_current = _load_yaml_mapping(plan.credentials_path)
+        if credentials_current != (plan.credentials_before or {}):
+            raise RuntimeError(
+                f"{plan.credentials_path} changed after preview; re-run --setup"
+            )
     launch_common.backup_existing(plan.path)
-    launch_common.atomic_write_json(plan.path, plan.after)
+    if plan.credentials_path is not None and plan.credentials_after is not None:
+        launch_common.backup_existing(plan.credentials_path)
+        # Publish the harmless loopback sentinel first.  If the later settings
+        # write fails, DSH retains its prior provider selection; the reverse
+        # order would leave a newly-selected Rapid route unable to authenticate.
+        _atomic_write_secure_text(
+            plan.credentials_path,
+            _serialize(plan.credentials_after, "yaml") + "\n",
+        )
+    if plan.format == "yaml":
+        _atomic_write_secure_text(plan.path, _serialize(plan.after, "yaml") + "\n")
+    else:
+        launch_common.atomic_write_json(plan.path, plan.after)
     return plan.path
 
 

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -725,7 +725,12 @@ def _test_tag_suppression(
 # answer that merely mentions the project — or reads some other file —
 # satisfies without ever having read the line the test asks for.
 E2E_FIRST_LINE_TOKEN = "rapid-mlx-e2e-first-line-sentinel"
-E2E_FIRST_LINE = f"# {E2E_FIRST_LINE_TOKEN}"
+# Keep the sentinel as a semantic TOML assignment rather than a comment.
+# Several competent agents (Kilo and DSH among them) interpret "first line"
+# as "first meaningful config line" and intentionally omit comments even
+# when asked not to.  A unique top-level key remains impossible to guess while
+# making the expected evidence part of the document rather than trivia.
+E2E_FIRST_LINE = f"{E2E_FIRST_LINE_TOKEN} = true"
 
 
 @contextlib.contextmanager
@@ -749,13 +754,11 @@ def _e2e_workspace():
     left lying around. Starting it in a directory we just created, holding
     one file we wrote, makes that set knowable.
 
-    **This is not a sandbox and does not pretend to be.** The agent still
-    runs as the user, with the user's environment and `$HOME`, and can
-    read anything the user can by absolute path. Isolating that would take
-    a real filesystem sandbox with its own home; what this gives is a
-    deterministic *working directory*, which is what the e2e tests depend
-    on. Codex additionally runs its own commands under Seatbelt on macOS,
-    which is its business, not something arranged here.
+    **This is not a sandbox and does not pretend to be.** The runner gives the
+    child a throwaway HOME and deterministic working directory, but the agent
+    still runs as the same OS user and can read anything that user can via an
+    absolute path. Codex additionally runs its own commands under Seatbelt on
+    macOS, which is its business, not something arranged here.
     """
     workdir = tempfile.mkdtemp(prefix="rapid-mlx-agent-e2e-")
     try:
@@ -860,7 +863,10 @@ def _agent_query(
     except ValueError:
         # Fallback: simple split if shlex can't parse
         cmd_parts = query_cmd.split()
-    cmd_parts = [part.replace("{query}", query) for part in cmd_parts]
+    cmd_parts = [
+        part.replace("{query}", query).replace("{cwd}", cwd or os.getcwd())
+        for part in cmd_parts
+    ]
     # Replace first part with full binary path
     cmd_parts[0] = binary_path
 
@@ -872,6 +878,33 @@ def _agent_query(
         for key in _ANTHROPIC_REMOTE_ENV:
             child_env.pop(key, None)
     child_env.update(env_overrides or {})
+
+    # DSH rc.6 imports Node's Zstd stream API during profile boot but its npm
+    # manifest declares no minimum Node engine.  Node 23.6 therefore installs
+    # cleanly and then crashes with an opaque ESM export stack.  Probe the
+    # capability selected by the exact child PATH and report the actionable
+    # runtime mismatch before launching the harness.
+    if Path(binary_path).name == "dsh":
+        node = shutil.which("node", path=child_env.get("PATH"))
+        if node is None:
+            return None, "DeepSeek Harness requires Node.js on PATH"
+        probe = subprocess.run(
+            [
+                node,
+                "-e",
+                "process.exit(typeof require('node:zlib').createZstdDecompress === 'function' ? 0 : 1)",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            stdin=subprocess.DEVNULL,
+            env=child_env,
+        )
+        if probe.returncode != 0:
+            return None, (
+                "DeepSeek Harness requires a Node.js runtime with the Zstd "
+                "stream API; update Node (Node 22.15+ works)"
+            )
 
     try:
         proc = subprocess.run(
@@ -1067,7 +1100,10 @@ def _test_e2e_file_read(
         out, err = _agent_query(
             binary,
             query_cmd,
-            "Read the first line of pyproject.toml",
+            (
+                "Read pyproject.toml and copy its first physical line exactly, "
+                "including any leading punctuation. Do not skip comment lines."
+            ),
             timeout,
             workdir,
             env_overrides,
@@ -1287,18 +1323,18 @@ class AgentTestRunner:
             )
             return report
 
-        # File-config agents are driven from a throwaway home.  In particular,
-        # Codex must not inherit the operator's plugins, skills, history, or
-        # config: those change its context budget and made #1598 depend on the
-        # contents of ``~/.codex``.  The same override also prevents this test
-        # runner from merging into the operator's real config.
+        # Every agent is driven from a throwaway home.  Limiting isolation to
+        # profiles with a dedicated ``home_env`` left env-configured CLIs
+        # (notably Claude Code) free to load the operator's plugins, hooks,
+        # history and credentials.  It also let file-config agents without a
+        # relocation variable (OpenCode/Qwen Code/Kilo) refresh the real
+        # ``~/.config`` during ``--test``.  HOME is therefore the universal
+        # boundary; tool-specific relocation variables are layered on top.
         active_config = self.profile.get_config_for_version(self.agent_version)
-        isolated_config_home: tempfile.TemporaryDirectory[str] | None = None
+        isolated_config_home = tempfile.TemporaryDirectory(
+            prefix=f"rapid-mlx-{self.profile.name}-home-"
+        )
         config_home_env = active_config.home_env
-        if config_home_env:
-            isolated_config_home = tempfile.TemporaryDirectory(
-                prefix=f"rapid-mlx-{self.profile.name}-home-"
-            )
 
         # Refresh the agent's on-disk config (e.g. ``~/.hermes/config.yaml``)
         # so e2e tests run against the CURRENT model_id + base_url instead
@@ -1310,30 +1346,29 @@ class AgentTestRunner:
         # ``setup_agent_config`` is a no-op for env-var-style profiles
         # (codex, opencode, aider) since those carry config via env only.
         try:
-            from .adapter import setup_agent_config
+            from .adapter import fetch_context_window, setup_agent_config
 
-            if isolated_config_home and config_home_env:
-                previous = os.environ.get(config_home_env)
-                os.environ[config_home_env] = isolated_config_home.name
-                try:
-                    setup_agent_config(
-                        self.profile,
-                        base_url=self.base_url,
-                        model_id=self.model_id,
-                        agent_version=self.agent_version,
-                    )
-                finally:
-                    if previous is None:
-                        os.environ.pop(config_home_env, None)
-                    else:
-                        os.environ[config_home_env] = previous
-            else:
+            context_length = fetch_context_window(self.base_url, self.model_id)
+
+            redirected = {"HOME": isolated_config_home.name}
+            if config_home_env:
+                redirected[config_home_env] = isolated_config_home.name
+            previous = {key: os.environ.get(key) for key in redirected}
+            os.environ.update(redirected)
+            try:
                 setup_agent_config(
                     self.profile,
                     base_url=self.base_url,
                     model_id=self.model_id,
                     agent_version=self.agent_version,
+                    context_length=context_length,
                 )
+            finally:
+                for key, value in previous.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value
         except Exception as exc:  # noqa: BLE001 — config refresh must never abort the sweep
             logger.warning(
                 "could not refresh %s config before harness sweep: %s",
@@ -1344,18 +1379,43 @@ class AgentTestRunner:
         t0 = time.time()
         streaming = self.profile.get_streaming_for_version(self.agent_version)
         testing = self.profile.get_testing_for_version(self.agent_version)
+        # Use the same server-advertised capacity for env-style profiles.
+        # File-style profiles consumed it above during setup; rendering env
+        # profiles with the 32K fallback here would make the test sweep and
+        # `agents --setup` exercise materially different configurations.
+        try:
+            from .adapter import fetch_context_window
+
+            context_length = fetch_context_window(self.base_url, self.model_id)
+        except Exception:  # noqa: BLE001 — retain the documented fallback
+            context_length = None
         rendered_config = self.profile.render_config(
             self.base_url,
             self.model_id,
             self.agent_version,
+            context_length=context_length,
         )
         env_overrides = (
             {str(key): str(value) for key, value in rendered_config.items()}
             if active_config.type == "env" and isinstance(rendered_config, dict)
             else None
         )
-        if isolated_config_home and config_home_env:
-            env_overrides = dict(env_overrides or {})
+        env_overrides = dict(env_overrides or {})
+        env_overrides["HOME"] = isolated_config_home.name
+        # Claude Code documents CLAUDE_CONFIG_DIR as its supported config
+        # relocation.  Set it even though HOME is redirected: some packaged
+        # launchers resolve the account home before applying the child env.
+        if self.profile.name == "claude-code":
+            env_overrides["CLAUDE_CONFIG_DIR"] = str(
+                Path(isolated_config_home.name) / ".claude"
+            )
+        # DSH's pi-ai OpenAI transport currently insists on resolving a
+        # credential even for a loopback endpoint.  The first-class setup
+        # stores this non-secret sentinel in DSH's managed credential file;
+        # the ephemeral test home gets the equivalent process-local value.
+        if self.profile.name == "deepseek-harness":
+            env_overrides["RAPID_MLX_API_KEY"] = "not-needed"
+        if config_home_env:
             env_overrides[config_home_env] = isolated_config_home.name
 
         # --- API tests ---
@@ -1471,7 +1531,6 @@ class AgentTestRunner:
         Returns:
             List of TestResult from the specific test module.
         """
-        import importlib.util
         import re
         from pathlib import Path
 
@@ -1533,13 +1592,6 @@ class AgentTestRunner:
 
         t0 = time.time()
         try:
-            # Load and execute the test module
-            spec = importlib.util.spec_from_file_location(
-                f"specific_test_{test_module_name}",
-                test_path,
-            )
-            mod = importlib.util.module_from_spec(spec)
-
             # Set base URL env var so specific test modules use the right server
             import sys
 
@@ -1548,10 +1600,24 @@ class AgentTestRunner:
             # Suppress sys.exit (test modules call exit() at the end)
             original_exit = sys.exit
             exec_error = None
+            namespace: dict = {}
             sys.exit = lambda *a: None
             try:
-                spec.loader.exec_module(mod)
-                run_suite = getattr(mod, "run_suite", None)
+                # Integration files are executable test programs. Some expose
+                # module-level results, while others intentionally guard the
+                # suite with ``if __name__ == "__main__"``. Importing under a
+                # synthetic module name silently skipped the latter (notably
+                # PydanticAI) and then reported a harness error without making
+                # a single SDK call. Execute with script semantics and collect
+                # the resulting globals for both styles.
+                namespace = {
+                    "__name__": "__main__",
+                    "__file__": str(test_path),
+                    "__builtins__": __builtins__,
+                }
+                source = test_path.read_bytes()
+                exec(compile(source, str(test_path), "exec"), namespace)
+                run_suite = namespace.get("run_suite")
                 if callable(run_suite):
                     run_suite()
             except SystemExit:
@@ -1597,7 +1663,7 @@ class AgentTestRunner:
                 ]
 
             # Extract results dict
-            results_dict = getattr(mod, "results", {})
+            results_dict = namespace.get("results", {})
             if not results_dict:
                 return [
                     TestResult(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7894,7 +7894,7 @@ def agents_command(args):
         # write atomically, and verify the server afterwards. Keep the generic
         # profile writer below for the remaining integrations until each one
         # receives an equally precise adapter.
-        if profile.name in {"claude-code", "continue"}:
+        if profile.name in {"claude-code", "continue", "deepseek-harness"}:
             from vllm_mlx.agents.setup import (
                 apply_setup_plan,
                 build_setup_plan,
@@ -7903,7 +7903,12 @@ def agents_command(args):
             )
 
             try:
-                plan = build_setup_plan(profile.name, base_url, model_id)
+                plan = build_setup_plan(
+                    profile.name,
+                    base_url,
+                    model_id,
+                    context_length=context_length,
+                )
             except (OSError, ValueError) as exc:
                 print(f"\n  {profile.display_name} setup failed: {exc}\n")
                 sys.exit(1)


### PR DESCRIPTION
## What changed

- adds first-class DeepSeek Harness (`dsh`) profile, safe setup flow, docs, alias, and real headless test coverage
- updates stale Aider, Hermes, Qwen Code, and Kilo Code binary/package/config contracts found during Mini dogfood
- isolates every agent test in a throwaway HOME and explicitly relocates Claude/DSH config
- feeds the server-advertised context window into test configs and raises realistic local CLI timeouts
- runs Python framework suites with script semantics so guarded PydanticAI/smolagents tests no longer false-fail or silently skip
- pins Kilo to the throwaway workspace with `--dir` and disables external plugins with `--pure`

## Why

The existing 12-profile sweep contained several false positives: missing binaries were treated as success, stale package names/config schemas skipped real clients, and some tests could load or write the operator’s active agent home. DSH also needs an explicit local provider, a non-secret loopback credential sentinel, and a compatible Node runtime diagnostic.

## User impact

`rapid-mlx agents dsh --setup` now previews and atomically applies a local Rapid-MLX provider while preserving unrelated settings and existing credentials. `rapid-mlx agents dsh --test` exercises the real headless CLI. Existing agent tests are safer and materially closer to real installed clients.

## Validation

- `ruff check` on agent/CLI/test changes
- 101 focused unit tests passed
- Mini, Qwen3.5-9B-4bit, isolated installs/homes:
  - Codex 12/12; Claude Code 13/13; Aider 3/3; Hermes 24/24
  - Qwen Code 13/13 (real chat/file/shell; 30K-token/59-tool prompt)
  - DeepSeek Harness 13/13 (real headless chat/file/shell)
  - LangChain 15/15; PydanticAI 15/15; smolagents 11/11
  - Kilo 12/13 initial full sweep; the sole failure exposed stale project-root reuse, fixed with `--dir {cwd} --pure`; targeted real file-read then passed
  - Continue wire/API passed; OpenCode wire/API passed with headless CLI explicitly skipped; OpenHands wire/API passed, Docker E2E unavailable on the Mini

## Safety

All third-party CLIs were installed into isolated prefixes. DSH has no install scripts. Kilo’s postinstall was inspected before isolated installation. Existing Codex/Claude processes and homes were not modified.