### PR TITLE
test(mtp): gate accelerators on parity and speed

### DIFF
--- a/bench/bench_spec_decode_mtp.py
+++ b/bench/bench_spec_decode_mtp.py
@@ -241,7 +241,69 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Benchmark fixed --mtp-max-k instead of the adaptive controller.",
     )
+    parser.add_argument(
+        "--require-lossless",
+        action="store_true",
+        help=(
+            "Fail unless every greedy MTP run has the exact same emitted-token "
+            "hash as its paired autoregressive run. Requires --temp 0 and a "
+            "baseline condition."
+        ),
+    )
+    parser.add_argument(
+        "--min-speedup",
+        type=float,
+        default=None,
+        help=(
+            "Fail unless pooled MTP throughput is at least this multiple of "
+            "the paired autoregressive baseline (for example 1.10)."
+        ),
+    )
     return parser.parse_args()
+
+
+def _evaluate_landing_gates(
+    results: dict[str, list[RunResult]],
+    *,
+    expected_pairs: int,
+    require_lossless: bool,
+    min_speedup: float | None,
+    speedup: float | None,
+) -> dict[str, Any]:
+    """Evaluate correctness/performance gates without hiding missing runs."""
+
+    baseline = {(r.run_idx, r.prompt_idx): r for r in results["none"]}
+    mtp = {(r.run_idx, r.prompt_idx): r for r in results["mtp"]}
+    paired_keys = sorted(baseline.keys() & mtp.keys())
+    mismatches = [
+        {"run_idx": key[0], "prompt_idx": key[1]}
+        for key in paired_keys
+        if baseline[key].token_sha256 != mtp[key].token_sha256
+    ]
+    complete = (
+        len(baseline) == expected_pairs
+        and len(mtp) == expected_pairs
+        and len(paired_keys) == expected_pairs
+    )
+    lossless_passed = (not require_lossless) or (complete and not mismatches)
+    speedup_passed = (not min_speedup) or (
+        complete and speedup is not None and speedup >= min_speedup
+    )
+    return {
+        "passed": lossless_passed and speedup_passed,
+        "complete_pairs": len(paired_keys),
+        "expected_pairs": expected_pairs,
+        "lossless": {
+            "required": require_lossless,
+            "passed": lossless_passed,
+            "mismatches": mismatches,
+        },
+        "performance": {
+            "minimum_speedup": min_speedup,
+            "observed_speedup": speedup,
+            "passed": speedup_passed,
+        },
+    }
 
 
 # Map from common base aliases / HF paths to their matching MTP sidecar.
@@ -493,6 +555,13 @@ def _summarize(
 def main() -> int:
     args = _parse_args()
 
+    if args.require_lossless and args.temp != 0:
+        raise SystemExit("--require-lossless requires --temp 0")
+    if (args.require_lossless or args.min_speedup is not None) and args.mtp_only:
+        raise SystemExit("landing gates require the paired AR baseline; remove --mtp-only")
+    if args.min_speedup is not None and args.min_speedup <= 0:
+        raise SystemExit("--min-speedup must be greater than zero")
+
     if args.dry_run:
         plan = _planned_matrix(args)
         if args.format == "markdown":
@@ -599,6 +668,13 @@ def main() -> int:
     mtp_summary = _summarize(
         "mtp", all_results["mtp"], baseline_summary.pooled_tok_per_sec
     )
+    gates = _evaluate_landing_gates(
+        all_results,
+        expected_pairs=args.runs * n_prompts,
+        require_lossless=args.require_lossless,
+        min_speedup=args.min_speedup,
+        speedup=mtp_summary.speedup_vs_baseline,
+    )
 
     out = {
         "model": args.model,
@@ -608,6 +684,7 @@ def main() -> int:
         "top_k": args.top_k,
         "seed": args.seed,
         "summaries": [asdict(baseline_summary), asdict(mtp_summary)],
+        "landing_gates": gates,
         "raw_runs": [asdict(r) for c in all_results.values() for r in c],
     }
     if args.format == "markdown":
@@ -625,6 +702,12 @@ def main() -> int:
             )
     else:
         print(json.dumps(out, indent=2))
+    if not gates["passed"]:
+        print(
+            "[bench_spec_decode_mtp] landing gate FAILED: " + json.dumps(gates),
+            file=sys.stderr,
+        )
+        return 2
     return 0
 
 

--- a/bench/bench_spec_decode_mtp.py
+++ b/bench/bench_spec_decode_mtp.py
@@ -558,7 +558,9 @@ def main() -> int:
     if args.require_lossless and args.temp != 0:
         raise SystemExit("--require-lossless requires --temp 0")
     if (args.require_lossless or args.min_speedup is not None) and args.mtp_only:
-        raise SystemExit("landing gates require the paired AR baseline; remove --mtp-only")
+        raise SystemExit(
+            "landing gates require the paired AR baseline; remove --mtp-only"
+        )
     if args.min_speedup is not None and args.min_speedup <= 0:
         raise SystemExit("--min-speedup must be greater than zero")
 

--- a/tests/test_bench_spec_decode_mtp_gates.py
+++ b/tests/test_bench_spec_decode_mtp_gates.py
@@ -1,0 +1,71 @@
+from bench.bench_spec_decode_mtp import RunResult, _evaluate_landing_gates
+
+
+def _run(condition: str, run: int, prompt: int, digest: str) -> RunResult:
+    return RunResult(
+        condition=condition,
+        run_idx=run,
+        prompt_idx=prompt,
+        decode_tok_per_sec=10.0,
+        n_tokens=10,
+        accept_attempts=0,
+        accept_count=0,
+        elapsed_seconds=1.0,
+        token_sha256=digest,
+        verify_kernel_calls=0,
+        verify_kernel_fallbacks=0,
+        verify_sync_seconds=0.0,
+        draft_seconds=0.0,
+        residual_sync_seconds=0.0,
+        verify_calls=0,
+        prompt_lookup_proposals=0,
+        prompt_lookup_drafted_tokens=0,
+        prompt_lookup_accepted_tokens=0,
+        prompt_lookup_rejections=0,
+        prompt_lookup_mtp_sync_seconds=0.0,
+    )
+
+
+def test_landing_gates_pass_complete_lossless_speedup():
+    results = {
+        "none": [_run("none", 0, 0, "same")],
+        "mtp": [_run("mtp", 0, 0, "same")],
+    }
+    gates = _evaluate_landing_gates(
+        results,
+        expected_pairs=1,
+        require_lossless=True,
+        min_speedup=1.1,
+        speedup=1.25,
+    )
+    assert gates["passed"] is True
+
+
+def test_landing_gates_report_hash_mismatch():
+    results = {
+        "none": [_run("none", 0, 0, "ar")],
+        "mtp": [_run("mtp", 0, 0, "mtp")],
+    }
+    gates = _evaluate_landing_gates(
+        results,
+        expected_pairs=1,
+        require_lossless=True,
+        min_speedup=None,
+        speedup=2.0,
+    )
+    assert gates["passed"] is False
+    assert gates["lossless"]["mismatches"] == [{"run_idx": 0, "prompt_idx": 0}]
+
+
+def test_landing_gates_fail_closed_on_missing_pair():
+    results = {"none": [_run("none", 0, 0, "same")], "mtp": []}
+    gates = _evaluate_landing_gates(
+        results,
+        expected_pairs=1,
+        require_lossless=True,
+        min_speedup=1.1,
+        speedup=None,
+    )
+    assert gates["passed"] is False
+    assert gates["complete_pairs"] == 0
+    assert gates["performance"]["passed"] is False


### PR DESCRIPTION
## What changed

- add `--require-lossless` to pair every greedy MTP run with AR and compare emitted-token hashes
- add `--min-speedup` to enforce a pooled throughput floor
- fail closed on missing/failed benchmark pairs
- include a machine-readable `landing_gates` verdict in JSON output

## Why

Accelerator experiments can otherwise look successful while silently changing output or benefiting from incomplete benchmark runs. These gates make correctness and performance explicit release criteria.

## Validation

- `120 passed`: MTP spec-decode, lossless, and new landing-gate tests
- Studio hardware gate on Qwen3.8-27B MTPLX artifact: AR 29.75 tok/s, Rapid MTP 37.58 tok/s (1.263x), exact token-hash parity
