### PR TITLE
fix(server): report live hybrid model metadata

### DIFF
--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -307,6 +307,88 @@ def test_engine_is_mllm_or_none_is_defensive():
     assert models_route._engine_is_mllm_or_none(_StubEngine(False)) is False
 
 
+def test_build_model_info_prefers_live_hybrid_probe(monkeypatch):
+    """The wire reports the scheduler's loaded profile, not stale alias data."""
+    from vllm_mlx.routes import models as models_route
+
+    restore = _stub_single_serve(
+        monkeypatch,
+        model_id="mlx-community/LFM2.5-1.2B-Instruct-4bit",
+        engine_is_mllm=False,
+    )
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    cfg.model_alias = "lfm2.5-1b-4bit"
+    cfg.engine._is_hybrid_model = lambda: True
+    try:
+        assert models_route._build_model_info("lfm2.5-1b-4bit").is_hybrid is True
+        assert (
+            models_route._build_model_info(
+                "mlx-community/LFM2.5-1.2B-Instruct-4bit"
+            ).is_hybrid
+            is True
+        )
+    finally:
+        restore()
+
+
+def test_build_model_info_keeps_static_hybrid_for_unserved_alias(monkeypatch):
+    """Discovery-only aliases retain registry metadata without a live engine."""
+    from vllm_mlx.routes import models as models_route
+
+    restore = _stub_single_serve(
+        monkeypatch, model_id="fake/other-model", engine_is_mllm=False
+    )
+    try:
+        assert models_route._build_model_info("lfm2.5-1b-4bit").is_hybrid is False
+    finally:
+        restore()
+
+
+def test_reported_hybrid_keeps_static_for_unmounted_registry_entry(monkeypatch):
+    """A registered model is discovery-only until its engine is attached."""
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes import models as models_route
+
+    entry = SimpleNamespace(engine=None, matches=lambda model_id: model_id == "alias")
+    registry = SimpleNamespace(get_entry=lambda _model_id: entry)
+    cfg = SimpleNamespace(model_registry=registry)
+    monkeypatch.setattr(models_route, "get_config", lambda: cfg)
+
+    assert models_route._reported_hybrid("alias", False) is False
+
+
+@pytest.mark.parametrize(
+    "probe",
+    [None, lambda: "yes", lambda: (_ for _ in ()).throw(RuntimeError("probe"))],
+)
+def test_build_model_info_does_not_backfill_unknown_live_hybrid(monkeypatch, probe):
+    """A loaded engine's unknown state must not be replaced by alias metadata."""
+    from vllm_mlx.routes import models as models_route
+
+    restore = _stub_single_serve(
+        monkeypatch,
+        model_id="mlx-community/LFM2.5-1.2B-Instruct-4bit",
+        engine_is_mllm=False,
+    )
+    from vllm_mlx.config import get_config
+
+    cfg = get_config()
+    cfg.model_alias = "lfm2.5-1b-4bit"
+    if probe is not None:
+        cfg.engine._is_hybrid_model = probe
+    try:
+        assert models_route._build_model_info("lfm2.5-1b-4bit").is_hybrid is None
+        # The same static alias remains useful when it is not the served model.
+        cfg.model_name = "fake/other-model"
+        cfg.model_alias = None
+        assert models_route._build_model_info("lfm2.5-1b-4bit").is_hybrid is False
+    finally:
+        restore()
+
+
 def test_build_model_info_raw_hf_path_honors_degraded_engine(monkeypatch):
     """The raw-HF-path branch of ``_build_model_info`` (no alias profile — the
     gemma-4 OptiQ case) must, once the served engine has degraded to text,

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -174,6 +174,59 @@ def _served_engine_is_mllm(model_id: str) -> bool | None:
         return None
 
 
+def _engine_is_hybrid_or_none(engine: object | None) -> bool | None:
+    """Return the loaded engine's runtime hybrid classification.
+
+    Batched engines may refine an alias profile after weights are loaded (for
+    example LFM2.5 exposes ``ArraysCache`` layers). The runtime probe is more
+    authoritative than the static alias row, just as live ``is_mllm`` is for
+    modality.
+    """
+    if engine is None:
+        return None
+    probe = getattr(engine, "_is_hybrid_model", None)
+    if not callable(probe):
+        return None
+    try:
+        value = probe()
+    except Exception:  # noqa: BLE001
+        return None
+    return value if isinstance(value, bool) else None
+
+
+def _reported_hybrid(model_id: str, static: bool | None) -> bool | None:
+    """Return the live hybrid verdict, or ``static`` for discovery-only ids.
+
+    A matching live engine is authoritative even when its probe is missing or
+    fails: in that case the truthful answer is ``None`` (unknown), not stale
+    alias metadata.  Static metadata remains useful only when no live engine is
+    serving this id.
+    """
+    try:
+        cfg = get_config()
+        if cfg.model_registry is not None:
+            try:
+                entry = cfg.model_registry.get_entry(model_id)
+            except KeyError:
+                return static
+            if entry is not None and entry.matches(model_id):
+                engine = getattr(entry, "engine", None)
+                # Registry entries exist before their engine is mounted. That
+                # state is discovery-only, so the curated alias value is still
+                # the best answer; only an attached engine owns the live truth.
+                if engine is None:
+                    return static
+                return _engine_is_hybrid_or_none(engine)
+            return static
+        candidate = getattr(cfg, "engine", None)
+        served = {cfg.model_name, cfg.model_alias} - {None}
+        if candidate is not None and model_id in served:
+            return _engine_is_hybrid_or_none(candidate)
+        return static
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _reported_modality(
     model_id: str, profile_modality: str, is_text_only: bool = False
 ) -> str:
@@ -734,6 +787,9 @@ def _build_model_info(model_id: str) -> ModelInfo:
     covers raw HF paths too, not just registered aliases).
     """
     profile = resolve_profile(model_id)
+    reported_hybrid = _reported_hybrid(
+        model_id, profile.is_hybrid if profile is not None else None
+    )
     # ``context_window`` is engine-derived (not profile-derived) so it
     # surfaces even for unregistered operator-supplied ids when an
     # engine is loaded for them. Resolution is best-effort: probe
@@ -802,7 +858,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         return ModelInfo(
             id=model_id,
             recommended_sampling=sampling,
-            is_hybrid=profile.is_hybrid,
+            is_hybrid=reported_hybrid,
             is_moe=profile.is_moe,
             tool_call_parser=eff_tool,
             reasoning_parser=eff_reasoning,
@@ -855,6 +911,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
             pass
         return ModelInfo(
             id=model_id,
+            is_hybrid=reported_hybrid,
             capabilities=capabilities,
             tool_call_parser=eff_tool,
             reasoning_parser=eff_reasoning,
@@ -892,7 +949,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
     return ModelInfo(
         id=model_id,
         recommended_sampling=sampling,
-        is_hybrid=profile.is_hybrid,
+        is_hybrid=reported_hybrid,
         is_moe=profile.is_moe,
         tool_call_parser=eff_tool,
         reasoning_parser=eff_reasoning,


### PR DESCRIPTION
## Necessity

A real LFM2.5 server enabled its runtime hybrid scheduler after inspecting the loaded cache architecture, while `/v1/models` advertised `is_hybrid: false`. Clients and the desktop therefore received metadata that contradicted the engine actually serving their requests.

Why this must land: clients use this audited metadata for diagnostics and feature decisions; a stale static value makes the endpoint actively misleading rather than merely incomplete.

## Why

Wire metadata must describe the loaded engine that will actually serve the client's request.

## Root cause and fix

`routes/models.py` always serialized the static alias profile's hybrid flag. Unlike modality and parser metadata, it never consulted the matching loaded engine. The route now prefers the matching engine's fail-closed `_is_hybrid_model()` result for served canonical IDs and aliases, while preserving static registry metadata for discovery-only entries and returning `None` defensively for incomplete engines.

## Validation

- Proved the guard: before the change, live Mini LFM2.5 returned `false` for both canonical and alias entries; after the change, both return `true`, matching the runtime `ArraysCache` probe and hybrid scheduler log.
- Mini: 4 concurrent requests, 10,017-token prompt, SSE disconnect/recovery, ordinary 400 error, and CORS preflight passed.
- `93 passed`: routes models, effective parsers, and route suite.
- Ruff check + format check and `git diff --check` passed.

## AI assistance

Codex reproduced the wire/runtime contradiction, authored the route and regression tests, and performed unit plus live-model verification. The maintainer can explain every changed line on demand.

- [x] I can explain every line on demand.
