### PR TITLE
fix(tests): allowlist the MTP prompt-lookup env knobs

### DIFF
--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -136,6 +136,22 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # fires, which tier engages — none of that changes. Default off
         # keeps the load bit-faithful to the published weights.
         "RAPID_MLX_FP8_LM_HEAD_AFFINE8",
+        # Prompt-lookup speculation knobs for the MTP draft path (#1969).
+        # Same shape as DISABLE_FUSED_SAMPLER: they tune a speculation
+        # fast path on an ALREADY-SELECTED model. Which checkpoint loads,
+        # which parser fires, which tier engages — none of that changes,
+        # and prompt-copy drafts are verified against the target model, so
+        # these cannot alter emitted tokens either. Read only by
+        # ``vllm_mlx.spec_decode.mtp.generator``.
+        #
+        # ``RAPID_MLX_MTP_PROMPT_LOOKUP`` is the explicit opt-in (default
+        # OFF) held until Qwen's hybrid SSM target path is proven
+        # token-lossless across verification chunk boundaries; the other
+        # three size the n-gram match window.
+        "RAPID_MLX_MTP_PROMPT_LOOKUP",
+        "RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS",
+        "RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM",
+        "RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM",
         # Test/integration helpers — server URL for integration suites,
         # not consulted at runtime by the engine.
         "RAPID_MLX_BASE_URL",


### PR DESCRIPTION
## What changed

Adds the four `RAPID_MLX_MTP_PROMPT_LOOKUP*` env vars introduced by #1969 to `ALLOWED_RAPID_MLX_ENV_VARS`.

## Why

**main is red.** On a clean checkout of `a5f9004f`, `tests/test_no_out_of_band_routing.py::test_no_routing_shaped_rapid_mlx_env_vars` fails:

```
spec_decode/mtp/generator.py:65  references env var `RAPID_MLX_MTP_PROMPT_LOOKUP`            — not in ALLOWED_RAPID_MLX_ENV_VARS
spec_decode/mtp/generator.py:349 references env var `RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS` — not in ALLOWED_RAPID_MLX_ENV_VARS
spec_decode/mtp/generator.py:352 references env var `RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM`  — not in ALLOWED_RAPID_MLX_ENV_VARS
spec_decode/mtp/generator.py:356 references env var `RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM`  — not in ALLOWED_RAPID_MLX_ENV_VARS
```

The test does exactly what it was written to do — it just never got its allowlist entry. This blocks every PR, not only MTP work, which is why it is split out rather than folded into whatever PR happens to trip over it.

## Why these are non-routing

Same shape as the existing `RAPID_MLX_DISABLE_FUSED_SAMPLER` entry: they tune a speculation fast path on an **already-selected** model. Which checkpoint loads, which parser fires, which tier engages — none of it changes. Prompt-copy drafts are verified against the target model, so they cannot alter emitted tokens either. Read only by `vllm_mlx.spec_decode.mtp.generator`.

`RAPID_MLX_MTP_PROMPT_LOOKUP` is the explicit opt-in (default **off**), held until Qwen's hybrid SSM target path is proven token-lossless across verification chunk boundaries; the other three size the n-gram match window.

## Validation

- `pytest tests/test_no_out_of_band_routing.py` → 14 passed (was 1 failed).
- **Proved the guard still bites:** renamed one knob to a routing-shaped `RAPID_MLX_FORCE_*` and the test failed again, then reverted. An allowlist that stopped refusing routing vars would be worse than the red it replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
