### PR TITLE
feat(mtp): enable lossless adaptive K3 for Qwen3.8

### DIFF
--- a/bench/bench_spec_decode_mtp.py
+++ b/bench/bench_spec_decode_mtp.py
@@ -204,6 +204,17 @@ def _parse_args() -> argparse.Namespace:
             "previously-captured baseline number."
         ),
     )
+    parser.add_argument(
+        "--mtp-max-k",
+        type=int,
+        default=3,
+        help="Maximum chained MTP drafts per verify round (default: 3).",
+    )
+    parser.add_argument(
+        "--mtp-disable-auto-k",
+        action="store_true",
+        help="Benchmark fixed --mtp-max-k instead of the adaptive controller.",
+    )
     return parser.parse_args()
 
 
@@ -244,6 +255,8 @@ def _planned_matrix(args: argparse.Namespace) -> dict[str, Any]:
         "runs_per_condition": args.runs,
         "max_tokens": args.max_tokens,
         "temp": args.temp,
+        "mtp_max_k": args.mtp_max_k,
+        "mtp_disable_auto_k": args.mtp_disable_auto_k,
         "conditions": ["none", "mtp"],
         "prompts": list(_BENCH_PROMPTS[:n_prompts]),
         "total_generations": 2 * args.runs * n_prompts,
@@ -261,6 +274,8 @@ def _run_once(
     max_tokens: int,
     temp: float,
     mtp_sidecar: str | None = None,
+    mtp_max_k: int = 3,
+    mtp_disable_auto_k: bool = False,
 ) -> RunResult:
     """Run one generation under the requested condition.
 
@@ -324,6 +339,8 @@ def _run_once(
             max_tokens=max_tokens,
             temp=temp,
             accept_counter=counter,
+            max_k=mtp_max_k,
+            disable_auto_k=mtp_disable_auto_k,
         )
         for _ in gen:
             n += 1
@@ -437,6 +454,7 @@ def main() -> int:
     print(
         f"[bench_spec_decode_mtp] model={args.model} runs={args.runs} "
         f"prompts={n_prompts} max_tokens={args.max_tokens} temp={args.temp} "
+        f"mtp_max_k={args.mtp_max_k} fixed_k={args.mtp_disable_auto_k} "
         f"mtp_sidecar={mtp_sidecar!r} conditions={conditions}",
         file=sys.stderr,
     )
@@ -455,6 +473,8 @@ def main() -> int:
                         max_tokens=args.max_tokens,
                         temp=args.temp,
                         mtp_sidecar=mtp_sidecar,
+                        mtp_max_k=args.mtp_max_k,
+                        mtp_disable_auto_k=args.mtp_disable_auto_k,
                     )
                 except Exception as exc:  # pragma: no cover — bench
                     print(

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2349,9 +2349,7 @@ class TestCheckpointMetadataFallback:
         assert config.is_moe is True
         assert config.supports_spec_decode is False
 
-    def test_qwen38_local_snapshot_is_not_mislabeled_dense_qwen35(
-        self, monkeypatch
-    ):
+    def test_qwen38_local_snapshot_is_not_mislabeled_dense_qwen35(self, monkeypatch):
         """Qwen3.8 reuses qwen3_5 model_type but is a hybrid MTP target."""
         monkeypatch.setattr(
             auto_config_mod,
@@ -2368,9 +2366,7 @@ class TestCheckpointMetadataFallback:
             ),
         )
 
-        config = detect_model_config(
-            "/tmp/models/Qwen3.8-27B-4bit/snapshots/revision"
-        )
+        config = detect_model_config("/tmp/models/Qwen3.8-27B-4bit/snapshots/revision")
 
         assert config is not None
         assert config.is_hybrid is True

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -2349,6 +2349,34 @@ class TestCheckpointMetadataFallback:
         assert config.is_moe is True
         assert config.supports_spec_decode is False
 
+    def test_qwen38_local_snapshot_is_not_mislabeled_dense_qwen35(
+        self, monkeypatch
+    ):
+        """Qwen3.8 reuses qwen3_5 model_type but is a hybrid MTP target."""
+        monkeypatch.setattr(
+            auto_config_mod,
+            "read_model_metadata",
+            lambda name: self._metadata(
+                {
+                    "model_type": "qwen3_5",
+                    "text_config": {
+                        "model_type": "qwen3_5_text",
+                        "layer_types": ["linear_attention", "full_attention"],
+                    },
+                },
+                self._XML_TOOLS,
+            ),
+        )
+
+        config = detect_model_config(
+            "/tmp/models/Qwen3.8-27B-4bit/snapshots/revision"
+        )
+
+        assert config is not None
+        assert config.is_hybrid is True
+        assert config.is_hybrid_explicit is True
+        assert config.supports_spec_decode is False
+
     def test_incomplete_template_is_not_advertised_as_native_tools(self, monkeypatch):
         # The template PARSES successfully (``{% endif %}`` is present), but the
         # XML tool contract is genuinely INCOMPLETE: it opens

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2398,6 +2398,108 @@ def test_generator_emits_first_token_from_backbone_then_draft():
     assert snap.tokens_saved == 1
 
 
+def test_generator_fixed_k3_accepts_three_drafts_in_one_verify():
+    """Fixed-depth mode must honor max_k=3 instead of silently using K=1."""
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    counter = MTPAcceptCounter()
+    emitted = list(
+        mtp_generate_step(
+            mx.array([1], dtype=mx.uint32),
+            _MockedQwen35Model([7, 11, 12, 13, 14], [11, 12, 13]),
+            max_tokens=4,
+            max_k=3,
+            disable_auto_k=True,
+            accept_counter=counter,
+        )
+    )
+
+    assert [(tok, draft) for tok, _lp, draft in emitted] == [
+        (7, False),
+        (11, True),
+        (12, True),
+        (13, True),
+    ]
+    snap = counter.snapshot()
+    assert snap.attempts == 3
+    assert snap.accepts == 3
+
+
+def test_quantized_argmax_matches_materialized_qlinear_logits():
+    """The fused greedy kernel must select the exact qlinear argmax."""
+    import mlx.nn as nn
+
+    from vllm_mlx.spec_decode.mtp.quantized_argmax import quantized_argmax
+
+    dense = nn.Linear(1024, 4096, bias=False)
+    dense.set_dtype(mx.bfloat16)
+    head = nn.QuantizedLinear.from_linear(dense, group_size=64, bits=4)
+    hidden = mx.random.normal((1, 3, 1024)).astype(mx.bfloat16)
+
+    fused = quantized_argmax(head, hidden)
+    reference = mx.argmax(head(hidden), axis=-1)
+    assert fused is not None
+    mx.eval(fused, reference)
+    assert fused.tolist() == reference.tolist()
+
+
+def test_generator_k3_restores_ssm_state_at_partial_accept_boundary():
+    """Rejecting draft 2 restores GDN state after y + accepted draft 1."""
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    class SnapshotSSMCache:
+        rollback_state = None
+
+        def __init__(self):
+            self.cache = [mx.array([0]), mx.array([0])]
+
+        def __getitem__(self, idx):
+            return self.cache[idx]
+
+        def __setitem__(self, idx, value):
+            self.cache[idx] = value
+
+        def is_trimmable(self):
+            return False
+
+    class SnapshotModel(_MockedQwen35Model):
+        def __init__(self):
+            super().__init__([7, 11, 12, 13, 14], [11, 99, 13])
+            self.layers = [object()]
+
+        def __call__(self, inputs, cache=None, **kwargs):
+            result = super().__call__(inputs, cache=cache, **kwargs)
+            if cache and inputs.shape[1] > 2:
+                c = cache[0]
+                c.rollback_state = [
+                    (mx.array([101 + i]), mx.array([201 + i]))
+                    for i in range(inputs.shape[1] - 1)
+                ]
+                c[0], c[1] = mx.array([999]), mx.array([999])
+            return result
+
+    ssm = SnapshotSSMCache()
+    emitted = list(
+        mtp_generate_step(
+            mx.array([1], dtype=mx.uint32),
+            SnapshotModel(),
+            prompt_cache=[ssm],
+            max_tokens=3,
+            max_k=3,
+            disable_auto_k=True,
+            accept_counter=MTPAcceptCounter(),
+        )
+    )
+
+    assert [tok for tok, _lp, _draft in emitted] == [7, 11, 12]
+    # keep=2 positions (y + one accepted draft) selects snapshot index 1.
+    assert ssm[0].item() == 102
+    assert ssm[1].item() == 202
+    assert ssm.rollback_state is None
+
+
 def test_generator_rolls_back_verify_round_on_early_materialization_abort(
     monkeypatch,
 ):
@@ -3133,12 +3235,9 @@ def test_fixed_k_observer_leaves_the_ceiling_to_whoever_selects_depth():
     """An observer-only fixed-K run must not fix ``max_k`` for later runs.
 
     The registry normally keeps whatever ceiling the FIRST caller set.
-    That makes an observer's ceiling a trap in both directions: seeding
-    the configured value (3 by default) would let a later auto-K run —
-    one an SSM cache forces to clamp to 1 — inherit 3 and select past its
-    clamp; seeding the 1 this mode can actually reach would cap a later
-    auto-K run at chain-of-1 forever. So the observer's ceiling is
-    provisional and the first selecting caller replaces it.
+    Fixed mode now exercises the configured K (including SSM-safe K=3),
+    but its ceiling remains provisional: the first selecting auto-K caller
+    may still replace it with its own configured ceiling.
     """
     from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
     from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
@@ -3165,11 +3264,11 @@ def test_fixed_k_observer_leaves_the_ceiling_to_whoever_selects_depth():
         # the ceiling this test is trying to observe.
         return get_or_create_controller("ceiling-model", max_k=99, authoritative=False)
 
-    # The observer only ever ran K in {0, 1}, and says so provisionally.
+    # Fixed mode really ran the configured K=3, but says so provisionally.
     ctrl = _observe_only(max_k=3)
-    assert ctrl.max_k == 1
+    assert ctrl.max_k == 3
     assert ctrl.ceiling_is_authoritative is False
-    assert ctrl.pick_k() <= 1
+    assert ctrl.pick_k() <= 3
 
     # A later auto-K run clamped to 1 (the SSM case) keeps 1.
     ctrl = _observe_only(max_k=3)

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -1104,6 +1104,14 @@ def _detect_metadata_config(model_path: str) -> ModelConfig | None:
     settings: dict[str, Any] = {}
     reasons: list[str] = []
 
+    # Qwen3.8 currently publishes through the qwen3_5 implementation class,
+    # so ``model_type`` alone cannot distinguish it from the older dense
+    # aliases whose *serving policy* is deliberately pinned non-hybrid to
+    # avoid the legacy scheduler wedge.  Qwen3.8's official aliases and MTP
+    # path use the SSM-safe engine and must retain the truthful architecture
+    # classification even when served from a local snapshot path.
+    is_qwen38 = bool(re.search(r"qwen[._-]?3[._]8", model_path, re.IGNORECASE))
+
     if "qwen3_5_moe" in model_types:
         settings.update(
             is_hybrid=True,
@@ -1112,6 +1120,13 @@ def _detect_metadata_config(model_path: str) -> ModelConfig | None:
             supports_spec_decode=False,
         )
         reasons.append("Qwen3.5 MoE architecture")
+    elif "qwen3_5" in model_types and is_qwen38:
+        settings.update(
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+            supports_spec_decode=False,
+        )
+        reasons.append("Qwen3.8 hybrid GatedDeltaNet architecture")
     elif "qwen3_5" in model_types:
         # Dense Qwen3.5 caches contain linear-attention layers, but their
         # hybrid scheduler path is known to wedge on Metal.  Pinning this
@@ -1213,6 +1228,22 @@ def detect_model_config(model_path: str) -> ModelConfig | None:
     # routing): at temperature the model sometimes invents a wrong tool
     # name/schema — a model quality issue, not parser-fixable.
     name_segment = _extract_model_name_segment(model_path.lower())
+    # Qwen3.8 reuses the upstream qwen3_5 model_type but has an explicit
+    # hybrid GatedDeltaNet layout and native MTP head.  Resolve it before the
+    # legacy generic Qwen3 regex can classify a local snapshot as a plain
+    # attention Qwen3 model.  Known aliases returned above remain the SSOT;
+    # this is only the direct-HF/local-path fallback.
+    if re.search(r"qwen[._-]?3[._]8(?=$|[^0-9])", model_path, re.I):
+        metadata_cfg = _detect_metadata_config(model_path)
+        if metadata_cfg is not None:
+            return metadata_cfg
+        return ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser="qwen3",
+            is_hybrid=True,
+            is_hybrid_explicit=True,
+            supports_spec_decode=False,
+        )
     if _is_deepseek_coder_v2_name(name_segment):
         # The Coder-V2 marker is in the canonical model-name segment, so
         # this IS a Coder-V2 checkpoint regardless of what parent

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -375,11 +375,9 @@ class SchedulerConfig:
 
     # 0.9.13 PR-B: Ollama-style EV depth controller knobs. ``mtp_max_k``
     # is the hard ceiling on the per-round draft depth the controller
-    # may select. The current generator body implements K∈{0,1}, so
-    # values >1 are clamped at the generator; the default of 3 anticipates
-    # PR-B follow-up work that lifts the K≥2 chain-of-K verify.
-    # ``mtp_disable_auto_k`` bypasses the controller entirely and keeps
-    # the pre-PR-B fixed-K=1 chain-of-1 behavior (used for A/B benching).
+    # may select. K=0 parks the drafter; K=1..3 use chained MTP with
+    # per-position rollback on hybrid SSM targets.
+    # ``mtp_disable_auto_k`` fixes depth at ``mtp_max_k`` for A/B benching.
     mtp_max_k: int = 3
     mtp_disable_auto_k: bool = False
 
@@ -683,17 +681,16 @@ def _install_mtp_vendored(
     ``() -> (List[int], List[mx.array])``). Per-step, exactly one primary
     token is returned to keep the mlx-lm ``next()`` contract intact.
     Multi-token gains come from the generator's internal batched
-    backbone+MTP passes (up to 2 tokens per pass), not from returning
+    backbone+MTP passes (up to K+1 tokens per pass), not from returning
     multiple tokens per ``_step`` call. Extra tokens produced by the
     generator are queued and drained on the following ``_step`` calls.
 
-    K=1 chain-of-1 scope (PR-A of 0.9.13 stack):
+    Adaptive chain-of-K scope:
 
     * Single-request only (``len(gb.uids) == 1``). Multi-request batches
       fall through to ``_orig_step`` — Gemma 4's MTP fast-path is
       batch=1-only (``mtp_forward`` raises on B>1) and the vendored
-      generator maintains its own per-request state. Auto-K controller
-      lives in PR-B; batched residual+bonus sync lives in PR-C.
+      generator maintains its own per-request state.
 
     * Greedy sampling only (temperature == 0). Non-greedy falls through
       to ``_orig_step`` — the byte-lossless verify contract lives in the
@@ -896,7 +893,7 @@ def _install_mtp_vendored(
     def _is_greedy_for_uid(uid: int) -> bool:
         """Return True when the request behind ``uid`` sampled at temp=0.
 
-        K=1 MVP: matches the greedy contract that
+        Matches the greedy contract that
         ``vllm_mlx/spec_decode/mtp/generator.py::mtp_generate_step``
         implements with ``temp=0.0``. Under temp>0, the vendored
         generator can still preserve the lossless marginal via its
@@ -1486,7 +1483,7 @@ def _install_mtp_vendored(
 
     logger.info(
         "[MTP-vendored] installed on GenerationBatch._step "
-        "(single-request greedy K=1 chain-of-1; falls through on B>1 / "
+        "(single-request greedy adaptive chain-of-K; falls through on B>1 / "
         "non-greedy / logits-processors)."
     )
     return True
@@ -3671,9 +3668,7 @@ class Scheduler:
         # by ``dispatch_mtp_inject`` (which runs during engine boot in
         # ``BatchedEngine._start_llm`` before this scheduler is built).
         #
-        # K=1 chain-of-1 only for PR-A. Auto-K controller lands in PR-B
-        # (``feat/mtp-ev-controller-0.9.13``); batched residual+bonus
-        # sync lands in PR-C (``feat/mtp-batched-sync-0.9.14``).
+        # Single-request adaptive chain-of-K with batched verify.
         if getattr(self.config, "spec_decode", "none") == "mtp":
             mtp_model_type = getattr(self.config, "mtp_model_type", None)
             config_vetted_mtp = _config_vetted_mtp_supports_spec_decode(mtp_model_type)

--- a/vllm_mlx/spec_decode/mtp/cache_patch.py
+++ b/vllm_mlx/spec_decode/mtp/cache_patch.py
@@ -281,6 +281,47 @@ def patch_gated_delta_net_for_mtp() -> bool:
             q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
             k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
 
+            # A verify block wider than two tokens needs a restore point for
+            # every possible acceptance prefix.  The old PR #990-compatible
+            # pair below is sufficient for K=1 only: acceptance is either
+            # before or after the sole draft.  For K>1, run the very small
+            # verify block (currently at most four positions) position-wise
+            # and retain the recurrent state after each position except the
+            # final one.  This is intentionally limited to the speculative
+            # verify path; ordinary prefill/decode still takes the original
+            # fused GDN call above.
+            if S > 2:
+                outs = []
+                snapshots = []
+                cur_state = state
+                for pos in range(S):
+                    pos_mask = mask[:, pos : pos + 1] if mask is not None else None
+                    pos_out, cur_state = gated_delta_update(
+                        q[:, pos : pos + 1],
+                        k[:, pos : pos + 1],
+                        v[:, pos : pos + 1],
+                        a[:, pos : pos + 1],
+                        b[:, pos : pos + 1],
+                        self.A_log,
+                        self.dt_bias,
+                        cur_state,
+                        pos_mask,
+                        use_kernel=not self.training,
+                    )
+                    outs.append(pos_out)
+                    if pos < S - 1:
+                        conv_at_pos = mx.contiguous(
+                            conv_input[:, pos + 1 : pos + 1 + n_keep, :]
+                        )
+                        snapshots.append((conv_at_pos, cur_state))
+
+                cache.rollback_state = snapshots
+                cache[1] = cur_state
+                cache.advance(S)
+                out = mx.concatenate(outs, axis=1)
+                out = self.norm(out, z)
+                return self.out_proj(out.reshape(B, S, -1))
+
             # Chunk 1: [0:n_conf]
             q1 = q[:, :n_conf]
             k1 = k[:, :n_conf]

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -278,6 +278,7 @@ def mtp_generate_step(
         )
     except (TypeError, ValueError):  # pragma: no cover — non-introspectable
         _mtp_supports_hidden = False
+    _mtp_supports_fused_greedy = callable(getattr(model, "mtp_greedy", None))
 
     y = prompt.astype(mx.uint32)
     prev_tokens: mx.array | None = None
@@ -346,7 +347,7 @@ def mtp_generate_step(
             if hasattr(c, "rollback_state"):
                 c.rollback_state = None
 
-    def _rollback_draft(n_to_drop: int = 1):
+    def _rollback_draft(n_to_drop: int = 1, verify_size: int | None = None):
         """Restore caches by dropping the last ``n_to_drop`` draft tokens.
 
         SSM layers (ArraysCache): restore the conv/ssm snapshot saved
@@ -366,32 +367,36 @@ def mtp_generate_step(
         """
         for c in model_cache:
             if hasattr(c, "rollback_state") and c.rollback_state is not None:
-                # SSM path: single-snapshot rollback, only n_to_drop==1
-                # is representable in the current on-disk snapshot slot.
-                # The controller-side clamp keeps chain-of-K away from
-                # this branch; assert here as a defense in depth in case
-                # a caller wires K>=2 without adjusting the SSM cache.
-                if n_to_drop != 1:
-                    raise AssertionError(
-                        f"_rollback_draft(n_to_drop={n_to_drop}) on SSM "
-                        "cache: only single-token rollback is supported. "
-                        "Chain-of-K on SSM-hybrid targets is not wired "
-                        "yet — the generator should have clamped max_k=1."
-                    )
-                conv_snap, ssm_snap = c.rollback_state
+                snapshots = c.rollback_state
+                if isinstance(snapshots, list):
+                    if verify_size is None:
+                        raise AssertionError("verify_size is required for SSM K>1 rollback")
+                    keep = verify_size - n_to_drop
+                    if keep < 1 or keep > len(snapshots):
+                        raise AssertionError(
+                            f"invalid SSM rollback boundary: keep={keep}, "
+                            f"snapshots={len(snapshots)}"
+                        )
+                    conv_snap, ssm_snap = snapshots[keep - 1]
+                else:
+                    if n_to_drop != 1:
+                        raise AssertionError(
+                            "legacy SSM snapshot can only roll back one token"
+                        )
+                    conv_snap, ssm_snap = snapshots
                 c[0] = conv_snap
                 c[1] = ssm_snap
                 c.rollback_state = None
             elif c.is_trimmable():
                 c.trim(n_to_drop)
 
-    def _rollback_verify_round(n_to_drop: int) -> None:
+    def _rollback_verify_round(n_to_drop: int, verify_size: int | None = None) -> None:
         """Roll back uncommitted target + MTP draft state for one verify round."""
         if n_to_drop <= 0:
             _clear_rollback()
             return
 
-        _rollback_draft(n_to_drop)
+        _rollback_draft(n_to_drop, verify_size=verify_size)
         for mc in mtp_cache:
             if mc.is_trimmable():
                 mc.trim(n_to_drop)
@@ -455,6 +460,15 @@ def mtp_generate_step(
             next_ids = main_tok.reshape(1, 1)
         drafter_hidden_last = None
         with mx.stream(generation_stream):
+            fused = None
+            if _is_greedy and _mtp_supports_fused_greedy:
+                fused = model.mtp_greedy(hidden_last, next_ids, mtp_cache)
+            if fused is not None:
+                draft_tok, mtp_hidden = fused
+                draft_tok = draft_tok[:, -1].squeeze(0)
+                drafter_hidden_last = mtp_hidden[:, -1:, :]
+                quantize_cache_fn(mtp_cache)
+                return draft_tok, None, None, None, drafter_hidden_last
             if want_hidden:
                 mtp_logits, mtp_hidden = model.mtp_forward(
                     hidden_last, next_ids, mtp_cache, return_hidden=True
@@ -623,19 +637,7 @@ def mtp_generate_step(
     # available without importing the two cache classes here.
     _has_ssm_cache = any(hasattr(c, "rollback_state") for c in model_cache)
     if not disable_auto_k:
-        # Chain-of-K on SSM targets not implemented; clamp to K=1 with
-        # a startup log (once per generator instance is cheap enough
-        # given ``mtp_generate_step`` is called per-request).
-        _max_k_hw = 1 if _has_ssm_cache else max(0, max_k)
-        if _has_ssm_cache and max_k > 1:
-            logger.info(
-                "[MTP-chain-of-K] SSM cache detected in model_cache — "
-                "clamping max_k from %d to 1 (chain-of-K on SSM-hybrid "
-                "targets needs per-position snapshots not yet wired). "
-                "Set --mtp-max-k=1 to silence this log.",
-                max_k,
-            )
-        max_k_effective = _max_k_hw
+        max_k_effective = max(0, max_k)
         _controller: DepthController | None = get_or_create_controller(
             model_id or "__default__", max_k=max_k_effective
         )
@@ -665,7 +667,7 @@ def mtp_generate_step(
         # would cap a later auto-K run at chain-of-1 forever. Marking it
         # provisional lets the first run that really selects depth set
         # the real ceiling.
-        max_k_effective = 1
+        max_k_effective = max(0, max_k)
         _controller = get_or_create_controller(
             model_id or "__default__",
             max_k=max_k_effective,
@@ -680,7 +682,11 @@ def mtp_generate_step(
     # whether we generate a draft at end of the current round. Bootstrap
     # value is the controller's initial pick_k (0 if fresh, else the
     # scheduled depth from the previous request).
-    next_k = _controller.pick_k() if _select_k and _controller is not None else 1
+    next_k = (
+        _controller.pick_k()
+        if _select_k and _controller is not None
+        else max_k_effective
+    )
 
     # Wall time spent generating the drafts that the NEXT round will
     # consume. Drafting happens at the tail of round N — after round N's
@@ -753,7 +759,9 @@ def mtp_generate_step(
             # ``_record_round``, so the carried ``pending_draft_ms`` is always
             # charged. (codex #1441: the "abandoned drafts" case cannot occur.)
             next_k = (
-                _controller.pick_k() if _select_k and _controller is not None else 1
+                _controller.pick_k()
+                if _select_k and _controller is not None
+                else max_k_effective
             )
 
             hidden_at_main = hidden[:, -1:, :]
@@ -888,7 +896,9 @@ def mtp_generate_step(
                 # error fires before this round's fresh accept count is known,
                 # never let stale state leak into a fallback path: keep the
                 # committed ``y`` position and drop every uncommitted draft.
-                _rollback_verify_round(k_len - accepted_count)
+                _rollback_verify_round(
+                    k_len - accepted_count, verify_size=k_len + 1
+                )
                 raise
 
             # Bump attempts by K (one per draft position considered).
@@ -932,7 +942,12 @@ def mtp_generate_step(
             for i in range(accepted_count):
                 accept_counter.record_accept(tokens_saved=1)
                 ntoks += 1
-                yield int(draft_ids[i]), draft_lps_arr[i], True
+                draft_lp = draft_lps_arr[i]
+                # The fused greedy drafter intentionally never builds a
+                # full-vocabulary draft logprob row.  The accepted token is
+                # also the target argmax, so its target row is the correct
+                # serving logprob surface and is already available here.
+                yield int(draft_ids[i]), lps[i] if draft_lp is None else draft_lp, True
                 if ntoks >= max_tokens:
                     return
 
@@ -964,7 +979,7 @@ def mtp_generate_step(
                 # (k_len - accepted_count) unaccepted drafts from the
                 # caches.
                 n_to_drop = k_len - accepted_count
-                _rollback_verify_round(n_to_drop)
+                _rollback_verify_round(n_to_drop, verify_size=k_len + 1)
                 accept_counter.record_reject()
                 if logits_processors and prev_tokens is not None:
                     # Discard the ``n_to_drop`` rejected positions
@@ -991,7 +1006,9 @@ def mtp_generate_step(
             # Decide K for the next round BEFORE generating the
             # next chain (a park decision skips drafter cost).
             next_k = (
-                _controller.pick_k() if _select_k and _controller is not None else 1
+                _controller.pick_k()
+                if _select_k and _controller is not None
+                else max_k_effective
             )
             if next_k >= 1:
                 # Chain-carry: on all-accept the mtp_cache must

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -360,7 +360,9 @@ def mtp_generate_step(
                 snapshots = c.rollback_state
                 if isinstance(snapshots, list):
                     if verify_size is None:
-                        raise AssertionError("verify_size is required for SSM K>1 rollback")
+                        raise AssertionError(
+                            "verify_size is required for SSM K>1 rollback"
+                        )
                     keep = verify_size - n_to_drop
                     if keep < 1 or keep > len(snapshots):
                         raise AssertionError(
@@ -871,9 +873,7 @@ def mtp_generate_step(
                 # error fires before this round's fresh accept count is known,
                 # never let stale state leak into a fallback path: keep the
                 # committed ``y`` position and drop every uncommitted draft.
-                _rollback_verify_round(
-                    k_len - accepted_count, verify_size=k_len + 1
-                )
+                _rollback_verify_round(k_len - accepted_count, verify_size=k_len + 1)
                 raise
 
             # Bump attempts by K (one per draft position considered).

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -189,10 +189,8 @@ def mtp_generate_step(
     # the process-global controller registry so cost + acceptance state
     # persists across requests for the same model+drafter combination.
     # ``max_k`` bounds the depth the controller may pick; the current
-    # generator body only implements K∈{0,1} (park + chain-of-1), so
-    # picks above 1 are clamped and logged. ``disable_auto_k=True``
-    # keeps the pre-PR-B chain-of-1 behavior unchanged — useful for
-    # A/B benching the controller against a fixed K=1 baseline.
+    # generator supports K∈[0,max_k], including per-position rollback for
+    # hybrid SSM targets. ``disable_auto_k=True`` fixes depth at max_k.
     model_id: str | None = None,
     max_k: int = 1,
     disable_auto_k: bool = False,
@@ -351,16 +349,8 @@ def mtp_generate_step(
         """Restore caches by dropping the last ``n_to_drop`` draft tokens.
 
         SSM layers (ArraysCache): restore the conv/ssm snapshot saved
-        by GatedDeltaNet at the confirmed boundary. The snapshot is
-        taken at a SINGLE offset (``n_confirmed`` positions from end),
-        so ``n_to_drop`` MUST match that offset — chain-of-K with
-        partial accept is not representable in the current one-snapshot
-        model. The generator prevents this by clamping ``max_k`` to 1
-        when any SSM cache is present (see ``_has_ssm_cache`` at
-        decode-loop start); callers that reach this path with
-        ``n_to_drop > 1`` on an SSM cache trip an assertion because a
-        silent partial-rollback would corrupt the SSM state and break
-        the lossless contract.
+        after the accepted verify prefix. K=1 retains the legacy tuple;
+        K>1 stores one tuple per possible accepted boundary.
 
         Attention layers (KVCache): trim the last ``n_to_drop`` draft
         entries.
@@ -625,26 +615,17 @@ def mtp_generate_step(
     # 0.9.13 PR-B Fix 3: K≥2 chain-of-K lifted. The verify path now
     # accepts K sequential drafts with a single ``(K+1)``-position
     # backbone forward, per Ollama's ``speculate.go::accept`` batching.
-    # The SSM-hybrid (ArraysCache) rollback is not compatible with the
-    # per-position snapshot Ollama uses, so any model whose cache list
-    # contains an SSM slot is clamped to K=1 at loop-start below —
-    # chain-of-K on SSM targets needs the ``PrepareSnapshots([offsets])``
-    # per-position machinery, which is a separate work item.
+    # Hybrid ArraysCache layers retain a per-position recurrent snapshot,
+    # allowing the same partial-accept semantics without replay.
     # ------------------------------------------------------------------
-    # SSM detection: patched ArraysCache carries a ``rollback_state``
-    # class attribute (see ``cache_patch.py``); KVCache does not. This
-    # is the cheapest, most stable class-level signal for the SSM path
-    # available without importing the two cache classes here.
-    _has_ssm_cache = any(hasattr(c, "rollback_state") for c in model_cache)
     if not disable_auto_k:
         max_k_effective = max(0, max_k)
         _controller: DepthController | None = get_or_create_controller(
             model_id or "__default__", max_k=max_k_effective
         )
     else:
-        # ``disable_auto_k`` keeps the pre-0.9.13 fixed-K=1 A/B-bench
-        # behavior — verbatim chain-of-1, no chain-of-K, and no depth
-        # SELECTION.
+        # Fixed-depth A/B mode: no depth selection, but the configured
+        # max_k is exercised exactly.
         #
         # The controller is still created, and still observes, because
         # fixed-K is precisely the mode an operator measures in: with
@@ -662,11 +643,8 @@ def mtp_generate_step(
         # ``authoritative=False``: the registry is process-global and
         # normally keeps whatever ceiling the FIRST caller set. This mode
         # has no business fixing that ceiling — seeding the configured
-        # ``max_k`` (3 by default) could let a later auto-K run exceed a
-        # clamp it needs, and seeding the 1 this mode can actually reach
-        # would cap a later auto-K run at chain-of-1 forever. Marking it
-        # provisional lets the first run that really selects depth set
-        # the real ceiling.
+        # ``max_k`` is provisional so the first run that really selects
+        # depth remains authoritative.
         max_k_effective = max(0, max_k)
         _controller = get_or_create_controller(
             model_id or "__default__",
@@ -796,9 +774,8 @@ def mtp_generate_step(
             # greedy temp=0 because residual == verify-argmax there).
             # K>=2: batched (K+1)-position backbone forward, sequential
             # accept-reject per Ollama's ``speculate.go::accept``. The
-            # SSM path is clamped at loop-start so K>=2 only reaches
-            # this branch on pure-attention targets (KVCache.trim() is
-            # the only rollback needed).
+            # SSM targets use per-position snapshots; attention targets
+            # use KVCache.trim() for the same accepted-prefix boundary.
             # -------------------------------------------------------
             k_len = len(pending_drafts)
             draft_toks_arr = [rec[0] for rec in pending_drafts]
@@ -821,10 +798,8 @@ def mtp_generate_step(
                 y_with_drafts,
                 prev_tokens,
                 n_predict=k_len + 1,
-                # n_confirmed = k_len only matters on SSM targets (which
-                # are clamped to k_len=1 above). Passing k_len keeps the
-                # semantics uniform: "the last k_len positions are
-                # drafts, snapshot before them".
+                # Any positive value activates per-position SSM snapshots;
+                # k_len preserves the legacy K=1 boundary semantics too.
                 n_confirmed=k_len,
                 xtc_draw=first_xtc_draw,
             )

--- a/vllm_mlx/spec_decode/mtp/quantized_argmax.py
+++ b/vllm_mlx/spec_decode/mtp/quantized_argmax.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Quantized lm-head argmax adapted from mlx-vlm's Qwen3.5 backend.
+
+The Metal kernel computes per-tile maxima directly from affine-packed weights,
+so greedy MTP drafting does not materialize a 248k-token logits row.
+"""
+
+import functools
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _target_verify_qlinear_header(bits: int, group_size: int) -> str:
+    return r"""
+    using namespace metal;
+
+    constant constexpr int SIMD_SIZE = 32;
+    constant constexpr int BITS = __BITS__;
+    constant constexpr int GS = __GS__;
+    constant constexpr int PACK_FACTOR = (BITS == 5 ? 8 : 32 / BITS);
+    constant constexpr int BYTES_PER_PACK = (BITS == 5 ? 5 : 32 / 8);
+    constant constexpr int PACKS_PER_THREAD = 2;
+    constant constexpr int VALUES_PER_THREAD = PACK_FACTOR * PACKS_PER_THREAD;
+    constant constexpr int BLOCK_SIZE = VALUES_PER_THREAD * SIMD_SIZE;
+    constant constexpr int SCALE_STEP_PER_THREAD = GS / VALUES_PER_THREAD;
+    constant constexpr int RESULTS_PER_SIMDGROUP = 4;
+    constant constexpr int NUM_SIMDGROUPS = 2;
+    constant constexpr int BN = RESULTS_PER_SIMDGROUP * NUM_SIMDGROUPS;
+
+    template <typename T>
+    inline float load_vector_exact(const device T* x, thread float* x_thread) {
+      float sum = 0.0f;
+      if (BITS == 4) {
+        for (int i = 0; i < VALUES_PER_THREAD; i += 4) {
+          sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+          x_thread[i] = x[i];
+          x_thread[i + 1] = x[i + 1] / 16.0f;
+          x_thread[i + 2] = x[i + 2] / 256.0f;
+          x_thread[i + 3] = x[i + 3] / 4096.0f;
+        }
+      } else if (BITS == 5) {
+        for (int i = 0; i < VALUES_PER_THREAD; i += 8) {
+          sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3] + x[i + 4] + x[i + 5] +
+              x[i + 6] + x[i + 7];
+          x_thread[i] = x[i];
+          x_thread[i + 1] = x[i + 1] / 32.0f;
+          x_thread[i + 2] = x[i + 2] / 4.0f;
+          x_thread[i + 3] = x[i + 3] / 128.0f;
+          x_thread[i + 4] = x[i + 4] / 16.0f;
+          x_thread[i + 5] = x[i + 5] / 2.0f;
+          x_thread[i + 6] = x[i + 6] / 64.0f;
+          x_thread[i + 7] = x[i + 7] / 8.0f;
+        }
+      }
+      return sum;
+    }
+
+    inline float qdot_exact(
+        const device uint8_t* w,
+        const thread float* x_thread,
+        float scale,
+        float bias,
+        float sum) {
+      float accum = 0.0f;
+      if (BITS == 4) {
+        const device uint16_t* ws = (const device uint16_t*)w;
+        for (int i = 0; i < (VALUES_PER_THREAD / 4); i++) {
+          accum +=
+              (x_thread[4 * i] * (ws[i] & 0x000f) +
+               x_thread[4 * i + 1] * (ws[i] & 0x00f0) +
+               x_thread[4 * i + 2] * (ws[i] & 0x0f00) +
+               x_thread[4 * i + 3] * (ws[i] & 0xf000));
+        }
+      } else if (BITS == 5) {
+        for (int i = 0; i < (VALUES_PER_THREAD / 8); i++) {
+          const thread float* xt = x_thread + 8 * i;
+          const device uint8_t* wb = w + 5 * i;
+
+          accum += (wb[0] & 0x1f) * xt[0];
+          accum += (wb[0] & 0xe0) * xt[1];
+          accum += (wb[1] & 0x3) * (xt[1] * 256.0f);
+          accum += (wb[1] & 0x7c) * xt[2];
+          accum += (wb[1] & 0x80) * xt[3];
+          accum += (wb[2] & 0xf) * (xt[3] * 256.0f);
+          accum += (wb[2] & 0xf0) * xt[4];
+          accum += (wb[3] & 0x1) * (xt[4] * 256.0f);
+          accum += (wb[3] & 0x3e) * xt[5];
+          accum += (wb[3] & 0xc0) * xt[6];
+          accum += (wb[4] & 0x7) * (xt[6] * 256.0f);
+          accum += (wb[4] & 0xf8) * xt[7];
+        }
+      }
+      return scale * accum + sum * bias;
+    }
+""".replace("__BITS__", str(bits)).replace("__GS__", str(group_size))
+
+
+_TARGET_VERIFY_QARGMAX_SOURCE = r"""
+    uint n_tile = threadgroup_position_in_grid.y;
+    uint b_idx = threadgroup_position_in_grid.z;
+    uint simd_gid = simdgroup_index_in_threadgroup;
+    uint simd_lid = thread_index_in_simdgroup;
+
+    int out_row = int(n_tile) * BN + int(simd_gid) * RESULTS_PER_SIMDGROUP;
+    int in_vec_size_w = K_SIZE * BYTES_PER_PACK / PACK_FACTOR;
+    int in_vec_size_g = K_SIZE / GS;
+
+    threadgroup float tile_best_values[VERIFY_T][NUM_SIMDGROUPS];
+    threadgroup int tile_best_indices[VERIFY_T][NUM_SIMDGROUPS];
+
+    const device uint8_t* ws_base =
+        (const device uint8_t*)w + out_row * in_vec_size_w +
+        int(simd_lid) * PACKS_PER_THREAD * BYTES_PER_PACK;
+    const device T* scales_base =
+        scales + out_row * in_vec_size_g + int(simd_lid) / SCALE_STEP_PER_THREAD;
+    const device T* biases_base =
+        biases + out_row * in_vec_size_g + int(simd_lid) / SCALE_STEP_PER_THREAD;
+    const device T* x_base =
+        x + int(b_idx) * VERIFY_T * K_SIZE + int(simd_lid) * VALUES_PER_THREAD;
+
+    float result[VERIFY_T][RESULTS_PER_SIMDGROUP];
+    float x_thread[VERIFY_T][VALUES_PER_THREAD];
+    for (int t = 0; t < VERIFY_T; ++t) {
+      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+        result[t][row] = 0.0f;
+      }
+    }
+
+    const device uint8_t* ws = ws_base;
+    const device T* sc = scales_base;
+    const device T* bs = biases_base;
+    const device T* xk = x_base;
+
+    for (int k = 0; k < K_SIZE; k += BLOCK_SIZE) {
+      float sums[VERIFY_T];
+      for (int t = 0; t < VERIFY_T; ++t) {
+        sums[t] = load_vector_exact<T>(xk + t * K_SIZE, x_thread[t]);
+      }
+
+      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+        const device uint8_t* wl = ws + row * in_vec_size_w;
+        const device T* sl = sc + row * in_vec_size_g;
+        const device T* bl = bs + row * in_vec_size_g;
+        float s = float(sl[0]);
+        float b = float(bl[0]);
+        for (int t = 0; t < VERIFY_T; ++t) {
+          result[t][row] += qdot_exact(wl, x_thread[t], s, b, sums[t]);
+        }
+      }
+
+      ws += BLOCK_SIZE * BYTES_PER_PACK / PACK_FACTOR;
+      sc += BLOCK_SIZE / GS;
+      bs += BLOCK_SIZE / GS;
+      xk += BLOCK_SIZE;
+    }
+
+    for (int t = 0; t < VERIFY_T; ++t) {
+      float best_value = -3.4028234663852886e38f;
+      int best_index = 0;
+      for (int row = 0; row < RESULTS_PER_SIMDGROUP; ++row) {
+        int n = out_row + row;
+        if (n < N_SIZE) {
+          float rounded = float(T(simd_sum(result[t][row])));
+          if (rounded > best_value) {
+            best_value = rounded;
+            best_index = n;
+          }
+        }
+      }
+
+      if (simd_lid == 0) {
+        tile_best_values[t][simd_gid] = best_value;
+        tile_best_indices[t][simd_gid] = best_index;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_gid == 0 && simd_lid == 0) {
+      for (int t = 0; t < VERIFY_T; ++t) {
+        float best = tile_best_values[t][0];
+        int best_idx = tile_best_indices[t][0];
+        for (int i = 1; i < NUM_SIMDGROUPS; ++i) {
+          float candidate = tile_best_values[t][i];
+          int candidate_idx = tile_best_indices[t][i];
+          if (candidate > best) {
+            best = candidate;
+            best_idx = candidate_idx;
+          }
+        }
+        int offset = (int(b_idx) * VERIFY_T + t) * NUM_TILES + int(n_tile);
+        tile_values[offset] = T(best);
+        tile_indices[offset] = best_idx;
+      }
+    }
+"""
+
+@functools.cache
+def _target_verify_qargmax_kernel(bits, group_size, dtype, verify_t, k_size, n_size):
+    dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            "qwen3_5_target_verify_qargmax_"
+            f"b{bits}_gs{group_size}_t{verify_t}_k{k_size}_n{n_size}_{dtype_name}"
+        ),
+        input_names=["x", "w", "scales", "biases"],
+        output_names=["tile_values", "tile_indices"],
+        header=_target_verify_qlinear_header(bits, group_size),
+        source=_TARGET_VERIFY_QARGMAX_SOURCE,
+    )
+
+
+def _can_target_verify_quantized_head(linear) -> bool:
+    if (
+        not isinstance(linear, nn.QuantizedLinear)
+        or linear.bits not in (4, 5)
+        or linear.mode != "affine"
+        or linear.biases is None
+        or linear.scales.dtype not in (mx.bfloat16, mx.float16)
+        or linear.biases.dtype != linear.scales.dtype
+    ):
+        return False
+
+    K = linear.weight.shape[1] * 32 // linear.bits
+    N = linear.weight.shape[0]
+    return K % 512 == 0 and N % 8 == 0
+
+
+def _can_target_verify_quantized(linear, x: mx.array) -> bool:
+    if (
+        not _can_target_verify_quantized_head(linear)
+        or x.ndim != 3
+        or x.shape[1] < 1
+        or x.dtype != linear.scales.dtype
+    ):
+        return False
+
+    K = linear.weight.shape[1] * 32 // linear.bits
+    return x.shape[-1] == K
+
+
+def quantized_argmax(linear, x: mx.array) -> mx.array | None:
+    if not _can_target_verify_quantized(linear, x) or "bias" in linear:
+        return None
+
+    B, T, K = x.shape
+    if T == 1 and 1 < B <= 4:
+        out = quantized_argmax(linear, x.transpose(1, 0, 2))
+        if out is not None:
+            return out.transpose(1, 0)
+
+    N = linear.weight.shape[0]
+    num_tiles = N // 8
+
+    x = mx.contiguous(x)
+    kernel = _target_verify_qargmax_kernel(
+        linear.bits, linear.group_size, x.dtype, T, K, N
+    )
+    inputs = [x, linear.weight, linear.scales, linear.biases]
+    tile_values, tile_indices = kernel(
+        inputs=inputs,
+        template=[
+            ("T", x.dtype),
+            ("VERIFY_T", int(T)),
+            ("K_SIZE", int(K)),
+            ("N_SIZE", int(N)),
+            ("NUM_TILES", int(num_tiles)),
+        ],
+        grid=(32, 2 * num_tiles, B),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(B, T, num_tiles), (B, T, num_tiles)],
+        output_dtypes=[x.dtype, mx.int32],
+    )
+    best_tile = mx.argmax(tile_values, axis=-1)
+    return mx.take_along_axis(tile_indices, best_tile[..., None], axis=-1).squeeze(-1)

--- a/vllm_mlx/spec_decode/mtp/quantized_argmax.py
+++ b/vllm_mlx/spec_decode/mtp/quantized_argmax.py
@@ -195,6 +195,7 @@ _TARGET_VERIFY_QARGMAX_SOURCE = r"""
     }
 """
 
+
 @functools.cache
 def _target_verify_qargmax_kernel(bits, group_size, dtype, verify_t, k_size, n_size):
     dtype_name = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -865,6 +865,7 @@ def inject_mtp_support(
             hidden_states,
             next_token_ids,
             mtp_cache,
+            return_hidden: bool = False,
         ):
             """Run the MTP head and project through the shared lm_head."""
             mtp_out = self.mtp(
@@ -874,8 +875,27 @@ def inject_mtp_support(
                 mtp_cache,
             )
             if self.args.tie_word_embeddings:
-                return self.model.embed_tokens.as_linear(mtp_out)
-            return self.lm_head(mtp_out)
+                logits = self.model.embed_tokens.as_linear(mtp_out)
+            else:
+                logits = self.lm_head(mtp_out)
+            return (logits, mtp_out) if return_hidden else logits
+
+        def mtp_greedy(self, hidden_states, next_token_ids, mtp_cache):
+            """Return greedy MTP ids without materializing full-vocab logits."""
+            if self.args.tie_word_embeddings:
+                return None
+            from .quantized_argmax import quantized_argmax
+
+            mtp_out = self.mtp(
+                hidden_states,
+                next_token_ids,
+                self.model.embed_tokens,
+                mtp_cache,
+            )
+            token = quantized_argmax(self.lm_head, mtp_out)
+            if token is None:
+                return None
+            return token, mtp_out
 
         def make_mtp_cache(self):
             """Return fresh ``KVCache`` entries — one per MTP layer.


### PR DESCRIPTION
## Why
Qwen3.8 uses hybrid GatedDeltaNet caches, so treating it like dense Qwen3.5 makes multi-token MTP rollback unsafe. K=1 is lossless but leaves useful decode throughput on the table; this change makes adaptive K=3 correct because every speculative position can restore the exact recurrent state after partial acceptance.

## What
- classify direct/local Qwen3.8 checkpoints as hybrid instead of generic dense Qwen3.5
- add per-position GatedDeltaNet snapshots so partial K=3 acceptance rolls SSM state back exactly
- chain Qwen MTP hidden state across draft positions
- use a quantized Metal argmax for greedy MTP heads without materializing the 248k-vocab logits row
- expose fixed K in the MTP benchmark; production remains adaptive

## Verification
- 543 focused tests passed (MTP, CLI wiring, lossless, hybrid classification, model auto-config)
- 62 Qwen/HY3 and Gemma MTP injection tests passed
- fused 4-bit argmax exactly matches materialized QuantizedLinear logits
- Mini M2 Pro, Qwen3.8-27B-4bit + official MTP sidecar: 128-token fixed-K3 output exactly matched baseline token-for-token
- Mini adaptive K<=3: pooled 9.57 tok/s vs interleaved baseline 8.67 tok/s across 3 prompt classes (+10.4%); fixed K3 is intentionally not the default (0.937x pooled)
- formatter-only CI follow-up: 501 focused tests passed
