### PR TITLE
test: mark test_event_loop as integration [skip-version-bump]

### DIFF
--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -24,6 +24,12 @@ import sys
 import time
 
 import aiohttp
+import pytest
+
+# This module drives a live server (see the docstring above) — without one
+# it fails on connect, and with one it sends real completions to whatever
+# is bound on :8000. Keep it out of the default unit sweep.
+pytestmark = pytest.mark.integration
 
 BASE = "http://127.0.0.1:8000"
 


### PR DESCRIPTION
## Summary

Scoped down after #1957 landed: that PR repaired the five deterministic semantic-conflict failures on main, so this PR now carries only the remaining two reds. `tests/test_event_loop.py`'s own docstring says it "Requires a running Rapid-MLX server on localhost:8000" — collected into the default unit sweep it fails on connect when no server is up, and when one IS up it silently sends real completions to whatever is bound on :8000 (on dev machines, the production serve). Mark the module `integration` — exactly the bucket `pytest.ini` deselects by default for "require running server" suites. Running the file directly as a script (`python tests/test_event_loop.py`) is unaffected.

This closes the last gap to a green `pytest tests/` on main: with #1957 merged, this branch runs 17,687 passed / 0 failed.

## Test plan

- [x] `pytest tests/test_event_loop.py` on this branch: 3 deselected, 0 failed (previously 2 connect-error failures with no server)
- [x] Full unit suite green on the pre-rebase branch containing this same hunk (17,687 passed / 0 failed); full suite re-run on the rebased branch before merge
- [x] `ruff check` + `ruff format --check` clean
- [x] Codex review round 1 on the superset diff (this hunk included): MERGE-SAFE, 0 BLOCKING / 0 MAJOR