### PR TITLE
fix: strip multi-line release note comments

### DIFF
--- a/scripts/build_release_notes.sh
+++ b/scripts/build_release_notes.sh
@@ -130,9 +130,38 @@ HIGHLIGHTS_PATH="$HIGHLIGHTS_DIR/$TAG.md"
 if git cat-file -e "$RELEASE_SHA:$HIGHLIGHTS_PATH" 2>/dev/null; then
   HIGHLIGHTS=$(
     git show "$RELEASE_SHA:$HIGHLIGHTS_PATH" |
-      # Drop whole-line HTML comments so drafting guidance left in the template
-      # can never ship, then trim leading blank lines ($( ) trims trailing ones).
-      sed -E '/^[[:space:]]*<!--.*-->[[:space:]]*$/d' |
+      # Drop complete whole-line HTML comment blocks so drafting guidance left
+      # in the template can never ship. Buffer until the closing marker so an
+      # unmatched opener fails safe instead of swallowing the remaining notes.
+      awk '
+        function flush_pending(    i) {
+          for (i = 1; i <= pending_count; i++) print pending[i]
+          pending_count = 0
+        }
+        in_comment {
+          pending[++pending_count] = $0
+          if ($0 ~ /-->/) {
+            in_comment = 0
+            if ($0 ~ /-->[[:space:]]*$/) pending_count = 0
+            else flush_pending()
+          }
+          next
+        }
+        /^[[:space:]]*<!--/ {
+          if ($0 ~ /-->/) {
+            if ($0 !~ /-->[[:space:]]*$/) print
+            next
+          }
+          in_comment = 1
+          pending[++pending_count] = $0
+          next
+        }
+        { print }
+        END {
+          if (in_comment) flush_pending()
+        }
+      ' |
+      # Trim leading blank lines ($( ) trims trailing ones).
       sed -e '/./,$!d'
   )
   if [ -n "$HIGHLIGHTS" ]; then

--- a/tests/release/test_build_release_notes.sh
+++ b/tests/release/test_build_release_notes.sh
@@ -105,6 +105,13 @@ contains "$BODY" "Install:" "no highlights: install line present"
 # --- 2b. highlights file present ---
 cat > docs/release-notes/v1.2.0.md <<'MD'
 <!-- drafting note that must not ship -->
+<!-- Scratch space for the next release's notes. Append as you land work; in the
+     version-bump PR, `git mv` this to vX.Y.Z.md and recreate this file empty.
+     Whole-line HTML comments like this one are stripped before publishing.
+     See README.md in this directory for what good notes look like. -->
+<!-- inline drafting note --> Visible inline release note.
+IMPORTANT RELEASE NOTE
+<!-- later whole-line drafting note must not ship -->
 This release is about speculative decoding.
 
 ## Highlights
@@ -116,6 +123,9 @@ does not consistently gain, so the adaptive controller parks speculation there.
 | -------- | --: | -: | -----: | ---------: |
 | Code     |  42 | 88 |  +110% |        71% |
 | Prose    |  44 | 45 |    +2% |     32-57% |
+
+<!-- unmatched drafting note stays visible rather than swallowing notes
+Visible after unmatched opener.
 MD
 commit e.txt 1 "feat: delta (#4)"   # picks up the notes file too (git add -A)
 commit f.txt 1 "chore: bump version to 1.2.0"
@@ -130,6 +140,13 @@ contains "$BODY" "does not consistently gain" "highlights: negative result intac
 contains "$BODY" "<details>" "highlights: commit list collapsed"
 contains "$BODY" "<summary>All changes</summary>" "highlights: <details> summary"
 lacks "$BODY" "drafting note that must not ship" "highlights: HTML comments stripped"
+lacks "$BODY" "Scratch space for the next release's notes" "highlights: multi-line HTML comments stripped"
+lacks "$BODY" "version-bump PR" "highlights: multi-line HTML comment body stripped"
+contains "$BODY" "<!-- inline drafting note --> Visible inline release note." "highlights: inline comment with visible suffix is preserved"
+contains "$BODY" "IMPORTANT RELEASE NOTE" "highlights: inline comment does not swallow following notes"
+lacks "$BODY" "later whole-line drafting note" "highlights: later whole-line comment is still stripped"
+contains "$BODY" "<!-- unmatched drafting note" "highlights: unmatched comment opener fails safe"
+contains "$BODY" "Visible after unmatched opener." "highlights: unmatched comment does not swallow following notes"
 contains "$BODY" "Install:" "highlights: install line still last"
 # order: prose before <details> before Install
 check "highlights: prose is above All changes" \


### PR DESCRIPTION
## What does this PR do?

Updates the release-notes builder to remove complete multi-line, whole-line HTML comment blocks as well as the existing single-line form.

The filter buffers a candidate block until its first closing marker. If the marker is missing, or if visible content follows it on the same line, the buffered text is restored unchanged so malformed drafting markup cannot silently swallow real release notes.

## Why is this needed?

Fixes #1961.

The scratch template in `docs/release-notes/unreleased.md` spans four lines, while the previous `sed` expression only removed comments whose opening and closing markers were on the same line. Without manual cleanup, that drafting guidance could enter a published GitHub Release body.

## AI assistance disclosure

Codex assisted with the implementation and tests in `scripts/build_release_notes.sh` and `tests/release/test_build_release_notes.sh`. I reviewed the state machine line by line against the whole-line requirement, used a red test to confirm the original defect, and had an independent review catch an inline-suffix case that could lose visible notes. I fixed that finding and re-ran the full offline release-notes test script.

## Test plan

- `bash tests/release/test_build_release_notes.sh` — 52 passed, 0 failed
- `bash -n scripts/build_release_notes.sh tests/release/test_build_release_notes.sh`
- `git diff --check`
- Verified the regression test fails on the original single-line-only filter
- Independently reviewed the final diff; no remaining findings
- Repository validator full-unit pass: 17,543 tests. Its remaining 28 failures were isolated to missing/outdated local test dependencies (`tomli-w`, `prometheus_client`, AnyIO, and Rich); after installing the versions allowed by `pyproject.toml`, all 80 tests in the affected files passed.

## Checklist

- [x] Tests pass locally (`tests/release/test_build_release_notes.sh`)
- [x] Lint/syntax checks pass for the changed shell files (`bash -n`); `shellcheck` is not installed locally
- [x] Repository self-validator was run and its environment-only failures were isolated and rechecked as documented above
- [x] Regression coverage was spot-checked against the broken production filter
- [x] No README/docs update is required
- [x] No breaking changes to existing API
