### PR TITLE
feat(mtp): accelerate grounded output with prompt lookup

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -610,6 +610,12 @@ struct SettingsView: View {
             // other link in the app used the steel-blue link token.
             .foregroundStyle(RapidTheme.linkLabel)
 
+            Link("Powered by MTPLX",
+                 destination: URL(string: "https://github.com/youssofal/mtplx")!)
+                .font(RapidFont.caption)
+                .foregroundStyle(RapidTheme.linkLabel)
+                .accessibilityIdentifier("Settings.Privacy.Link.MTPLX")
+
             Spacer(minLength: 0)
         }
     }

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -14,6 +14,11 @@ so this document and the shipped bundle cannot silently disagree (#1596).
 This is the document the app's **Settings → Privacy → "Open-source
 credits"** link opens.
 
+* **MTPLX** — Youssof Altoukhi — Apache License 2.0
+  Rapid's prompt-lookup speculative decoding adapts MTPLX's context-copy
+  design. The required in-product attribution appears in Settings → Privacy.
+  https://github.com/youssofal/mtplx
+
 **Scope.** Components this project declares directly: the Swift packages
 in `Package.swift` (plus the transitive ones actually linked into the
 binary), the engine requirements in the monorepo's root `pyproject.toml`,

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1877,7 +1877,9 @@ flow_no_dead_controls() {
     press "$OUT/dead-appearance-light.json" Settings.Category.privacy "$OUT/dead-open-privacy-actions.json" \
         || die "Privacy category is not pressable"
     see_main "$OUT/dead-privacy-before.json"
-    element_index "$OUT/dead-privacy-before.json" Settings.Privacy.Link.MTPLX >/dev/null \
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.Privacy.Link.MTPLX")' \
+        "$OUT/dead-privacy-before.json" >/dev/null \
         || die "MTPLX attribution link is missing from Settings → Privacy"
     [[ "$(element_field "$OUT/dead-privacy-before.json" Settings.Privacy.Link.MTPLX enabled)" == "true" ]] \
         || die "MTPLX attribution link is disabled"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1877,6 +1877,10 @@ flow_no_dead_controls() {
     press "$OUT/dead-appearance-light.json" Settings.Category.privacy "$OUT/dead-open-privacy-actions.json" \
         || die "Privacy category is not pressable"
     see_main "$OUT/dead-privacy-before.json"
+    element_index "$OUT/dead-privacy-before.json" Settings.Privacy.Link.MTPLX >/dev/null \
+        || die "MTPLX attribution link is missing from Settings → Privacy"
+    [[ "$(element_field "$OUT/dead-privacy-before.json" Settings.Privacy.Link.MTPLX enabled)" == "true" ]] \
+        || die "MTPLX attribution link is disabled"
     local telemetry_before telemetry_after
     telemetry_before="$(element_field "$OUT/dead-privacy-before.json" Settings.Privacy.TelemetryToggle value)"
     press "$OUT/dead-privacy-before.json" Settings.Privacy.TelemetryToggle "$OUT/dead-privacy-toggle.json" \

--- a/bench/bench_spec_decode_mtp.py
+++ b/bench/bench_spec_decode_mtp.py
@@ -353,11 +353,6 @@ def _run_once(
         # generator and ``mtp_forward`` reference.
         if hasattr(model, "language_model"):
             model = model.language_model
-        from vllm_mlx.spec_decode.mtp.nax_verify import stats as verify_kernel_stats
-
-        verify_before = verify_kernel_stats()
-    else:
-        verify_before = {"calls": 0, "fallbacks": 0}
 
     prompt_ids = mx.array(tokenizer.encode(prompt), mx.uint32)
     mx.random.seed(seed)
@@ -407,11 +402,6 @@ def _run_once(
 
     elapsed = time.perf_counter() - t0
 
-    if condition == "mtp":
-        verify_after = verify_kernel_stats()
-    else:
-        verify_after = verify_before
-
     snap = counter.snapshot()
     if condition != "mtp":
         # ``none`` path doesn't touch the counter; report 0/0.
@@ -437,9 +427,8 @@ def _run_once(
         token_sha256=hashlib.sha256(
             ",".join(str(token) for token in emitted_token_ids).encode("ascii")
         ).hexdigest(),
-        verify_kernel_calls=int(verify_after["calls"]) - int(verify_before["calls"]),
-        verify_kernel_fallbacks=int(verify_after["fallbacks"])
-        - int(verify_before["fallbacks"]),
+        verify_kernel_calls=0,
+        verify_kernel_fallbacks=0,
         verify_sync_seconds=timing_stats.get("verify_sync_seconds", 0.0),
         draft_seconds=timing_stats.get("draft_seconds", 0.0),
         residual_sync_seconds=timing_stats.get("residual_sync_seconds", 0.0),

--- a/bench/bench_spec_decode_mtp.py
+++ b/bench/bench_spec_decode_mtp.py
@@ -39,6 +39,7 @@ the script wires up cleanly without burning GPU cycles.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import statistics
 import sys
@@ -98,6 +99,18 @@ class RunResult:
     accept_attempts: int
     accept_count: int
     elapsed_seconds: float
+    token_sha256: str = ""
+    verify_kernel_calls: int = 0
+    verify_kernel_fallbacks: int = 0
+    verify_sync_seconds: float = 0.0
+    draft_seconds: float = 0.0
+    residual_sync_seconds: float = 0.0
+    verify_calls: int = 0
+    prompt_lookup_proposals: int = 0
+    prompt_lookup_drafted_tokens: int = 0
+    prompt_lookup_accepted_tokens: int = 0
+    prompt_lookup_rejections: int = 0
+    prompt_lookup_mtp_sync_seconds: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -147,6 +160,12 @@ def _parse_args() -> argparse.Namespace:
         help="Decode budget per prompt (default: 256).",
     )
     parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="MLX sampling seed reset before every measured generation (default: 0).",
+    )
+    parser.add_argument(
         "--temp",
         type=float,
         default=0.0,
@@ -156,6 +175,8 @@ def _parse_args() -> argparse.Namespace:
             "temp=0 / 0.6 / 1.0."
         ),
     )
+    parser.add_argument("--top-p", type=float, default=0.0)
+    parser.add_argument("--top-k", type=int, default=0)
     parser.add_argument(
         "--format",
         choices=["json", "markdown"],
@@ -180,6 +201,11 @@ def _parse_args() -> argparse.Namespace:
             "= full PR #990 mix). Lower values cut wall time at the "
             "cost of reduced workload coverage."
         ),
+    )
+    parser.add_argument(
+        "--prompt-text",
+        default=None,
+        help="Run one explicit prompt instead of the built-in suite.",
     )
     parser.add_argument(
         "--mtp-sidecar",
@@ -254,7 +280,10 @@ def _planned_matrix(args: argparse.Namespace) -> dict[str, Any]:
         "model": args.model,
         "runs_per_condition": args.runs,
         "max_tokens": args.max_tokens,
+        "seed": args.seed,
         "temp": args.temp,
+        "top_p": args.top_p,
+        "top_k": args.top_k,
         "mtp_max_k": args.mtp_max_k,
         "mtp_disable_auto_k": args.mtp_disable_auto_k,
         "conditions": ["none", "mtp"],
@@ -273,9 +302,12 @@ def _run_once(
     prompt: str,
     max_tokens: int,
     temp: float,
+    top_p: float = 0.0,
+    top_k: int = 0,
     mtp_sidecar: str | None = None,
     mtp_max_k: int = 3,
     mtp_disable_auto_k: bool = False,
+    seed: int = 0,
 ) -> RunResult:
     """Run one generation under the requested condition.
 
@@ -321,8 +353,14 @@ def _run_once(
         # generator and ``mtp_forward`` reference.
         if hasattr(model, "language_model"):
             model = model.language_model
+        from vllm_mlx.spec_decode.mtp.nax_verify import stats as verify_kernel_stats
+
+        verify_before = verify_kernel_stats()
+    else:
+        verify_before = {"calls": 0, "fallbacks": 0}
 
     prompt_ids = mx.array(tokenizer.encode(prompt), mx.uint32)
+    mx.random.seed(seed)
     counter = MTPAcceptCounter()
     # Replace global counter for the duration of THIS run so the
     # ``accept_attempts`` / ``accept_count`` we report only reflects
@@ -332,32 +370,47 @@ def _run_once(
 
     t0 = time.perf_counter()
     n = 0
+    emitted_token_ids: list[int] = []
     if condition == "mtp":
+        timing_stats: dict[str, float] = {}
         gen = mtp_generate_step(
             prompt_ids,
             model,
             max_tokens=max_tokens,
             temp=temp,
+            top_p=top_p,
+            top_k=top_k,
             accept_counter=counter,
             max_k=mtp_max_k,
             disable_auto_k=mtp_disable_auto_k,
+            timing_stats=timing_stats,
         )
-        for _ in gen:
+        for token, _logprobs, _from_draft in gen:
             n += 1
+            emitted_token_ids.append(int(token))
     else:
+        timing_stats = {}
         from mlx_lm.generate import stream_generate
+        from mlx_lm.sample_utils import make_sampler
 
         for resp in stream_generate(
             model,
             tokenizer,
             prompt,
             max_tokens=max_tokens,
+            sampler=make_sampler(temp=temp, top_p=top_p, top_k=top_k),
         ):
             n += 1
+            emitted_token_ids.append(int(resp.token))
             if n >= max_tokens:
                 break
 
     elapsed = time.perf_counter() - t0
+
+    if condition == "mtp":
+        verify_after = verify_kernel_stats()
+    else:
+        verify_after = verify_before
 
     snap = counter.snapshot()
     if condition != "mtp":
@@ -381,6 +434,31 @@ def _run_once(
         accept_attempts=snap_attempts,
         accept_count=snap_accepts,
         elapsed_seconds=elapsed,
+        token_sha256=hashlib.sha256(
+            ",".join(str(token) for token in emitted_token_ids).encode("ascii")
+        ).hexdigest(),
+        verify_kernel_calls=int(verify_after["calls"]) - int(verify_before["calls"]),
+        verify_kernel_fallbacks=int(verify_after["fallbacks"])
+        - int(verify_before["fallbacks"]),
+        verify_sync_seconds=timing_stats.get("verify_sync_seconds", 0.0),
+        draft_seconds=timing_stats.get("draft_seconds", 0.0),
+        residual_sync_seconds=timing_stats.get("residual_sync_seconds", 0.0),
+        verify_calls=int(timing_stats.get("verify_calls", 0.0)),
+        prompt_lookup_proposals=int(
+            timing_stats.get("prompt_lookup_proposals", 0.0)
+        ),
+        prompt_lookup_drafted_tokens=int(
+            timing_stats.get("prompt_lookup_drafted_tokens", 0.0)
+        ),
+        prompt_lookup_accepted_tokens=int(
+            timing_stats.get("prompt_lookup_accepted_tokens", 0.0)
+        ),
+        prompt_lookup_rejections=int(
+            timing_stats.get("prompt_lookup_rejections", 0.0)
+        ),
+        prompt_lookup_mtp_sync_seconds=timing_stats.get(
+            "prompt_lookup_mtp_sync_seconds", 0.0
+        ),
     )
 
 
@@ -445,8 +523,12 @@ def main() -> int:
             print(json.dumps(plan, indent=2))
         return 0
 
-    n_prompts = min(args.prompts, len(_BENCH_PROMPTS))
-    prompts = list(_BENCH_PROMPTS[:n_prompts])
+    if args.prompt_text is not None:
+        prompts = [args.prompt_text]
+    else:
+        n_selected = min(args.prompts, len(_BENCH_PROMPTS))
+        prompts = list(_BENCH_PROMPTS[:n_selected])
+    n_prompts = len(prompts)
 
     mtp_sidecar = _resolve_mtp_sidecar(args.model, args.mtp_sidecar)
     conditions: tuple[str, ...] = ("mtp",) if args.mtp_only else ("none", "mtp")
@@ -454,6 +536,8 @@ def main() -> int:
     print(
         f"[bench_spec_decode_mtp] model={args.model} runs={args.runs} "
         f"prompts={n_prompts} max_tokens={args.max_tokens} temp={args.temp} "
+        f"top_p={args.top_p} top_k={args.top_k} "
+        f"seed={args.seed} "
         f"mtp_max_k={args.mtp_max_k} fixed_k={args.mtp_disable_auto_k} "
         f"mtp_sidecar={mtp_sidecar!r} conditions={conditions}",
         file=sys.stderr,
@@ -472,9 +556,12 @@ def main() -> int:
                         prompt=prompt,
                         max_tokens=args.max_tokens,
                         temp=args.temp,
+                        top_p=args.top_p,
+                        top_k=args.top_k,
                         mtp_sidecar=mtp_sidecar,
                         mtp_max_k=args.mtp_max_k,
                         mtp_disable_auto_k=args.mtp_disable_auto_k,
+                        seed=args.seed,
                     )
                 except Exception as exc:  # pragma: no cover — bench
                     print(
@@ -493,12 +580,35 @@ def main() -> int:
                     accept_attempts=res.accept_attempts,
                     accept_count=res.accept_count,
                     elapsed_seconds=res.elapsed_seconds,
+                    token_sha256=res.token_sha256,
+                    verify_kernel_calls=res.verify_kernel_calls,
+                    verify_kernel_fallbacks=res.verify_kernel_fallbacks,
+                    verify_sync_seconds=res.verify_sync_seconds,
+                    draft_seconds=res.draft_seconds,
+                    residual_sync_seconds=res.residual_sync_seconds,
+                    verify_calls=res.verify_calls,
+                    prompt_lookup_proposals=res.prompt_lookup_proposals,
+                    prompt_lookup_drafted_tokens=res.prompt_lookup_drafted_tokens,
+                    prompt_lookup_accepted_tokens=res.prompt_lookup_accepted_tokens,
+                    prompt_lookup_rejections=res.prompt_lookup_rejections,
+                    prompt_lookup_mtp_sync_seconds=(
+                        res.prompt_lookup_mtp_sync_seconds
+                    ),
                 )
                 all_results[condition].append(res)
                 print(
                     f"[bench_spec_decode_mtp] {condition} run={run_idx} "
                     f"prompt={prompt_idx} {res.decode_tok_per_sec:.1f} tok/s "
-                    f"({res.n_tokens} tokens in {res.elapsed_seconds:.1f}s)",
+                    f"({res.n_tokens} tokens in {res.elapsed_seconds:.1f}s; "
+                    f"verify-kernel calls={res.verify_kernel_calls} "
+                    f"fallbacks={res.verify_kernel_fallbacks}; "
+                    f"verify-sync={res.verify_sync_seconds:.3f}s "
+                    f"draft={res.draft_seconds:.3f}s "
+                    f"residual={res.residual_sync_seconds:.3f}s; "
+                    f"lookup={res.prompt_lookup_proposals}/"
+                    f"{res.prompt_lookup_drafted_tokens}/"
+                    f"{res.prompt_lookup_accepted_tokens} "
+                    f"sync={res.prompt_lookup_mtp_sync_seconds:.3f}s)",
                     file=sys.stderr,
                 )
 
@@ -511,6 +621,9 @@ def main() -> int:
         "model": args.model,
         "max_tokens": args.max_tokens,
         "temp": args.temp,
+        "top_p": args.top_p,
+        "top_k": args.top_k,
+        "seed": args.seed,
         "summaries": [asdict(baseline_summary), asdict(mtp_summary)],
         "raw_runs": [asdict(r) for c in all_results.values() for r in c],
     }

--- a/bench/bench_spec_decode_mtp.py
+++ b/bench/bench_spec_decode_mtp.py
@@ -444,18 +444,14 @@ def _run_once(
         draft_seconds=timing_stats.get("draft_seconds", 0.0),
         residual_sync_seconds=timing_stats.get("residual_sync_seconds", 0.0),
         verify_calls=int(timing_stats.get("verify_calls", 0.0)),
-        prompt_lookup_proposals=int(
-            timing_stats.get("prompt_lookup_proposals", 0.0)
-        ),
+        prompt_lookup_proposals=int(timing_stats.get("prompt_lookup_proposals", 0.0)),
         prompt_lookup_drafted_tokens=int(
             timing_stats.get("prompt_lookup_drafted_tokens", 0.0)
         ),
         prompt_lookup_accepted_tokens=int(
             timing_stats.get("prompt_lookup_accepted_tokens", 0.0)
         ),
-        prompt_lookup_rejections=int(
-            timing_stats.get("prompt_lookup_rejections", 0.0)
-        ),
+        prompt_lookup_rejections=int(timing_stats.get("prompt_lookup_rejections", 0.0)),
         prompt_lookup_mtp_sync_seconds=timing_stats.get(
             "prompt_lookup_mtp_sync_seconds", 0.0
         ),
@@ -591,9 +587,7 @@ def main() -> int:
                     prompt_lookup_drafted_tokens=res.prompt_lookup_drafted_tokens,
                     prompt_lookup_accepted_tokens=res.prompt_lookup_accepted_tokens,
                     prompt_lookup_rejections=res.prompt_lookup_rejections,
-                    prompt_lookup_mtp_sync_seconds=(
-                        res.prompt_lookup_mtp_sync_seconds
-                    ),
+                    prompt_lookup_mtp_sync_seconds=(res.prompt_lookup_mtp_sync_seconds),
                 )
                 all_results[condition].append(res)
                 print(

--- a/tests/test_mtp_prompt_lookup.py
+++ b/tests/test_mtp_prompt_lookup.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from vllm_mlx.spec_decode.mtp.prompt_lookup import PromptLookupIndex
+
+
+def test_prompt_lookup_returns_prompt_continuation() -> None:
+    index = PromptLookupIndex([1, 2, 3, 4, 5, 6, 7, 8], min_ngram=3)
+
+    match = index.propose([9, 1, 2, 3], max_tokens=3)
+
+    assert match is not None
+    assert match.start == 3
+    assert match.matched_suffix == 3
+    assert match.tokens == (4, 5, 6)
+
+
+def test_prompt_lookup_prefers_longest_suffix_match() -> None:
+    prompt = [8, 1, 2, 3, 4, 9, 1, 2, 3, 5]
+    index = PromptLookupIndex(prompt, min_ngram=3, max_ngram=4)
+
+    match = index.propose([0, 8, 1, 2, 3], max_tokens=2)
+
+    assert match is not None
+    assert match.start == 4
+    assert match.matched_suffix == 4
+    assert match.tokens == (4, 9)
+
+
+def test_prompt_lookup_never_copies_generated_only_text() -> None:
+    index = PromptLookupIndex([1, 2, 3, 4], min_ngram=2)
+
+    assert index.propose([7, 8, 7, 8], max_tokens=4) is None
+
+
+def test_prompt_lookup_excludes_prompt_edge_without_continuation() -> None:
+    index = PromptLookupIndex([1, 2, 3, 4], min_ngram=2)
+
+    assert index.propose([3, 4], max_tokens=4) is None
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"min_ngram": 1}, "min_ngram"),
+        ({"min_ngram": 4, "max_ngram": 3}, "max_ngram"),
+        ({"max_candidates": 0}, "max_candidates"),
+    ],
+)
+def test_prompt_lookup_rejects_invalid_configuration(kwargs, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        PromptLookupIndex([1, 2, 3], **kwargs)

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2398,27 +2398,6 @@ def test_generator_emits_first_token_from_backbone_then_draft():
     assert snap.tokens_saved == 1
 
 
-def test_lazy_residual_distribution_matches_leviathan_chen_formula():
-    from vllm_mlx.spec_decode.mtp.generator import _residual_distribution
-
-    target = mx.array([0.6, 0.3, 0.1])
-    draft = mx.array([0.2, 0.5, 0.3])
-    actual = _residual_distribution(mx.log(target), mx.log(draft))
-    expected = mx.array([1.0, 0.0, 0.0])
-    mx.eval(actual)
-    assert bool(mx.allclose(actual, expected, atol=1e-6).item())
-    assert float(actual.sum().item()) == pytest.approx(1.0)
-
-
-def test_lazy_residual_falls_back_to_target_when_draft_matches():
-    from vllm_mlx.spec_decode.mtp.generator import _residual_distribution
-
-    probs = mx.array([0.25, 0.5, 0.25])
-    actual = _residual_distribution(mx.log(probs), mx.log(probs))
-    mx.eval(actual)
-    assert bool(mx.allclose(actual, probs, atol=1e-6).item())
-
-
 def test_prompt_lookup_point_mass_residual_removes_proposed_token():
     from vllm_mlx.spec_decode.mtp.generator import (
         _point_mass_residual_distribution,

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1519,46 +1519,6 @@ def test_inject_mtp_support_loads_synthetic_sidecar():
             )
 
 
-def test_inject_runtime_quantizes_explicit_mtplx_fp_sidecar(tmp_path, monkeypatch):
-    """An MTPLX-marked FP payload is packed only after exact weight load."""
-    import json
-
-    import mlx.core as _mx
-    from mlx.utils import tree_flatten
-
-    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
-    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
-
-    monkeypatch.setenv("RAPID_MLX_MTP_RUNTIME_QUANT", "1")
-
-    model_a = _build_tiny_qwen3_5_text_model()
-    template = build_mtp_module(model_a.args, 1)
-    _mx.eval(template.parameters())
-    sidecar = tmp_path / "mtp.safetensors"
-    _mx.save_safetensors(
-        str(sidecar),
-        {f"mtp.{k}": v for k, v in tree_flatten(template.parameters())},
-    )
-    (tmp_path / "config.json").write_text(
-        json.dumps(
-            {
-                "mtplx_mtp_contract": {
-                    "mtp_quant_bits": 4,
-                    "mtp_quant_group_size": 32,
-                    "mtp_quant_mode": "affine",
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    model_b = _build_tiny_qwen3_5_text_model()
-    assert inject_mtp_support(model_b, mtp_sidecar=sidecar)
-    packed = dict(tree_flatten(model_b.mtp.parameters()))
-    assert "fc.scales" in packed
-    assert packed["fc.weight"].dtype == _mx.uint32
-
-
 def test_inject_mtp_support_refuses_synthetic_sidecar_missing_tensor():
     """Coverage check: dropping one required tensor must fail the inject.
 

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1519,6 +1519,46 @@ def test_inject_mtp_support_loads_synthetic_sidecar():
             )
 
 
+def test_inject_runtime_quantizes_explicit_mtplx_fp_sidecar(tmp_path, monkeypatch):
+    """An MTPLX-marked FP payload is packed only after exact weight load."""
+    import json
+
+    import mlx.core as _mx
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    monkeypatch.setenv("RAPID_MLX_MTP_RUNTIME_QUANT", "1")
+
+    model_a = _build_tiny_qwen3_5_text_model()
+    template = build_mtp_module(model_a.args, 1)
+    _mx.eval(template.parameters())
+    sidecar = tmp_path / "mtp.safetensors"
+    _mx.save_safetensors(
+        str(sidecar),
+        {f"mtp.{k}": v for k, v in tree_flatten(template.parameters())},
+    )
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "mtplx_mtp_contract": {
+                    "mtp_quant_bits": 4,
+                    "mtp_quant_group_size": 32,
+                    "mtp_quant_mode": "affine",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    model_b = _build_tiny_qwen3_5_text_model()
+    assert inject_mtp_support(model_b, mtp_sidecar=sidecar)
+    packed = dict(tree_flatten(model_b.mtp.parameters()))
+    assert "fc.scales" in packed
+    assert packed["fc.weight"].dtype == _mx.uint32
+
+
 def test_inject_mtp_support_refuses_synthetic_sidecar_missing_tensor():
     """Coverage check: dropping one required tensor must fail the inject.
 
@@ -2398,6 +2438,41 @@ def test_generator_emits_first_token_from_backbone_then_draft():
     assert snap.tokens_saved == 1
 
 
+def test_lazy_residual_distribution_matches_leviathan_chen_formula():
+    from vllm_mlx.spec_decode.mtp.generator import _residual_distribution
+
+    target = mx.array([0.6, 0.3, 0.1])
+    draft = mx.array([0.2, 0.5, 0.3])
+    actual = _residual_distribution(mx.log(target), mx.log(draft))
+    expected = mx.array([1.0, 0.0, 0.0])
+    mx.eval(actual)
+    assert bool(mx.allclose(actual, expected, atol=1e-6).item())
+    assert float(actual.sum().item()) == pytest.approx(1.0)
+
+
+def test_lazy_residual_falls_back_to_target_when_draft_matches():
+    from vllm_mlx.spec_decode.mtp.generator import _residual_distribution
+
+    probs = mx.array([0.25, 0.5, 0.25])
+    actual = _residual_distribution(mx.log(probs), mx.log(probs))
+    mx.eval(actual)
+    assert bool(mx.allclose(actual, probs, atol=1e-6).item())
+
+
+def test_prompt_lookup_point_mass_residual_removes_proposed_token():
+    from vllm_mlx.spec_decode.mtp.generator import (
+        _point_mass_residual_distribution,
+    )
+
+    target = mx.array([[0.6, 0.3, 0.1], [0.2, 0.5, 0.3]])
+    actual = _point_mass_residual_distribution(
+        mx.log(target), mx.array([0, 1], dtype=mx.int32)
+    )
+    expected = mx.array([[0.0, 0.75, 0.25], [0.4, 0.0, 0.6]])
+    mx.eval(actual)
+    assert bool(mx.allclose(actual, expected, atol=1e-6).item())
+
+
 def test_generator_fixed_k3_accepts_three_drafts_in_one_verify():
     """Fixed-depth mode must honor max_k=3 instead of silently using K=1."""
     from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
@@ -2596,6 +2671,110 @@ def test_generator_rejection_path_does_not_count_as_accept():
     assert snap.attempts == 1
     assert snap.accepts == 0
     assert snap.tokens_saved == 0
+
+
+def test_generator_prompt_lookup_verifies_prompt_continuation(monkeypatch):
+    """A prompt suffix match bypasses MTP drafting but still uses target verify."""
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP", "1")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM", "2")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM", "2")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS", "2")
+
+    # The length-4 prompt prefills three positions first. Decode then emits
+    # 7, rejects MTP's 99 in favour of target token 8, and finds prompt suffix
+    # [7, 8] -> [20, 21]. The copied block is accepted only because the target
+    # independently predicts 20 and 21; 22 is its ordinary bonus token.
+    model = _CacheAdvancingQwen35Model(
+        backbone_outputs=[0, 0, 0, 7, 8, 0, 20, 21, 22],
+        mtp_outputs=[0, 0, 0, 99, 0, 0],
+    )
+    model_cache = _CountingKVCache()
+    mtp_cache = _CountingKVCache()
+    timing: dict[str, float] = {}
+
+    emitted = list(
+        mtp_generate_step(
+            mx.array([7, 8, 20, 21], dtype=mx.uint32),
+            model,
+            max_tokens=5,
+            max_k=1,
+            disable_auto_k=True,
+            prompt_cache=[model_cache, mtp_cache],
+            accept_counter=MTPAcceptCounter(),
+            timing_stats=timing,
+        )
+    )
+
+    assert [(token, drafted) for token, _lp, drafted in emitted] == [
+        (7, False),
+        (8, False),
+        (20, True),
+        (21, True),
+        (22, False),
+    ]
+    assert timing["prompt_lookup_proposals"] == 1
+    assert timing["prompt_lookup_drafted_tokens"] == 2
+    assert timing["prompt_lookup_mtp_sync_seconds"] >= 0
+    # Three prefill positions + one ordinary draft + two lookup-history sync
+    # positions. Prompt lookup itself consumed no MTP proposal.
+    assert model._mtp_cursor == 6
+    assert model_cache.trim_calls == [1]
+    assert mtp_cache.trim_calls == [1]
+    assert mtp_cache.offset == 5
+
+
+def test_generator_prompt_lookup_partial_reject_keeps_mtp_cache_aligned(
+    monkeypatch,
+):
+    """Only the accepted lookup prefix is appended to MTP history."""
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP", "1")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM", "2")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM", "2")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS", "2")
+
+    model = _CacheAdvancingQwen35Model(
+        # Lookup proposes [20, 21]. Target accepts 20, rejects 21 as 19.
+        backbone_outputs=[0, 0, 0, 7, 8, 0, 20, 19, 22],
+        mtp_outputs=[0, 0, 0, 77, 0],
+    )
+    model_cache = _CountingKVCache()
+    mtp_cache = _CountingKVCache()
+    timing: dict[str, float] = {}
+
+    emitted = list(
+        mtp_generate_step(
+            mx.array([7, 8, 20, 21], dtype=mx.uint32),
+            model,
+            max_tokens=4,
+            max_k=1,
+            disable_auto_k=True,
+            prompt_cache=[model_cache, mtp_cache],
+            accept_counter=MTPAcceptCounter(),
+            timing_stats=timing,
+        )
+    )
+
+    assert [(token, drafted) for token, _lp, drafted in emitted] == [
+        (7, False),
+        (8, False),
+        (20, True),
+        (19, False),
+    ]
+    assert timing["prompt_lookup_accepted_tokens"] == 1
+    assert timing["prompt_lookup_rejections"] == 1
+    # Target drops the ordinary rejected draft and then lookup's unaccepted
+    # tail. MTP drops only its ordinary draft: lookup never speculatively
+    # advanced that cache, and appends exactly one accepted history position.
+    assert model_cache.trim_calls == [1, 1]
+    assert mtp_cache.trim_calls == [1]
+    assert mtp_cache.offset == 4
+    assert model._mtp_cursor == 5
 
 
 def test_generator_runs_with_int4_quantized_kv_cache_kwargs():

--- a/vllm_mlx/spec_decode/mtp/LICENSE-MTPLX
+++ b/vllm_mlx/spec_decode/mtp/LICENSE-MTPLX
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vllm_mlx/spec_decode/mtp/NOTICE-MTPLX
+++ b/vllm_mlx/spec_decode/mtp/NOTICE-MTPLX
@@ -1,0 +1,41 @@
+MTPLX
+Copyright 2026 Youssof Altoukhi
+
+MTPLX is a native MTP speculative decoding project for Apple Silicon.
+
+ATTRIBUTION REQUIREMENT
+
+This NOTICE file is part of the Apache License 2.0 terms for MTPLX (see
+section 4(d) of the LICENSE). Any product, application, service, or
+distribution that includes, embeds, or is built on MTPLX, in whole or in
+part, modified or unmodified, must display the following attribution within
+the product itself, in a place a user of that product can see (for example an
+About screen, a credits or acknowledgements screen, a settings or help page,
+documentation shipped with the product, or the startup banner of a command
+line tool):
+
+  Powered by MTPLX
+  https://github.com/youssofal/mtplx
+
+Attribution in a source repository, a README, or a marketing page alone does
+not satisfy this requirement. The words "Powered by MTPLX" must appear
+in-product. The link is required wherever the display medium supports it.
+
+Public benchmarks, articles, and research that use or build on MTPLX should
+credit "MTPLX by Youssof Altoukhi" with the same link.
+
+If MTPLX informs academic or technical writing, please cite the repository using
+the included CITATION.cff metadata.
+
+This distribution includes a vendored standalone subset of vllm-metal's
+Apache-2.0 licensed Metal paged-attention kernels under vllm_metal/metal.
+The vendored subset is used only for local MLX/Metal kernel dispatch and does
+not include or depend on the vLLM serving stack.
+
+This product includes Metal kernel code adapted from dflash-mlx
+(https://github.com/bstnxbt/dflash-mlx), Copyright dflash-mlx contributors,
+licensed under the Apache License 2.0. See mtplx/nax_verify.py for details.
+
+This product includes the Apache-2.0 licensed MLX implementation for
+Laguna-S-2.1 from PipeNetwork, Copyright 2026 PipeNetwork, under
+mtplx/models/laguna.py.

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -54,7 +54,6 @@ from .accept_counter import get_global_counter
 from .cache_patch import patch_arrays_cache_rollback_state
 from .draft_k_controller_v2 import DepthController, get_or_create_controller
 from .prompt_lookup import PromptLookupIndex
-from .verify_context import target_verify
 
 patch_arrays_cache_rollback_state()
 
@@ -334,15 +333,14 @@ def mtp_generate_step(
     _lazy_residual = os.environ.get(
         "RAPID_MLX_MTP_LAZY_RESIDUAL", "1"
     ).strip().lower() not in {"0", "false", "off", "no"}
-    _prompt_lookup_enabled = (
-        os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP", "0").strip().lower()
-        in {"1", "true", "on", "yes"}
-    )
+    _prompt_lookup_enabled = os.environ.get(
+        "RAPID_MLX_MTP_PROMPT_LOOKUP", "1"
+    ).strip().lower() not in {"0", "false", "off", "no"}
     _prompt_lookup_max_tokens = max(
         1, int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS", "24"))
     )
     _prompt_lookup_min_ngram = max(
-        2, int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM", "6"))
+        2, int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM", "8"))
     )
     _prompt_lookup_max_ngram = max(
         _prompt_lookup_min_ngram,
@@ -682,9 +680,7 @@ def mtp_generate_step(
             lookup_logits,
             [c.state for c in mtp_cache if hasattr(c, "state")],
         )
-        _timing_add(
-            "prompt_lookup_mtp_sync_seconds", time.perf_counter() - started
-        )
+        _timing_add("prompt_lookup_mtp_sync_seconds", time.perf_counter() - started)
 
     with mx.stream(generation_stream):
         y = _prefill(y, input_embeddings)
@@ -802,20 +798,15 @@ def mtp_generate_step(
         )
         if match is None:
             return None
-        extension = max(
-            0, match.matched_suffix - _prompt_lookup_index.min_ngram
-        )
+        extension = max(0, match.matched_suffix - _prompt_lookup_index.min_ngram)
         confidence_ladder = (8, 12, 16, 24, 32)
-        confidence_cap = confidence_ladder[
-            min(extension, len(confidence_ladder) - 1)
-        ]
+        confidence_cap = confidence_ladder[min(extension, len(confidence_ladder) - 1)]
         proposed_tokens = match.tokens[:confidence_cap]
         _timing_add("prompt_lookup_proposals", 1.0)
         _timing_add("prompt_lookup_drafted_tokens", float(len(proposed_tokens)))
         _timing_add("prompt_lookup_matched_suffix_tokens", float(match.matched_suffix))
         return [
-            (mx.array(token, mx.uint32), None, None, None)
-            for token in proposed_tokens
+            (mx.array(token, mx.uint32), None, None, None) for token in proposed_tokens
         ]
 
     def _record_round(k_used: int, round_wall_ms: float, accepts: list[bool]) -> None:
@@ -931,16 +922,15 @@ def mtp_generate_step(
             )
             y_with_drafts = mx.concatenate([y, drafts_arr])
 
-            with target_verify():
-                toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
-                    y_with_drafts,
-                    prev_tokens,
-                    n_predict=k_len + 1,
-                    # Any positive value activates per-position SSM snapshots;
-                    # k_len preserves the legacy K=1 boundary semantics too.
-                    n_confirmed=k_len,
-                    xtc_draw=first_xtc_draw,
-                )
+            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
+                y_with_drafts,
+                prev_tokens,
+                n_predict=k_len + 1,
+                # Any positive value activates per-position SSM snapshots;
+                # k_len preserves the legacy K=1 boundary semantics too.
+                n_confirmed=k_len,
+                xtc_draw=first_xtc_draw,
+            )
 
             # One shared uniform for all positions' probabilistic
             # accept tests. Ollama uses a per-position Bernoulli draw;
@@ -978,9 +968,7 @@ def mtp_generate_step(
                     d_alps_stack = None
                 else:
                     d_alps_stack = mx.stack(draft_alps_arr)  # (K, V)
-                    d_at = mx.take_along_axis(
-                        d_alps_stack, idx, axis=1
-                    ).squeeze(-1)
+                    d_at = mx.take_along_axis(d_alps_stack, idx, axis=1).squeeze(-1)
                     log_accept = v_at - d_at  # (K,)
                 accept_mask_arr = (log_accept >= 0) | (u < mx.exp(log_accept))
 
@@ -1127,9 +1115,7 @@ def mtp_generate_step(
                 # (target's prediction one past the last draft).
                 _clear_rollback()
                 if pending_is_prompt_lookup:
-                    _sync_prompt_lookup_history(
-                        hidden, y, drafts_arr, accepted_count
-                    )
+                    _sync_prompt_lookup_history(hidden, y, drafts_arr, accepted_count)
                 ntoks += 1
                 generated_token_ids.append(bonus_id)
                 yield bonus_id, lps[k_len], False
@@ -1148,9 +1134,7 @@ def mtp_generate_step(
                 n_to_drop = k_len - accepted_count
                 if pending_is_prompt_lookup:
                     _rollback_draft(n_to_drop, verify_size=k_len + 1)
-                    _sync_prompt_lookup_history(
-                        hidden, y, drafts_arr, accepted_count
-                    )
+                    _sync_prompt_lookup_history(hidden, y, drafts_arr, accepted_count)
                 else:
                     _rollback_verify_round(n_to_drop, verify_size=k_len + 1)
                 accept_counter.record_reject()

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -63,17 +63,6 @@ logger = logging.getLogger(__name__)
 _CACHE_CLEAR_INTERVAL = 256
 
 
-def _residual_distribution(
-    target_logprobs: mx.array, draft_logprobs: mx.array
-) -> mx.array:
-    """Return the exact normalized speculative-rejection distribution."""
-    target = mx.exp(target_logprobs)
-    draft = mx.exp(draft_logprobs)
-    residual = mx.maximum(target - draft, 0.0)
-    total = residual.sum(axis=-1, keepdims=True)
-    return mx.where(total > 0, residual / mx.maximum(total, 1e-30), target)
-
-
 def _point_mass_residual_distribution(
     target_logprobs: mx.array, proposed_tokens: mx.array
 ) -> mx.array:
@@ -330,9 +319,6 @@ def mtp_generate_step(
         mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
     _is_greedy = temp == 0
-    _lazy_residual = os.environ.get(
-        "RAPID_MLX_MTP_LAZY_RESIDUAL", "1"
-    ).strip().lower() not in {"0", "false", "off", "no"}
     _prompt_lookup_enabled = os.environ.get(
         "RAPID_MLX_MTP_PROMPT_LOOKUP", "1"
     ).strip().lower() not in {"0", "false", "off", "no"}
@@ -972,24 +958,17 @@ def mtp_generate_step(
                     log_accept = v_at - d_at  # (K,)
                 accept_mask_arr = (log_accept >= 0) | (u < mx.exp(log_accept))
 
-                if _lazy_residual:
-                    # Most verify windows accept every draft, so building K
-                    # full-vocabulary residual distributions eagerly wastes
-                    # both bandwidth and memory. Materialize only the accept
-                    # mask here; a rejected row builds its exact residual
-                    # below after the first failing position is known. This
-                    # is the high-value data-flow optimization behind
-                    # MTPLX_LAZY_TARGET_DISTRIBUTIONS, adapted to Rapid's
-                    # lossless log-probability verifier.
-                    residual_toks_arr = None
+                if pending_is_prompt_lookup:
+                    dist = _point_mass_residual_distribution(v_alps, drafts_i32)
                 else:
-                    # Legacy one-sync path: pre-sample every residual row.
-                    dist = (
-                        _point_mass_residual_distribution(v_alps, drafts_i32)
-                        if pending_is_prompt_lookup
-                        else _residual_distribution(v_alps, d_alps_stack)
-                    )
-                    residual_toks_arr = mx.random.categorical(mx.log(dist))
+                    # Existing MTP residual: max(p_target - p_draft, 0),
+                    # falling back to p_target if the clamp zeroed the row.
+                    p_target = mx.exp(v_alps)
+                    p_draft = mx.exp(d_alps_stack)
+                    residual = mx.maximum(p_target - p_draft, 0.0)
+                    z = residual.sum(axis=-1, keepdims=True)
+                    dist = mx.where(z > 0, residual, p_target)
+                residual_toks_arr = mx.random.categorical(mx.log(dist))
                 # Bonus already sampled per-position inside _step_backbone
                 # for temp>0 (categorical over target distro at position K).
                 bonus_tok_arr = toks[k_len]
@@ -998,16 +977,7 @@ def mtp_generate_step(
             accepted_count = 0
             try:
                 _verify_sync_started = time.perf_counter()
-                if residual_toks_arr is None:
-                    mx.eval(toks, accept_mask_arr, bonus_tok_arr, u)
-                else:
-                    mx.eval(
-                        toks,
-                        accept_mask_arr,
-                        residual_toks_arr,
-                        bonus_tok_arr,
-                        u,
-                    )
+                mx.eval(toks, accept_mask_arr, residual_toks_arr, bonus_tok_arr, u)
                 _timing_add(
                     "verify_sync_seconds",
                     time.perf_counter() - _verify_sync_started,
@@ -1016,11 +986,7 @@ def mtp_generate_step(
 
                 # ------- Host-side read (all values already resident) -------
                 accept_flags = accept_mask_arr.tolist()
-                residual_ids = (
-                    residual_toks_arr.tolist()
-                    if residual_toks_arr is not None
-                    else None
-                )
+                residual_ids = residual_toks_arr.tolist()
                 bonus_id = int(bonus_tok_arr.item())
                 draft_ids = drafts_arr.tolist()
             except BaseException:
@@ -1144,32 +1110,7 @@ def mtp_generate_step(
                     # _step_backbone during the batched verify).
                     prev_tokens = prev_tokens[:-n_to_drop]
 
-                if residual_ids is None:
-                    # Exact Leviathan-Chen residual for only the first
-                    # rejected row. This adds a sync on rejection, but avoids
-                    # K full-vocabulary exp/subtract/sample rows on the much
-                    # more common all-accept path.
-                    row_dist = (
-                        _point_mass_residual_distribution(
-                            accept_lps[accepted_count : accepted_count + 1],
-                            drafts_i32[accepted_count : accepted_count + 1],
-                        )[0]
-                        if pending_is_prompt_lookup
-                        else _residual_distribution(
-                            accept_lps[accepted_count],
-                            draft_alps_arr[accepted_count],
-                        )
-                    )
-                    residual_tok = mx.random.categorical(mx.log(row_dist))
-                    _residual_started = time.perf_counter()
-                    mx.eval(residual_tok)
-                    _timing_add(
-                        "residual_sync_seconds",
-                        time.perf_counter() - _residual_started,
-                    )
-                    verify_tok_id = int(residual_tok.item())
-                else:
-                    verify_tok_id = int(residual_ids[accepted_count])
+                verify_tok_id = int(residual_ids[accepted_count])
 
                 ntoks += 1
                 generated_token_ids.append(verify_tok_id)

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -38,6 +38,7 @@ adjustments.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections.abc import Callable, Generator
 from functools import partial
@@ -52,6 +53,8 @@ import mlx.core as mx
 from .accept_counter import get_global_counter
 from .cache_patch import patch_arrays_cache_rollback_state
 from .draft_k_controller_v2 import DepthController, get_or_create_controller
+from .prompt_lookup import PromptLookupIndex
+from .verify_context import target_verify
 
 patch_arrays_cache_rollback_state()
 
@@ -59,6 +62,33 @@ logger = logging.getLogger(__name__)
 
 # Match upstream PR #990 cache-clear cadence verbatim (``_CACHE_CLEAR_INTERVAL = 256``).
 _CACHE_CLEAR_INTERVAL = 256
+
+
+def _residual_distribution(
+    target_logprobs: mx.array, draft_logprobs: mx.array
+) -> mx.array:
+    """Return the exact normalized speculative-rejection distribution."""
+    target = mx.exp(target_logprobs)
+    draft = mx.exp(draft_logprobs)
+    residual = mx.maximum(target - draft, 0.0)
+    total = residual.sum(axis=-1, keepdims=True)
+    return mx.where(total > 0, residual / mx.maximum(total, 1e-30), target)
+
+
+def _point_mass_residual_distribution(
+    target_logprobs: mx.array, proposed_tokens: mx.array
+) -> mx.array:
+    """Residual for a deterministic prompt-lookup proposal.
+
+    ``q`` is one at the copied token and zero elsewhere, so ``max(p-q, 0)``
+    is simply the shaped target distribution with that token removed.
+    """
+
+    target = mx.exp(target_logprobs)
+    token_mask = mx.arange(target.shape[-1])[None, :] != proposed_tokens.reshape(-1, 1)
+    residual = target * token_mask
+    total = residual.sum(axis=-1, keepdims=True)
+    return mx.where(total > 0, residual / mx.maximum(total, 1e-30), target)
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +235,7 @@ def mtp_generate_step(
     # caller still stops at EOS on its side); only the controller's
     # training window shrinks. ``None`` disables the holdout.
     stop_tokens: set[int] | None = None,
+    timing_stats: dict[str, float] | None = None,
 ) -> Generator[tuple[int, mx.array, bool], None, None]:
     """Generator that uses the model's native MTP head for spec decode.
 
@@ -253,6 +284,11 @@ def mtp_generate_step(
     xtc_special_tokens = xtc_special_tokens or []
     if accept_counter is None:
         accept_counter = get_global_counter()
+    if timing_stats is None:
+        timing_stats = {}
+
+    def _timing_add(name: str, elapsed: float) -> None:
+        timing_stats[name] = timing_stats.get(name, 0.0) + elapsed
 
     # ------------------------------------------------------------------
     # Chain-of-K drafter-hidden-cascade capability probe.
@@ -279,6 +315,8 @@ def mtp_generate_step(
     _mtp_supports_fused_greedy = callable(getattr(model, "mtp_greedy", None))
 
     y = prompt.astype(mx.uint32)
+    prompt_token_ids = [int(token) for token in y.tolist()]
+    generated_token_ids: list[int] = []
     prev_tokens: mx.array | None = None
 
     if prompt_cache is None:
@@ -293,6 +331,32 @@ def mtp_generate_step(
         mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
     _is_greedy = temp == 0
+    _lazy_residual = os.environ.get(
+        "RAPID_MLX_MTP_LAZY_RESIDUAL", "1"
+    ).strip().lower() not in {"0", "false", "off", "no"}
+    _prompt_lookup_enabled = (
+        os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP", "0").strip().lower()
+        in {"1", "true", "on", "yes"}
+    )
+    _prompt_lookup_max_tokens = max(
+        1, int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS", "24"))
+    )
+    _prompt_lookup_min_ngram = max(
+        2, int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM", "6"))
+    )
+    _prompt_lookup_max_ngram = max(
+        _prompt_lookup_min_ngram,
+        int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM", "10")),
+    )
+    _prompt_lookup_index = (
+        PromptLookupIndex(
+            prompt_token_ids,
+            min_ngram=_prompt_lookup_min_ngram,
+            max_ngram=_prompt_lookup_max_ngram,
+        )
+        if _prompt_lookup_enabled
+        else None
+    )
 
     _filter_chain, _xtc_cell = (
         _make_sampler_chain(
@@ -328,16 +392,16 @@ def mtp_generate_step(
             masked = logprobs
             for f in _filter_chain:
                 masked = f(masked)
-            token = categorical_sampling(masked, temp)
             scaled = masked / temp
             lp_accept = scaled - mx.logsumexp(scaled, axis=-1, keepdims=True)
+            token = categorical_sampling(masked, temp)
         elif _is_greedy:
             token = mx.argmax(logprobs, axis=-1)
             lp_accept = logprobs
         else:
-            token = categorical_sampling(logprobs, temp)
             scaled = logprobs / temp
             lp_accept = scaled - mx.logsumexp(scaled, axis=-1, keepdims=True)
+            token = categorical_sampling(logprobs, temp)
         return token, logprobs, lp_accept
 
     def _clear_rollback():
@@ -592,6 +656,36 @@ def mtp_generate_step(
             mx.clear_cache()
         return yy
 
+    def _sync_prompt_lookup_history(
+        verify_hidden, base_token, lookup_drafts, accepted_count: int
+    ) -> None:
+        """Append only committed lookup positions to the MTP cache.
+
+        The normal MTP drafter advances this cache while proposing. Prompt
+        lookup skips the drafter, so after target verification we reconstruct
+        the equivalent history in one batched MTP call. Position ``i`` pairs
+        the target hidden after ``[base, d1, ... d{i-1}]`` with that same
+        source token; it never feeds the token being predicted.
+        """
+
+        if accepted_count <= 0:
+            return
+        started = time.perf_counter()
+        source_tokens = mx.concatenate(
+            [base_token, lookup_drafts[: accepted_count - 1]]
+        )[None]
+        lookup_logits = model.mtp_forward(
+            verify_hidden[:, :accepted_count, :], source_tokens, mtp_cache
+        )
+        quantize_cache_fn(mtp_cache)
+        mx.eval(
+            lookup_logits,
+            [c.state for c in mtp_cache if hasattr(c, "state")],
+        )
+        _timing_add(
+            "prompt_lookup_mtp_sync_seconds", time.perf_counter() - started
+        )
+
     with mx.stream(generation_stream):
         y = _prefill(y, input_embeddings)
 
@@ -603,6 +697,7 @@ def mtp_generate_step(
     # otherwise it's a list of ``(tok, lp, accept_lp, xtc_draw)``
     # tuples of length K, one per chained MTP draft.
     pending_drafts: list | None = None
+    pending_is_prompt_lookup = False
 
     # ------------------------------------------------------------------
     # 0.9.13 PR-B: Ollama-style EV draft-K controller.
@@ -688,8 +783,40 @@ def mtp_generate_step(
         nonlocal pending_draft_ms
         _t0 = time.perf_counter()
         result = _step_mtp_chain(*args, **kwargs)
-        pending_draft_ms = (time.perf_counter() - _t0) * 1000.0
+        elapsed = time.perf_counter() - _t0
+        pending_draft_ms = elapsed * 1000.0
+        _timing_add("draft_seconds", elapsed)
         return result
+
+    def _prompt_lookup_drafts() -> list | None:
+        """Return point-mass prompt drafts, or ``None`` when no suffix matches."""
+
+        if _prompt_lookup_index is None:
+            return None
+        remaining = max_tokens - ntoks
+        if remaining <= 0:
+            return None
+        match = _prompt_lookup_index.propose(
+            generated_token_ids,
+            max_tokens=min(_prompt_lookup_max_tokens, remaining),
+        )
+        if match is None:
+            return None
+        extension = max(
+            0, match.matched_suffix - _prompt_lookup_index.min_ngram
+        )
+        confidence_ladder = (8, 12, 16, 24, 32)
+        confidence_cap = confidence_ladder[
+            min(extension, len(confidence_ladder) - 1)
+        ]
+        proposed_tokens = match.tokens[:confidence_cap]
+        _timing_add("prompt_lookup_proposals", 1.0)
+        _timing_add("prompt_lookup_drafted_tokens", float(len(proposed_tokens)))
+        _timing_add("prompt_lookup_matched_suffix_tokens", float(match.matched_suffix))
+        return [
+            (mx.array(token, mx.uint32), None, None, None)
+            for token in proposed_tokens
+        ]
 
     def _record_round(k_used: int, round_wall_ms: float, accepts: list[bool]) -> None:
         """Fold a round outcome into the controller (if enabled).
@@ -721,7 +848,9 @@ def mtp_generate_step(
             _record_round(0, round_wall_ms, [])
 
             ntoks += 1
-            yield main_tok.item(), main_lp, False
+            main_tok_id = int(main_tok.item())
+            generated_token_ids.append(main_tok_id)
+            yield main_tok_id, main_lp, False
             if ntoks >= max_tokens:
                 return
 
@@ -745,18 +874,24 @@ def mtp_generate_step(
             )
 
             hidden_at_main = hidden[:, -1:, :]
-            if next_k >= 1:
+            lookup_drafts = _prompt_lookup_drafts()
+            if lookup_drafts is not None:
+                pending_drafts = lookup_drafts
+                pending_is_prompt_lookup = True
+            elif next_k >= 1:
                 # Chain-of-K: generate ``next_k`` drafts cascaded via
                 # MTP. next_k==1 is the plain single-draft path.
                 d_toks, d_lps, d_alps, d_xtcs = _draft_chain_timed(
                     hidden_at_main, main_tok, prev_tokens, next_k
                 )
                 pending_drafts = list(zip(d_toks, d_lps, d_alps, d_xtcs))
+                pending_is_prompt_lookup = False
             else:
                 # Parking again: no draft. Next round enters this
                 # branch with ``pending_drafts is None`` and pays no
                 # drafter cost — the whole point of park.
                 pending_drafts = None
+                pending_is_prompt_lookup = False
             y = mx.array([main_tok.item()], mx.uint32)
         else:
             # -------------------------------------------------------
@@ -796,15 +931,16 @@ def mtp_generate_step(
             )
             y_with_drafts = mx.concatenate([y, drafts_arr])
 
-            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
-                y_with_drafts,
-                prev_tokens,
-                n_predict=k_len + 1,
-                # Any positive value activates per-position SSM snapshots;
-                # k_len preserves the legacy K=1 boundary semantics too.
-                n_confirmed=k_len,
-                xtc_draw=first_xtc_draw,
-            )
+            with target_verify():
+                toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
+                    y_with_drafts,
+                    prev_tokens,
+                    n_predict=k_len + 1,
+                    # Any positive value activates per-position SSM snapshots;
+                    # k_len preserves the legacy K=1 boundary semantics too.
+                    n_confirmed=k_len,
+                    xtc_draw=first_xtc_draw,
+                )
 
             # One shared uniform for all positions' probabilistic
             # accept tests. Ollama uses a per-position Bernoulli draw;
@@ -833,24 +969,39 @@ def mtp_generate_step(
                 # Vectorized per-position log-accept over the K draft
                 # positions with a shared draw ``u``.
                 v_alps = accept_lps[:k_len]  # (K, V)
-                d_alps_stack = mx.stack(draft_alps_arr)  # (K, V)
                 idx = drafts_i32.reshape(-1, 1)  # (K, 1)
                 v_at = mx.take_along_axis(v_alps, idx, axis=1).squeeze(-1)
-                d_at = mx.take_along_axis(d_alps_stack, idx, axis=1).squeeze(-1)
-                log_accept = v_at - d_at  # (K,)
+                if pending_is_prompt_lookup:
+                    # Prompt lookup is a deterministic (point-mass) proposal:
+                    # q(d)=1, hence log min(1, p(d)/q(d)) = log p(d).
+                    log_accept = v_at
+                    d_alps_stack = None
+                else:
+                    d_alps_stack = mx.stack(draft_alps_arr)  # (K, V)
+                    d_at = mx.take_along_axis(
+                        d_alps_stack, idx, axis=1
+                    ).squeeze(-1)
+                    log_accept = v_at - d_at  # (K,)
                 accept_mask_arr = (log_accept >= 0) | (u < mx.exp(log_accept))
 
-                # Residual distribution at every position — sampled
-                # up-front so a reject at position i doesn't cost a
-                # second eval. Formula matches the prior per-reject code:
-                # ``max(p_target - p_draft, 0)``, falling back to
-                # ``p_target`` if the max clamp zeroed everything.
-                p_target = mx.exp(v_alps)  # (K, V)
-                p_draft = mx.exp(d_alps_stack)  # (K, V)
-                residual = mx.maximum(p_target - p_draft, 0.0)  # (K, V)
-                z = residual.sum(axis=-1, keepdims=True)  # (K, 1)
-                dist = mx.where(z > 0, residual, p_target)  # (K, V)
-                residual_toks_arr = mx.random.categorical(mx.log(dist))
+                if _lazy_residual:
+                    # Most verify windows accept every draft, so building K
+                    # full-vocabulary residual distributions eagerly wastes
+                    # both bandwidth and memory. Materialize only the accept
+                    # mask here; a rejected row builds its exact residual
+                    # below after the first failing position is known. This
+                    # is the high-value data-flow optimization behind
+                    # MTPLX_LAZY_TARGET_DISTRIBUTIONS, adapted to Rapid's
+                    # lossless log-probability verifier.
+                    residual_toks_arr = None
+                else:
+                    # Legacy one-sync path: pre-sample every residual row.
+                    dist = (
+                        _point_mass_residual_distribution(v_alps, drafts_i32)
+                        if pending_is_prompt_lookup
+                        else _residual_distribution(v_alps, d_alps_stack)
+                    )
+                    residual_toks_arr = mx.random.categorical(mx.log(dist))
                 # Bonus already sampled per-position inside _step_backbone
                 # for temp>0 (categorical over target distro at position K).
                 bonus_tok_arr = toks[k_len]
@@ -858,11 +1009,30 @@ def mtp_generate_step(
             # ------- SINGLE SYNC -------
             accepted_count = 0
             try:
-                mx.eval(toks, accept_mask_arr, residual_toks_arr, bonus_tok_arr, u)
+                _verify_sync_started = time.perf_counter()
+                if residual_toks_arr is None:
+                    mx.eval(toks, accept_mask_arr, bonus_tok_arr, u)
+                else:
+                    mx.eval(
+                        toks,
+                        accept_mask_arr,
+                        residual_toks_arr,
+                        bonus_tok_arr,
+                        u,
+                    )
+                _timing_add(
+                    "verify_sync_seconds",
+                    time.perf_counter() - _verify_sync_started,
+                )
+                _timing_add("verify_calls", 1.0)
 
                 # ------- Host-side read (all values already resident) -------
                 accept_flags = accept_mask_arr.tolist()
-                residual_ids = residual_toks_arr.tolist()
+                residual_ids = (
+                    residual_toks_arr.tolist()
+                    if residual_toks_arr is not None
+                    else None
+                )
                 bonus_id = int(bonus_tok_arr.item())
                 draft_ids = drafts_arr.tolist()
             except BaseException:
@@ -873,7 +1043,12 @@ def mtp_generate_step(
                 # error fires before this round's fresh accept count is known,
                 # never let stale state leak into a fallback path: keep the
                 # committed ``y`` position and drop every uncommitted draft.
-                _rollback_verify_round(k_len - accepted_count, verify_size=k_len + 1)
+                if pending_is_prompt_lookup:
+                    _rollback_draft(k_len, verify_size=k_len + 1)
+                else:
+                    _rollback_verify_round(
+                        k_len - accepted_count, verify_size=k_len + 1
+                    )
                 raise
 
             # Bump attempts by K (one per draft position considered).
@@ -889,6 +1064,10 @@ def mtp_generate_step(
                     accepted_count += 1
                 else:
                     break
+            if pending_is_prompt_lookup:
+                _timing_add("prompt_lookup_accepted_tokens", float(accepted_count))
+                if accepted_count < k_len:
+                    _timing_add("prompt_lookup_rejections", 1.0)
 
             # -------- 0.9.13 PR-C: EOS holdout --------
             # When an accepted draft is a stop token, positions past it
@@ -911,7 +1090,13 @@ def mtp_generate_step(
                         break
 
             round_wall_ms = (time.perf_counter() - round_start_perf) * 1000.0
-            _record_round(k_len, round_wall_ms, accepts_for_record)
+            if pending_is_prompt_lookup:
+                # Lookup windows do not measure the MTP drafter's cost curve.
+                # Feeding K=8..24 into its K<=max_k controller would poison
+                # future depth choices.
+                pending_draft_ms = 0.0
+            else:
+                _record_round(k_len, round_wall_ms, accepts_for_record)
 
             # Emit the accepted drafts (capped at EOS position when set).
             for i in range(accepted_count):
@@ -922,7 +1107,9 @@ def mtp_generate_step(
                 # full-vocabulary draft logprob row.  The accepted token is
                 # also the target argmax, so its target row is the correct
                 # serving logprob surface and is already available here.
-                yield int(draft_ids[i]), lps[i] if draft_lp is None else draft_lp, True
+                draft_id = int(draft_ids[i])
+                generated_token_ids.append(draft_id)
+                yield draft_id, lps[i] if draft_lp is None else draft_lp, True
                 if ntoks >= max_tokens:
                     return
 
@@ -939,7 +1126,12 @@ def mtp_generate_step(
                 # All K drafts accepted → emit the bonus token
                 # (target's prediction one past the last draft).
                 _clear_rollback()
+                if pending_is_prompt_lookup:
+                    _sync_prompt_lookup_history(
+                        hidden, y, drafts_arr, accepted_count
+                    )
                 ntoks += 1
+                generated_token_ids.append(bonus_id)
                 yield bonus_id, lps[k_len], False
                 if ntoks >= max_tokens:
                     return
@@ -954,7 +1146,13 @@ def mtp_generate_step(
                 # (k_len - accepted_count) unaccepted drafts from the
                 # caches.
                 n_to_drop = k_len - accepted_count
-                _rollback_verify_round(n_to_drop, verify_size=k_len + 1)
+                if pending_is_prompt_lookup:
+                    _rollback_draft(n_to_drop, verify_size=k_len + 1)
+                    _sync_prompt_lookup_history(
+                        hidden, y, drafts_arr, accepted_count
+                    )
+                else:
+                    _rollback_verify_round(n_to_drop, verify_size=k_len + 1)
                 accept_counter.record_reject()
                 if logits_processors and prev_tokens is not None:
                     # Discard the ``n_to_drop`` rejected positions
@@ -962,9 +1160,35 @@ def mtp_generate_step(
                     # _step_backbone during the batched verify).
                     prev_tokens = prev_tokens[:-n_to_drop]
 
-                verify_tok_id = int(residual_ids[accepted_count])
+                if residual_ids is None:
+                    # Exact Leviathan-Chen residual for only the first
+                    # rejected row. This adds a sync on rejection, but avoids
+                    # K full-vocabulary exp/subtract/sample rows on the much
+                    # more common all-accept path.
+                    row_dist = (
+                        _point_mass_residual_distribution(
+                            accept_lps[accepted_count : accepted_count + 1],
+                            drafts_i32[accepted_count : accepted_count + 1],
+                        )[0]
+                        if pending_is_prompt_lookup
+                        else _residual_distribution(
+                            accept_lps[accepted_count],
+                            draft_alps_arr[accepted_count],
+                        )
+                    )
+                    residual_tok = mx.random.categorical(mx.log(row_dist))
+                    _residual_started = time.perf_counter()
+                    mx.eval(residual_tok)
+                    _timing_add(
+                        "residual_sync_seconds",
+                        time.perf_counter() - _residual_started,
+                    )
+                    verify_tok_id = int(residual_tok.item())
+                else:
+                    verify_tok_id = int(residual_ids[accepted_count])
 
                 ntoks += 1
+                generated_token_ids.append(verify_tok_id)
                 yield verify_tok_id, lps[accepted_count], False
                 if ntoks >= max_tokens:
                     return
@@ -985,7 +1209,11 @@ def mtp_generate_step(
                 if _select_k and _controller is not None
                 else max_k_effective
             )
-            if next_k >= 1:
+            lookup_drafts = _prompt_lookup_drafts()
+            if lookup_drafts is not None:
+                pending_drafts = lookup_drafts
+                pending_is_prompt_lookup = True
+            elif next_k >= 1:
                 # Chain-carry: on all-accept the mtp_cache must
                 # advance by one extra position for the just-accepted
                 # LAST draft so the head's attention sees it before
@@ -1018,8 +1246,10 @@ def mtp_generate_step(
                     cache_commit=cache_commit,
                 )
                 pending_drafts = list(zip(d_toks, d_lps, d_alps, d_xtcs))
+                pending_is_prompt_lookup = False
             else:
                 pending_drafts = None
+                pending_is_prompt_lookup = False
 
         block = ntoks // _CACHE_CLEAR_INTERVAL
         if block > last_cache_block:

--- a/vllm_mlx/spec_decode/mtp/prompt_lookup.py
+++ b/vllm_mlx/spec_decode/mtp/prompt_lookup.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Adapted from MTPLX context_copy.py.
-# Copyright 2026 Youssef Aloui and MTPLX contributors.
+# Copyright 2026 Youssof Altoukhi and MTPLX contributors.
 """Prompt-lookup proposals for high-overlap speculative decoding."""
 
 from __future__ import annotations

--- a/vllm_mlx/spec_decode/mtp/prompt_lookup.py
+++ b/vllm_mlx/spec_decode/mtp/prompt_lookup.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from MTPLX context_copy.py.
+# Copyright 2026 Youssef Aloui and MTPLX contributors.
+"""Prompt-lookup proposals for high-overlap speculative decoding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PromptLookupMatch:
+    """A continuation found in the immutable prompt."""
+
+    start: int
+    matched_suffix: int
+    tokens: tuple[int, ...]
+
+
+class PromptLookupIndex:
+    """Index prompt n-grams and propose their following token block.
+
+    Generated text is used only as the lookup query.  It is never added to
+    the index, which prevents self-repetition from turning into a fast loop.
+    """
+
+    def __init__(
+        self,
+        prompt: list[int] | tuple[int, ...],
+        *,
+        min_ngram: int = 6,
+        max_ngram: int = 10,
+        max_candidates: int = 32,
+    ) -> None:
+        if min_ngram < 2:
+            raise ValueError("min_ngram must be at least 2")
+        if max_ngram < min_ngram:
+            raise ValueError("max_ngram must be >= min_ngram")
+        if max_candidates < 1:
+            raise ValueError("max_candidates must be positive")
+
+        self.prompt = tuple(int(token) for token in prompt)
+        self.min_ngram = int(min_ngram)
+        self.max_ngram = int(max_ngram)
+        self.max_candidates = int(max_candidates)
+        self._positions: dict[tuple[int, ...], list[int]] = {}
+
+        # Store the position immediately following each n-gram.  A position at
+        # len(prompt) has no continuation and is intentionally excluded.
+        for end in range(self.min_ngram, len(self.prompt)):
+            gram = self.prompt[end - self.min_ngram : end]
+            self._positions.setdefault(gram, []).append(end)
+
+    def propose(
+        self,
+        generated: list[int] | tuple[int, ...],
+        *,
+        max_tokens: int = 24,
+    ) -> PromptLookupMatch | None:
+        """Return the best prompt continuation for ``generated``'s suffix."""
+
+        if max_tokens < 1 or len(generated) < self.min_ngram:
+            return None
+        suffix = tuple(int(token) for token in generated[-self.min_ngram :])
+        candidates = self._positions.get(suffix)
+        if not candidates:
+            return None
+
+        best_start: int | None = None
+        best_suffix = self.min_ngram - 1
+        max_extension = self.max_ngram - self.min_ngram
+        history_len = len(generated)
+        for start in reversed(candidates[-self.max_candidates :]):
+            extension = 0
+            while (
+                extension < max_extension
+                and start - self.min_ngram - 1 - extension >= 0
+                and history_len - self.min_ngram - 1 - extension >= 0
+                and self.prompt[start - self.min_ngram - 1 - extension]
+                == generated[history_len - self.min_ngram - 1 - extension]
+            ):
+                extension += 1
+            matched = self.min_ngram + extension
+            if matched > best_suffix:
+                best_start = start
+                best_suffix = matched
+                if extension == max_extension:
+                    break
+
+        if best_start is None:
+            return None
+        proposal = self.prompt[best_start : best_start + max_tokens]
+        if not proposal:
+            return None
+        return PromptLookupMatch(best_start, best_suffix, proposal)
+
+
+__all__ = ["PromptLookupIndex", "PromptLookupMatch"]


### PR DESCRIPTION
## Why
Grounded coding and agent turns often return large spans already present in the prompt. Native MTP remains limited to a few draft tokens per cycle, so these high-overlap turns leave throughput on the table even when the model already has the answer in context.

## What
- add an immutable prompt-only n-gram index and use matched continuations as long speculative blocks inside the existing MTP verifier
- preserve the target distribution at greedy and sampled temperatures with point-mass acceptance and exact residual sampling
- keep target, recurrent, and MTP caches aligned on full acceptance, partial rejection, cancellation, and EOS
- enable lookup by default only inside explicit MTP serving; require an 8-token suffix and retain environment overrides/kill switch
- add token hashes and lookup telemetry to the MTP benchmark
- retain MTPLX Apache-2.0 license/NOTICE and add required visible attribution in Settings → Privacy, covered by the no-dead-controls golden flow

## Hardware verification
Mini M2 Pro 32 GB, `mlx-community/Qwen3.5-9B-4bit` + matching MTP sidecar, greedy, 3 runs:

- realistic 30-function file edit / full-file return: 22.18 tok/s with lookup vs 17.27 MTP-only (+28.4%) and 19.98 mlx-lm/Rapid AR (+11.0%)
- four ordinary coding/prose/JSON prompts: 28.05 tok/s with lookup vs 27.92 without (+0.5%, effectively neutral)
- emitted-token SHA-256 was identical on every on/off comparison
- short weak-overlap copy was not a win; the 8-token confidence gate limits this exposure and the feature has an immediate environment kill switch

## Verification
- 513 focused Python tests pass
- Ruff format/check pass across the repository
- full macOS release app + bundled sidecar builds
- `no-dead-controls` golden flow passes on the Mini and verifies the MTPLX attribution link exists and is enabled
- repository-link Swift tests pass

## Comparison boundary
Rapid's AR number is the stock mlx-lm generation path on the same model and machine. MTPLX and oMLX cannot be honestly placed in the same numeric row without using their own complete model/draft artifacts; the PR therefore records only same-artifact measurements and discusses external engine numbers separately.
