### PR TITLE
fix(mllm): serve hybrid VLM caches correctly

### DIFF
--- a/tests/test_mllm_hybrid_probe.py
+++ b/tests/test_mllm_hybrid_probe.py
@@ -122,6 +122,18 @@ def test_arrayscache_is_accepted_only_for_serialized_compatibility():
     )
 
 
+def test_mlx_vlm_arrayscache_is_accepted_in_serialized_mode(monkeypatch):
+    """The VLM namespace owns a class distinct from mlx-lm's ArraysCache."""
+    from mlx_vlm.models import cache as vlm_cache
+
+    native_arrays_cache = type("ArraysCache", (), {})
+    monkeypatch.setattr(vlm_cache, "ArraysCache", native_arrays_cache)
+
+    cache = native_arrays_cache()
+    assert first_incompatible_mllm_cache_type([cache]) == "ArraysCache"
+    assert first_incompatible_mllm_cache_type([cache], allow_arrays_cache=True) is None
+
+
 def test_arrayscache_scheduler_mode_requires_singleton_limits():
     config = MLLMSchedulerConfig(
         max_num_seqs=1,

--- a/tests/test_mllm_process_loop_errors.py
+++ b/tests/test_mllm_process_loop_errors.py
@@ -103,3 +103,35 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     assert not scheduler._detokenizer_pool
     assert not scheduler._pending_abort_ids
     assert not scheduler._aborted_queue_ids
+
+
+def test_scheduler_step_does_not_turn_internal_failure_into_fake_success() -> None:
+    """A model/runtime error must terminate as an error without leaking details."""
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    request = MLLMRequest(request_id="runtime-failure", prompt="hello")
+    scheduler.requests = {request.request_id: request}
+    scheduler.waiting = __import__("collections").deque()
+    scheduler.running = {request.request_id: request}
+    scheduler.request_id_to_uid = {request.request_id: 42}
+    scheduler.uid_to_request_id = {42: request.request_id}
+    scheduler.finished_req_ids = set()
+    scheduler._detokenizer_pool = {}
+    scheduler._pending_abort_ids = set()
+    scheduler._aborted_queue_ids = set()
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator.next.side_effect = RuntimeError(
+        "private runtime detail: /Users/example/model"
+    )
+    scheduler._process_pending_aborts = MagicMock()
+    scheduler._schedule_waiting = MagicMock(return_value=[])
+
+    output = scheduler._step_no_queue()
+
+    assert output.finished_request_ids == {request.request_id}
+    assert len(output.outputs) == 1
+    terminal = output.outputs[0]
+    assert terminal.finished is True
+    assert terminal.finish_reason == "length"
+    assert terminal.error == "MLLM inference failed due to an internal engine error"
+    assert "/Users/example" not in terminal.error
+    scheduler.batch_generator.remove.assert_called_once_with([42])

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -333,6 +333,20 @@ def test_build_model_info_prefers_live_hybrid_probe(monkeypatch):
         restore()
 
 
+def test_mllm_engine_reports_loaded_hybrid_cache_profile():
+    """MLLM has no text EngineCore; its loaded cache probe is authoritative."""
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._is_mllm = True
+    engine._mllm_is_hybrid = True
+    engine._engine = None
+    assert engine._is_hybrid_model() is True
+
+    engine._mllm_is_hybrid = False
+    assert engine._is_hybrid_model() is False
+
+
 def test_build_model_info_keeps_static_hybrid_for_unserved_alias(monkeypatch):
     """Discovery-only aliases retain registry metadata without a live engine."""
     from vllm_mlx.routes import models as models_route

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -901,6 +901,9 @@ class BatchedEngine(BaseEngine):
         self._mllm_scheduler = None  # MLLMScheduler for MLLM
         self._model_load_executor = None  # mlx-step worker (#170)
         self._mllm_instance = None  # MLXMultimodalLM instance
+        # The MLLM lane has no text EngineCore/model_config to query. Set this
+        # from the loaded language backbone's concrete cache probe instead.
+        self._mllm_is_hybrid: bool | None = None
         self._loaded = False
         self._engine_started = False  # Track if engine loop is running
         self._start_time: float | None = None
@@ -1205,6 +1208,7 @@ class BatchedEngine(BaseEngine):
             _probe_mllm_cache_type, language_model
         ).result()
         arrays_cache_compat = cache_type == "ArraysCache"
+        self._mllm_is_hybrid = arrays_cache_compat
         if cache_type is not None and not arrays_cache_compat:
             raise RuntimeError(
                 f"Model '{self._model_name}' uses a hybrid/linear-attention "
@@ -2340,6 +2344,8 @@ class BatchedEngine(BaseEngine):
         Returns False on any access error so a malformed engine state
         never *enables* the new path — fails closed.
         """
+        if self._is_mllm and self._mllm_is_hybrid is not None:
+            return self._mllm_is_hybrid
         try:
             return bool(self._engine.engine.model_config.is_hybrid)
         except (AttributeError, TypeError):

--- a/vllm_mlx/mllm_cache_compat.py
+++ b/vllm_mlx/mllm_cache_compat.py
@@ -30,6 +30,11 @@ def first_incompatible_mllm_cache_type(
         pass
     else:
         supported_types += (vlm_cache.KVCache, vlm_cache.RotatingKVCache)
+        # mlx-vlm owns a distinct ArraysCache class as well. Hybrid VLM
+        # backbones return this native type, so the serialized compatibility
+        # lane must accept it for the same reason it accepts mlx-lm's class.
+        if allow_arrays_cache and hasattr(vlm_cache, "ArraysCache"):
+            supported_types += (vlm_cache.ArraysCache,)
 
     for cache in caches:
         if not isinstance(cache, supported_types):

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1197,6 +1197,11 @@ class MLLMScheduler:
                 # Arbitrary RuntimeError/ValueError text may include caller
                 # data or local paths that happen to match the old markers.
                 is_client_error = isinstance(e, ClientRequestError)
+                public_error = (
+                    err_msg
+                    if is_client_error
+                    else "MLLM inference failed due to an internal engine error"
+                )
                 # Create error outputs (queue delivery deferred to caller).
                 for request_id in error_ids:
                     output.outputs.append(
@@ -1204,8 +1209,11 @@ class MLLMScheduler:
                             request_id=request_id,
                             output_text="",
                             finished=True,
-                            error=err_msg if is_client_error else None,
+                            error=public_error,
                             error_kind=("invalid_request" if is_client_error else None),
+                            # Preserve the established terminal reason for
+                            # internal aborts; the non-None error is what
+                            # prevents routes from serializing fake success.
                             finish_reason="error" if is_client_error else "length",
                         )
                     )


### PR DESCRIPTION
## What changed

- accept mlx-vlm native `ArraysCache` in the serialized hybrid MLLM lane
- surface internal MLLM scheduler failures as bounded errors instead of HTTP 200 empty completions
- report the loaded hybrid cache profile correctly from `/v1/models`
- add regressions for the namespace split, error propagation, and live metadata

## Why this happened

mlx-vlm and mlx-lm define distinct `ArraysCache` classes. Startup correctly detected Qwen3.8 as a serialized hybrid MLLM, but request-time validation only admitted the mlx-lm class. The resulting runtime error was then converted into an empty `finish_reason=length` success.

## Validation

- Mini M2 Pro: 32 targeted cache/error/metadata tests passed
- Mini M2 Pro: 76 MLLM batching, VLM route, and corrupt-image tests passed
- Ruff check and format check passed
- Real Qwen3.8-27B mixed 3.5bpw MLLM server: non-streaming and streaming chat return correct content; `/v1/models` reports `is_hybrid: true`
- Mini real-model extended dogfood: 16k-token prompt completed HTTP 200 (333.96s under heavy swap); forced Hermes tool call returned valid schema; two simultaneous requests both returned correct content; 256x256 PNG vision returned `red` in 3.22s