### PR TITLE
test: restore main-head contract gates

### DIFF
--- a/tests/test_claude_code_profile.py
+++ b/tests/test_claude_code_profile.py
@@ -1,5 +1,6 @@
 """Regression coverage for the Claude Code agent discovery surface (#1531)."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from vllm_mlx.agents import get_profile, list_profiles, load_profiles
@@ -48,11 +49,21 @@ def test_claude_code_profile_has_runnable_test_command():
     )
 
 
-def test_claude_code_e2e_receives_rendered_environment():
+def test_claude_code_e2e_receives_rendered_environment(tmp_path):
     profile = get_profile("claude-code")
     assert profile is not None
+    isolated_home = tmp_path / "isolated-claude-home"
+    isolated_home.mkdir()
+    temporary_home = SimpleNamespace(
+        name=str(isolated_home),
+        cleanup=lambda: None,
+    )
 
     with (
+        patch(
+            "vllm_mlx.agents.testing.tempfile.TemporaryDirectory",
+            return_value=temporary_home,
+        ),
         patch(
             "vllm_mlx.agents.testing.AgentTestRunner._server_available",
             return_value=True,
@@ -85,8 +96,14 @@ def test_claude_code_e2e_receives_rendered_environment():
             model_id="qwen3.5-9b-4bit",
         ).run()
 
-    assert e2e_chat.call_args.kwargs["env_overrides"] == {
+    env = e2e_chat.call_args.kwargs["env_overrides"]
+    assert {
+        key: env[key]
+        for key in ("ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY", "ANTHROPIC_MODEL")
+    } == {
         "ANTHROPIC_BASE_URL": "http://localhost:8000",
         "ANTHROPIC_API_KEY": "not-needed",
         "ANTHROPIC_MODEL": "qwen3.5-9b-4bit",
     }
+    assert env["HOME"] == str(isolated_home)
+    assert env["CLAUDE_CONFIG_DIR"] == f"{env['HOME']}/.claude"

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -545,7 +545,8 @@ class TestLaunchCommand:
         assert excinfo.value.code == 0
         targets = json.loads(capsys.readouterr().out)
         ids = [target["id"] for target in targets]
-        assert len(ids) == len(set(ids)) == 14
+        assert len(ids) == len(set(ids)) == 15
+        assert "deepseek-harness" in ids
         assert ids[:4] == ["cline", "claude-code", "continue-dev", "cursor"]
         assert {target["kind"] for target in targets} == {
             "config_writer",

--- a/tests/test_model_profiles_ssot.py
+++ b/tests/test_model_profiles_ssot.py
@@ -257,6 +257,7 @@ def test_legacy_string_value_still_loads(tmp_path) -> None:
         patch.object(ma, "_aliases", None),
         patch.object(ma, "_hf_to_alias", None),
         patch("vllm_mlx.model_aliases.os.path.join", return_value=str(legacy)),
+        patch("vllm_mlx.user_aliases.load_user_aliases", return_value={}),
     ):
         profiles = ma.list_profiles()
 

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -3068,19 +3068,65 @@ def test_mtp_controller_key_separates_sidecars():
     assert _mtp_controller_key("", "mlx-community/Head-A") is None
 
 
-def test_scheduler_config_model_name_is_the_last_field():
-    """``SchedulerConfig`` is constructed positionally by external
-    callers, so a field added mid-list silently rebinds every argument
-    after it. ``model_name`` must stay at the end.
-    """
+def test_scheduler_config_preserves_the_historical_positional_prefix():
+    """New fields append after, rather than shifting, the historical tail."""
     from vllm_mlx.scheduler import SchedulerConfig
 
     names = [f.name for f in dataclasses.fields(SchedulerConfig)]
-    assert names[-1] == "model_name", (
-        f"model_name must be the last field to preserve positional "
-        f"construction; it is at index {names.index('model_name')} of "
-        f"{len(names)}"
-    )
+    historical_prefix = [
+        "max_num_seqs",
+        "prefill_batch_size",
+        "completion_batch_size",
+        "prefill_step_size",
+        "enable_prefix_cache",
+        "prefix_cache_size",
+        "prefix_cache_index",
+        "use_memory_aware_cache",
+        "cache_memory_mb",
+        "cache_memory_percent",
+        "kv_cache_dtype",
+        "kv_cache_quantization",
+        "kv_cache_quantization_bits",
+        "kv_cache_quantization_group_size",
+        "kv_cache_min_quantize_tokens",
+        "kv_cache_turboquant",
+        "kv_cache_turboquant_bits",
+        "kv_cache_turboquant_group_size",
+        "kv_cache_turboquant_mode",
+        "kv_disk_checkpoint_interval",
+        "use_paged_cache",
+        "paged_cache_block_size",
+        "max_cache_blocks",
+        "hybrid_cache_entries",
+        "spec_decode",
+        "enable_mtp",
+        "mtp_num_draft_tokens",
+        "mtp_optimistic",
+        "dflash_drafter_path",
+        "enable_suffix_decoding",
+        "suffix_max_draft",
+        "suffix_max_suffix_len",
+        "suffix_min_confidence",
+        "suffix_min_draft_len",
+        "max_concurrent_requests",
+        "gpu_memory_utilization",
+        "metal_pressure_evict_fraction",
+        "metal_cap_kv_bytes_per_token",
+        "pflash_config",
+        "mtp_sidecar",
+        "mtp_model_type",
+        "mtp_max_k",
+        "mtp_disable_auto_k",
+        "response_cache_entries",
+        "non_trimmable_exact_prefix_reuse",
+        "dspark_num_speculative_tokens",
+        "adaptive_prefill",
+        "adaptive_prefill_min_tokens",
+        "adaptive_prefill_min_chunk_size",
+        "model_name",
+    ]
+    assert names[:50] == historical_prefix
+    assert names[49:] == ["model_name", "vision_min_pixels", "vision_max_pixels"]
 
 
 def test_fixed_k_observer_leaves_the_ceiling_to_whoever_selects_depth():

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -1044,6 +1044,18 @@ def _check_env_constant(
                 "external-model discovery/resolution boundary."
             )
         return
+    if value == "RAPID_MLX_USER_ALIASES_FILE":
+        # Narrow test-isolation/config-location exception for user aliases.
+        # The file's CONTENT can affect alias resolution, so this is not a
+        # general non-routing allowlist entry: only the persistence module may
+        # read the override. Any engine/router consumer is a new hidden routing
+        # surface and must fail this gate.
+        if rel != "user_aliases.py":
+            offenders.append(
+                f"{rel}:{lineno} references `{value}` outside the approved "
+                "user-alias persistence boundary."
+            )
+        return
     if value in ALLOWED_RAPID_MLX_ENV_VARS:
         return
     if ENV_VAR_ROUTING_PATTERN.match(value):


### PR DESCRIPTION
## Necessity

Clean `origin/main` has five deterministic unit failures, so every unrelated PR's full-unit validation is red and the release gate cannot distinguish regressions from stale contracts. These failures were introduced by already-landed Claude isolation, DeepSeek Harness discovery, user aliases, and MLLM pixel-bound changes. The sixth failure originally reproduced during this work (missing Qwen3.8 size metadata) was independently fixed by #1954 and is intentionally absent after rebasing.

## Why

Main must have a trustworthy green unit baseline before unrelated fixes can be reviewed or released.

## Fix

- Assert Claude Code's new isolated `HOME` / `CLAUDE_CONFIG_DIR` while retaining the Anthropic environment contract.
- Include DeepSeek Harness in the explicit launch registry contract.
- Isolate the legacy built-in-alias fixture from the new user alias store.
- Preserve `SchedulerConfig`'s historical positional prefix and assert new vision fields append after it (moving `model_name` would itself break compatibility).
- Classify the user-alias file override as a persistence-path knob, not forbidden engine routing.

## Validation

- Proved the original six failures on a detached clean-main worktree; rebased after #1954 independently removed the Qwen3.8 manifest failure.
- The remaining five exact regressions pass on this branch.
- 255 affected tests pass across Claude profile, launch CLI, model profiles/user aliases/sizes, MTP config, and routing-env contracts.
- Ruff check/format and `git diff --check` pass.

## AI assistance

Codex reproduced each main-head failure, traced it to the corresponding landed behavior, authored the contract updates, and ran the checks above. The maintainer can explain every changed line.

- [x] I can explain every line on demand.
