### PR TITLE
fix(mtp): require opt-in for prompt lookup

### DIFF
--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2674,6 +2674,11 @@ def test_prompt_lookup_requires_an_audited_model_capability(monkeypatch):
 
     from vllm_mlx.spec_decode.mtp.generator import _prompt_lookup_is_enabled
 
+    monkeypatch.delenv("RAPID_MLX_MTP_PROMPT_LOOKUP", raising=False)
+    assert not _prompt_lookup_is_enabled(
+        SimpleNamespace(mtp_prompt_lookup_supported=True)
+    )
+
     monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP", "1")
     assert not _prompt_lookup_is_enabled(SimpleNamespace())
     assert not _prompt_lookup_is_enabled(

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -60,7 +60,9 @@ def _prompt_lookup_is_enabled(model) -> bool:
     """Return whether this model may use audited prompt-copy speculation."""
     if not getattr(model, "mtp_prompt_lookup_supported", False):
         return False
-    return os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP", "1").strip().lower() not in {
+    # Explicit opt-in until Qwen's hybrid SSM target path is proven
+    # token-lossless across the different verification chunk boundaries.
+    return os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP", "0").strip().lower() not in {
         "0",
         "false",
         "off",


### PR DESCRIPTION
## Why

Studio validation on the real `mlx-community/Qwen3.8-27B-4bit` target found that prompt lookup reaches 60.34 tok/s on a grounded code-copy workload, but changes the greedy token stream after speculative chunk-boundary changes in Qwen hybrid SSM. The decoded text later diverges semantically, so this is not safe as a default despite the performance win.

## What

- preserve the implementation and audited Qwen capability gate
- change prompt lookup from default-on to explicit `RAPID_MLX_MTP_PROMPT_LOOKUP=1` opt-in
- pin the safe default in regression coverage

## Validation

- Studio real-model paired run: AR and ordinary MTP token SHA match; lookup run differs (reproduced at lookup windows K=24, K=3, and K=1)
- `ruff check .`
- 3 focused capability/default/lookup generator tests passed
