### PR TITLE
test(mac): make release dogfood match settled UI state

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.transcription.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.transcription.txt
@@ -8,6 +8,13 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
+          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXStaticText id="Sidebar.Residency" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXGroup id="Audio.Mode" desc="Audio mode" enabled=true
@@ -24,6 +31,8 @@ AXApplication title="Rapid-MLX"
               AXStaticText value=text enabled=true
               AXStaticText value=text enabled=true
               AXButton id="Readiness.Action" desc="Download & start" enabled=true
+            AXGroup enabled=true
+              AXStaticText value=text enabled=true
             AXButton id="Audio.Transcription.Run" desc="Transcribe" enabled=false
       AXImage id="checkmark.circle.fill" desc="Selected" enabled=true
       AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -12,17 +12,27 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true
           AXStaticText value=text enabled=true
-          AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
+          AXStaticText value=text enabled=true
+          AXGroup desc="lfm2.5-1b-4bit isn't downloaded yet, It downloads once (~<size>), then starts in seconds." enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
-            AXButton id="Readiness.Action" desc="Start" enabled=true
+            AXButton id="Readiness.Action" desc="Download & start" enabled=true
           AXStaticText value=text enabled=true
           AXScrollArea
             AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
           AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add PDF, CSV, or TXT files" enabled=true
           AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
-          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Download lfm2.5-1b-4bit before sending." enabled=false
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true
       AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -893,6 +893,12 @@ def _emit_catalog(subcommand, alias):
         print("Available models")
         print("Alias                  Parser           Reasoning")
         print("---------------------  ---------------  ---------")
+        if _setting("FAKE_INCLUDE_STARTER") == "1":
+            # A production catalog always contains the onboarding starter.
+            # Most flows deliberately keep the compact single-chat-row
+            # fixture, but fresh-install must exercise the real default
+            # selection contract rather than falling back to fake-alias.
+            print("lfm2.5-1b-4bit        hermes           none")
         print("fake-alias             hermes           qwen3")
         print("fake-external-alias    hermes           qwen3")
         # A video-generation row, in the tagged section the real engine

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1075,7 +1075,10 @@ wait_send_idle() {
 
 flow_fresh_install() {
     log "1/6 fresh install and onboarding"
-    start_persona fresh-install
+    # The real engine registry always contains the starter. Without this row,
+    # the fake catalog makes the app correctly fall back to its only chat row
+    # and the assertion below can never prove the production first-run rule.
+    start_persona fresh-install FAKE_INCLUDE_STARTER=1
     see_main "$OUT/consent-visible.json"
     jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$OUT/consent-visible.json" >/dev/null \
         || die "fresh install did not show telemetry consent"
@@ -3058,7 +3061,30 @@ flow_audio_readiness() {
     [[ "$speech_loaded" == 1 ]] \
         || die "Speech stayed behind Download & start after its model became ready"
 
-    press "$OUT/speech-loaded.json" Audio.Mode.Transcription "$OUT/transcription.json" \
+    # Residency is polled independently from Audio readiness. The sidecar can
+    # be ready several frames before the sidebar's first residency snapshot;
+    # switching tabs immediately made the transcription baseline alternate
+    # between "no resident" and the correctly resident TTS model depending on
+    # poll timing. Wait for the user-visible state that must follow readiness
+    # before recording the next settled screen.
+    local speech_resident=0
+    for ((i=0; i<120; i++)); do
+        see_main "$OUT/speech-resident.json"
+        if jq -e '.data.ui_elements as $elements
+                  | any(range(1; $elements | length);
+                        $elements[.].identifier == "Sidebar.Residency"
+                        and $elements[.].value == "fake-qwen3-tts"
+                        and $elements[. - 1].identifier == "Sidebar.Residency"
+                        and $elements[. - 1].description == "Lock")' \
+                 "$OUT/speech-resident.json" >/dev/null; then
+            speech_resident=1; break
+        fi
+        sleep 0.25
+    done
+    [[ "$speech_resident" == 1 ]] \
+        || die "ready fake-qwen3-tts never appeared as the locked resident model"
+
+    press "$OUT/speech-resident.json" Audio.Mode.Transcription "$OUT/transcription.json" \
         || die "Audio transcription segment is not pressable"
     local transcription_ready=0
     for ((i=0; i<40; i++)); do

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -24,6 +24,7 @@ ROOT = Path(__file__).resolve().parent.parent
 DRIVER = ROOT / "apps/rapid-mac/scripts/rapid-ax.swift"
 HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
 DOGFOOD = ROOT / "apps/rapid-mac/scripts/dogfood-isolate.sh"
+FAKE_SIDECAR = ROOT / "apps/rapid-mac/scripts/fake-rapid-mlx.sh"
 
 
 def test_trust_command_checks_permission_reach_and_lock():
@@ -146,3 +147,31 @@ def test_harness_reaps_its_own_fake_before_relaunch_without_global_sweep():
     assert relaunch.index("cleanup_fake_sidecars") < relaunch.index(
         '"$PERSONA/launch.sh"'
     )
+
+
+def test_fresh_install_fixture_contains_the_real_starter():
+    """The starter assertion is meaningless if the fake catalog omits it."""
+    flow = HARNESS.read_text().split("flow_fresh_install() {", 1)[1].split("\n}", 1)[0]
+    fake = FAKE_SIDECAR.read_text()
+    assert "start_persona fresh-install FAKE_INCLUDE_STARTER=1" in flow
+    assert 'if _setting("FAKE_INCLUDE_STARTER") == "1":' in fake
+    assert 'print("lfm2.5-1b-4bit' in fake
+
+
+def test_audio_baseline_waits_for_residency_poll_to_settle():
+    flow = (
+        HARNESS.read_text().split("flow_audio_readiness() {", 1)[1].split("\n}", 1)[0]
+    )
+    correlated_row = "any(range(1; $elements | length);"
+    resident_alias = '$elements[.].value == "fake-qwen3-tts"'
+    resident_lock = '$elements[. - 1].description == "Lock"'
+    settled_guard = '[[ "$speech_resident" == 1 ]]'
+    switch = 'press "$OUT/speech-resident.json" Audio.Mode.Transcription'
+    assert correlated_row in flow
+    assert resident_alias in flow
+    assert resident_lock in flow
+    assert settled_guard in flow
+    assert switch in flow
+    assert flow.index(resident_alias) < flow.index(switch)
+    assert flow.index(resident_lock) < flow.index(switch)
+    assert flow.index(settled_guard) < flow.index(switch)


### PR DESCRIPTION
## Necessity

The release GUI suite was red on clean `main`: its fresh-install fixture omitted the production starter while asserting that starter was selected, and Audio captured an independently-polled residency card before it had settled. Without this fix, release dogfood either fails deterministically on the impossible starter contract or flakes on the Audio transition.

Why this must land: a red or flaky release gate cannot distinguish a shippable GUI from a regression, so maintainers either block good releases or learn to ignore the only full-app control audit.

## Why

The GUI gate must observe production-equivalent, settled states to remain a trustworthy release signal.

## What changed

- Let the fresh-install fake catalog opt into the real `lfm2.5-1b-4bit` starter.
- Record the honest cold-start `Download & start` structure.
- Wait for the exact ready TTS alias and lock marker to appear in the residency sidebar before switching to Transcription.
- Pin the resulting resident-model and stop-current-model warning structure.
- Add static contracts so neither synchronization rule can silently disappear.

## Validation

- Mini, macOS 26.5.2: release build succeeded.
- Mini: `./scripts/gui-golden-flows.sh` — PASS all; artifacts `/tmp/rapid-gui-golden-20260815T142402Z`.
- `54 passed`: GUI preflight, walk completeness, fake image catalog, AX baseline variance.
- `bash -n` and `git diff --check` passed.

## AI assistance

Codex reproduced the failures, diagnosed the fixture and polling races, authored the changes in the five touched files, and ran the checks above. The maintainer reviewed the observed AX trees and generated baselines against the visible product states.

- [x] I can explain every non-generated line on demand. The two AX snapshots are generated artifacts and were verified through the named Mini flow.
