### PR TITLE
feat(mtp): accelerate compact Qwen3.8 with an audited fast lane

### DIFF
--- a/bench/bench_qwen38_mtp_context.py
+++ b/bench/bench_qwen38_mtp_context.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Measure paired AR/MTP decode and memory at a controlled prompt length."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+from typing import Any
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--mtp-sidecar", required=True)
+    parser.add_argument("--prompt-tokens", type=int, default=4096)
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--repeats", type=int, default=2)
+    parser.add_argument("--draft-block-size", type=int, default=3)
+    parser.add_argument(
+        "--memory-limit-gb",
+        type=float,
+        help="Optional MLX allocator limit, applied before model load",
+    )
+    return parser.parse_args()
+
+
+def _encode(processor: Any, text: str) -> list[int]:
+    tokenizer = getattr(processor, "tokenizer", processor)
+    encoded = tokenizer.encode(text)
+    return encoded.tolist() if hasattr(encoded, "tolist") else list(encoded)
+
+
+def _render(processor: Any, content: str) -> str:
+    messages = [{"role": "user", "content": content}]
+    kwargs = {"tokenize": False, "add_generation_prompt": True}
+    try:
+        return processor.apply_chat_template(
+            messages, enable_thinking=False, **kwargs
+        )
+    except TypeError:
+        return processor.apply_chat_template(messages, **kwargs)
+
+
+def _controlled_prompt(processor: Any, target: int) -> tuple[str, int]:
+    lines = [
+        f"Record {index:05d}: project cobalt has checkpoint {index % 97}; "
+        f"owner team-{index % 13}; status verified."
+        for index in range(target)
+    ]
+    request = (
+        "\nUsing the records above, explain a reliable validation strategy in "
+        "detail. Do not enumerate every record."
+    )
+    low, high = 1, len(lines)
+    best = _render(processor, lines[0] + request)
+    best_count = len(_encode(processor, best))
+    while low <= high:
+        middle = (low + high) // 2
+        rendered = _render(processor, "\n".join(lines[:middle]) + request)
+        count = len(_encode(processor, rendered))
+        if count <= target:
+            best, best_count = rendered, count
+            low = middle + 1
+        else:
+            high = middle - 1
+    if best_count < int(target * 0.98):
+        raise RuntimeError(f"could only construct {best_count} tokens for target {target}")
+    return best, best_count
+
+
+def main() -> int:
+    args = _args()
+    if min(args.prompt_tokens, args.max_tokens, args.repeats) <= 0:
+        raise SystemExit("token counts and repeats must be positive")
+
+    import mlx.core as mx
+    from mlx_vlm import generate, load
+    from mlx_vlm.speculative.drafters import load_drafter
+
+    if args.memory_limit_gb is not None:
+        if args.memory_limit_gb <= 0:
+            raise SystemExit("--memory-limit-gb must be positive")
+        mx.set_memory_limit(int(args.memory_limit_gb * 1e9))
+    model, processor = load(args.model)
+    drafter, draft_kind = load_drafter(args.mtp_sidecar, kind="mtp")
+    mx.eval(model.parameters(), drafter.parameters())
+    mx.clear_cache()
+    prompt, actual_prompt_tokens = _controlled_prompt(processor, args.prompt_tokens)
+    records = []
+    for repetition in range(args.repeats):
+        for mode in ("ar", "mtp"):
+            mx.clear_cache()
+            mx.reset_peak_memory()
+            active_before_gb = mx.get_active_memory() / 1e9
+            kwargs = {
+                "max_tokens": args.max_tokens,
+                "temperature": 0,
+                "verbose": False,
+            }
+            if mode == "mtp":
+                kwargs.update(
+                    draft_model=drafter,
+                    draft_kind=draft_kind,
+                    draft_block_size=args.draft_block_size,
+                )
+            result = generate(model, processor, prompt, **kwargs)
+            records.append(
+                {
+                    "repetition": repetition,
+                    "mode": mode,
+                    "prompt_tokens": actual_prompt_tokens,
+                    "generation_tokens": result.generation_tokens,
+                    "generation_tps": result.generation_tps,
+                    "peak_memory_gb": mx.get_peak_memory() / 1e9,
+                    "active_before_gb": active_before_gb,
+                    "active_after_gb": mx.get_active_memory() / 1e9,
+                    "finish_reason": result.finish_reason,
+                    "sha256": hashlib.sha256(result.text.encode()).hexdigest(),
+                }
+            )
+    summary = {}
+    for mode in ("ar", "mtp"):
+        rows = [row for row in records if row["mode"] == mode]
+        summary[mode] = {
+            "mean_tps": statistics.mean(row["generation_tps"] for row in rows),
+            "max_peak_memory_gb": max(row["peak_memory_gb"] for row in rows),
+        }
+    summary["speedup"] = summary["mtp"]["mean_tps"] / summary["ar"]["mean_tps"]
+    summary["identical_pairs"] = sum(
+        records[index]["sha256"] == records[index + 1]["sha256"]
+        for index in range(0, len(records), 2)
+    )
+    print(json.dumps({"records": records, "summary": summary}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/bench_qwen38_mtp_context.py
+++ b/bench/bench_qwen38_mtp_context.py
@@ -36,9 +36,7 @@ def _render(processor: Any, content: str) -> str:
     messages = [{"role": "user", "content": content}]
     kwargs = {"tokenize": False, "add_generation_prompt": True}
     try:
-        return processor.apply_chat_template(
-            messages, enable_thinking=False, **kwargs
-        )
+        return processor.apply_chat_template(messages, enable_thinking=False, **kwargs)
     except TypeError:
         return processor.apply_chat_template(messages, **kwargs)
 
@@ -66,7 +64,9 @@ def _controlled_prompt(processor: Any, target: int) -> tuple[str, int]:
         else:
             high = middle - 1
     if best_count < int(target * 0.98):
-        raise RuntimeError(f"could only construct {best_count} tokens for target {target}")
+        raise RuntimeError(
+            f"could only construct {best_count} tokens for target {target}"
+        )
     return best, best_count
 
 

--- a/bench/bench_qwen38_mtp_mmbench.py
+++ b/bench/bench_qwen38_mtp_mmbench.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Paired AR/MTP MMBench gate for the compact Qwen3.8-27B SKU."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import re
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--mtp-sidecar", required=True)
+    parser.add_argument("--samples", type=int, default=300)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--draft-block-size", type=int, default=3)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _answer(text: str) -> str | None:
+    tail = text.split("</think>")[-1]
+    match = re.search(r"\b([A-D])\b", tail)
+    return match.group(1) if match else None
+
+
+def _summary(records: list[dict[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for mode in ("ar", "mtp"):
+        rows = [row for row in records if row["mode"] == mode]
+        result[mode] = {
+            "correct": sum(bool(row["correct"]) for row in rows),
+            "total": len(rows),
+            "accuracy": sum(bool(row["correct"]) for row in rows) / len(rows),
+            "mean_tps": sum(float(row["generation_tps"]) for row in rows) / len(rows),
+        }
+    paired = {mode: {} for mode in ("ar", "mtp")}
+    for row in records:
+        paired[row["mode"]][row["index"]] = row
+    common = sorted(set(paired["ar"]) & set(paired["mtp"]))
+    result["paired"] = {
+        "common_correct": sum(
+            paired["ar"][i]["correct"] and paired["mtp"][i]["correct"] for i in common
+        ),
+        "mtp_only_correct": sum(
+            not paired["ar"][i]["correct"] and paired["mtp"][i]["correct"]
+            for i in common
+        ),
+        "ar_only_correct": sum(
+            paired["ar"][i]["correct"] and not paired["mtp"][i]["correct"]
+            for i in common
+        ),
+        "identical_outputs": sum(
+            paired["ar"][i]["sha256"] == paired["mtp"][i]["sha256"] for i in common
+        ),
+    }
+    result["speedup"] = result["mtp"]["mean_tps"] / result["ar"]["mean_tps"]
+    return result
+
+
+def main() -> int:
+    args = _args()
+    if args.samples <= 0 or args.max_tokens <= 0:
+        raise SystemExit("--samples and --max-tokens must be positive")
+
+    from datasets import load_dataset
+    from mlx_vlm import generate, load
+    from mlx_vlm.prompt_utils import apply_chat_template
+    from mlx_vlm.speculative.drafters import load_drafter
+
+    dataset = load_dataset("lmms-lab/MMBench_EN", split="dev")
+    indices = list(range(len(dataset)))
+    random.Random(42).shuffle(indices)
+    indices = indices[: args.samples]
+    model, processor = load(args.model)
+    drafter, draft_kind = load_drafter(args.mtp_sidecar, kind="mtp")
+    records: list[dict[str, Any]] = []
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    with (
+        tempfile.TemporaryDirectory(prefix="rapid-mtp-mmbench-") as temp_dir,
+        args.output.open("w") as stream,
+    ):
+        for ordinal, index in enumerate(indices):
+            row = dataset[index]
+            options = {key: row[key] for key in "ABCD" if row.get(key)}
+            hint = (row.get("hint") or "").strip()
+            prompt = (
+                ((f"Hint: {hint}\n") if hint else "")
+                + row["question"]
+                + "\n"
+                + "\n".join(f"{key}. {value}" for key, value in options.items())
+                + "\n\nAnswer with the single option letter only."
+            )
+            image_path = Path(temp_dir) / f"{index}.png"
+            row["image"].convert("RGB").save(image_path)
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ]
+            formatted = apply_chat_template(
+                processor,
+                model.config,
+                messages,
+                num_images=1,
+                enable_thinking=False,
+            )
+            modes = ("ar", "mtp") if ordinal % 2 == 0 else ("mtp", "ar")
+            for mode in modes:
+                kwargs: dict[str, Any] = {
+                    "image": [str(image_path)],
+                    "max_tokens": args.max_tokens,
+                    "temperature": 0,
+                    "verbose": False,
+                }
+                if mode == "mtp":
+                    kwargs.update(
+                        draft_model=drafter,
+                        draft_kind=draft_kind,
+                        draft_block_size=args.draft_block_size,
+                    )
+                started = time.perf_counter()
+                output = generate(model, processor, formatted, **kwargs)
+                elapsed = time.perf_counter() - started
+                text = output.text if hasattr(output, "text") else str(output)
+                generated = int(getattr(output, "generation_tokens", 0) or 0)
+                record = {
+                    "index": index,
+                    "mode": mode,
+                    "gold": row["answer"],
+                    "prediction": _answer(text),
+                    "correct": _answer(text) == row["answer"],
+                    "generation_tokens": generated,
+                    "generation_tps": generated / elapsed if elapsed else 0.0,
+                    "elapsed_s": elapsed,
+                    "sha256": hashlib.sha256(text.encode()).hexdigest(),
+                }
+                records.append(record)
+                stream.write(json.dumps(record) + "\n")
+                stream.flush()
+            if (ordinal + 1) % 10 == 0:
+                print(json.dumps({"completed": ordinal + 1, **_summary(records)}))
+
+    summary = _summary(records)
+    args.output.with_suffix(".summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n"
+    )
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/bench_qwen38_mtp_sku.py
+++ b/bench/bench_qwen38_mtp_sku.py
@@ -44,7 +44,12 @@ def _parse_args() -> argparse.Namespace:
         default="mmlu-pro",
     )
     parser.add_argument("--samples", type=int, default=None)
+    parser.add_argument(
+        "--indices",
+        help="Comma-separated zero-based dataset row indices for targeted reruns",
+    )
     parser.add_argument("--draft-block-size", type=int, default=3)
+    parser.add_argument("--max-tokens", type=int, default=None)
     parser.add_argument("--code-timeout", type=float, default=4.0)
     parser.add_argument("--output", type=Path)
     parser.add_argument("--dry-run", action="store_true")
@@ -274,10 +279,22 @@ def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
 
 def main() -> int:
     args = _parse_args()
-    default_samples, max_tokens = _task_defaults(args.task)
+    default_samples, task_max_tokens = _task_defaults(args.task)
+    max_tokens = args.max_tokens or task_max_tokens
     samples = args.samples if args.samples is not None else default_samples
     if samples <= 0:
         raise SystemExit("--samples must be positive")
+    if max_tokens <= 0:
+        raise SystemExit("--max-tokens must be positive")
+    indices = None
+    if args.indices:
+        try:
+            indices = [int(value) for value in args.indices.split(",")]
+        except ValueError as exc:
+            raise SystemExit("--indices must be comma-separated integers") from exc
+        if not indices or min(indices) < 0 or len(indices) != len(set(indices)):
+            raise SystemExit("--indices must contain unique non-negative integers")
+        samples = len(indices)
     plan = {
         "model": args.model,
         "mtp_sidecar": args.mtp_sidecar,
@@ -287,6 +304,7 @@ def main() -> int:
         "temperature": 0,
         "thinking": args.task == "humaneval",
         "draft_block_size": args.draft_block_size,
+        "indices": indices,
     }
     if args.dry_run:
         print(json.dumps(plan, indent=2))
@@ -295,14 +313,18 @@ def main() -> int:
     from mlx_vlm import load
     from mlx_vlm.speculative.drafters import load_drafter
 
-    rows = _dataset(args.task, samples)
+    if indices is None:
+        indexed_rows = list(enumerate(_dataset(args.task, samples)))
+    else:
+        source_rows = _dataset(args.task, max(indices) + 1)
+        indexed_rows = [(index, source_rows[index]) for index in indices]
     model, processor = load(args.model)
     drafter, draft_kind = load_drafter(args.mtp_sidecar, kind="mtp")
     output = args.output
     stream = output.open("w") if output is not None else sys.stdout
     records: list[dict[str, Any]] = []
     try:
-        for index, row in enumerate(rows):
+        for index, row in indexed_rows:
             raw_prompt, gold = _render_item(args.task, row)
             prompt = _chat_prompt(
                 processor,

--- a/bench/bench_qwen38_mtp_sku.py
+++ b/bench/bench_qwen38_mtp_sku.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Paired AR/MTP capability and throughput gate for the 24 GB Qwen3.8 SKU.
+
+This bench intentionally evaluates the same checkpoint twice, once with plain
+autoregressive decoding and once with an external MTP sidecar.  Every item is
+paired, so the report can distinguish a real answer flip from ordinary score
+noise.  It also records completion hashes: equal hashes are stronger evidence
+than equal aggregate accuracy.
+
+The default model/head pair is the proposed 24 GB SKU.  Dataset rows are read
+from Hugging Face's datasets-server API in stable source order; no ``datasets``
+dependency or local dataset cache is required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import statistics
+import sys
+import urllib.parse
+import urllib.request
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MODEL = "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX"
+DEFAULT_HEAD = "mlx-community/Qwen3.8-27B-MTP-4bit"
+_DATASETS_SERVER = "https://datasets-server.huggingface.co/rows"
+_LETTERS = "ABCDEFGHIJ"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--mtp-sidecar", default=DEFAULT_HEAD)
+    parser.add_argument(
+        "--task",
+        choices=("mmlu-pro", "gsm8k"),
+        default="mmlu-pro",
+    )
+    parser.add_argument("--samples", type=int, default=None)
+    parser.add_argument("--draft-block-size", type=int, default=3)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def _task_defaults(task: str) -> tuple[int, int]:
+    if task == "mmlu-pro":
+        return 500, 24
+    return 150, 512
+
+
+def _fetch_rows(dataset: str, config: str, split: str, count: int) -> list[dict]:
+    rows: list[dict] = []
+    for offset in range(0, count, 100):
+        length = min(100, count - offset)
+        query = urllib.parse.urlencode(
+            {
+                "dataset": dataset,
+                "config": config,
+                "split": split,
+                "offset": offset,
+                "length": length,
+            }
+        )
+        with urllib.request.urlopen(f"{_DATASETS_SERVER}?{query}") as response:
+            payload = json.load(response)
+        rows.extend(item["row"] for item in payload["rows"])
+    if len(rows) != count:
+        raise RuntimeError(
+            f"requested {count} rows but datasets-server returned {len(rows)}"
+        )
+    return rows
+
+
+def _dataset(task: str, count: int) -> list[dict]:
+    if task == "mmlu-pro":
+        return _fetch_rows("TIGER-Lab/MMLU-Pro", "default", "test", count)
+    return _fetch_rows("openai/gsm8k", "main", "test", count)
+
+
+def _render_item(task: str, row: dict) -> tuple[str, str]:
+    if task == "mmlu-pro":
+        options = "\n".join(
+            f"{_LETTERS[index]}. {option}"
+            for index, option in enumerate(row["options"])
+        )
+        return (
+            "Choose the best answer. Reply with only the letter.\n\n"
+            f"{row['question']}\n{options}\nAnswer:",
+            row["answer"],
+        )
+    match = re.search(r"####\s*([-0-9,.]+)", row["answer"])
+    if match is None:
+        raise ValueError("GSM8K answer has no #### final-answer marker")
+    return (
+        "Solve this problem. Give a brief calculation and end with FINAL: "
+        f"followed by only the numeric answer.\n\n{row['question']}",
+        match.group(1).replace(",", ""),
+    )
+
+
+def _extract_answer(task: str, text: str) -> str | None:
+    if task == "mmlu-pro":
+        match = re.search(r"(?:^|\b)([A-J])(?:\b|$)", text.strip().upper())
+        return match.group(1) if match else None
+    matches = re.findall(
+        r"FINAL\s*:\s*\$?\s*(-?[\d,]+(?:\.\d+)?)",
+        text,
+        re.IGNORECASE,
+    )
+    return matches[-1].replace(",", "") if matches else None
+
+
+def _chat_prompt(processor: Any, prompt: str) -> str:
+    kwargs = {"tokenize": False, "add_generation_prompt": True}
+    messages = [{"role": "user", "content": prompt}]
+    try:
+        return processor.apply_chat_template(
+            messages,
+            enable_thinking=False,
+            **kwargs,
+        )
+    except TypeError:
+        return processor.apply_chat_template(messages, **kwargs)
+
+
+def _condition_result(
+    *,
+    mode: str,
+    model: Any,
+    processor: Any,
+    drafter: Any,
+    draft_kind: str,
+    prompt: str,
+    task: str,
+    gold: str,
+    max_tokens: int,
+    draft_block_size: int,
+) -> dict[str, Any]:
+    from mlx_vlm import generate
+
+    kwargs: dict[str, Any] = {
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "verbose": False,
+    }
+    if mode == "mtp":
+        kwargs.update(
+            draft_model=drafter,
+            draft_kind=draft_kind,
+            draft_block_size=draft_block_size,
+        )
+    result = generate(model, processor, prompt, **kwargs)
+    prediction = _extract_answer(task, result.text)
+    return {
+        "prediction": prediction,
+        "correct": prediction == gold,
+        "generation_tokens": result.generation_tokens,
+        "generation_tps": round(result.generation_tps, 3),
+        "peak_memory_gb": round(result.peak_memory, 3),
+        "finish_reason": result.finish_reason,
+        "sha256": hashlib.sha256(result.text.encode()).hexdigest(),
+    }
+
+
+def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
+    flips = Counter(
+        (record["ar"]["correct"], record["mtp"]["correct"]) for record in records
+    )
+    return {
+        "samples": len(records),
+        "ar_correct": sum(record["ar"]["correct"] for record in records),
+        "mtp_correct": sum(record["mtp"]["correct"] for record in records),
+        "ar_only_correct": flips[(True, False)],
+        "mtp_only_correct": flips[(False, True)],
+        "identical_completions": sum(
+            record["ar"]["sha256"] == record["mtp"]["sha256"] for record in records
+        ),
+        "ar_mean_tps": round(
+            statistics.mean(record["ar"]["generation_tps"] for record in records),
+            3,
+        ),
+        "mtp_mean_tps": round(
+            statistics.mean(record["mtp"]["generation_tps"] for record in records),
+            3,
+        ),
+        "max_peak_memory_gb": max(
+            record[mode]["peak_memory_gb"]
+            for record in records
+            for mode in ("ar", "mtp")
+        ),
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    default_samples, max_tokens = _task_defaults(args.task)
+    samples = args.samples if args.samples is not None else default_samples
+    if samples <= 0:
+        raise SystemExit("--samples must be positive")
+    plan = {
+        "model": args.model,
+        "mtp_sidecar": args.mtp_sidecar,
+        "task": args.task,
+        "samples": samples,
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "thinking": False,
+        "draft_block_size": args.draft_block_size,
+    }
+    if args.dry_run:
+        print(json.dumps(plan, indent=2))
+        return 0
+
+    from mlx_vlm import load
+    from mlx_vlm.speculative.drafters import load_drafter
+
+    rows = _dataset(args.task, samples)
+    model, processor = load(args.model)
+    drafter, draft_kind = load_drafter(args.mtp_sidecar, kind="mtp")
+    output = args.output
+    stream = output.open("w") if output is not None else sys.stdout
+    records: list[dict[str, Any]] = []
+    try:
+        for index, row in enumerate(rows):
+            raw_prompt, gold = _render_item(args.task, row)
+            prompt = _chat_prompt(processor, raw_prompt)
+            record: dict[str, Any] = {"index": index, "gold": gold}
+            if args.task == "mmlu-pro":
+                record["category"] = row["category"]
+            for mode in ("ar", "mtp"):
+                record[mode] = _condition_result(
+                    mode=mode,
+                    model=model,
+                    processor=processor,
+                    drafter=drafter,
+                    draft_kind=draft_kind,
+                    prompt=prompt,
+                    task=args.task,
+                    gold=gold,
+                    max_tokens=max_tokens,
+                    draft_block_size=args.draft_block_size,
+                )
+            records.append(record)
+            print(json.dumps(record, sort_keys=True), file=stream, flush=True)
+            if (index + 1) % 10 == 0:
+                print(f"completed {index + 1}/{samples}", file=sys.stderr)
+    finally:
+        if output is not None:
+            stream.close()
+
+    print(json.dumps({"plan": plan, "summary": _summarize(records)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/bench_qwen38_mtp_sku.py
+++ b/bench/bench_qwen38_mtp_sku.py
@@ -18,7 +18,9 @@ import argparse
 import hashlib
 import json
 import re
+import shutil
 import statistics
+import subprocess
 import sys
 import urllib.parse
 import urllib.request
@@ -38,11 +40,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--mtp-sidecar", default=DEFAULT_HEAD)
     parser.add_argument(
         "--task",
-        choices=("mmlu-pro", "gsm8k"),
+        choices=("mmlu-pro", "gsm8k", "humaneval"),
         default="mmlu-pro",
     )
     parser.add_argument("--samples", type=int, default=None)
     parser.add_argument("--draft-block-size", type=int, default=3)
+    parser.add_argument("--code-timeout", type=float, default=4.0)
     parser.add_argument("--output", type=Path)
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args()
@@ -51,7 +54,9 @@ def _parse_args() -> argparse.Namespace:
 def _task_defaults(task: str) -> tuple[int, int]:
     if task == "mmlu-pro":
         return 500, 24
-    return 150, 512
+    if task == "gsm8k":
+        return 150, 512
+    return 40, 640
 
 
 def _fetch_rows(dataset: str, config: str, split: str, count: int) -> list[dict]:
@@ -80,7 +85,14 @@ def _fetch_rows(dataset: str, config: str, split: str, count: int) -> list[dict]
 def _dataset(task: str, count: int) -> list[dict]:
     if task == "mmlu-pro":
         return _fetch_rows("TIGER-Lab/MMLU-Pro", "default", "test", count)
-    return _fetch_rows("openai/gsm8k", "main", "test", count)
+    if task == "gsm8k":
+        return _fetch_rows("openai/gsm8k", "main", "test", count)
+    return _fetch_rows(
+        "openai/openai_humaneval",
+        "openai_humaneval",
+        "test",
+        count,
+    )
 
 
 def _render_item(task: str, row: dict) -> tuple[str, str]:
@@ -94,13 +106,20 @@ def _render_item(task: str, row: dict) -> tuple[str, str]:
             f"{row['question']}\n{options}\nAnswer:",
             row["answer"],
         )
-    match = re.search(r"####\s*([-0-9,.]+)", row["answer"])
-    if match is None:
-        raise ValueError("GSM8K answer has no #### final-answer marker")
+    if task == "gsm8k":
+        match = re.search(r"####\s*([-0-9,.]+)", row["answer"])
+        if match is None:
+            raise ValueError("GSM8K answer has no #### final-answer marker")
+        return (
+            "Solve this problem. Give a brief calculation and end with FINAL: "
+            f"followed by only the numeric answer.\n\n{row['question']}",
+            match.group(1).replace(",", ""),
+        )
     return (
-        "Solve this problem. Give a brief calculation and end with FINAL: "
-        f"followed by only the numeric answer.\n\n{row['question']}",
-        match.group(1).replace(",", ""),
+        "Complete this Python function correctly. Return only one Python code "
+        "block containing a complete executable solution, including imports and "
+        f"the function definition.\n\n{row['prompt']}",
+        row["task_id"],
     )
 
 
@@ -108,6 +127,8 @@ def _extract_answer(task: str, text: str) -> str | None:
     if task == "mmlu-pro":
         match = re.search(r"(?:^|\b)([A-J])(?:\b|$)", text.strip().upper())
         return match.group(1) if match else None
+    if task == "humaneval":
+        return None
     matches = re.findall(
         r"FINAL\s*:\s*\$?\s*(-?[\d,]+(?:\.\d+)?)",
         text,
@@ -116,17 +137,56 @@ def _extract_answer(task: str, text: str) -> str | None:
     return matches[-1].replace(",", "") if matches else None
 
 
-def _chat_prompt(processor: Any, prompt: str) -> str:
+def _chat_prompt(processor: Any, prompt: str, *, thinking: bool) -> str:
     kwargs = {"tokenize": False, "add_generation_prompt": True}
     messages = [{"role": "user", "content": prompt}]
     try:
         return processor.apply_chat_template(
             messages,
-            enable_thinking=False,
+            enable_thinking=thinking,
             **kwargs,
         )
     except TypeError:
         return processor.apply_chat_template(messages, **kwargs)
+
+
+def _extract_python(text: str) -> str:
+    blocks = re.findall(r"```(?:python)?\s*(.*?)```", text, re.DOTALL | re.IGNORECASE)
+    if blocks:
+        return blocks[-1].strip()
+    return re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+
+
+def _run_humaneval_sandbox(
+    code: str,
+    row: dict[str, Any],
+    *,
+    timeout: float,
+) -> tuple[bool, str]:
+    """Run one generated solution in a deny-by-default macOS sandbox."""
+
+    sandbox_exec = shutil.which("sandbox-exec")
+    if sandbox_exec is None:
+        raise RuntimeError(
+            "HumanEval requires macOS sandbox-exec; refusing to execute generated "
+            "code directly on the host"
+        )
+    profile = (
+        "(version 1) (deny default) (allow process*) "
+        "(allow file-read*) (allow sysctl-read)"
+    )
+    program = f"{code}\n{row['test']}\ncheck({row['entry_point']})\n"
+    try:
+        result = subprocess.run(
+            [sandbox_exec, "-p", profile, "/usr/bin/python3", "-c", program],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "timeout"
+    return result.returncode == 0, result.stderr[-500:]
 
 
 def _condition_result(
@@ -141,6 +201,8 @@ def _condition_result(
     gold: str,
     max_tokens: int,
     draft_block_size: int,
+    row: dict[str, Any],
+    code_timeout: float,
 ) -> dict[str, Any]:
     from mlx_vlm import generate
 
@@ -157,15 +219,28 @@ def _condition_result(
         )
     result = generate(model, processor, prompt, **kwargs)
     prediction = _extract_answer(task, result.text)
-    return {
+    correct = prediction == gold
+    sandbox_error = None
+    completion = result.text
+    if task == "humaneval":
+        completion = _extract_python(result.text)
+        correct, sandbox_error = _run_humaneval_sandbox(
+            completion,
+            row,
+            timeout=code_timeout,
+        )
+    record = {
         "prediction": prediction,
-        "correct": prediction == gold,
+        "correct": correct,
         "generation_tokens": result.generation_tokens,
         "generation_tps": round(result.generation_tps, 3),
         "peak_memory_gb": round(result.peak_memory, 3),
         "finish_reason": result.finish_reason,
-        "sha256": hashlib.sha256(result.text.encode()).hexdigest(),
+        "sha256": hashlib.sha256(completion.encode()).hexdigest(),
     }
+    if sandbox_error and not correct:
+        record["sandbox_error"] = sandbox_error
+    return record
 
 
 def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
@@ -210,7 +285,7 @@ def main() -> int:
         "samples": samples,
         "max_tokens": max_tokens,
         "temperature": 0,
-        "thinking": False,
+        "thinking": args.task == "humaneval",
         "draft_block_size": args.draft_block_size,
     }
     if args.dry_run:
@@ -229,7 +304,11 @@ def main() -> int:
     try:
         for index, row in enumerate(rows):
             raw_prompt, gold = _render_item(args.task, row)
-            prompt = _chat_prompt(processor, raw_prompt)
+            prompt = _chat_prompt(
+                processor,
+                raw_prompt,
+                thinking=args.task == "humaneval",
+            )
             record: dict[str, Any] = {"index": index, "gold": gold}
             if args.task == "mmlu-pro":
                 record["category"] = row["category"]
@@ -245,6 +324,8 @@ def main() -> int:
                     gold=gold,
                     max_tokens=max_tokens,
                     draft_block_size=args.draft_block_size,
+                    row=row,
+                    code_timeout=args.code_timeout,
                 )
             records.append(record)
             print(json.dumps(record, sort_keys=True), file=stream, flush=True)

--- a/bench/build_qwen38_mtplx_candidate.py
+++ b/bench/build_qwen38_mtplx_candidate.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Assemble a zero-copy MTPLX experiment view over the mixed Qwen3.8 base.
+
+This does not requantize or rewrite the backbone.  It creates symlinks to the
+already-audited mixed-3.5bpw files, adds MTPLX's precision-specific MTP
+sidecar, and stamps only the runtime metadata MTPLX needs to load the pair.
+The resulting directory is an experiment view, not a publishable artifact;
+publishing must materialize the links and record immutable source revisions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", type=Path, required=True)
+    parser.add_argument("--mtplx-reference", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--promote",
+        action="append",
+        choices=(
+            "linear-out-all",
+            "linear-out-last16",
+            "last8-mlp",
+            "lm-head",
+            "embed",
+        ),
+        default=[],
+        help="Copy selected Q8 modules from the MTPLX reference into an overlay",
+    )
+    parser.add_argument(
+        "--materialize-backbone",
+        action="store_true",
+        help="Rewrite base shards without promoted keys (required by glob loaders)",
+    )
+    return parser.parse_args()
+
+
+def _read_json(path: Path) -> dict:
+    with path.open() as stream:
+        return json.load(stream)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _selected_module(key: str, promotions: set[str]) -> str | None:
+    suffixes = (".weight", ".scales", ".biases")
+    module = next((key.removesuffix(s) for s in suffixes if key.endswith(s)), None)
+    if module is None:
+        return None
+    if "lm-head" in promotions and module == "language_model.lm_head":
+        return module
+    if "embed" in promotions and module == "language_model.model.embed_tokens":
+        return module
+    if ".linear_attn.out_proj" in module:
+        if "linear-out-all" in promotions:
+            return module
+        if "linear-out-last16" in promotions:
+            layer = int(module.split(".layers.", 1)[1].split(".", 1)[0])
+            if layer >= 48:
+                return module
+    if "last8-mlp" in promotions and ".mlp." in module:
+        layer = int(module.split(".layers.", 1)[1].split(".", 1)[0])
+        if layer >= 56:
+            return module
+    return None
+
+
+def _build_overlay(
+    *, base: Path, reference: Path, output: Path, config: dict, promotions: set[str]
+) -> set[str]:
+    if not promotions:
+        return set()
+    from safetensors import safe_open
+    from safetensors.numpy import save_file
+
+    base_index = _read_json(base / "model.safetensors.index.json")
+    ref_index = _read_json(reference / "model.safetensors.index.json")
+    ref_quant = _read_json(reference / "config.json")["quantization"]
+    selected: dict[str, str] = {}
+    modules: set[str] = set()
+    for key, shard in ref_index["weight_map"].items():
+        module = _selected_module(key, promotions)
+        if module is not None and key in base_index["weight_map"]:
+            selected[key] = shard
+            modules.add(module)
+    if not selected:
+        raise RuntimeError(f"promotions selected no tensors: {sorted(promotions)}")
+
+    by_shard: dict[str, list[str]] = defaultdict(list)
+    for key, shard in selected.items():
+        by_shard[shard].append(key)
+    tensors = {}
+    for shard, keys in by_shard.items():
+        with safe_open(reference / shard, framework="numpy") as stream:
+            for key in keys:
+                tensors[key] = stream.get_tensor(key)
+    # mlx-lm discovers checkpoint shards with ``model*.safetensors`` rather
+    # than trusting the index alone. Keep the promotion overlay in that glob;
+    # a custom name appears in the index but is silently skipped at load time.
+    overlay_name = "model-promoted-q8.safetensors"
+    save_file(tensors, output / overlay_name)
+    for key in selected:
+        base_index["weight_map"][key] = overlay_name
+    _write_json(output / "model.safetensors.index.json", base_index)
+
+    quant = config["quantization"]
+    for module in sorted(modules):
+        if module not in ref_quant:
+            raise RuntimeError(f"reference config has no quantization rule for {module}")
+        quant[module] = ref_quant[module]
+    return set(selected)
+
+
+def _materialize_base_shards(
+    *, base: Path, output: Path, excluded_keys: set[str]
+) -> None:
+    import mlx.core as mx
+
+    index = _read_json(base / "model.safetensors.index.json")
+    by_shard: dict[str, list[str]] = defaultdict(list)
+    for key, shard in index["weight_map"].items():
+        if key not in excluded_keys:
+            by_shard[shard].append(key)
+    for shard, keys in sorted(by_shard.items()):
+        source = base / shard
+        # ``safe_open(..., framework='mlx')`` currently routes BF16 through
+        # NumPy on some safetensors builds and raises "bfloat16 not
+        # understood". MLX's native loader preserves BF16 and remains lazy.
+        all_tensors = mx.load(str(source))
+        tensors = {key: all_tensors[key] for key in keys}
+        mx.save_safetensors(str(output / shard), tensors)
+        del tensors, all_tensors
+        mx.clear_cache()
+
+
+def main() -> int:
+    args = _args()
+    base = args.base.resolve(strict=True)
+    reference = args.mtplx_reference.resolve(strict=True)
+    output = args.output
+    if output.exists() and any(output.iterdir()):
+        raise SystemExit(f"refusing to overwrite non-empty output: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+
+    if args.promote and not args.materialize_backbone:
+        raise SystemExit("--promote requires --materialize-backbone for MLX glob loaders")
+
+    for source in base.iterdir():
+        if source.name in {"config.json", "model.safetensors.index.json"}:
+            continue
+        if args.materialize_backbone and source.name.startswith("model-"):
+            continue
+        (output / source.name).symlink_to(source)
+
+    mtp_source = reference / "mtp.safetensors"
+    (output / "mtp.safetensors").symlink_to(mtp_source.resolve(strict=True))
+
+    ref_config = _read_json(reference / "config.json")
+    contract = ref_config["mtplx_mtp_contract"]
+    config = _read_json(base / "config.json")
+    config["mlx_lm_extra_tensors"] = {"mtp_file": "mtp.safetensors"}
+    config["mtplx_mtp_contract"] = contract
+    promoted_keys = _build_overlay(
+        base=base,
+        reference=reference,
+        output=output,
+        config=config,
+        promotions=set(args.promote),
+    )
+    if args.materialize_backbone:
+        _materialize_base_shards(
+            base=base,
+            output=output,
+            excluded_keys=promoted_keys,
+        )
+    _write_json(output / "config.json", config)
+
+    if not (output / "model.safetensors.index.json").exists():
+        (output / "model.safetensors.index.json").symlink_to(
+            base / "model.safetensors.index.json"
+        )
+
+    ref_runtime = _read_json(reference / "mtplx_runtime.json")
+    runtime = {
+        "arch_id": ref_runtime["arch_id"],
+        "artifact_role": "rapid-mlx-experiment-view",
+        "base_trunk": os.fspath(base),
+        "exactness_baseline": {},
+        "mtp_contract": contract,
+        "mtp_depth_default": ref_runtime.get("mtp_depth_default", 3),
+        "mtp_depth_max": ref_runtime.get("mtp_depth_max", 3),
+        "mtp_sidecar": ref_runtime.get("mtp_sidecar", "fp16"),
+        "mtplx_version": ref_runtime.get("mtplx_version"),
+        "precision_variant": ref_runtime.get("precision_variant", "fp16"),
+        "public_model_id": "rapid-qwen38-27b-mixed-3.5bpw-mtplx-experiment",
+        "recommended_draft_sampler": ref_runtime.get(
+            "recommended_draft_sampler",
+            {"temperature": 1.0, "top_p": 0.95, "top_k": 20},
+        ),
+        "recommended_profile": ref_runtime.get("recommended_profile", "turbo"),
+        "verified_on": {
+            "status": "unverified",
+            "model": "Qwen3.8-27B-mixed-3.5bpw-MTPLX-experiment",
+        },
+        "rapid_mlx_candidate": {
+            "backbone_unchanged": True,
+            "base": os.fspath(base),
+            "mtp_reference": os.fspath(reference),
+            "purpose": "runtime compatibility and speed experiment only",
+            "promotions": sorted(set(args.promote)),
+        },
+    }
+    _write_json(output / "mtplx_runtime.json", runtime)
+    print(output.resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/build_qwen38_mtplx_candidate.py
+++ b/bench/build_qwen38_mtplx_candidate.py
@@ -116,7 +116,9 @@ def _build_overlay(
     quant = config["quantization"]
     for module in sorted(modules):
         if module not in ref_quant:
-            raise RuntimeError(f"reference config has no quantization rule for {module}")
+            raise RuntimeError(
+                f"reference config has no quantization rule for {module}"
+            )
         quant[module] = ref_quant[module]
     return set(selected)
 
@@ -153,7 +155,9 @@ def main() -> int:
     output.mkdir(parents=True, exist_ok=True)
 
     if args.promote and not args.materialize_backbone:
-        raise SystemExit("--promote requires --materialize-backbone for MLX glob loaders")
+        raise SystemExit(
+            "--promote requires --materialize-backbone for MLX glob loaders"
+        )
 
     for source in base.iterdir():
         if source.name in {"config.json", "model.safetensors.index.json"}:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -58,7 +58,7 @@ The base text-only install is ~460 MB. Vision/audio/etc. ship as opt-in extras.
 | Extra | Install | Adds |
 |---|---|---|
 | `vision` | `pip install 'rapid-mlx[vision]'` | mlx-vlm + opencv + torch (~322 MB) for VLMs (Gemma 4, Qwen-VL, video) |
-| `dflash` | `pip install 'rapid-mlx[dflash]'` | mlx-vlm for DFlash speculative decoding on supported 8-bit aliases |
+| `dflash` | `pip install 'rapid-mlx[dflash]'` | Lightweight mlx-vlm runtime for DFlash and single-user `mtp-fast` decoding |
 | `audio` | `pip install 'rapid-mlx[audio]'` | mlx-audio + spacy + scipy (~600 MB) for TTS / STT |
 | `embeddings` | `pip install 'rapid-mlx[embeddings]'` | mlx-embeddings (~50 MB) for `/v1/embeddings` |
 | `chat` | `pip install 'rapid-mlx[chat]'` | Gradio web UI (~150 MB) |
@@ -66,7 +66,8 @@ The base text-only install is ~460 MB. Vision/audio/etc. ship as opt-in extras.
 | `all` | `pip install 'rapid-mlx[all]'` | Everything above (~1.1 GB) |
 
 Homebrew installs the text-only package and does not provide Python extras.
-To switch a Homebrew installation to DFlash, use an isolated tool install:
+To switch a Homebrew installation to DFlash or `mtp-fast`, use an isolated
+tool install:
 
 ```bash
 brew uninstall rapid-mlx

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -144,6 +144,11 @@ rapid-mlx serve <mtp-eligible-qwen-checkpoint> \
 rapid-mlx serve qwen3.6-27b-8bit \
   --speculative-config '{"method":"mtp","model":"mlx-community/Qwen3.6-27B-MTP-4bit","num_speculative_tokens":3}'
 
+# Throughput-oriented single-user MTP for the compact Qwen3.8-27B build.
+# Long outputs use mlx-vlm MTP; max_tokens <= 64 automatically uses AR.
+rapid-mlx serve rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX \
+  --speculative-config '{"method":"mtp-fast","model":"mlx-community/Qwen3.8-27B-MTP-4bit","min_output_tokens":64}'
+
 # SuffixDecoding for explicit high-overlap workloads
 rapid-mlx serve gemma-4-12b-4bit \
   --speculative-config '{"method":"suffix","num_speculative_tokens":8}'

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -74,7 +74,14 @@ into the same config path.
 | `{"method":"mtp","model":"<sidecar-head-repo>"}` | Attach a standalone MTP **sidecar head** (e.g. `mlx-community/Qwen3.6-27B-MTP-4bit`) to a full base checkpoint. The base must be MTP-eligible; the head repo goes in the `model` field — **not** in the `serve` positional. See [MTP sidecar heads are not standalone models](#mtp-sidecar-heads-are-not-standalone-models) below. Gemma 4 sidecar MTP remains disabled after its greedy-lossless A/B failed. |
 | `{"method":"mtp","num_speculative_tokens":3}` | Set the MTP max-K controller ceiling. |
 | `{"method":"mtp","disable_auto_k":true}` | Disable the MTP EV depth controller for fixed-K parity benches. |
+| `{"method":"mtp-fast","model":"<sidecar-head-repo>"}` | Enable the mlx-vlm single-user MTP throughput lane. This is distinct from the lossless batched `mtp` engine, supports image inputs, and automatically uses AR when `max_tokens` is 64 or lower. Requires `rapid-mlx[dflash]` (or `[vision]` for a full multimodal install). |
 | `{"method":"suffix","num_speculative_tokens":8}` | Enable explicit SuffixDecoding for high-overlap workloads. |
+
+`mtp-fast` is deliberately opt-in and hardware-sensitive. The audited
+Qwen3.8-27B mixed-3.5bpw pair measured about 1.5–1.6x on M3 Ultra, but was
+slightly slower than AR on M2 Pro. Use it for long, single-user generation on
+hardware where an A/B proves a win; keep the regular batched server for
+multi-user throughput.
 
 #### MTP is not free — measure before you enable it
 

--- a/reports/benchmarks/qwen38-27b-mtp-sku.md
+++ b/reports/benchmarks/qwen38-27b-mtp-sku.md
@@ -1,0 +1,92 @@
+# Qwen3.8-27B compact MTP SKU gate
+
+Date: 2026-08-16
+
+## Product decision
+
+Ship the existing mixed-precision backbone plus the official Q4 MTP sidecar,
+rather than publishing a larger MTPLX-specific requantization:
+
+- backbone: `rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX`
+  (`d8b68e21eab505332d4a456dacec6d4125c96d73`)
+- sidecar: `mlx-community/Qwen3.8-27B-MTP-4bit`
+  (`b643c01b6d3b094e325edb6ebd832e16c486c575`)
+- combined payload: 13,872,252 KiB (about 13.23 GiB)
+- sidecar `model.safetensors` SHA-256:
+  `76663c101e7e8ea9c0ae17bcb95183cd7f733ce424c912b8b264a7b1c48e4cc6`
+
+This composition is smaller and faster on the target Studio than the tested
+15 GiB MTPLX-specific candidate. Rapid exposes it through the explicit
+`mtp-fast` single-user lane and leaves the existing lossless batched MTP path
+unchanged.
+
+## Speed and memory
+
+M3 Ultra Studio, mlx-vlm MTP, block size 3:
+
+| workload | AR | MTP | speedup | peak |
+|---|---:|---:|---:|---:|
+| short text | 39.7 tok/s | 62.4 tok/s | 1.57x | about 15.3 GB |
+| 1K prompt + 256 output | 38.67 tok/s | 58.44 tok/s | 1.51x | 17.09 GB |
+| 2K prompt + 256 output | 38.36 tok/s | 59.78 tok/s | 1.56x | 18.76 GB |
+| 4K prompt + 256 output | 38.28 tok/s | 57.50 tok/s | 1.50x | not used for the low-memory gate |
+
+Rapid OpenAI-server dogfood on the same Studio produced 256 tokens in 4.05 s
+(about 63 tok/s end-to-end), returned valid SSE termination, parsed a Hermes
+tool call, and processed a real image payload.
+
+M2 Pro Mini is not an MTP-fast target: the same mlx-vlm path measured 11.06
+tok/s AR versus 10.67 tok/s MTP. Keep the lane opt-in until hardware-aware
+autotuning can prove a win on the current machine. Short outputs are always
+routed to AR (default threshold: `max_tokens <= 64`).
+
+An 18 GB Mac is a constrained tier, not the default claim. A 1K-context run
+stayed at 17.09 decimal GB peak; 2K reached 18.76 GB before OS/application
+headroom. Recommend a 1K context cap and AR fallback on that tier. The 24 GB
+tier has adequate headroom for the normal MTP path.
+
+## Capability gates
+
+All comparisons use the same backbone and paired prompts, greedy decoding:
+
+| gate | AR | MTP | paired result |
+|---|---:|---:|---|
+| MMLU-Pro 500 | 224/500 | 224/500 | 500/500 byte-identical |
+| GSM8K 150 | 143/150 | 144/150 | MTP +1, AR +0 |
+| HumanEval 40 | 22/40 adjusted | 22/40 adjusted | four apparent flips vanished at 1280-token rerun |
+| MMBench-EN 300 | 260/300 | 260/300 | 300/300 byte-identical |
+
+The HumanEval absolute number is from the local paired harness, not the
+model-card EvalPlus harness. The paired conclusion is the gate being used.
+MMBench is a one-letter, image-prefill-dominated workload: MTP measured 0.999x,
+which validates the production decision to route `max_tokens <= 64` to AR.
+
+Raw Studio artifacts live under
+`/Users/raullenstudio/qwen38-mtp-24gb/results/`; Mini MTPLX artifacts live
+under `/Volumes/mac-storage/qwen38-mtp-mixed/`.
+
+## Rejected artifact experiments
+
+MTPLX 2.7.2 verify kernels specialize 4/8-bit operations; the mixed backbone
+contains many 2/3-bit modules. A direct MTP graft reached only 1.17x on Mini.
+Promoting every linear-attention output projection to Q8 produced a roughly
+15 GiB candidate and recovered a 1.65x multiplier on Mini (13.81 tok/s), but
+only 44.62 tok/s on Studio versus the 62.4 tok/s mlx-vlm composition. Promoting
+only the last 16 layers reached 1.07x. Neither candidate beats the smaller
+unchanged backbone plus Q4 sidecar, so neither should be published.
+
+## Reproduction
+
+- `bench/bench_qwen38_mtp_sku.py`: paired MMLU-Pro, GSM8K, HumanEval
+- `bench/bench_qwen38_mtp_context.py`: controlled context/memory gate
+- `bench/bench_qwen38_mtp_mmbench.py`: paired multimodal MMBench gate
+- `bench/build_qwen38_mtplx_candidate.py`: rejected precision-allocation
+  experiments
+
+Server invocation:
+
+```bash
+rapid-mlx serve rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX \
+  --speculative-config \
+  '{"method":"mtp-fast","model":"mlx-community/Qwen3.8-27B-MTP-4bit","min_output_tokens":64}'
+```

--- a/tests/test_bench_qwen38_mtp_mmbench.py
+++ b/tests/test_bench_qwen38_mtp_mmbench.py
@@ -1,0 +1,48 @@
+from bench.bench_qwen38_mtp_mmbench import _answer, _summary
+
+
+def test_answer_uses_post_thinking_option() -> None:
+    assert _answer("A maybe</think>final B") == "B"
+    assert _answer("no option") is None
+
+
+def test_summary_reports_paired_flips_and_speedup() -> None:
+    records = [
+        {
+            "index": 1,
+            "mode": "ar",
+            "correct": True,
+            "generation_tps": 10.0,
+            "sha256": "same",
+        },
+        {
+            "index": 1,
+            "mode": "mtp",
+            "correct": True,
+            "generation_tps": 15.0,
+            "sha256": "same",
+        },
+        {
+            "index": 2,
+            "mode": "ar",
+            "correct": False,
+            "generation_tps": 10.0,
+            "sha256": "ar",
+        },
+        {
+            "index": 2,
+            "mode": "mtp",
+            "correct": True,
+            "generation_tps": 15.0,
+            "sha256": "mtp",
+        },
+    ]
+
+    summary = _summary(records)
+
+    assert summary["ar"]["accuracy"] == 0.5
+    assert summary["mtp"]["accuracy"] == 1.0
+    assert summary["paired"]["mtp_only_correct"] == 1
+    assert summary["paired"]["ar_only_correct"] == 0
+    assert summary["paired"]["identical_outputs"] == 1
+    assert summary["speedup"] == 1.5

--- a/tests/test_bench_qwen38_mtp_sku.py
+++ b/tests/test_bench_qwen38_mtp_sku.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parents[1] / "bench" / "bench_qwen38_mtp_sku.py"
+_SPEC = importlib.util.spec_from_file_location("bench_qwen38_mtp_sku", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+bench = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(bench)
+
+
+def test_extract_mmlu_letter_and_gsm_final_answer() -> None:
+    assert bench._extract_answer("mmlu-pro", "B") == "B"
+    assert bench._extract_answer("mmlu-pro", "Answer: I") == "I"
+    assert bench._extract_answer("gsm8k", "work\nFINAL: $1,234") == "1234"
+    assert bench._extract_answer("gsm8k", "work\nFINAL: -12.5") == "-12.5"
+
+
+def test_render_gsm_normalizes_gold_commas() -> None:
+    prompt, gold = bench._render_item(
+        "gsm8k",
+        {"question": "What is it?", "answer": "reasoning\n#### 1,234"},
+    )
+    assert "What is it?" in prompt
+    assert gold == "1234"
+
+
+def test_summary_reports_paired_flips_and_hashes() -> None:
+    records = [
+        {
+            "ar": {
+                "correct": True,
+                "sha256": "same",
+                "generation_tps": 10.0,
+                "peak_memory_gb": 14.0,
+            },
+            "mtp": {
+                "correct": True,
+                "sha256": "same",
+                "generation_tps": 16.0,
+                "peak_memory_gb": 15.0,
+            },
+        },
+        {
+            "ar": {
+                "correct": True,
+                "sha256": "ar",
+                "generation_tps": 12.0,
+                "peak_memory_gb": 14.2,
+            },
+            "mtp": {
+                "correct": False,
+                "sha256": "mtp",
+                "generation_tps": 18.0,
+                "peak_memory_gb": 15.2,
+            },
+        },
+    ]
+
+    summary = bench._summarize(records)
+
+    assert summary == {
+        "samples": 2,
+        "ar_correct": 2,
+        "mtp_correct": 1,
+        "ar_only_correct": 1,
+        "mtp_only_correct": 0,
+        "identical_completions": 1,
+        "ar_mean_tps": 11.0,
+        "mtp_mean_tps": 17.0,
+        "max_peak_memory_gb": 15.2,
+    }

--- a/tests/test_bench_qwen38_mtp_sku.py
+++ b/tests/test_bench_qwen38_mtp_sku.py
@@ -26,6 +26,15 @@ def test_render_gsm_normalizes_gold_commas() -> None:
     assert gold == "1234"
 
 
+def test_extract_python_prefers_fenced_completion() -> None:
+    text = "analysis first\n```python\ndef answer():\n    return 42\n```"
+    assert bench._extract_python(text) == "def answer():\n    return 42"
+
+
+def test_humaneval_defaults_match_model_card_gate() -> None:
+    assert bench._task_defaults("humaneval") == (40, 640)
+
+
 def test_summary_reports_paired_flips_and_hashes() -> None:
     records = [
         {

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -386,6 +386,124 @@ def test_healthz_and_models_routes() -> None:
     assert body["data"][0]["id"] == "qwen3.5-27b-8bit"
 
 
+@_skip_without_mlx_vlm
+@pytest.mark.parametrize(("max_tokens", "uses_drafter"), [(32, False), (128, True)])
+def test_mtp_fast_short_output_gate(monkeypatch, max_tokens, uses_drafter) -> None:
+    """The throughput lane must leave short classification answers on AR."""
+    import mlx_vlm
+    import mlx_vlm.prompt_utils
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        mlx_vlm.prompt_utils,
+        "apply_chat_template",
+        lambda *args, **kwargs: "rendered prompt",
+    )
+
+    def _generate(*args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(text="ok", prompt_tokens=4, generation_tokens=1)
+
+    monkeypatch.setattr(mlx_vlm, "generate", _generate)
+    drafter = MagicMock()
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=drafter,
+            kind="mtp",
+            drafter_repo="mlx-community/Qwen3.8-27B-MTP-4bit",
+        ),
+        served_model_name="qwen3.8-27b-mixed-3.5bpw",
+        default_max_tokens=512,
+        cors_origins=["*"],
+        runtime_label="MTP fast",
+        min_speculative_output_tokens=64,
+    )
+
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.8-27b-mixed-3.5bpw",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": max_tokens,
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert (captured.get("draft_model") is drafter) is uses_drafter
+    assert (captured.get("draft_kind") == "mtp") is uses_drafter
+
+
+@_skip_without_mlx_vlm
+def test_mtp_fast_preserves_image_parts(monkeypatch) -> None:
+    """The VLM lane must pass images to generation instead of hallucinating."""
+    import mlx_vlm
+    import mlx_vlm.prompt_utils
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.models import mllm
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+    from vllm_mlx.speculative.dflash.server import _build_app
+
+    captured: dict = {}
+
+    def _template(*args, **kwargs):
+        captured["template_kwargs"] = kwargs
+        captured["messages"] = args[2]
+        return "rendered multimodal prompt"
+
+    monkeypatch.setattr(mlx_vlm.prompt_utils, "apply_chat_template", _template)
+    monkeypatch.setattr(mllm, "process_image_input", lambda _value: "/tmp/image.png")
+
+    def _generate(*args, **kwargs):
+        captured["generate_kwargs"] = kwargs
+        return SimpleNamespace(text="image", prompt_tokens=4, generation_tokens=1)
+
+    monkeypatch.setattr(mlx_vlm, "generate", _generate)
+    app = _build_app(
+        model=MagicMock(),
+        processor=MagicMock(),
+        runtime=DFlashRuntime(
+            drafter=MagicMock(),
+            kind="mtp",
+            drafter_repo="mlx-community/Qwen3.8-27B-MTP-4bit",
+        ),
+        served_model_name="qwen3.8-27b-mixed-3.5bpw",
+        default_max_tokens=512,
+        cors_origins=["*"],
+        allow_multimodal=True,
+    )
+
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3.8-27b-mixed-3.5bpw",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,AA=="},
+                        },
+                    ],
+                }
+            ],
+            "max_tokens": 96,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert captured["template_kwargs"]["num_images"] == 1
+    assert captured["messages"][0]["content"][1] == {"type": "image"}
+    assert captured["generate_kwargs"]["image"] == ["/tmp/image.png"]
+
+
 def test_run_dflash_server_wires_security_configuration(monkeypatch) -> None:
     """DFlash must enforce the same auth, rate, and body guards as serve.
 

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -65,6 +65,18 @@ def test_parse_dspark_speculative_config_accepts_native_depth() -> None:
     assert cfg.num_speculative_tokens == 5
 
 
+def test_parse_mtp_fast_config_accepts_sidecar_and_short_output_gate() -> None:
+    cfg = parse_speculative_config(
+        '{"method":"mtp-fast","model":"mlx-community/Qwen3.8-27B-MTP-4bit",'
+        '"min_output_tokens":96}'
+    )
+
+    assert cfg is not None
+    assert cfg.method == "mtp-fast"
+    assert cfg.model == "mlx-community/Qwen3.8-27B-MTP-4bit"
+    assert cfg.min_output_tokens == 96
+
+
 def test_parse_speculative_config_normalizes_registered_alias() -> None:
     cfg = parse_speculative_config('{"method":"ngram"}')
 
@@ -226,6 +238,7 @@ def _spec_config_args(**overrides):
         "speculative_config": None,
         "enable_ddtree": False,
         "enable_dflash": False,
+        "enable_mtp_fast": False,
         "spec_decode": "none",
         "dflash_drafter_path": "",
         "mtp_num_draft_tokens": 1,
@@ -241,6 +254,26 @@ def _spec_config_args(**overrides):
     }
     data.update(overrides)
     return SimpleNamespace(**data)
+
+
+def test_speculative_config_mtp_fast_selects_dedicated_runtime() -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        speculative_config=(
+            '{"method":"mtp-fast",'
+            '"model":"mlx-community/Qwen3.8-27B-MTP-4bit",'
+            '"min_output_tokens":96}'
+        )
+    )
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.enable_mtp_fast is True
+    assert args.spec_decode == "none"
+    assert args.mtp_sidecar == "mlx-community/Qwen3.8-27B-MTP-4bit"
+    assert args.mtp_fast_min_output_tokens == 96
+    assert args.enable_dflash is False
 
 
 def test_speculative_config_mtp_normalizes_to_legacy_spec_decode() -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1915,6 +1915,8 @@ def _normalize_speculative_config_or_exit(args):
             "spec_decode": "none",
             "dflash_drafter_path": "",
             "enable_mtp": False,
+            "enable_mtp_fast": False,
+            "mtp_fast_min_output_tokens": 64,
             "mtp_num_draft_tokens": 1,
             "mtp_optimistic": False,
             "mtp_sidecar": None,
@@ -1941,6 +1943,8 @@ def _normalize_speculative_config_or_exit(args):
             conflicts.append("dflash_drafter_path")
         if getattr(args, "enable_mtp", False):
             conflicts.append("enable_mtp")
+        if getattr(args, "enable_mtp_fast", False):
+            conflicts.append("enable_mtp_fast")
         if (getattr(args, "mtp_sidecar", None) or "").strip():
             conflicts.append("mtp_sidecar")
         # Idempotency guard: after ``_fill_runtime_defaults(overwrite=True)``
@@ -1987,6 +1991,8 @@ def _normalize_speculative_config_or_exit(args):
             fields.append("dflash_drafter_path")
         if getattr(args, "enable_mtp", False):
             fields.append("enable_mtp")
+        if getattr(args, "enable_mtp_fast", False):
+            fields.append("enable_mtp_fast")
         if (getattr(args, "mtp_sidecar", None) or "").strip():
             fields.append("mtp_sidecar")
         if getattr(args, "mtp_max_k", None) is not None:
@@ -2220,6 +2226,10 @@ def _normalize_speculative_config_or_exit(args):
             args.mtp_max_k = 3
         if config.disable_auto_k is not None:
             args.mtp_disable_auto_k = config.disable_auto_k
+    elif config.method == "mtp-fast":
+        args.enable_mtp_fast = True
+        args.mtp_sidecar = config.model
+        args.mtp_fast_min_output_tokens = config.min_output_tokens or 64
     elif config.method == "suffix":
         args.suffix_decoding = True
         if config.num_speculative_tokens is not None:
@@ -2674,14 +2684,15 @@ def serve_command(args):
     # find_spec("mlx_vlm")`` doesn't trigger a load — safe to run on the
     # hot CLI path.
     _wants_dflash = getattr(args, "enable_dflash", False)
-    if _wants_dflash:
+    _wants_mtp_fast = getattr(args, "enable_mtp_fast", False)
+    if _wants_dflash or _wants_mtp_fast:
         from .speculative.dflash.eligibility import have_runtime
 
         if not have_runtime():
+            _mode = "DFlash" if _wants_dflash else "MTP fast"
             print(
-                "\n  Error: DFlash speculative decoding "
-                '(--speculative-config \'{"method":"dflash"}\') requires '
-                "mlx-vlm 0.5.0+ for the DFlash drafter hooks.\n"
+                f"\n  Error: {_mode} speculative decoding requires "
+                "mlx-vlm 0.5.0+ for the drafter hooks.\n"
                 "\n  Install in a Python environment with:\n"
                 "    pip install 'rapid-mlx[dflash]'\n"
                 "\n  Homebrew installs the text-only package. Homebrew users "
@@ -2690,6 +2701,15 @@ def serve_command(args):
                 "    uv tool install 'rapid-mlx[dflash]'\n"
             )
             sys.exit(1)
+    if _wants_mtp_fast and not (getattr(args, "mtp_sidecar", None) or "").strip():
+        print(
+            "\n  Error: MTP fast mode requires an explicit sidecar model, e.g. "
+            "--speculative-config "
+            "'{\"method\":\"mtp-fast\",\"model\":"
+            "\"mlx-community/Qwen3.8-27B-MTP-4bit\"}'.\n",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     # R10-C1: AUDIO-SERVE-MODE FORK. The boot guard above only checks
     # that the ``[audio]`` extra is installed — it doesn't route the
@@ -3357,9 +3377,9 @@ def serve_command(args):
         features.append(auth_feature)
     if args.rate_limit > 0:
         features.append(f"rate-limit: {args.rate_limit}/min")
-    if gc_control and not args.enable_dflash:
+    if gc_control and not (args.enable_dflash or args.enable_mtp_fast):
         features.append("gc-control")
-    if args.pin_system_prompt and not args.enable_dflash:
+    if args.pin_system_prompt and not (args.enable_dflash or args.enable_mtp_fast):
         features.append("pin-system-prompt")
     # Show CORS in the startup banner when CLI flag or env-var-driven
     # config produced an origin list (``configure_cors_from_env`` is what
@@ -3368,13 +3388,18 @@ def serve_command(args):
         features.append(f"cors: {', '.join(cors_origins)}")
     if args.enable_dflash:
         features.append("dflash: single-user")
+    if args.enable_mtp_fast:
+        features.append(
+            f"mtp-fast: single-user (AR for max_tokens <= "
+            f"{args.mtp_fast_min_output_tokens})"
+        )
     if args.enable_ddtree:
         features.append("ddtree: experimental single-user")
     if features:
         print(f"  Features: {', '.join(features)}")
     print(f"  Model: {args.model}")
     # Store MCP config path for FastAPI startup
-    if args.mcp_config and not args.enable_dflash:
+    if args.mcp_config and not (args.enable_dflash or args.enable_mtp_fast):
         print(f"MCP config: {args.mcp_config}")
         os.environ["RAPID_MLX_MCP_CONFIG"] = args.mcp_config
 
@@ -3423,6 +3448,50 @@ def serve_command(args):
                 args.tool_call_parser if args.enable_auto_tool_choice else None
             ),
             reasoning_parser_name=args.reasoning_parser,
+        )
+        return
+
+    # Throughput-oriented MTP uses mlx-vlm's single-user draft/verify lane.
+    # It is deliberately a separate method from the existing lossless MTP
+    # engine: callers must explicitly choose the numerical trade-off, and
+    # short outputs automatically bypass speculation because setup overhead
+    # dominates there.
+    if args.enable_mtp_fast:
+        from .speculative.dflash.server import run_dflash_server
+
+        _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
+        _check_memory_capacity(args.model)
+        server._sync_config()
+        run_dflash_server(
+            main_model_repo=args.model,
+            drafter_repo=args.mtp_sidecar,
+            host=args.host,
+            port=args.port,
+            served_model_name=(
+                args.served_model_name
+                or getattr(args, "_original_alias", None)
+                or args.model
+            ),
+            default_max_tokens=effective_max_tokens,
+            cors_origins=cors_origins,
+            uvicorn_log_level=uvicorn_log_level,
+            no_thinking=args.no_thinking,
+            api_key=server._api_key,
+            rate_limit=args.rate_limit,
+            max_request_bytes=server._max_request_bytes,
+            body_receive_timeout_seconds=server._body_receive_timeout_seconds,
+            default_timeout=server._default_timeout,
+            max_concurrent_requests=args.max_concurrent_requests,
+            cors_policy=server.get_resolved_cors_policy(),
+            tool_call_parser=(
+                args.tool_call_parser if args.enable_auto_tool_choice else None
+            ),
+            reasoning_parser_name=args.reasoning_parser,
+            draft_kind="mtp",
+            runtime_label="MTP fast",
+            allow_4bit_target=True,
+            min_speculative_output_tokens=args.mtp_fast_min_output_tokens,
+            allow_multimodal=True,
         )
         return
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2705,8 +2705,8 @@ def serve_command(args):
         print(
             "\n  Error: MTP fast mode requires an explicit sidecar model, e.g. "
             "--speculative-config "
-            "'{\"method\":\"mtp-fast\",\"model\":"
-            "\"mlx-community/Qwen3.8-27B-MTP-4bit\"}'.\n",
+            '\'{"method":"mtp-fast","model":'
+            '"mlx-community/Qwen3.8-27B-MTP-4bit"}\'.\n',
             file=sys.stderr,
         )
         sys.exit(2)

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -32,6 +32,7 @@ class SpeculativeConfig:
     max_suffix_len: int | None = None
     min_confidence: float | None = None
     min_draft_len: int | None = None
+    min_output_tokens: int | None = None
     raw: dict[str, Any] | None = None
 
 
@@ -46,6 +47,10 @@ _METHOD_KEYS = {
     "dflash": frozenset({"model"}),
     "dspark": frozenset({"num_speculative_tokens"}),
     "mtp": frozenset({"model", "num_speculative_tokens", "disable_auto_k"}),
+    # Explicit throughput-oriented mlx-vlm lane. Kept distinct from ``mtp``:
+    # the existing batched-engine implementation is lossless/token-identical,
+    # while this lane may take numerically different greedy decisions.
+    "mtp-fast": frozenset({"model", "min_output_tokens"}),
     "suffix": frozenset(
         {
             "num_speculative_tokens",
@@ -153,6 +158,9 @@ def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
         max_suffix_len=_positive_int(payload.get("max_suffix_len"), "max_suffix_len"),
         min_confidence=_confidence(payload.get("min_confidence"), "min_confidence"),
         min_draft_len=_positive_int(payload.get("min_draft_len"), "min_draft_len"),
+        min_output_tokens=_positive_int(
+            payload.get("min_output_tokens"), "min_output_tokens"
+        ),
         raw=dict(payload),
     )
 

--- a/vllm_mlx/spec_decode/registry.py
+++ b/vllm_mlx/spec_decode/registry.py
@@ -92,6 +92,13 @@ register_spec_decoder(
 )
 register_spec_decoder(
     SpecDecoderPlugin(
+        method="mtp-fast",
+        description="Throughput-oriented MTP via the mlx-vlm single-user bridge",
+        config_enabled=True,
+    )
+)
+register_spec_decoder(
+    SpecDecoderPlugin(
         method="suffix",
         description=("Explicit suffix / n-gram speculation for high-overlap workloads"),
         config_enabled=True,

--- a/vllm_mlx/speculative/dflash/runtime.py
+++ b/vllm_mlx/speculative/dflash/runtime.py
@@ -81,6 +81,6 @@ def load_runtime(drafter_repo: str, kind: str = "dflash") -> DFlashRuntime:
     # Import here, not at module top, so the optional dep stays optional.
     from mlx_vlm.speculative.drafters import load_drafter
 
-    logger.info("Loading DFlash drafter: %s (kind=%s)", drafter_repo, kind)
+    logger.info("Loading speculative drafter: %s (kind=%s)", drafter_repo, kind)
     drafter, resolved_kind = load_drafter(drafter_repo, kind=kind)
     return DFlashRuntime(drafter=drafter, kind=resolved_kind, drafter_repo=drafter_repo)

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -2257,7 +2257,9 @@ def run_dflash_server(
             rt = load_runtime(drafter_repo, kind=draft_kind)
         return m, p, rt
 
-    logger.info("%s: loading main model via mlx-vlm: %s", runtime_label, main_model_repo)
+    logger.info(
+        "%s: loading main model via mlx-vlm: %s", runtime_label, main_model_repo
+    )
     model, processor, runtime = _dflash_executor.submit(_load_all).result()
 
     app = _build_app(

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -2203,7 +2203,7 @@ def run_dflash_server(
     """
     if not have_runtime():
         raise RuntimeError(
-            "DFlash server requires mlx-vlm 0.5.0+ — install with "
+            f"{runtime_label} mode requires mlx-vlm 0.5.0+ — install with "
             "pip install 'rapid-mlx[dflash]'. Homebrew installs the "
             "text-only package; switch to an isolated uv tool install "
             "for optional extras."
@@ -2243,7 +2243,11 @@ def run_dflash_server(
     def _load_all():
         t0 = time.perf_counter()
         m, p = load(main_model_repo)
-        logger.info("DFlash: main model loaded in %.1fs", time.perf_counter() - t0)
+        logger.info(
+            "%s: main model loaded in %.1fs",
+            runtime_label,
+            time.perf_counter() - t0,
+        )
         # Preserve the historical one-argument call for DFlash so external
         # monkeypatches/wrappers around this programmatic entry point remain
         # compatible. Other drafter families must opt in explicitly.
@@ -2253,7 +2257,7 @@ def run_dflash_server(
             rt = load_runtime(drafter_repo, kind=draft_kind)
         return m, p, rt
 
-    logger.info("DFlash: loading main model via mlx-vlm: %s", main_model_repo)
+    logger.info("%s: loading main model via mlx-vlm: %s", runtime_label, main_model_repo)
     model, processor, runtime = _dflash_executor.submit(_load_all).result()
 
     app = _build_app(

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -625,6 +625,9 @@ def _build_app(
     cors_policy: Any | None = None,
     tool_call_parser: str | None = None,
     reasoning_parser_name: str | None = None,
+    runtime_label: str = "DFlash",
+    min_speculative_output_tokens: int = 0,
+    allow_multimodal: bool = False,
 ) -> FastAPI:
     """Create the FastAPI application for DFlash mode.
 
@@ -696,7 +699,7 @@ def _build_app(
                 ) from exc
             raise
 
-    app = FastAPI(title="Rapid-MLX (DFlash)")
+    app = FastAPI(title=f"Rapid-MLX ({runtime_label})")
     # DFlash has one GPU worker and serializes generation with
     # ``_dflash_lock``. Bound its waiting room as well so a burst cannot
     # accumulate an unbounded number of requests and their parsed bodies.
@@ -769,9 +772,10 @@ def _build_app(
     async def healthz() -> dict[str, Any]:
         return {
             "status": "ok",
-            "engine": "dflash",
+            "engine": runtime.kind,
             "mode": "single-user-serial",
             "drafter": runtime.drafter_repo,
+            "min_speculative_output_tokens": min_speculative_output_tokens,
         }
 
     @app.get(
@@ -939,12 +943,22 @@ def _build_app(
             # an uncancellable overrun can be abandoned and its admission slot
             # released immediately (round-5 #2) — nothing serial is left running
             # behind it, unlike a timed-out generation worker.
-            def _render() -> str:
-                return _render_prompt(
-                    processor,
-                    model,
-                    request,
-                    enable_thinking=effective_thinking,
+            def _render() -> tuple[str, list[str]]:
+                if allow_multimodal:
+                    return _render_multimodal_prompt(
+                        processor,
+                        model,
+                        request,
+                        enable_thinking=effective_thinking,
+                    )
+                return (
+                    _render_prompt(
+                        processor,
+                        model,
+                        request,
+                        enable_thinking=effective_thinking,
+                    ),
+                    [],
                 )
 
             # codex round-8 #1: validate the remaining budget BEFORE submitting
@@ -974,11 +988,11 @@ def _build_app(
             render_future = render_cf  # tracked for the cleanup handler
             render_awaitable = asyncio.wrap_future(render_cf)
             if request_deadline is None:
-                prompt = await render_awaitable
+                prompt, image_paths = await render_awaitable
             else:
                 render_budget = request_deadline - loop.time()
                 try:
-                    prompt = await asyncio.wait_for(
+                    prompt, image_paths = await asyncio.wait_for(
                         asyncio.shield(render_awaitable), timeout=render_budget
                     )
                 except asyncio.TimeoutError as exc:
@@ -1009,9 +1023,19 @@ def _build_app(
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
-                draft_model=runtime.drafter,
-                draft_kind=runtime.kind,
             )
+            if image_paths:
+                gen_kwargs["image"] = image_paths
+            # MTP has a fixed draft/verify setup cost. Paired Qwen3.8
+            # measurements show that very short answers (classification,
+            # one-token MMLU) are materially faster on plain AR. Dedicated
+            # speculative runtimes may therefore set a request-length gate;
+            # DFlash keeps its historical always-on default of zero.
+            if max_tokens > min_speculative_output_tokens:
+                gen_kwargs.update(
+                    draft_model=runtime.drafter,
+                    draft_kind=runtime.kind,
+                )
 
             # Pass the REMAINING budget (post-render) to the completion helper,
             # not the original timeout, so the single absolute deadline
@@ -1185,6 +1209,83 @@ def _render_prompt(
         messages,
         **template_kwargs,
     )
+
+
+def _render_multimodal_prompt(
+    processor: Any,
+    model: Any,
+    request: ChatCompletionRequest,
+    *,
+    enable_thinking: bool | None = None,
+) -> tuple[str, list[str]]:
+    """Render an OpenAI chat request and materialize its image inputs.
+
+    The MTP fast lane loads the full VLM through mlx-vlm, so unlike DFlash it
+    can preserve image content. Convert OpenAI ``image_url`` parts into the
+    image placeholders expected by the processor and pass the corresponding
+    local paths to generation. Unsupported media is rejected instead of being
+    silently discarded.
+    """
+    from mlx_vlm.prompt_utils import apply_chat_template
+
+    from ...models.mllm import process_image_input
+
+    messages: list[dict[str, Any]] = []
+    image_paths: list[str] = []
+    for raw_message in request.messages:
+        message = raw_message.model_dump(exclude_none=True)
+        content = raw_message.content
+        if isinstance(content, list):
+            prepared_content: list[dict[str, Any] | str] = []
+            for raw_part in content:
+                part = (
+                    raw_part.model_dump(exclude_none=True)
+                    if hasattr(raw_part, "model_dump")
+                    else raw_part
+                )
+                if not isinstance(part, dict):
+                    if isinstance(part, str):
+                        prepared_content.append(part)
+                        continue
+                    raise ValueError("Unsupported multimodal content part")
+                part_type = part.get("type", "")
+                if part_type == "text":
+                    prepared_content.append(part)
+                elif part_type in {"image_url", "image"}:
+                    source = (
+                        part.get("image_url")
+                        if part_type == "image_url"
+                        else part.get("image") or part.get("url")
+                    )
+                    image_paths.append(process_image_input(source))
+                    prepared_content.append({"type": "image"})
+                else:
+                    raise ValueError(
+                        f"MTP fast mode does not support {part_type or 'unknown'} "
+                        "content parts"
+                    )
+            content = prepared_content
+        message["content"] = content
+        messages.append(message)
+
+    effective_thinking = False if enable_thinking is None else enable_thinking
+    template_kwargs: dict[str, Any] = {
+        "num_images": len(image_paths),
+        "num_audios": 0,
+        "enable_thinking": effective_thinking,
+    }
+    if request.tools:
+        from ...api.tool_calling import convert_tools_for_template
+
+        template_kwargs["tools"] = convert_tools_for_template(request.tools)
+
+    prompt = apply_chat_template(
+        processor,
+        model.config,
+        messages,
+        **template_kwargs,
+    )
+    return prompt, image_paths
 
 
 async def _stream_with_admission(
@@ -2074,6 +2175,11 @@ def run_dflash_server(
     cors_policy: Any | None = None,
     tool_call_parser: str | None = "hermes",
     reasoning_parser_name: str | None = "qwen3",
+    draft_kind: str = "dflash",
+    runtime_label: str = "DFlash",
+    allow_4bit_target: bool = False,
+    min_speculative_output_tokens: int = 0,
+    allow_multimodal: bool = False,
 ) -> None:
     """Load the model + DFlash drafter via mlx-vlm and start uvicorn.
 
@@ -2111,7 +2217,7 @@ def run_dflash_server(
         _looks_like_4bit,  # noqa: PLC2701 — internal helper
     )
 
-    if _looks_like_4bit(main_model_repo):
+    if _looks_like_4bit(main_model_repo) and not allow_4bit_target:
         raise DFlashUnavailable(
             f"DFlash cannot run on a 4-bit quantized model "
             f"(main_model_repo={main_model_repo!r}); upstream PoC measured "
@@ -2138,7 +2244,13 @@ def run_dflash_server(
         t0 = time.perf_counter()
         m, p = load(main_model_repo)
         logger.info("DFlash: main model loaded in %.1fs", time.perf_counter() - t0)
-        rt = load_runtime(drafter_repo)
+        # Preserve the historical one-argument call for DFlash so external
+        # monkeypatches/wrappers around this programmatic entry point remain
+        # compatible. Other drafter families must opt in explicitly.
+        if draft_kind == "dflash":
+            rt = load_runtime(drafter_repo)
+        else:
+            rt = load_runtime(drafter_repo, kind=draft_kind)
         return m, p, rt
 
     logger.info("DFlash: loading main model via mlx-vlm: %s", main_model_repo)
@@ -2161,11 +2273,14 @@ def run_dflash_server(
         cors_policy=cors_policy,
         tool_call_parser=tool_call_parser,
         reasoning_parser_name=reasoning_parser_name,
+        runtime_label=runtime_label,
+        min_speculative_output_tokens=min_speculative_output_tokens,
+        allow_multimodal=allow_multimodal,
     )
 
     print()
     host_display = "localhost" if host == "0.0.0.0" else host
-    print(f"  Ready: http://{host_display}:{port}/v1  (DFlash mode)")
+    print(f"  Ready: http://{host_display}:{port}/v1  ({runtime_label} mode)")
     print(f"  Docs:  http://{host_display}:{port}/docs")
     print()
 


### PR DESCRIPTION
## What changed

- add an explicit `mtp-fast` speculative-config method backed by mlx-vlm's single-user MTP draft/verify path
- keep short outputs on AR by default (`max_tokens <= 64`)
- preserve OpenAI streaming, Hermes tool calls, reasoning parsing, security/admission controls, and real image inputs
- add paired MMLU-Pro, GSM8K, HumanEval, MMBench, context/memory, and precision-allocation benchmark harnesses
- document the audited Qwen3.8-27B mixed-3.5bpw + official Q4 MTP composition and rejected larger MTPLX artifact experiments

## Why

The existing lossless batched MTP path preserves exact output but only delivers a small throughput gain. On an M3 Ultra, the mlx-vlm MTP path takes the compact 13 GB Qwen3.8-27B mixed model from about 40 tok/s to about 60–63 tok/s while adding only the 253 MB official sidecar. A larger MTPLX-specific requantization was slower on the target Studio, so this keeps the existing audited backbone unchanged.

The method remains explicit and single-user because the speedup is hardware-sensitive: it regressed slightly on an M2 Pro Mini. Short classification-style outputs automatically bypass speculation.

## Validation

- Studio unit/integration: `171 passed, 1 skipped`
- benchmark helper tests: `7 passed`
- Ruff on all changed Python files: passed
- Rapid OpenAI server dogfood: non-stream, SSE `[DONE]`, Hermes tool call, real image request all HTTP 200
- Studio long output: 256 tokens in 4.05 s (~63 tok/s end-to-end)
- MMLU-Pro 500: AR 224, MTP 224; 500/500 byte-identical
- GSM8K 150: AR 143, MTP 144; no AR-only regression
- HumanEval 40 paired: equal after truncation reruns
- MMBench-EN 300: AR 260, MTP 260; 300/300 byte-identical
- 1K context peak: 17.09 GB; 2K context peak: 18.76 GB

## Usage

```bash
rapid-mlx serve rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX \
  --speculative-config \
  '{"method":"mtp-fast","model":"mlx-community/Qwen3.8-27B-MTP-4bit","min_output_tokens":64}'
```
