### PR TITLE
fix(mtp): isolate prompt lookup to audited Qwen backends

### DIFF
--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1359,6 +1359,7 @@ def test_inject_mtp_support_attaches_four_surfaces():
     injected = inject_mtp_support(model, allow_random_init=True)
     assert injected is True
     assert validate_mtp_support(model) is True
+    assert model.mtp_prompt_lookup_supported is True
 
 
 def test_inject_mtp_support_rejects_non_qwen35_model():
@@ -2310,6 +2311,8 @@ class _CountingKVCache:
 class _CacheAdvancingQwen35Model(_MockedQwen35Model):
     """Mock that advances supplied cache doubles on each forward."""
 
+    mtp_prompt_lookup_supported = True
+
     def __init__(self, backbone_outputs: list[int], mtp_outputs: list[int]):
         super().__init__(backbone_outputs, mtp_outputs)
         self.layers = [object()]
@@ -2663,6 +2666,25 @@ def test_generator_prompt_lookup_verifies_prompt_continuation(monkeypatch):
     assert model_cache.trim_calls == [1]
     assert mtp_cache.trim_calls == [1]
     assert mtp_cache.offset == 5
+
+
+def test_prompt_lookup_requires_an_audited_model_capability(monkeypatch):
+    """An env opt-in cannot force unaudited MTP backends into prompt lookup."""
+    from types import SimpleNamespace
+
+    from vllm_mlx.spec_decode.mtp.generator import _prompt_lookup_is_enabled
+
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP", "1")
+    assert not _prompt_lookup_is_enabled(SimpleNamespace())
+    assert not _prompt_lookup_is_enabled(
+        SimpleNamespace(mtp_prompt_lookup_supported=False)
+    )
+    assert _prompt_lookup_is_enabled(SimpleNamespace(mtp_prompt_lookup_supported=True))
+
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP", "off")
+    assert not _prompt_lookup_is_enabled(
+        SimpleNamespace(mtp_prompt_lookup_supported=True)
+    )
 
 
 def test_generator_prompt_lookup_partial_reject_keeps_mtp_cache_aligned(

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -55,6 +55,19 @@ from .cache_patch import patch_arrays_cache_rollback_state
 from .draft_k_controller_v2 import DepthController, get_or_create_controller
 from .prompt_lookup import PromptLookupIndex
 
+
+def _prompt_lookup_is_enabled(model) -> bool:
+    """Return whether this model may use audited prompt-copy speculation."""
+    if not getattr(model, "mtp_prompt_lookup_supported", False):
+        return False
+    return os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP", "1").strip().lower() not in {
+        "0",
+        "false",
+        "off",
+        "no",
+    }
+
+
 patch_arrays_cache_rollback_state()
 
 logger = logging.getLogger(__name__)
@@ -272,10 +285,10 @@ def mtp_generate_step(
     xtc_special_tokens = xtc_special_tokens or []
     if accept_counter is None:
         accept_counter = get_global_counter()
-    if timing_stats is None:
-        timing_stats = {}
 
     def _timing_add(name: str, elapsed: float) -> None:
+        if timing_stats is None:
+            return
         timing_stats[name] = timing_stats.get(name, 0.0) + elapsed
 
     # ------------------------------------------------------------------
@@ -303,8 +316,19 @@ def mtp_generate_step(
     _mtp_supports_fused_greedy = callable(getattr(model, "mtp_greedy", None))
 
     y = prompt.astype(mx.uint32)
-    prompt_token_ids = [int(token) for token in y.tolist()]
+    _prompt_lookup_enabled = _prompt_lookup_is_enabled(model)
+    # Avoid copying a potentially long prompt back to the CPU for every other
+    # MTP backend. Prompt lookup is opt-in per model because its cache-history
+    # synchronization contract must be audited for that architecture first.
+    prompt_token_ids = (
+        [int(token) for token in y.tolist()] if _prompt_lookup_enabled else []
+    )
     generated_token_ids: list[int] = []
+
+    def _remember_generated(token_id: int) -> None:
+        if _prompt_lookup_enabled:
+            generated_token_ids.append(token_id)
+
     prev_tokens: mx.array | None = None
 
     if prompt_cache is None:
@@ -319,9 +343,6 @@ def mtp_generate_step(
         mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
     _is_greedy = temp == 0
-    _prompt_lookup_enabled = os.environ.get(
-        "RAPID_MLX_MTP_PROMPT_LOOKUP", "1"
-    ).strip().lower() not in {"0", "false", "off", "no"}
     _prompt_lookup_max_tokens = max(
         1, int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS", "24"))
     )
@@ -826,7 +847,7 @@ def mtp_generate_step(
 
             ntoks += 1
             main_tok_id = int(main_tok.item())
-            generated_token_ids.append(main_tok_id)
+            _remember_generated(main_tok_id)
             yield main_tok_id, main_lp, False
             if ntoks >= max_tokens:
                 return
@@ -1062,7 +1083,7 @@ def mtp_generate_step(
                 # also the target argmax, so its target row is the correct
                 # serving logprob surface and is already available here.
                 draft_id = int(draft_ids[i])
-                generated_token_ids.append(draft_id)
+                _remember_generated(draft_id)
                 yield draft_id, lps[i] if draft_lp is None else draft_lp, True
                 if ntoks >= max_tokens:
                     return
@@ -1083,7 +1104,7 @@ def mtp_generate_step(
                 if pending_is_prompt_lookup:
                     _sync_prompt_lookup_history(hidden, y, drafts_arr, accepted_count)
                 ntoks += 1
-                generated_token_ids.append(bonus_id)
+                _remember_generated(bonus_id)
                 yield bonus_id, lps[k_len], False
                 if ntoks >= max_tokens:
                     return
@@ -1113,7 +1134,7 @@ def mtp_generate_step(
                 verify_tok_id = int(residual_ids[accepted_count])
 
                 ntoks += 1
-                generated_token_ids.append(verify_tok_id)
+                _remember_generated(verify_tok_id)
                 yield verify_tok_id, lps[accepted_count], False
                 if ntoks >= max_tokens:
                     return

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -803,6 +803,11 @@ def inject_mtp_support(
           — the GatedDeltaNet rollback patch is tracked separately.
         """
 
+        # The generic generator only enables prompt-copy speculation for
+        # backends whose MTP cache-history synchronization has been audited.
+        # This injector covers the Qwen 3.5/3.6/3.8 family.
+        mtp_prompt_lookup_supported = True
+
         def __call__(  # type: ignore[override]
             self,
             inputs,
@@ -918,6 +923,11 @@ def inject_mtp_support(
             return [KVCache() for _ in self.mtp.layers]
 
     inner.__class__ = _Qwen3_5WithMTP
+    # Some callers retain the VLM-style outer wrapper and pass it onward.
+    # Mirror the capability there so the gate follows the injected model
+    # regardless of which supported shape reaches the generator.
+    if model is not inner:
+        model.mtp_prompt_lookup_supported = True
     logger.info(
         "[mtp.inject] Patched %s with MTP surfaces "
         "(return_hidden, n_confirmed, mtp_forward, make_mtp_cache).",


### PR DESCRIPTION
## Why

Prompt lookup was introduced in the generic MTP generator. Non-MTP models were unaffected, but unaudited MTP backends such as Gemma 4 and HY3 could technically enter the new cache-history synchronization path. Their smoke tests prove boot compatibility, not that prompt-copy cache synchronization is valid for those architectures.

## What

- require an explicit `mtp_prompt_lookup_supported` model capability
- advertise it only from the audited Qwen 3.5/3.6/3.8 injector
- keep Gemma 4, HY3, legacy MTP, and non-MTP models on their prior path even when the env flag is explicitly enabled
- avoid prompt CPU copies and generated-token bookkeeping on unsupported models
- make timing collection a true no-op when the caller did not request it
- cover capability opt-in, env kill switch, and Qwen injection

## Validation

- `ruff check .`
- 10 focused prompt-lookup/Qwen injection tests passed
- 62 Gemma 4 + HY3 injection tests passed
- broader MTP run: 165 passed; two unrelated local-environment/flaky failures (missing pydantic through system Python 3.14 import path, pre-existing random quantized argmax test) left to standard CI
