### PR TITLE
fix(mac): keep media models out of Launch commands

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ConnectToolsView.swift
@@ -97,7 +97,11 @@ struct ConnectToolsView: View {
     /// resolved. Anything less and the snippets below would be a
     /// half-filled template.
     private var configReady: Bool {
-        port > 0 && !bearer.isEmpty && resolvedModel != nil
+        let selectedModelIsServing = readiness?.isReady ?? true
+        return port > 0
+            && !bearer.isEmpty
+            && resolvedModel != nil
+            && selectedModelIsServing
     }
 
     /// One concise sentence naming what is missing.

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -166,7 +166,17 @@ struct ContentView: View {
         .onChange(of: server.state) { _, newState in
             // Sync the picker breadcrumb when the server lands in
             // ``.ready(<alias>)`` against a different alias than shown.
-            if case .ready(let serving) = newState, !serving.isEmpty, serving != alias {
+            if case .ready(let serving) = newState,
+               !serving.isEmpty,
+               serving != alias,
+               ContentView.shouldSyncChatAlias(
+                   serving: serving,
+                   catalogEntries: catalogEntries,
+                   knownMediaAliases: Set(
+                       audio.audioModels.map(\.alias) + imageGen.imageModels.map(\.alias)
+                   ),
+                   section: section
+               ) {
                 alias = serving
             }
             // Retire pending-Ready provenance the moment the app serves some
@@ -723,6 +733,24 @@ struct ContentView: View {
 
     static func quickstartCanPresent(in section: SidebarSection) -> Bool {
         section == .chat
+    }
+
+    /// A process-wide server transition must not overwrite the Chat model
+    /// selection when Audio, Images, or Video starts its own resident model.
+    /// Unknown aliases remain eligible because custom text model ids are not
+    /// necessarily present in the catalog snapshot.
+    static func shouldSyncChatAlias(
+        serving: String,
+        catalogEntries: [ModelEntry],
+        knownMediaAliases: Set<String> = [],
+        section: SidebarSection
+    ) -> Bool {
+        guard section == .chat else { return false }
+        guard !knownMediaAliases.contains(serving) else { return false }
+        guard let entry = catalogEntries.first(where: { $0.alias == serving }) else {
+            return true
+        }
+        return entry.kind == .chat
     }
 
     /// True when the Quickstart sheet is up AND owns the pending

--- a/apps/rapid-mac/Tests/RapidTests/LaunchMediaResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchMediaResidencyTests.swift
@@ -1,0 +1,73 @@
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Launch ignores non-chat residency")
+struct LaunchMediaResidencyTests {
+    private let entries = [
+        ModelEntry(alias: "chat-model", hfRepo: nil, sizeOnDisk: nil, cached: true),
+        ModelEntry(
+            alias: "image-model", hfRepo: nil, sizeOnDisk: nil, cached: true,
+            kind: .image
+        ),
+        ModelEntry(
+            alias: "audio-model", hfRepo: nil, sizeOnDisk: nil, cached: true,
+            kind: .audio
+        ),
+        ModelEntry(
+            alias: "video-model", hfRepo: nil, sizeOnDisk: nil, cached: true,
+            kind: .video
+        ),
+    ]
+    private let mediaAliases: Set<String> = ["image-model", "audio-model", "video-model"]
+
+    @Test("Only chat residents replace the Chat model selection")
+    func knownMediaAliasesDoNotSync() {
+        #expect(ContentView.shouldSyncChatAlias(
+            serving: "chat-model", catalogEntries: entries,
+            knownMediaAliases: mediaAliases, section: .chat
+        ))
+        #expect(!ContentView.shouldSyncChatAlias(
+            serving: "image-model", catalogEntries: entries,
+            knownMediaAliases: mediaAliases, section: .chat
+        ))
+        #expect(!ContentView.shouldSyncChatAlias(
+            serving: "audio-model", catalogEntries: entries,
+            knownMediaAliases: mediaAliases, section: .chat
+        ))
+        #expect(!ContentView.shouldSyncChatAlias(
+            serving: "video-model", catalogEntries: entries,
+            knownMediaAliases: mediaAliases, section: .chat
+        ))
+    }
+
+    @Test("Custom aliases remain eligible as text models")
+    func unknownAliasStillSyncs() {
+        #expect(ContentView.shouldSyncChatAlias(
+            serving: "org/custom-text-model", catalogEntries: entries,
+            knownMediaAliases: mediaAliases, section: .chat
+        ))
+    }
+
+    @Test("Server transitions outside Chat never replace its selection")
+    func nonChatSectionsNeverSync() {
+        for section in [SidebarSection.audio, .images, .launch] {
+            #expect(!ContentView.shouldSyncChatAlias(
+                serving: "org/unknown-media-model",
+                catalogEntries: entries,
+                knownMediaAliases: mediaAliases,
+                section: section
+            ))
+        }
+    }
+
+    @Test("A media picker can classify an alias missing from the shared catalog snapshot")
+    func mediaCatalogWinsUnknownFallback() {
+        #expect(!ContentView.shouldSyncChatAlias(
+            serving: "late-audio-model",
+            catalogEntries: entries,
+            knownMediaAliases: ["late-audio-model"],
+            section: .chat
+        ))
+    }
+}

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3091,7 +3091,44 @@ flow_audio_readiness() {
     [[ "$speech_resident" == 1 ]] \
         || die "ready fake-qwen3-tts never appeared as the locked resident model"
 
-    press "$OUT/speech-resident.json" Audio.Mode.Transcription "$OUT/transcription.json" \
+    # A media resident is process-wide state, not the Chat model selection.
+    # Launch commands must neither advertise the TTS alias to coding agents
+    # nor remain copyable while their selected chat model is not serving.
+    press "$OUT/speech-resident.json" Sidebar.Launch "$OUT/launch-from-audio.json" \
+        || die "Sidebar.Launch is not pressable from an Audio residency"
+    local launch_copy_count=0
+    for ((i=0; i<40; i++)); do
+        see_main "$OUT/launch-from-audio.json"
+        launch_copy_count="$(jq '[.data.ui_elements[]?
+                                  | (.identifier // "")
+                                  | select(startswith("Launch.Integration.Copy."))]
+                                 | unique | length' "$OUT/launch-from-audio.json")"
+        [[ "$launch_copy_count" == 14 ]] && break
+        sleep 0.25
+    done
+    [[ "$launch_copy_count" == 14 ]] \
+        || die "Launch did not finish loading integrations from Audio"
+    if jq -e '[.data.ui_elements[]?
+               | select(((.identifier // "") | startswith("Launch.Integration.Copy."))
+                        and .enabled == true)] | length > 0' \
+            "$OUT/launch-from-audio.json" >/dev/null; then
+        die "Launch enabled agent commands while an Audio model was serving"
+    fi
+    if jq -e '[.data.ui_elements[]? | .value? | strings]
+              | any(contains("fake-qwen3-tts")
+                    and (contains("--model")
+                         or contains(" -m ")
+                         or contains("ANTHROPIC_MODEL")
+                         or contains("HERMES_INFERENCE_MODEL")))' \
+            "$OUT/launch-from-audio.json" >/dev/null; then
+        die "Launch leaked the resident Audio alias into an agent command"
+    fi
+    press "$OUT/launch-from-audio.json" Sidebar.Audio "$OUT/audio-after-launch.json" \
+        || die "Sidebar.Audio is not pressable after checking Launch"
+    wait_identifier Audio.Mode.Transcription "$OUT/audio-after-launch.json" \
+        || die "Audio did not settle after returning from Launch"
+
+    press "$OUT/audio-after-launch.json" Audio.Mode.Transcription "$OUT/transcription.json" \
         || die "Audio transcription segment is not pressable"
     local transcription_ready=0
     for ((i=0; i<40; i++)); do

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -166,12 +166,17 @@ def test_audio_baseline_waits_for_residency_poll_to_settle():
     resident_alias = '$elements[.].value == "fake-qwen3-tts"'
     resident_lock = '$elements[. - 1].description == "Lock"'
     settled_guard = '[[ "$speech_resident" == 1 ]]'
-    switch = 'press "$OUT/speech-resident.json" Audio.Mode.Transcription'
+    launch_check = 'press "$OUT/speech-resident.json" Sidebar.Launch'
+    return_to_audio = 'press "$OUT/launch-from-audio.json" Sidebar.Audio'
+    switch = 'press "$OUT/audio-after-launch.json" Audio.Mode.Transcription'
     assert correlated_row in flow
     assert resident_alias in flow
     assert resident_lock in flow
     assert settled_guard in flow
+    assert launch_check in flow
+    assert return_to_audio in flow
     assert switch in flow
-    assert flow.index(resident_alias) < flow.index(switch)
-    assert flow.index(resident_lock) < flow.index(switch)
-    assert flow.index(settled_guard) < flow.index(switch)
+    assert flow.index(resident_alias) < flow.index(launch_check)
+    assert flow.index(resident_lock) < flow.index(launch_check)
+    assert flow.index(settled_guard) < flow.index(launch_check)
+    assert flow.index(launch_check) < flow.index(return_to_audio) < flow.index(switch)


### PR DESCRIPTION
## What changed

- keep Audio/Image/Video server transitions from overwriting the Chat model selection
- disable Launch integration commands unless the selected Chat model is the model actually serving
- extend the Audio golden flow through the Launch page and back

## Why

`ContentView` treated every process-wide `.ready(alias)` transition as a Chat model transition. Starting Whisper from Audio therefore changed the shared Chat alias to `whisper-small`. `ConnectToolsView` then considered any live port/key/model triple copyable without checking that its selected Chat model matched the resident server.

## User impact

After using Audio or Images, Launch no longer generates invalid commands such as `codex -m whisper-small`. The user's Chat selection remains intact, and all integration Copy buttons stay disabled until that Chat model is actually serving.

## Validation

- Mini AX golden flow `audio-readiness`: pass; starts TTS, opens Launch, verifies all 14 commands disabled and free of the Audio alias, returns to Audio, then starts STT
- 4 focused Swift unit cases cover chat/media/custom aliases and non-Chat navigation
- release app rebuilt on Mini
- `bash -n` and `git diff --check` passed
