### PR TITLE
feat(rapid-mac): recognize the Qwen 3.8 family [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelInfoCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelInfoCatalog.swift
@@ -142,7 +142,8 @@ enum ModelInfoCatalog {
             ? String(alias.prefix(ModelCatalog.maxAliasBytes))
             : alias
         let a = boundedAlias.lowercased()
-        // Qwen family — order matters (qwen3.6 before qwen3)
+        // Qwen family — order matters (qwen3.8 / qwen3.6 before qwen3)
+        if a.contains("qwen3.8") { return ("Qwen 3.8", 32_768) }
         if a.contains("qwen3.6") { return ("Qwen 3.6", 32_768) }
         if a.contains("qwen3.5") { return ("Qwen 3.5", 32_768) }
         if a.contains("qwen3-coder-next") { return ("Qwen 3 Coder Next", 32_768) }

--- a/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
@@ -280,6 +280,12 @@ enum ToolUseCapability {
         // cycle-13 F-13-2 confirms /v1/models exposes the parser
         // correctly; PR #318 auto-scale gate verified.
         KnownFamily(prefix: "qwen3.6-", minSizeBillions: 3.0, note: "hybrid+MoE, qwen3_coder_xml parser; cycle-13 F-13-2 closure"),
+        // qwen3.8 — hybrid family, hermes parser. Release eval on
+        // rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX (our own mixed-precision
+        // build) scored 25/30 tool-calling scenarios, including the
+        // parallel and sequential multi-tool levels, with no control-token
+        // leakage into content.
+        KnownFamily(prefix: "qwen3.8-", minSizeBillions: 3.0, note: "hybrid, hermes parser; release eval 25/30 tool scenarios on 27b-mixed-3.5bpw"),
         // qwopus — Qwen+Opus distillation, hermes parser. PR #333
         // closure-verified 5/5 weather tool calls on qwopus-27b-8bit.
         KnownFamily(prefix: "qwopus-", minSizeBillions: 3.0, note: "PR #333 closure-verified 5/5 weather tool calls on 27b-8bit"),

--- a/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityCatalogCoverageTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityCatalogCoverageTests.swift
@@ -339,6 +339,10 @@ struct ToolUseCapabilityCatalogCoverageTests {
         "qwen3.6-35b-mxfp4": .known,
         "qwen3.6-35b-nvfp4": .known,
         "qwen3.6-35b-ud": .known,
+        // qwen3.8 — hybrid family, hermes parser. The mixed-3.5bpw entry
+        // is our own build; release eval scored 25/30 tool scenarios.
+        "qwen3.8-27b-4bit": .known,
+        "qwen3.8-27b-mixed-3.5bpw": .known,
         // qwopus — Qwen+Opus distillation, hermes parser. PR #333
         // closure-verified 5/5 weather tool calls on qwopus-27b-8bit.
         "qwopus-27b-4bit": .known,

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -2,3 +2,76 @@
      version-bump PR, `git mv` this to vX.Y.Z.md and recreate this file empty.
      Whole-line HTML comments like this one are stripped before publishing.
      See README.md in this directory for what good notes look like. -->
+
+## Highlights
+
+### Qwen3.8-27B, in our own mixed-precision build
+
+`qwen3.8-27b-mixed-3.5bpw` serves [`rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX`](https://huggingface.co/rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX)
+— a Rapid-MLX quantization that spends its bits where they matter instead of
+flattening every tensor to 4-bit. It lands at **13.0 GB of weights against the
+4-bit build's 15.0 GB**, so it fits a 24 GB Mac with room for real context.
+
+Measured through `rapid-mlx serve` on an M3 Ultra (8K prompt, whole process
+tree): **20 GB peak, 323 tok/s prefill, 40 tok/s decode, zero swap.** In the
+release eval it answers **10/10 coding tasks and 25/30 tool-calling scenarios**,
+including the parallel and sequential multi-tool levels.
+
+```bash
+rapid-mlx chat qwen3.8-27b-mixed-3.5bpw
+```
+
+One honest caveat: on the 10-task MATH subset it scored 5/10 with thinking
+disabled, below its 4-bit sibling's league. It is a strong coding and
+tool-calling model at this footprint; if your work is arithmetic-heavy,
+`qwen3.6-35b-4bit` or `gemma-4-26b-4bit` remain the safer picks. That is also
+why it is **not** a built-in RAM-tier recommendation yet.
+
+### Name your own models
+
+`rapid-mlx alias` gives every model a name you choose, stored in your own
+config — no repo edit, no fork:
+
+```bash
+rapid-mlx alias set fast qwen3.5-4b-4bit
+rapid-mlx alias set mine some-org/Some-Model-MLX-4bit
+rapid-mlx alias list
+rapid-mlx serve fast
+```
+
+Aliases can point at a built-in alias or any Hugging Face repo id. They cannot
+shadow a built-in name or chain to another user alias, and a malformed store
+fails closed rather than silently resolving to the wrong weights.
+
+### DeepSeek Harness joins the agent lineup
+
+`rapid-mlx agents dsh --setup` wires DeepSeek Harness to your local server the
+same way the Tier-1 agents are wired, and `rapid-mlx launch` lists it alongside
+the rest. The agent test sweep now runs each agent inside a throwaway home, so
+running it can no longer read or rewrite your real agent config.
+
+### Vision: opt-in pixel bounds
+
+`--vision-min-pixels` / `--vision-max-pixels` bound what a multimodal model's
+image preprocessor produces. Large photos on a memory-tight Mac were the
+motivating case: capping the long edge keeps a vision request from ballooning
+the KV cache. Both default to off, preserving each processor's own behavior.
+
+## Mac app
+
+- **Updates are now Sparkle's job, end to end.** The in-app DMG installer is
+  gone; the app checks, downloads, verifies the signature, and installs through
+  Sparkle. Builds from 0.12.12 onward keep themselves up to date; older builds
+  are told to download once from rapidmlx.com and never see a broken in-app
+  install path again.
+- Qwen 3.8 models are recognized as their own family — correct name in the
+  picker, and their verified tool-calling shows as a capability instead of
+  "unknown".
+
+## Fixes
+
+- `/v1/models` reports a hybrid model's live metadata instead of a stale
+  snapshot.
+- A client disconnecting mid-stream no longer logs a false "missing finish"
+  warning.
+- Rejected CORS preflights return the correct content length.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -10,10 +10,12 @@
 `qwen3.8-27b-mixed-3.5bpw` serves [`rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX`](https://huggingface.co/rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX)
 — a Rapid-MLX quantization that spends its bits where they matter instead of
 flattening every tensor to 4-bit. It lands at **13.0 GB of weights against the
-4-bit build's 15.0 GB**, so it fits a 24 GB Mac with room for real context.
+4-bit build's 15.0 GB**.
 
-Measured through `rapid-mlx serve` on an M3 Ultra (8K prompt, whole process
-tree): **20 GB peak, 323 tok/s prefill, 40 tok/s decode, zero swap.** In the
+Measured through `rapid-mlx serve` on an M3 Ultra (8K prompt, peak across the
+whole process tree): **20 GB peak, 323 tok/s prefill, 40 tok/s decode, zero
+swap.** Plan for a 48 GB Mac or larger — at that peak a 32 GB machine has very
+little left for anything else, and the app's own fit warning will say so. In the
 release eval it answers **10/10 coding tasks and 25/30 tool-calling scenarios**,
 including the parallel and sequential multi-tool levels.
 
@@ -22,10 +24,10 @@ rapid-mlx chat qwen3.8-27b-mixed-3.5bpw
 ```
 
 One honest caveat: on the 10-task MATH subset it scored 5/10 with thinking
-disabled, below its 4-bit sibling's league. It is a strong coding and
-tool-calling model at this footprint; if your work is arithmetic-heavy,
-`qwen3.6-35b-4bit` or `gemma-4-26b-4bit` remain the safer picks. That is also
-why it is **not** a built-in RAM-tier recommendation yet.
+disabled. It is a strong coding and tool-calling model at this footprint; if
+your work is arithmetic-heavy, `qwen3.6-35b-4bit` or `gemma-4-26b-4bit` remain
+the safer picks. That is also why it is **not** a built-in RAM-tier
+recommendation.
 
 ### Name your own models
 


### PR DESCRIPTION
## Summary

The engine catalog ships two Qwen 3.8 aliases — `qwen3.8-27b-4bit` (released in v0.12.13) and `qwen3.8-27b-mixed-3.5bpw` (#1954, unreleased) — but the Mac app recognized neither:

- `ModelInfoCatalog.familyAndContext` matched them on the bare `qwen3` branch and labelled them **"Qwen 3"** in the picker.
- `ToolUseCapability.knownFamilies` had no `qwen3.8-` entry, so both resolved to `.unknown` and the picker rendered a **"· no tools"** badge on a model whose tool calling we have measured.

This adds the family to both surfaces plus its rows in the coverage expectation table, and drafts the v0.12.14 release-note highlights.

**Why these two aliases clear the same bar as the other listed families:** a release eval of `rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX` (our own mixed-precision build) driven through `rapid-mlx serve` on an M3 Ultra scored **25/30 tool-calling scenarios** — including the L3 parallel and L4 sequential multi-tool levels — and **10/10 coding**, with no control-token leakage into `content`. Footprint measured through the serve process tree at an 8K prompt: 20 GB peak, 323 tok/s prefill, 40 tok/s decode, zero swap.

**What this PR deliberately does NOT do:** add Qwen 3.8 to `model_recommendations.json`. The same eval scored **5/10 on the MATH-500 subset** (with thinking off, the harness default) for a four-suite composite of 76 — below the incumbents at every tier it could occupy (24 GB `bonsai-27b-2bit` at 86, 32 GB `gemma-4-26b-4bit` at 87) and below the 18 GB tier's 82, which the table's monotonic-by-RAM capability contract forbids. Re-evaluating the family with `enable_thinking=True` against the same incumbents is follow-up work, not a release blocker.

## Review corrections (codex round 1)

Codex raised one MAJOR that was real and is fixed in `450e2166`: the draft notes claimed the build "fits a 24 GB Mac with room for real context". The app's own `ModelSizing` contradicts that — a 27B alias estimates to 14.85 GB weights (4-bit default; `parseBitsPerWeight` does not read a `bpw` token) + 1.2 base + 6.0 KV reserve = **22.05 GB against 19.2 GB usable on a 24 GB Mac → `.tooBig`**. The notes now point at 48 GB and up and say plainly that a 32 GB machine will see the fit warning. Also dropped an unmeasured "below its 4-bit sibling's league" comparison (no MATH figure was collected for the 4-bit build).

Two codex observations recorded as follow-ups rather than fixed here: `ModelSizing.parseBitsPerWeight` does not understand `bpw` naming (it over-estimates, i.e. errs toward warning the user — safe direction), and `ToolUseCapabilityCatalogCoverageTests`' `expectedMatrix` is never walked by any `@Test`, so its rows are documentation rather than an enforced contract. Both predate this PR.

## Test plan

- [x] `swift test --no-parallel` **green in CI** (`build` job, step "swift test" → success) — cannot run locally, this Mac has CommandLineTools only with no swift-testing
- [x] `swift build` clean locally — 0 errors, 311/311 modules
- [x] `verify recommendation + eligibility contracts` green in CI (the tier-table contract script)
- [x] Release eval on `qwen3.8-27b-mixed-3.5bpw`: tool_calling 25/30, coding 10/10, reasoning 5/10, general 7/10
- [x] Live smoke through `rapid-mlx serve`: correct chat answer, clean hermes `tool_calls` with `finish_reason: tool_calls` and empty `content`, SSE streaming intact
- [x] Footprint measured via `scripts/benchmark_model_recommendations.py`: 20.0 GB 8K peak, 0 MB swap delta