### PR TITLE
feat(agents): promote DeepSeek Harness to Tier-1

### DIFF
--- a/.github/workflows/agent-gate.yml
+++ b/.github/workflows/agent-gate.yml
@@ -55,10 +55,26 @@ jobs:
     # serve). Each check is individually bounded, but they stack, and a
     # run where every check PASSES near its own limit could otherwise be
     # cancelled by Actions for exceeding the job budget.
-    # Raised from 75: DeepSeek Harness is the fifth Tier-1 agent, adding one
-    # more 2x480s worst case (~16 min) to the script's ~42 min four-agent tail
-    # → ~58 min. Preserving the same ~33 min of stacked-extras headroom that
-    # justified 75 gives ~91, rounded to 90.
+    #
+    # Raised from 75: DeepSeek Harness is the fifth Tier-1 agent.
+    #
+    # This job and auto-release.yml's tier1-agent-gate run the SAME
+    # agent_smoke.sh, so they must not quote different worst cases. The one
+    # arithmetic, from the script's own budgets (AGENT_TO=480 x2 attempts for
+    # claude/codex/aider/dsh, HERMES_TO=600 x3 for hermes):
+    #   four agents  3x960 + 1800 = 4680s ~= 78 min
+    #   five agents  4x960 + 1800 = 5640s ~= 94 min
+    # An earlier revision of this comment claimed ~42 min for the four-agent
+    # tail; that predated the 35B gate model and the 600s hermes budget and was
+    # simply stale. Do not reintroduce it — recompute from AGENT_TO/HERMES_TO.
+    #
+    # 90 rather than auto-release's 125 because this manual job does NOT run
+    # the release-gate extras (coherence golden + perf) — those are gated on
+    # RAPID_MLX_RELEASE_GATE=1, which only the release path sets. 94 min of
+    # pathological-retry tail still exceeds 90, but that path requires every
+    # agent to burn every retry; a genuine hang fails on its own per-agent
+    # budget long before, and this job is operator-triggered rather than
+    # release-blocking, so the tighter cap is the deliberate trade.
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4

--- a/.github/workflows/agent-gate.yml
+++ b/.github/workflows/agent-gate.yml
@@ -1,7 +1,8 @@
 name: Tier-1 agent gate
 
-# Re-verifies the four Tier-1 (flagship) agents — Claude Code, Codex, Hermes,
-# Aider — end-to-end against a real local model on Apple Silicon, then reuses the
+# Re-verifies the five Tier-1 (flagship) agents — Claude Code, Codex, Hermes,
+# Aider, DeepSeek Harness — end-to-end against a real local model on Apple
+# Silicon, then reuses the
 # same warm serve to run the deep output-coherence golden (#1247) and a
 # decode-throughput perf check. This is the one release check GitHub-hosted
 # runners structurally cannot do (no Metal, no weights, no agent binaries), so it
@@ -45,16 +46,20 @@ concurrency:
 jobs:
   tier1-smoke:
     runs-on: [self-hosted, macOS, rapidmlx-studio]
-    # Headroom above the script's own worst case (~42 min if every agent hits
-    # every per-command timeout) so the smoke exits on its own, prints its
-    # summary, and runs cleanup — instead of GitHub cancelling mid-run. A
-    # passing run finishes in ~5-8 min; the tail only matters on regressions.
+    # Headroom above the script's own worst case so the smoke exits on its own,
+    # prints its summary, and runs cleanup — instead of GitHub cancelling
+    # mid-run. A passing run finishes in ~5-8 min; the tail only matters on
+    # regressions.
     # Raised from 55: the release path now adds the coherence golden and a
-    # perf measurement on top of the four agents (all on the same warm
+    # perf measurement on top of the agents (all on the same warm
     # serve). Each check is individually bounded, but they stack, and a
     # run where every check PASSES near its own limit could otherwise be
     # cancelled by Actions for exceeding the job budget.
-    timeout-minutes: 75
+    # Raised from 75: DeepSeek Harness is the fifth Tier-1 agent, adding one
+    # more 2x480s worst case (~16 min) to the script's ~42 min four-agent tail
+    # → ~58 min. Preserving the same ~33 min of stacked-extras headroom that
+    # justified 75 gives ~91, rounded to 90.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Tier-1 agent re-verification

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,7 +7,8 @@ name: Auto-release on version bump
 #
 # Flow:  detect (hosted)  →  tier1-agent-gate (self-hosted Studio)  →  release
 # The release job ``needs`` the gate, so a version bump cannot tag or publish
-# unless the four Tier-1 agents (Claude Code / Codex / Hermes / Aider) re-verify
+# unless the five Tier-1 agents (Claude Code / Codex / Hermes / Aider /
+# DeepSeek Harness) re-verify
 # green against the exact source being released. Mirrors Apple MLX's
 # ``publish needs: test_wheel``.
 #
@@ -158,7 +159,7 @@ jobs:
   #    GitHub-hosted runners have no Metal, no weights, no agent binaries, so
   #    this is the one release check CI can't do elsewhere. Builds the EXACT
   #    source being released into a fresh venv (it isn't on PyPI yet) and
-  #    re-verifies the four Tier-1 agents end-to-end. A failure here blocks the
+  #    re-verifies the five Tier-1 agents end-to-end. A failure here blocks the
   #    release job below. Skipped for an emergency forced release.
   #
   #    SECURITY: this self-hosted job runs only on push to the protected main
@@ -168,20 +169,28 @@ jobs:
     needs: detect
     if: needs.detect.outputs.should_release == 'true' && needs.detect.outputs.force != 'true'
     runs-on: [self-hosted, macOS, rapidmlx-studio]
-    # 90, not 55: the four Tier-1 agents run SERIALLY against a 35B hybrid, each
-    # with retries and a per-agent budget. Worst case = claude+codex+aider at
-    # 2x480s each (2880s) + hermes at 3x600s (1800s) = 4680s ~= 78 min. On a cold
-    # Studio shader cache the first large-context request of each agent also pays
-    # a one-time Metal-kernel compile. 55 min guillotined the run mid-agent (the
-    # job was "cancelled" before any RESULT could print). The step warms kernels
+    # 90, not 55: the Tier-1 agents run SERIALLY against a 35B hybrid, each
+    # with retries and a per-agent budget. On a cold Studio shader cache the
+    # first large-context request of each agent also pays a one-time
+    # Metal-kernel compile. 55 min guillotined the run mid-agent (the job was
+    # "cancelled" before any RESULT could print). The step warms kernels
     # untimed up front (hard-bounded to ~10 min) so the healthy path finishes in
-    # minutes; 90 min is headroom so a slow-but-passing cold run reaches a verdict
-    # instead of being killed. A genuine hang still fails on the per-agent budgets.
+    # minutes; the cap is headroom so a slow-but-passing cold run reaches a
+    # verdict instead of being killed. A genuine hang still fails on the
+    # per-agent budgets.
     # 105, not 90: the coherence golden + perf measurement now run after the
-    # four agents on the same warm serve. They are minutes on a healthy run,
-    # but they stack on top of the ~78 min worst case above, and a run where
-    # every check PASSES near its own budget must not be guillotined.
-    timeout-minutes: 105
+    # agents on the same warm serve. They are minutes on a healthy run, but
+    # they stack on top of the agent worst case, and a run where every check
+    # PASSES near its own budget must not be guillotined.
+    # 125, not 105: DeepSeek Harness joined as the FIFTH Tier-1 agent, so the
+    # worst case grows by one more 2x480s agent. Recomputed:
+    # claude+codex+aider+dsh at 2x480s each (3840s) + hermes at 3x600s (1800s)
+    # = 5640s ~= 94 min, versus ~78 min for four. Keeping the same ~27 min of
+    # extras/cold-compile headroom that took 78 -> 105 gives 94 + 27 ~= 121,
+    # rounded to 125. Measured on the Studio, dsh solves the task in 17-64s
+    # (warm/cold) — the budget is for the pathological retry path, not the
+    # expected one.
+    timeout-minutes: 125
     # Serialize with the manual agent-gate.yml so two runs never contend for the
     # single runner / the serve port.
     concurrency:

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Also: word-level timestamps on transcription, and local text-to-music at
 |---|---|
 | **Apple-Silicon-native** | Pure MLX kernels — no llama.cpp fallback, no Metal shim. Continuous batching, prompt cache (radix + DeltaNet RNN snapshots), and a quantized live KV cache (int4/int8 on the continuous-batching cache + TurboQuant K8V4 codec) run at native MLX bandwidth on M1 → M4. |
 | **Drop-in OpenAI / Anthropic API** | `/v1/chat/completions`, `/v1/responses` (Codex CLI), `/v1/messages` (Anthropic SDK / Claude Code), `/v1/embeddings`, `/v1/audio/*`, `/v1/videos` — same wire as ChatGPT / Claude, no client adapter. |
-| **First-class ecosystem coverage** | 12 agent CLIs and 3 Python frameworks are wire-verified against real weights every release (4 are Tier-1, re-verified on current binaries) — Codex CLI, Claude Code, OpenCode, Qwen Code, OpenHands, Hermes Agent, Aider, Kilo Code, DeepSeek Harness, GitHub Copilot, Factory Droid, Moonshot Kimi Code + LangChain, PydanticAI, smolagents. |
+| **First-class ecosystem coverage** | 12 agent CLIs and 3 Python frameworks are wire-verified against real weights every release (5 are Tier-1, re-verified on current binaries) — Codex CLI, Claude Code, OpenCode, Qwen Code, OpenHands, Hermes Agent, Aider, Kilo Code, DeepSeek Harness, GitHub Copilot, Factory Droid, Moonshot Kimi Code + LangChain, PydanticAI, smolagents. |
 
 → [Full feature breakdown](https://rapidmlx.com/docs/index.html)
 
@@ -206,7 +206,7 @@ Also: word-level timestamps on transcription, and local text-to-music at
 |---|---|---|
 | **Chat in the terminal** | `rapid-mlx chat qwen3.5-9b-4bit` | Streaming REPL, `/help` for slash commands, `--think` / `--no-think` to control CoT. |
 | **OpenAI server for your apps** | `rapid-mlx serve qwen3.5-9b-4bit` | Point Aider, LibreChat, Open WebUI, or LangChain at `http://localhost:8000/v1`. |
-| **Agent backends** | `rapid-mlx serve qwen3.6-35b-8bit &`<br>`rapid-mlx agents codex --setup && codex` | 8 agents auto-configure via `agents <name> --setup` once the server is up (11 wire-verified total, 4 Tier-1) — see [Agent support](#agent-support). |
+| **Agent backends** | `rapid-mlx serve qwen3.6-35b-8bit &`<br>`rapid-mlx agents codex --setup && codex` | 9 agents auto-configure via `agents <name> --setup` once the server is up (12 wire-verified total, 5 Tier-1) — see [Agent support](#agent-support). |
 | **Benchmark your Mac** | `rapid-mlx bench qwen3.5-9b-4bit --submit` | Standardized B=1 bench, opens a PR to publish your row on [rapidmlx.com](https://rapidmlx.com). |
 
 → [One-shot IDE setup](https://rapidmlx.com/docs/cli.html#launch) with `rapid-mlx launch <claude-code|cline|continue-dev>`
@@ -215,19 +215,21 @@ Also: word-level timestamps on transcription, and local text-to-music at
 
 ## Agent Support
 
-All 11 agents below are wire-verified against real weights every release via their own integration-test cell. Of these, four are **Tier-1** — **Claude Code, Codex CLI, Hermes, and Aider** — re-verified end-to-end against the *current* client binary every release, with one guardian per API wire (Anthropic `/v1/messages`, OpenAI `/v1/responses`, and `/v1/chat/completions` covered for both tool-calling depth and reach). The other seven are **Tier-2**: wire-verified in the matrix and configured on-demand. The first eight agents each ship a `rapid-mlx agents <name> --setup` config template (except Claude Code, which is one env-var); GitHub Copilot, Factory Droid, and Moonshot Kimi Code plug in through their own documented BYOK config (auth-gated, so the matrix cell is a wire smoke).
+All 12 agents below are wire-verified against real weights every release via their own integration-test cell. Of these, five are **Tier-1** — **Claude Code, Codex CLI, Hermes, Aider, and DeepSeek Harness** — re-verified end-to-end against the *current* client binary every release, with one guardian per API wire (Anthropic `/v1/messages`, OpenAI `/v1/responses`, and `/v1/chat/completions` covered for tool-calling depth, reach, and DeepSeek's own harness protocol). The other seven are **Tier-2**: wire-verified in the matrix and configured on-demand. The first nine agents each ship a `rapid-mlx agents <name> --setup` config template (except Claude Code, which is one env-var); GitHub Copilot, Factory Droid, and Moonshot Kimi Code plug in through their own documented BYOK config (auth-gated, so the matrix cell is a wire smoke).
 
-**Tier-1 (4):** Claude Code · Codex CLI · Hermes · Aider — last re-verified end-to-end 2026-07-28 on current binaries (claude 2.1.211, codex 0.145.0, hermes 0.9.0, aider 0.86.2) against rapid-mlx 0.11.1.
+Tier-1 is not a label — it is a job that blocks the release. `tests/integrations/agent_smoke.sh` drives each of the five through the same real multi-step bug-fix task against a local 35B model and asserts the repo's own test suite goes green afterwards; if any one of them fails, the version cannot tag or publish.
+
+**Tier-1 (5):** Claude Code · Codex CLI · Hermes · Aider — last re-verified end-to-end 2026-07-28 on current binaries (claude 2.1.211, codex 0.145.0, hermes 0.9.0, aider 0.86.2) against rapid-mlx 0.11.1. DeepSeek Harness — promoted 2026-08-17, verified on dsh 0.1.0-rc.7 against `qwen3.6-35b-8bit`.
 **Tier-2 (7):** OpenCode · Qwen Code · OpenHands · Kilo Code · GitHub Copilot · Factory Droid · Moonshot Kimi Code.
 
-| Agents (11) | Frameworks (3) |
+| Agents (12) | Frameworks (3) |
 |---|---|
 | [Codex CLI](https://github.com/openai/codex) · [Claude Code](https://www.anthropic.com/claude-code) · [OpenCode](https://github.com/sst/opencode) · [Qwen Code](https://github.com/QwenLM/qwen-code) · [OpenHands](https://github.com/All-Hands-AI/OpenHands) · [Hermes Agent](https://github.com/NousResearch/hermes-agent) · [Aider](https://aider.chat) · [Kilo Code](https://github.com/Kilo-Org/kilocode) · [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) · [GitHub Copilot](https://github.com/features/copilot) · [Factory Droid](https://factory.ai) · [Moonshot Kimi Code](https://github.com/MoonshotAI/kimi-cli) | [LangChain](https://langchain.com) (+ [LangGraph](https://langchain-ai.github.io/langgraph/)) · [PydanticAI](https://ai.pydantic.dev) · [smolagents](https://github.com/huggingface/smolagents) |
 
 Also compatible with OpenAI-compatible clients that allow direct local endpoints via `http://localhost:8000/v1` — LibreChat, Open WebUI, and more plug in with a single URL change.
 
-→ [Full 11-agent + 3-framework matrix (test cells + xfail reasons)](https://rapidmlx.com/docs/matrix.html)
-→ [Codex CLI](https://rapidmlx.com/docs/matrix.html#agent-codex-cli) · [Claude Code](https://rapidmlx.com/docs/matrix.html#agent-claude-code) · [OpenCode](https://rapidmlx.com/docs/matrix.html#agent-opencode) · [Qwen Code](https://rapidmlx.com/docs/matrix.html#agent-qwen-code) · [OpenHands](https://rapidmlx.com/docs/matrix.html#agent-openhands) · [Hermes](https://rapidmlx.com/docs/matrix.html#agent-hermes-agent) · [Aider](https://rapidmlx.com/docs/matrix.html#agent-aider) · [Kilo Code](https://rapidmlx.com/docs/matrix.html#agent-kilo-code) · [Copilot](https://rapidmlx.com/docs/matrix.html#agent-copilot) · [Droid](https://rapidmlx.com/docs/matrix.html#agent-droid) · [Kimi Code](https://rapidmlx.com/docs/matrix.html#agent-kimi-code)
+→ [Full 12-agent + 3-framework matrix (test cells + xfail reasons)](https://rapidmlx.com/docs/matrix.html)
+→ [Codex CLI](https://rapidmlx.com/docs/matrix.html#agent-codex-cli) · [Claude Code](https://rapidmlx.com/docs/matrix.html#agent-claude-code) · [OpenCode](https://rapidmlx.com/docs/matrix.html#agent-opencode) · [Qwen Code](https://rapidmlx.com/docs/matrix.html#agent-qwen-code) · [OpenHands](https://rapidmlx.com/docs/matrix.html#agent-openhands) · [Hermes](https://rapidmlx.com/docs/matrix.html#agent-hermes-agent) · [Aider](https://rapidmlx.com/docs/matrix.html#agent-aider) · [Kilo Code](https://rapidmlx.com/docs/matrix.html#agent-kilo-code) · [DeepSeek Harness](https://rapidmlx.com/docs/matrix.html#agent-deepseek-harness) · [Copilot](https://rapidmlx.com/docs/matrix.html#agent-copilot) · [Droid](https://rapidmlx.com/docs/matrix.html#agent-droid) · [Kimi Code](https://rapidmlx.com/docs/matrix.html#agent-kimi-code)
 
 ---
 

--- a/community-benchmarks/schema.json
+++ b/community-benchmarks/schema.json
@@ -343,9 +343,12 @@
         },
         "langchain": {
           "$ref": "#/$defs/harnessAdapterResult"
+        },
+        "deepseek-harness": {
+          "$ref": "#/$defs/harnessAdapterResult"
         }
       },
-      "description": "v2 only. Per-adapter results from the agent-harness gauntlet. Required iff ``tier`` is ``harness`` or ``all``; absent for tier=speed and tier=smoke. Each entry carries a pass/fail flag, the round-trip duration, and a short error excerpt on failure (null on pass)."
+      "description": "v2 only. Per-adapter results from the agent-harness gauntlet. Required iff ``tier`` is ``harness`` or ``all``; absent for tier=speed and tier=smoke. Each entry carries a pass/fail flag, the round-trip duration, and a short error excerpt on failure (null on pass). NOTE the deliberate asymmetry: ``deepseek-harness`` joined HARNESS_PROFILES after this schema shipped, so it is an allowed property but NOT in ``required``. Adding it to ``required`` would retroactively invalidate the historical submissions that carry only the original five adapters, and would reject every submission from a rapid-mlx older than the release that added it. ``additionalProperties: false`` is what needed to change so a current six-adapter payload validates at all."
     },
     "run_group": {
       "type": "string",

--- a/docs/agents/deepseek-harness.md
+++ b/docs/agents/deepseek-harness.md
@@ -4,9 +4,16 @@ Run the official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harn
 against a local Rapid-MLX server. Rapid uses Harness's generic
 `openai-completions` provider; it does not impersonate the DeepSeek cloud API.
 
-> DeepSeek currently labels Harness a developer preview. Rapid pins the
-> configuration contract exercised by `@deepseek-ai/dsh@0.1.0-rc.6`; review
-> release notes before upgrading across incompatible preview releases.
+**DeepSeek Harness is a Tier-1 agent.** That is a release gate, not a badge:
+every version bump runs `dsh` through a real multi-step bug-fix task against a
+local 35B model in `tests/integrations/agent_smoke.sh` and asserts the repo's
+own test suite goes green afterwards. If `dsh` regresses, the release cannot
+tag or publish. See the [agent matrix](matrix.md#agent-deepseek-harness).
+
+> DeepSeek currently labels Harness a developer preview. Rapid tracks the
+> configuration contract exercised by `@deepseek-ai/dsh@0.1.0-rc.7` (verified
+> 2026-08-17; the rc.6 → rc.7 upgrade did not change the provider schema).
+> Review release notes before upgrading across incompatible preview releases.
 
 ## Setup
 

--- a/docs/agents/matrix.md
+++ b/docs/agents/matrix.md
@@ -56,7 +56,7 @@ truthfully from the authoritative test suite in
 > parser and `hermes` tool-call family with Qwen 3.6, exercising the same
 > wire without loading a 15 GB weight blob per test process.
 
-## Agent × Family (11 agents × 5 families)
+## Agent × Family (12 agents × 5 families)
 
 Source: `tests/integrations/README.md` "Current cell status" (pilot run
 2026-07-06, four always-on families; Hy3 column is `xfail(strict=True)` from
@@ -72,6 +72,7 @@ Source: `tests/integrations/README.md` "Current cell status" (pilot run
 | <a id="agent-hermes-agent"></a>[hermes-agent](hermes-agent.md) | `/v1/chat/completions` | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
 | <a id="agent-aider"></a>aider | bash CLI → `/v1/chat/completions` | ✅ | ✅ | ✅ | ✅ | XFAIL (Ultra) |
 | <a id="agent-kilo-code"></a>kilo-code | `/v1/chat/completions` | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
+| <a id="agent-deepseek-harness"></a>[deepseek-harness](deepseek-harness.md) | `/v1/chat/completions` | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
 | <a id="agent-copilot"></a>copilot | `/v1/chat/completions` (wire smoke) | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
 | <a id="agent-droid"></a>droid | `/v1/chat/completions` (wire smoke) | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
 | <a id="agent-kimi-code"></a>kimi-code | `/v1/chat/completions` (wire smoke) | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) |
@@ -86,6 +87,13 @@ Notes on cell shape:
   text-action tags don't require OpenAI `tool_calls`, so aider PASSes on
   DeepSeek and OpenHands PASSes on DeepSeek (but XFAILs on gpt-oss — format
   mismatch, see legend).
+- **deepseek-harness** is the only cell whose agent is published by the same
+  vendor as one of the model families, and it gets no special treatment for
+  it: the wire cell is the shared OpenAI tool-call smoke, and the DeepSeek
+  column XFAILs on R1-Distill exactly like every other tool-calling agent.
+  Its Qwen 3.6 and gpt-oss cells were run strict against real weights on
+  2026-08-17; see the `†` footnote in `tests/integrations/README.md` for
+  which columns are recorded from the shared code path instead.
 - **copilot / droid / kimi-code** are **wire-smoke only** in CI: their BYOK
   routes are documented and verified, but driving the real CLI binaries is
   blocked on vendor OAuth / first-run onboarding. The wire smoke still
@@ -108,19 +116,23 @@ shape.
 ## Totals
 
 Across the four always-on families (Qwen 3.6, Gemma 4, DeepSeek, gpt-oss);
-the Hy3 column adds 11 more agent cells, all `xfail(strict=True)`:
+the Hy3 column adds 12 more agent cells, all `xfail(strict=True)`:
 
-- **Agents:** 11 agents × 4 families = 44 cells → **36 PASS · 8 XFAIL ·
-  0 FAIL**. The 8 XFAIL are the 7 DeepSeek arch cells (opencode, qwen-code,
-  hermes-agent, kilo-code, copilot, droid, kimi-code) + 1 gpt-oss × OpenHands
-  format cell.
+- **Agents:** 12 agents × 4 families = 48 cells → **39 PASS · 9 XFAIL ·
+  0 FAIL**. The 9 XFAIL are the 8 DeepSeek arch cells (opencode, qwen-code,
+  hermes-agent, kilo-code, deepseek-harness, copilot, droid, kimi-code) + 1
+  gpt-oss × OpenHands format cell. DeepSeek Harness is in the arch group for
+  the same reason as the rest: the R1-Distill checkpoint cannot emit
+  OpenAI-shape `tool_calls`, and DSH drives rapid-mlx over that same wire —
+  being DeepSeek's own client buys it no exemption from its own
+  checkpoint's gap.
 - **Frameworks:** 3 frameworks × 4 families = 12 cells → the two
   `tool_calls`-dependent frameworks (LangChain, PydanticAI) XFAIL on DeepSeek;
   smolagents PASSes everywhere.
-- **Combined always-on run** (56 cells excluding Hy3): **46 PASS · 10 XFAIL
-  · 0 FAIL** — 9 XFAIL are the DeepSeek R1-Distill architectural
+- **Combined always-on run** (60 cells excluding Hy3): **49 PASS · 11 XFAIL
+  · 0 FAIL** — 10 XFAIL are the DeepSeek R1-Distill architectural
   tool-emission cells, 1 is gpt-oss × OpenHands.
-- **Hy3 (0.11.0):** +14 cells, all `xfail(strict=True)` (Ultra-only). The
+- **Hy3 (0.11.0):** +15 cells, all `xfail(strict=True)` (Ultra-only). The
   CI-runnable coverage is the 8-test offline `test_hy3_offline.py`
   (**8 PASS** in the normal `pytest tests/` sweep).
 
@@ -146,5 +158,6 @@ Without a running server every cell **skips** (non-strict) so a naive
 
 - Per-agent setup: [codex-cli](codex-cli.md) · [claude-code](claude-code.md)
   · [opencode](opencode.md) · [qwen-code](qwen-code.md) ·
-  [openhands](openhands.md) · [hermes-agent](hermes-agent.md)
+  [openhands](openhands.md) · [hermes-agent](hermes-agent.md) ·
+  [deepseek-harness](deepseek-harness.md)
 - [AI client compatibility](../guides/ai-clients.md) · [Tool calling](../guides/tool-calling.md)

--- a/docs/guides/ai-clients.md
+++ b/docs/guides/ai-clients.md
@@ -73,11 +73,13 @@ config, plus an honest test-backed [support matrix](../agents/matrix.md):
 [OpenCode](../agents/opencode.md) ·
 [Qwen Code](../agents/qwen-code.md) ·
 [OpenHands](../agents/openhands.md) ·
-[Hermes Agent](../agents/hermes-agent.md).
+[Hermes Agent](../agents/hermes-agent.md) ·
+[DeepSeek Harness](../agents/deepseek-harness.md).
 
 | Client | Type | Setup | Status | Notes |
 |--------|------|-------|--------|-------|
 | [Aider](https://aider.chat) | CLI | `OPENAI_API_BASE=http://localhost:8000/v1 aider --model openai/default` | Verified | Architect mode, edit-and-commit |
+| [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | CLI / TUI / web | `rapid-mlx agents dsh --setup` | Verified | Tier-1 release gate; generic `openai-completions` provider, never `deepseek-official`. Needs Node 22.15+ |
 | [OpenCode](https://github.com/sst/opencode) | TUI | `rapid-mlx agents opencode --setup` | Compatible | Claude Code-like terminal UX |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | CLI | `rapid-mlx agents claude-code --setup` | Compatible | Safe diff/confirm/backup flow; uses Anthropic `/v1/messages` |
 | [Cursor](https://cursor.com) | IDE | `RAPID_MLX_API_KEY=your-secret rapid-mlx launch cursor --server-url https://your-public-host` | Not compatible locally | BYOK requests pass through Cursor's servers; public HTTPS and server auth are required |

--- a/scripts/release_check_m3.sh
+++ b/scripts/release_check_m3.sh
@@ -26,8 +26,9 @@ MODEL="${MODEL:-qwen3.5-9b-4bit}"
 PY="${PY:-python3.12}"
 PORT="${PORT:-8000}"
 
-# G7b's consolidated `bench --tier harness` runs 5 harness profiles
-# (codex/opencode/hermes/aider/langchain) under ONE shared per-profile cap
+# G7b's consolidated `bench --tier harness` runs 6 harness profiles
+# (codex/opencode/hermes/aider/langchain/deepseek-harness) under ONE shared
+# per-profile cap
 # (tier_runner's HARNESS_PROFILE_TIMEOUT_S, library default 300s). That default
 # is sized for a single fast harness — codex/opencode/aider/langchain each
 # finish <135s on the 9B gauntlet model — but the hermes profile runs 20+
@@ -362,8 +363,9 @@ run_g7_smol() {
 # Two-part gate.
 #
 # Part A — `bench --tier harness`: smoke-tests `/v1/chat/completions`
-# parser/router for the five first-class harnesses (codex / opencode /
-# hermes / aider / langchain). Doesn't touch `/v1/responses` (the runner
+# parser/router for the six first-class harnesses (codex / opencode /
+# hermes / aider / langchain / deepseek-harness). Doesn't touch
+# `/v1/responses` (the runner
 # only knows Chat Completions today). Consolidated in PR #2 of the
 # bench-tier series: a single `bench --tier harness` call replaces the
 # prior five sequential `agents <name> --test` invocations — same
@@ -385,7 +387,7 @@ run_g7b() {
   set +e
   (
     set -e
-    echo "  Part A: bench --tier harness (chat-completions smoke for all 5 first-class harnesses)"
+    echo "  Part A: bench --tier harness (chat-completions smoke for all 6 first-class harnesses)"
     "$PY" -m vllm_mlx.cli bench "$MODEL" --tier harness \
       --base-url "http://127.0.0.1:$PORT"
 

--- a/scripts/release_check_m3_random.py
+++ b/scripts/release_check_m3_random.py
@@ -75,7 +75,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # Mirror of ``vllm_mlx.bench.tier_runner.HARNESS_PROFILES`` — hardcoded
 # here so this script doesn't need to import the package (which would
 # pull mlx_lm at module-load and fail in a clean-venv sanity run).
-HARNESS_PROFILES = ("codex", "opencode", "hermes", "aider", "langchain")
+HARNESS_PROFILES = (
+    "codex",
+    "opencode",
+    "hermes",
+    "aider",
+    "langchain",
+    "deepseek-harness",
+)
 
 # Mirror of ``vllm_mlx.api.utils.MLLM_PATTERNS``, for the same reason as
 # HARNESS_PROFILES: importing the package pulls mlx_lm at module load.

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -7,7 +7,7 @@ Rapid-MLX server on `http://localhost:8000` and a loaded model — the fixtures
 `skip` cells when no server is reachable, so a naïve `pytest tests/` still
 comes out green.
 
-## Two matrices — 11 agents + 3 frameworks × 6 families
+## Two matrices — 12 agents + 3 frameworks × 6 families
 
 0.10.2 PR-2 pilot expanded the matrices to the 0.10.2 **Tier-1 four
 families** (added DeepSeek V4) and the finalized **top-10** commercial /
@@ -103,6 +103,7 @@ for operator scope call in the PR body).
 | hermes-agent | `/v1/chat/completions` | `TestHermesAgent` (wire smoke via OpenAI SDK) | `test_hermes.py` (real 62-tool E2E) |
 | aider | shell subprocess → `/v1/chat/completions` | `TestAider` (**real bash-CLI harness** — drives aider one-shot with `--message`, asserts add.py corrected) | `test_aider.sh` (same harness, standalone) |
 | kilo-code | `/v1/chat/completions` | `TestKiloCode` (wire smoke via OpenAI SDK) | (matrix only) |
+| deepseek-harness | `/v1/chat/completions` | `TestDeepSeekHarness` (wire smoke via OpenAI SDK) | `agent_smoke.sh` (Tier-1 release gate — real `dsh` binary fixes a real bug, repo test suite must go green) |
 | copilot | `/v1/chat/completions` | `TestCopilot` (**wire smoke only** — real CLI needs `gh auth login`, deferred) | (subprocess cell deferred) |
 | droid | `/v1/chat/completions` | `TestDroid` (**wire smoke only** — real CLI needs Factory session token, deferred) | (subprocess cell deferred) |
 | kimi-code | `/v1/chat/completions` | `TestKimiCode` (**wire smoke only** — real CLI needs Moonshot auth flow, deferred) | (subprocess cell deferred) |
@@ -336,9 +337,22 @@ Full V4 Flash coverage tracked in follow-up issue **#1041**
 | hermes-agent | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) | ✅ |
 | aider | ✅ | ✅ | ✅ | ✅ | XFAIL (Ultra) | exp |
 | kilo-code | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) | ✅ |
+| deepseek-harness | ✅† | ✅ | XFAIL (arch) | ✅† | XFAIL (Ultra) | ✅ |
 | copilot | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) | ✅ |
 | droid | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) | ✅ |
 | kimi-code | ✅ | ✅ | XFAIL (arch) | ✅ | XFAIL (Ultra) | ✅ |
+
+† `deepseek-harness` joined the matrix on 2026-08-17. Its Qwen 3.6 and gpt-oss
+cells were run strict (`RAPID_MLX_MATRIX_STRICT=1`) against real weights that
+day — `qwen3.6-35b-8bit` and `gpt-oss-20b-MXFP4-Q8` respectively. The Gemma 4
+and Muse cells are recorded from the shared code path rather than an
+independent run: `TestDeepSeekHarness.test_smoke` is a one-line call to the
+same `_run_openai_tool_smoke` helper that backs `kilo-code`, `copilot`,
+`droid` and `kimi-code`, and the helper's only per-agent input is a label used
+in failure messages — so those columns measure the server's tool-call wire for
+the family, which those four identical cells already record. The next full
+matrix run resolves them for real; if any disagrees, this footnote is the bug
+report.
 
 ### Framework × Family matrix (3 × 6 = 18)
 

--- a/tests/integrations/agent_smoke.sh
+++ b/tests/integrations/agent_smoke.sh
@@ -6,18 +6,19 @@
 # this — no Metal, no weights, and release-preflight skips every gate that needs
 # a live `rapid-mlx serve`.
 #
-# Boots `rapid-mlx serve`, then drives the FOUR Tier-1 (flagship) agents —
-# Claude Code, Codex, Hermes, Aider — through a real multi-step bug-fix task
-# against the local model, and asserts each one actually made the test pass.
+# Boots `rapid-mlx serve`, then drives the FIVE Tier-1 (flagship) agents —
+# Claude Code, Codex, Hermes, Aider, DeepSeek Harness — through a real
+# multi-step bug-fix task against the local model, and asserts each one
+# actually made the test pass.
 #
 #   Usage:   RAPID_MLX_VENV=~/rapid-mlx-audit-venv ./agent_smoke.sh [model-alias]
 #   Default: model-alias = qwen3.6-35b-8bit   (strong 8-bit — never 4-bit,
 #            which confounds "weak model" with "broken integration")
 #
-# Exit code: 0 iff all four Tier-1 agents PASS. Non-zero blocks the release.
+# Exit code: 0 iff all five Tier-1 agents PASS. Non-zero blocks the release.
 # Non-destructive on the shared Studio: it starts only its own server (and kills
-# only that one), and backs up / restores (or removes) ~/.codex and ~/.hermes
-# config it touches.
+# only that one), and backs up / restores (or removes) the ~/.codex, ~/.hermes
+# and ~/.dsh config it touches.
 set -uo pipefail
 
 # Resolved HERE, before anything runs: ``seed_repo``/``verify`` cd into the
@@ -44,9 +45,13 @@ WORK="$HOME/agent-smoke-work"
 LOG="$HOME/agent-smoke-serve.log"
 SERVE_PID=""
 
-# Throwaway config homes. codex and hermes both relocate their entire config
-# directory via these variables, and `agents <x> --setup` honours them, so this
-# gate never reads or writes the operator's real ~/.codex or ~/.hermes.
+# Throwaway config homes. codex, hermes and dsh all relocate their entire
+# config directory via these variables, and `agents <x> --setup` honours them,
+# so this gate never reads or writes the operator's real ~/.codex, ~/.hermes or
+# ~/.dsh. DSH_HOME matters more than the other two: `agents dsh --setup` also
+# writes a credential file (.credentials.yaml) beside settings.yaml, so an
+# un-redirected run would touch the operator's credential store, not just a
+# provider block.
 #
 # This replaces backup-then-restore as the PRIMARY protection. That approach
 # has two failure modes we actually hit: the restore never runs if the script
@@ -71,7 +76,8 @@ SERVE_PID=""
 # anyway. One definition, owned by the side that actually makes the decision.
 export CODEX_HOME="${CODEX_HOME_OVERRIDE:-$(mktemp -d)}"
 export HERMES_HOME="${HERMES_HOME_OVERRIDE:-$(mktemp -d)}"
-for _home_var in CODEX_HOME HERMES_HOME; do
+export DSH_HOME="${DSH_HOME_OVERRIDE:-$(mktemp -d)}"
+for _home_var in CODEX_HOME HERMES_HOME DSH_HOME; do
   eval "_home_val=\${$_home_var}"
   # Resolve it EXACTLY as _resolve_config_path will (strip, then expanduser)
   # and re-export the result, so the value this script validates, backs up and
@@ -103,6 +109,7 @@ sys.stdout.write(os.path.realpath(os.path.expanduser(v)) if v else "")' \
   case "$_home_var" in
     CODEX_HOME)  _home_real="$(python3 -c 'import os,sys; sys.stdout.write(os.path.realpath(os.path.expanduser("~/.codex")))')" ;;
     HERMES_HOME) _home_real="$(python3 -c 'import os,sys; sys.stdout.write(os.path.realpath(os.path.expanduser("~/.hermes")))')" ;;
+    DSH_HOME)    _home_real="$(python3 -c 'import os,sys; sys.stdout.write(os.path.realpath(os.path.expanduser("~/.dsh")))')" ;;
     *)           _home_real="" ;;
   esac
   if [ -n "$_home_real" ] && [ "${_home_val}" = "$_home_real" ]; then
@@ -115,6 +122,7 @@ done
 unset _home_var _home_val _home_real
 CODEX_CFG="$CODEX_HOME/config.toml"
 HERMES_CFG="$HERMES_HOME/config.yaml"
+DSH_CFG="$DSH_HOME/settings.yaml"
 
 # Portable timeout: coreutils `timeout`, or `gtimeout`, else a bash fallback
 # (background the command, hard-kill after N seconds). macOS ships neither
@@ -162,10 +170,13 @@ cleanup() {
   fi
   restore_cfg "$CODEX_CFG"
   restore_cfg "$HERMES_CFG"
-  # Both live under throwaway homes now, so this is just tidying temp files —
-  # the operator's real ~/.codex and ~/.hermes were never touched.
+  restore_cfg "$DSH_CFG"
+  # All three live under throwaway homes now, so this is just tidying temp
+  # files — the operator's real ~/.codex, ~/.hermes and ~/.dsh were never
+  # touched.
   [ -n "${CODEX_HOME_OVERRIDE:-}" ] || rm -rf "$CODEX_HOME"
   [ -n "${HERMES_HOME_OVERRIDE:-}" ] || rm -rf "$HERMES_HOME"
+  [ -n "${DSH_HOME_OVERRIDE:-}" ] || rm -rf "$DSH_HOME"
   rm -rf "$WORK" "$LOG"
 }
 trap cleanup EXIT
@@ -175,7 +186,7 @@ fail() { echo "SMOKE-ABORT: $*" >&2; exit 3; }
 
 echo "== versions =="
 printf "  rapid-mlx  %s\n" "$($RMLX --version 2>&1 | head -1)"
-for b in claude codex aider hermes; do
+for b in claude codex aider hermes dsh; do
   command -v "$b" >/dev/null 2>&1 && printf "  %-9s  %s\n" "$b" "$($b --version 2>&1 | head -1)" \
                                   || printf "  %-9s  MISSING\n" "$b"
 done
@@ -245,7 +256,7 @@ fi
 # kernels, which alone pushes cold start to ~240s (a warm shader cache serves the
 # same model in ~15s). The old 240s budget sat right on that cold-compile knee and
 # flaked the release gate by ~1-2s. 600s clears the cold compile with margin and
-# still leaves ample room under the 55-min job timeout for the four agent runs. A
+# still leaves ample room under the job timeout for the five agent runs. A
 # genuine hang (never binds) still fails — it just gets a realistic deadline.
 for i in $(seq 1 120); do
   curl -s -m 3 "$B/v1/models" 2>/dev/null | grep -q '"id"' && { echo "serve READY (~$((i*5))s)"; break; }
@@ -273,7 +284,7 @@ done
 # 0.11.3 on every serving path. It is purely one-time cold-compile latency.
 #
 # So warm the LARGE-context kernels here, untimed, on BOTH routes the agents use
-# (/v1/chat/completions for codex/hermes/aider, /v1/messages for claude), and
+# (/v1/chat/completions for codex/hermes/aider/dsh, /v1/messages for claude), and
 # RETRY until a request returns fast — a fast return proves the cold compile is
 # fully paid and cached before any timed agent starts. Generous per-request
 # timeout so the compile completes untimed; best-effort, never fatal.
@@ -349,9 +360,9 @@ TASK='Run python3 test_calc.py, it fails. Fix the bug in calc.py so all assertio
 # The agents (codex especially) are non-deterministic, so give each up to 2
 # attempts (hermes 3) — a single miss must not flap the release gate.
 #
-# Run the four SERIALLY, one at a time, against the warm server. An earlier
-# revision overlapped all four to collapse wall-clock from ~sum to ~max, on the
-# theory that an agent leaves the GPU idle between generations so the four fill
+# Run the five SERIALLY, one at a time, against the warm server. An earlier
+# revision overlapped them to collapse wall-clock from ~sum to ~max, on the
+# theory that an agent leaves the GPU idle between generations so they fill
 # each other's gaps. In practice their turns overlap heavily, and batching 5-6
 # in-flight requests — each a 25-38k-token agent prompt — onto the ONE GPU
 # starves every stream (measured on the Studio: 12 output tokens in 65s at
@@ -410,6 +421,30 @@ run_aider() {
   echo "$r" > "$WORK/aider.result"
 }
 
+# ---- DeepSeek Harness (uses $DSH_HOME/settings.yaml rendered below) ------
+# RAPID_MLX_API_KEY is passed explicitly even though `--setup` also writes the
+# same sentinel into $DSH_HOME/.credentials.yaml: DSH's pi-ai transport insists
+# on RESOLVING a credential for the provider before it will dispatch, and the
+# env var is the path that does not depend on the credential store having been
+# written. Belt and braces, same as ANTHROPIC_API_KEY / OPENAI_API_KEY above.
+#
+# `--profile headless` is the one-shot task profile (answer, print, exit); the
+# interactive `web` / `tui` profiles would block forever on a gate runner.
+# NOTE: dsh exits 0 even when it fails outright (a bad provider prints
+# `NO_ADAPTER: ...` and still returns 0), so the exit status is deliberately
+# ignored here — `verify` re-running the real test is the only signal that
+# means anything. Do not "improve" this into an exit-code check.
+run_dsh() {
+  local r=FAIL
+  for _try in 1 2; do
+    seed_repo dsh
+    TO "$AGENT_TO" env RAPID_MLX_API_KEY=not-needed \
+      dsh --profile headless "$TASK" >/dev/null 2>&1
+    [ "$(verify dsh)" = PASS ] && { r=PASS; break; }
+  done
+  echo "$r" > "$WORK/dsh.result"
+}
+
 # Render the two agent config files up front (distinct paths → no collision),
 # THEN launch. --base-url points setup at OUR serve port (not the default
 # :8000). For hermes it is REQUIRED: Hermes rejects any model whose
@@ -425,8 +460,14 @@ run_aider() {
 # back to the operator's real config no matter what this script exported.
 # Fingerprinting the real files and checking them afterwards catches that, and
 # anything else nobody has thought of yet.
+#
+# ~/.dsh contributes TWO paths, not one: `agents dsh --setup` writes the
+# provider block to settings.yaml AND a credential sentinel to
+# .credentials.yaml. Fingerprinting only the settings file would let a
+# redirect failure rewrite the operator's real credential store unnoticed.
 _real_fingerprint() {
-  for f in "$HOME/.codex/config.toml" "$HOME/.hermes/config.yaml"; do
+  for f in "$HOME/.codex/config.toml" "$HOME/.hermes/config.yaml" \
+           "$HOME/.dsh/settings.yaml" "$HOME/.dsh/.credentials.yaml"; do
     if [ -f "$f" ]; then shasum -a 256 "$f" 2>/dev/null; else echo "absent $f"; fi
   done
 }
@@ -438,6 +479,11 @@ patch_port "$CODEX_CFG"
 save_cfg "$HERMES_CFG"
 "$RMLX" agents hermes --setup --base-url "$B/v1" >/dev/null 2>&1
 patch_port "$HERMES_CFG"
+save_cfg "$DSH_CFG"
+# --yes: dsh's setup is the interactive plan/apply flow, and this gate has no
+# tty to answer the confirmation prompt with.
+"$RMLX" agents dsh --setup --yes --base-url "$B/v1" >/dev/null 2>&1
+patch_port "$DSH_CFG"
 
 if [ "$(_real_fingerprint)" != "$_REAL_BEFORE" ]; then
   echo "SMOKE-ABORT: \`agents --setup\` modified the operator's REAL config despite" >&2
@@ -448,7 +494,7 @@ if [ "$(_real_fingerprint)" != "$_REAL_BEFORE" ]; then
   exit 3
 fi
 
-echo "running 4 Tier-1 agents serially (budget ${AGENT_TO}s, hermes ${HERMES_TO}s)…"
+echo "running 5 Tier-1 agents serially (budget ${AGENT_TO}s, hermes ${HERMES_TO}s)…"
 # Serial, NOT backgrounded: overlapping them oversubscribes the single GPU and
 # flakes the gate (see the rationale above run_claude). Each runs to completion
 # — with its own retries + per-agent timeout — before the next starts, so it
@@ -458,15 +504,18 @@ run_claude
 run_codex
 run_hermes
 run_aider
+run_dsh
 
 # Restore the config files only after every agent has finished using them.
 restore_cfg "$CODEX_CFG"
 restore_cfg "$HERMES_CFG"
+restore_cfg "$DSH_CFG"
 
 R_CLAUDE=$(cat "$WORK/claude.result" 2>/dev/null || echo FAIL)
 R_CODEX=$(cat "$WORK/codex.result" 2>/dev/null || echo FAIL)
 R_HERMES=$(cat "$WORK/hermes.result" 2>/dev/null || echo FAIL)
 R_AIDER=$(cat "$WORK/aider.result" 2>/dev/null || echo FAIL)
+R_DSH=$(cat "$WORK/dsh.result" 2>/dev/null || echo FAIL)
 
 # ---- report --------------------------------------------------------------
 echo
@@ -475,8 +524,9 @@ printf "  claude-code  %s\n" "$R_CLAUDE"
 printf "  codex-cli    %s\n" "$R_CODEX"
 printf "  hermes       %s\n" "$R_HERMES"
 printf "  aider        %s\n" "$R_AIDER"
+printf "  dsh          %s\n" "$R_DSH"
 
-for r in "$R_CLAUDE" "$R_CODEX" "$R_HERMES" "$R_AIDER"; do
+for r in "$R_CLAUDE" "$R_CODEX" "$R_HERMES" "$R_AIDER" "$R_DSH"; do
   [ "$r" = PASS ] || { echo "RESULT: FAIL — a Tier-1 agent regressed; this blocks the release."; exit 1; }
 done
 
@@ -516,4 +566,4 @@ if [ "${RAPID_MLX_RELEASE_GATE:-0}" = "1" ]; then
   echo "== release-gate extras PASSED (coherence + perf) =="
 fi
 
-echo "RESULT: PASS — all four Tier-1 agents verified on $ALIAS."
+echo "RESULT: PASS — all five Tier-1 agents verified on $ALIAS."

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -476,12 +476,21 @@ _DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS = frozenset(
     {
         # test_agents_matrix.py — OpenAI-wire agents that require true
         # ``tool_calls`` emission (opencode, qwen-code, hermes, kilo-code,
-        # copilot, droid, kimi-code). CodexCLI + ClaudeCode use text-only
-        # routes and PASS on R1-Distill, so they are NOT in this list.
+        # deepseek-harness, copilot, droid, kimi-code). CodexCLI +
+        # ClaudeCode use text-only routes and PASS on R1-Distill, so they
+        # are NOT in this list.
+        #
+        # DeepSeek Harness is in this list despite being DeepSeek's own
+        # client: the gap is in the R1-Distill CHECKPOINT's tool emission,
+        # not in the harness. DSH drives rapid-mlx over the generic
+        # ``openai-completions`` provider and needs the same OpenAI-shape
+        # ``tool_calls`` every other wire agent needs, so it inherits the
+        # same architectural xfail.
         "test_agents_matrix.py::TestOpenCode",
         "test_agents_matrix.py::TestQwenCode",
         "test_agents_matrix.py::TestHermesAgent",
         "test_agents_matrix.py::TestKiloCode",
+        "test_agents_matrix.py::TestDeepSeekHarness",
         "test_agents_matrix.py::TestCopilot",
         "test_agents_matrix.py::TestDroid",
         "test_agents_matrix.py::TestKimiCode",
@@ -577,7 +586,7 @@ _GPTOSS_OPENHANDS_XFAIL_REASON = (
 # Following the same G8 discipline as the V4-Flash precedent
 # (root-caused note in ``_FAMILY_ALIASES['deepseek'].reason`` +
 # README §"DeepSeek family — architectural tool-emission gap"): rather
-# than downgrade the 14 Hy3 cells (11 agents + 3 frameworks) to plain
+# than downgrade the 15 Hy3 cells (12 agents + 3 frameworks) to plain
 # ``skip`` (G8: "root-cause failures, do not hide behind skips"), every
 # Hy3 cell is marked
 # ``xfail(strict=True)``. These are structural placeholders + a weekly
@@ -664,7 +673,7 @@ def pytest_collection_modifyitems(
                     strict=True,
                 )
             )
-        # Hy3 — every matrix cell (all 14: 11 agents + 3 frameworks), 166 GB
+        # Hy3 — every matrix cell (all 15: 12 agents + 3 frameworks), 166 GB
         # Ultra-only. The matrix parametrizes by a single ``family`` argument,
         # so every Hy3 matrix nodeid ends in exactly ``[hy3]`` (never a
         # combined id like ``[agent-hy3]``). The bare ``[hy3]`` token is NOT

--- a/tests/integrations/test_agents_matrix.py
+++ b/tests/integrations/test_agents_matrix.py
@@ -666,6 +666,33 @@ class TestKiloCode:
         _run_openai_tool_smoke(rapid_mlx_server, family_alias, agent_label="kilo-code")
 
 
+class TestDeepSeekHarness:
+    """DeepSeek Harness /v1/chat/completions with tool call.
+
+    DSH reaches rapid-mlx through its GENERIC ``openai-completions``
+    provider (see ``deepseek-harness.yaml``), never the
+    ``deepseek-official`` adapter — pointing the official adapter at a
+    loopback server would require a fake API key and would claim the local
+    endpoint carries the official service's model/capacity contract. The
+    wire is therefore plain OpenAI-compat, and this cell smokes the
+    tool call that DSH's fs / bash / str-replace tools all ride on.
+
+    Cell shape follows hermes: a lightweight wire cell here, with the real
+    end-to-end drive of the ``dsh`` binary living in the Tier-1 release
+    gate (``agent_smoke.sh``), which fixes a real bug in a real repo and
+    asserts the repo's own test suite goes green.
+    """
+
+    def test_smoke(
+        self,
+        rapid_mlx_server: dict[str, Any],
+        family_alias: FamilyAlias,
+    ) -> None:
+        _run_openai_tool_smoke(
+            rapid_mlx_server, family_alias, agent_label="deepseek-harness"
+        )
+
+
 class TestCopilot:
     """GitHub Copilot CLI wire smoke.
 

--- a/tests/integrations/test_strict_xfail_registry.py
+++ b/tests/integrations/test_strict_xfail_registry.py
@@ -49,13 +49,13 @@ import pytest
 # Independent, checked-in snapshot of every strict-xfail matrix cell.
 # --------------------------------------------------------------------------- #
 #
-# 24 cells total, one strict-xfail per line. Grouped by the reason family
+# 26 cells total, one strict-xfail per line. Grouped by the reason family
 # (see tests/integrations/conftest.py for the root-cause of each group).
 # Editing this set is the ONLY sanctioned way to add/remove a strict-xfail
 # in the matrix — the assertion below fails until this snapshot matches the
 # markers the conftest hook actually applies.
 
-# 9 × DeepSeek R1-Distill tool-call cells — R1 distillation dropped OpenAI
+# 10 × DeepSeek R1-Distill tool-call cells — R1 distillation dropped OpenAI
 # tool_call emission (conftest ``_DEEPSEEK_R1_TOOLCALL_XFAIL_NODEIDS``).
 _DEEPSEEK_STRICT_XFAIL = frozenset(
     {
@@ -63,6 +63,9 @@ _DEEPSEEK_STRICT_XFAIL = frozenset(
         "tests/integrations/test_agents_matrix.py::TestQwenCode::test_smoke[deepseek]",
         "tests/integrations/test_agents_matrix.py::TestHermesAgent::test_smoke[deepseek]",
         "tests/integrations/test_agents_matrix.py::TestKiloCode::test_smoke[deepseek]",
+        # DeepSeek's own harness is not exempt: the gap is the R1-Distill
+        # checkpoint's tool emission, and DSH rides the same OpenAI wire.
+        "tests/integrations/test_agents_matrix.py::TestDeepSeekHarness::test_smoke[deepseek]",
         "tests/integrations/test_agents_matrix.py::TestCopilot::test_smoke[deepseek]",
         "tests/integrations/test_agents_matrix.py::TestDroid::test_smoke[deepseek]",
         "tests/integrations/test_agents_matrix.py::TestKimiCode::test_smoke[deepseek]",
@@ -78,7 +81,7 @@ _GPTOSS_STRICT_XFAIL = frozenset(
     }
 )
 
-# 14 × Hy3 cells — 166 GB single-node-infeasible, Ultra-only (family-wide:
+# 15 × Hy3 cells — 166 GB single-node-infeasible, Ultra-only (family-wide:
 # every agent + framework class × [hy3]).
 _HY3_STRICT_XFAIL = frozenset(
     {
@@ -90,6 +93,7 @@ _HY3_STRICT_XFAIL = frozenset(
         "tests/integrations/test_agents_matrix.py::TestHermesAgent::test_smoke[hy3]",
         "tests/integrations/test_agents_matrix.py::TestAider::test_smoke[hy3]",
         "tests/integrations/test_agents_matrix.py::TestKiloCode::test_smoke[hy3]",
+        "tests/integrations/test_agents_matrix.py::TestDeepSeekHarness::test_smoke[hy3]",
         "tests/integrations/test_agents_matrix.py::TestCopilot::test_smoke[hy3]",
         "tests/integrations/test_agents_matrix.py::TestDroid::test_smoke[hy3]",
         "tests/integrations/test_agents_matrix.py::TestKimiCode::test_smoke[hy3]",
@@ -105,10 +109,10 @@ _EXPECTED_STRICT_XFAIL_NODEIDS = (
 
 # Redundant count tripwires — make the coverage delta obvious even before
 # the reviewer diffs the nodeid set. Guarded against snapshot typos below.
-_EXPECTED_DEEPSEEK_COUNT = 9
+_EXPECTED_DEEPSEEK_COUNT = 10
 _EXPECTED_GPTOSS_COUNT = 1
-_EXPECTED_HY3_COUNT = 14
-_EXPECTED_STRICT_XFAIL_COUNT = 24
+_EXPECTED_HY3_COUNT = 15
+_EXPECTED_STRICT_XFAIL_COUNT = 26
 
 
 class _StrictXfailCollector:

--- a/tests/test_bench_tier_harness.py
+++ b/tests/test_bench_tier_harness.py
@@ -887,7 +887,7 @@ def test_harness_profile_timeout_env_var_respected(monkeypatch):
 class TestHarnessProfilesFilter:
     """G12 (random-coverage) sets ``RAPID_MLX_HARNESS_PROFILES_FILTER``
     to scope a ``--tier harness`` sweep to a randomly-picked subset of
-    the 5 first-class harnesses. The filter must:
+    the first-class harnesses. The filter must:
       * accept a single profile (``"codex"``)
       * accept comma-separated multi (``"codex,aider"``)
       * tolerate whitespace + trailing commas

--- a/tests/test_bench_tier_smoke.py
+++ b/tests/test_bench_tier_smoke.py
@@ -216,8 +216,14 @@ def test_resolve_base_url_strips_v1_suffix():
     assert _resolve_base_url(None) is None
 
 
-def test_harness_profiles_list_has_five_in_correct_order():
-    """The 5 first-class harnesses must be in the documented order."""
+def test_harness_profiles_list_is_exact_and_in_documented_order():
+    """The first-class harnesses must be in the documented order.
+
+    Deliberately not named for a count — the previous
+    ``..._has_five_...`` spelling went stale the moment a sixth harness
+    was added, and a test whose name disagrees with its assertion is a
+    slower way to learn the same thing.
+    """
     assert HARNESS_PROFILES == (
         "codex",
         "opencode",

--- a/tests/test_bench_tier_smoke.py
+++ b/tests/test_bench_tier_smoke.py
@@ -218,7 +218,14 @@ def test_resolve_base_url_strips_v1_suffix():
 
 def test_harness_profiles_list_has_five_in_correct_order():
     """The 5 first-class harnesses must be in the documented order."""
-    assert HARNESS_PROFILES == ("codex", "opencode", "hermes", "aider", "langchain")
+    assert HARNESS_PROFILES == (
+        "codex",
+        "opencode",
+        "hermes",
+        "aider",
+        "langchain",
+        "deepseek-harness",
+    )
 
 
 def test_find_free_port_in_range_uses_band():

--- a/tests/test_deepseek_harness_tier1.py
+++ b/tests/test_deepseek_harness_tier1.py
@@ -21,6 +21,7 @@ red, which is the only property that makes a guard worth having.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -54,13 +55,15 @@ def test_harness_profiles_mirror_in_release_check_is_in_lockstep() -> None:
     mirror_src = (REPO_ROOT / "scripts" / "release_check_m3_random.py").read_text(
         encoding="utf-8"
     )
-    namespace: dict[str, object] = {}
     match = re.search(
-        r"^HARNESS_PROFILES = \((?:[^)]*)\)", mirror_src, re.MULTILINE | re.DOTALL
+        r"^HARNESS_PROFILES = (\([^)]*\))", mirror_src, re.MULTILINE | re.DOTALL
     )
     assert match, "release_check_m3_random.py no longer defines HARNESS_PROFILES"
-    exec(match.group(0), namespace)  # noqa: S102 — literal tuple from our own repo
-    assert namespace["HARNESS_PROFILES"] == HARNESS_PROFILES
+    # literal_eval, not exec: this only ever needs to read a tuple of string
+    # literals, and it should stay unable to do anything else even if that
+    # file grows something executable next to the assignment.
+    mirrored = ast.literal_eval(match.group(1))
+    assert mirrored == HARNESS_PROFILES
 
 
 def test_bench_submission_schema_accepts_every_harness_profile() -> None:

--- a/tests/test_deepseek_harness_tier1.py
+++ b/tests/test_deepseek_harness_tier1.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek Harness is a Tier-1 agent — pin the wiring that makes that true.
+
+"Tier-1" in this repo is not a label in a README, it is two concrete
+mechanisms:
+
+1. ``tests/integrations/agent_smoke.sh`` drives the REAL ``dsh`` binary
+   through a real bug-fix task on every release; the release job ``needs``
+   that gate, so a regression cannot tag or publish.
+2. ``bench --tier harness`` / release_check_m3.sh G7b smoke the
+   chat-completions wire for every first-class harness.
+
+Both are shell/CI surfaces that no unit test would otherwise touch, so the
+Tier-1 claim could rot silently — the profile would keep loading, the docs
+would keep saying "Tier-1", and nothing would fail. These tests assert the
+wiring itself.
+
+Each test below is written so that REMOVING the thing it guards makes it
+red, which is the only property that makes a guard worth having.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SMOKE = REPO_ROOT / "tests" / "integrations" / "agent_smoke.sh"
+
+
+@pytest.fixture(scope="module")
+def smoke_src() -> str:
+    return SMOKE.read_text(encoding="utf-8")
+
+
+def test_dsh_is_a_first_class_harness_profile() -> None:
+    """``bench --tier harness`` must actually sweep deepseek-harness."""
+    from vllm_mlx.bench.tier_runner import HARNESS_PROFILES
+
+    assert "deepseek-harness" in HARNESS_PROFILES
+
+
+def test_harness_profiles_mirror_in_release_check_is_in_lockstep() -> None:
+    """release_check_m3_random.py hardcodes a mirror of HARNESS_PROFILES.
+
+    It cannot import the real one (importing the package pulls mlx_lm at
+    module load), so the mirror is copy-paste by design — and copy-paste
+    is exactly what drifts. Compare the two directly.
+    """
+    from vllm_mlx.bench.tier_runner import HARNESS_PROFILES
+
+    mirror_src = (REPO_ROOT / "scripts" / "release_check_m3_random.py").read_text(
+        encoding="utf-8"
+    )
+    namespace: dict[str, object] = {}
+    match = re.search(
+        r"^HARNESS_PROFILES = \((?:[^)]*)\)", mirror_src, re.MULTILINE | re.DOTALL
+    )
+    assert match, "release_check_m3_random.py no longer defines HARNESS_PROFILES"
+    exec(match.group(0), namespace)  # noqa: S102 — literal tuple from our own repo
+    assert namespace["HARNESS_PROFILES"] == HARNESS_PROFILES
+
+
+def test_bench_submission_schema_accepts_every_harness_profile() -> None:
+    """``harness_result`` uses ``additionalProperties: false``.
+
+    A profile added to HARNESS_PROFILES but not to the schema makes every
+    ``--tier harness --submit`` run fail validation at submission time,
+    which is a long way from the change that caused it.
+    """
+    import json
+
+    from vllm_mlx.bench.tier_runner import HARNESS_PROFILES
+
+    schema = json.loads(
+        (REPO_ROOT / "community-benchmarks" / "schema.json").read_text(encoding="utf-8")
+    )
+    allowed = set(schema["properties"]["harness_result"]["properties"])
+    missing = set(HARNESS_PROFILES) - allowed
+    assert not missing, (
+        f"harness_result schema rejects {sorted(missing)}; add them to "
+        f"community-benchmarks/schema.json properties (required stays as-is — "
+        f"see that field's description for the back-compat reason)"
+    )
+
+
+def test_release_gate_runs_dsh_and_counts_it(smoke_src: str) -> None:
+    """The gate must define, invoke, and grade dsh — all three."""
+    assert "run_dsh()" in smoke_src, "no run_dsh function"
+    assert re.search(r"^run_dsh$", smoke_src, re.MULTILINE), (
+        "run_dsh is defined but never invoked — a Tier-1 agent that never runs"
+    )
+    assert '"$R_DSH"' in smoke_src, "dsh result is never graded in the pass loop"
+
+
+def test_release_gate_grades_dsh_in_the_blocking_loop(smoke_src: str) -> None:
+    """dsh's result must be in the loop that exits non-zero, not just printed.
+
+    Printing a FAIL and still exiting 0 is the failure mode that makes a
+    gate decorative.
+    """
+    loop = re.search(r"^for r in (.+); do$", smoke_src, re.MULTILINE)
+    assert loop, "the Tier-1 pass/fail loop is gone"
+    assert "$R_DSH" in loop.group(1), (
+        f"dsh missing from the blocking loop: {loop.group(1)}"
+    )
+
+
+def test_release_gate_redirects_and_guards_dsh_home(smoke_src: str) -> None:
+    """DSH_HOME must be redirected AND validated like CODEX_HOME/HERMES_HOME.
+
+    ``agents dsh --setup`` writes a credential file, so an un-redirected or
+    blank DSH_HOME does more damage than a stray provider block.
+    """
+    assert "export DSH_HOME=" in smoke_src
+    guard = re.search(r"^for _home_var in (.+); do$", smoke_src, re.MULTILINE)
+    assert guard, "the throwaway-home guard loop is gone"
+    assert "DSH_HOME" in guard.group(1), (
+        f"DSH_HOME skips the blank/real-config guard: {guard.group(1)}"
+    )
+    assert re.search(r"DSH_HOME\)\s+_home_real=", smoke_src), (
+        "DSH_HOME has no ~/.dsh case in the real-config refusal, so the guard "
+        "silently falls through to the empty default and never fires"
+    )
+
+
+def test_release_gate_fingerprints_the_real_dsh_credential_store(
+    smoke_src: str,
+) -> None:
+    """Both files ``--setup`` can write must be fingerprinted, not just one."""
+    fingerprint = re.search(r"_real_fingerprint\(\) \{.*?\n\}", smoke_src, re.DOTALL)
+    assert fingerprint, "_real_fingerprint is gone"
+    body = fingerprint.group(0)
+    assert ".dsh/settings.yaml" in body
+    assert ".dsh/.credentials.yaml" in body, (
+        "the credential file --setup writes is not fingerprinted, so a "
+        "redirect failure could rewrite it unnoticed"
+    )
+
+
+def test_release_gate_does_not_trust_dsh_exit_code(smoke_src: str) -> None:
+    """dsh exits 0 on hard failure, so grading must come from ``verify``.
+
+    Measured on 0.1.0-rc.7: a settings.yaml naming an unregistered provider
+    prints ``NO_ADAPTER: ...`` and still returns 0. If someone "tidies" the
+    runner into an exit-code check, every dsh run passes forever.
+    """
+    run_dsh = re.search(r"run_dsh\(\) \{.*?\n\}", smoke_src, re.DOTALL)
+    assert run_dsh, "run_dsh is gone"
+    assert '[ "$(verify dsh)" = PASS ]' in run_dsh.group(0), (
+        "run_dsh no longer grades on verify(); dsh's exit status is not a "
+        "pass signal (it returns 0 even when it fails outright)"
+    )
+
+
+def test_dsh_profile_warns_that_exit_code_is_not_a_pass_signal() -> None:
+    """The trap above must be documented where an integrator will hit it."""
+    from vllm_mlx.agents import get_profile, load_profiles
+
+    load_profiles()
+    profile = get_profile("dsh")
+    assert profile is not None
+    assert any("exits 0" in issue for issue in profile.known_issues), (
+        "the exit-code trap is not in known_issues"
+    )

--- a/vllm_mlx/agents/profiles/deepseek-harness.yaml
+++ b/vllm_mlx/agents/profiles/deepseek-harness.yaml
@@ -58,5 +58,6 @@ capabilities:
 
 known_issues:
   - "DeepSeek Harness is currently a developer preview and may make compatibility-breaking configuration changes."
-  - "The current DSH release requires Node's Zstd stream API (Node 22.15+ works) but does not declare that minimum in its npm manifest."
+  - "The current DSH release requires Node's Zstd stream API (Node 22.15+ works) but does not declare that minimum in its npm manifest (still true as of 0.1.0-rc.7)."
   - "Use the generic openai-completions provider, not deepseek-official, for a local Rapid-MLX endpoint."
+  - "dsh exits 0 even when a task fails outright (a bad provider prints NO_ADAPTER and still returns 0), so never treat its exit status as a pass signal — assert on the work it was supposed to do."

--- a/vllm_mlx/bench/tier_runner.py
+++ b/vllm_mlx/bench/tier_runner.py
@@ -31,16 +31,24 @@ from dataclasses import dataclass
 
 from ..http_auth import rapid_mlx_auth_headers
 
-# The 5 first-class harnesses in the documented order. Used by both
+# The 6 first-class harnesses in the documented order. Used by both
 # ``--tier harness`` and the release_check_m3.sh G7b gate. Keep this
 # list in lock-step with the G7b shell loop in scripts/release_check_m3.sh
-# — if a harness is added/removed here, the script must be updated too.
+# AND with the hardcoded mirror in scripts/release_check_m3_random.py
+# — if a harness is added/removed here, both must be updated too.
+#
+# ``deepseek-harness`` is appended rather than slotted in beside the other
+# CLIs on purpose: ``test_bench_tier_smoke`` pins this tuple exactly and
+# ``test_bench_tier_harness`` indexes it (``HARNESS_PROFILES[1:]``), so
+# growing it at the tail is the change that cannot silently reinterpret an
+# existing positional assertion.
 HARNESS_PROFILES: tuple[str, ...] = (
     "codex",
     "opencode",
     "hermes",
     "aider",
     "langchain",
+    "deepseek-harness",
 )
 
 # Deterministic ephemeral-port range the tier runner probes when no
@@ -1040,9 +1048,12 @@ def _run_harness(
     # error_excerpt is ``null`` (schema enforces ``["string", "null"]``);
     # on fail, the first 200 chars of the existing detail line — same
     # truncation cap as schema. The dict is keyed by adapter name; the
-    # schema's ``additionalProperties: false`` plus ``required`` of all
-    # 5 keys means this stays in lock-step with HARNESS_PROFILES (a
-    # mismatch is a schema-validation failure at submission time).
+    # schema's ``additionalProperties: false`` means an adapter absent
+    # from the schema's ``properties`` is a validation failure at
+    # submission time, so a new HARNESS_PROFILES entry must be added
+    # there too. ``required`` deliberately still lists only the original
+    # five — see the ``harness_result`` description in schema.json for why
+    # a newer adapter is allowed-but-not-required.
     #
     # When ``HARNESS_PROFILES_FILTER`` is active, ``per_harness`` only
     # contains entries for the filtered profiles — the resulting payload


### PR DESCRIPTION
## Why

DeepSeek Harness shipped in #1952 with a first-class setup flow, docs and 13 tests — but **zero automated coverage**. It sat in neither tier, was absent from `HARNESS_PROFILES`, and was absent from the release gate, so nothing would have caught an rc.8 configuration-schema break; the only thing pinning the contract was prose in `known_issues`. #1952 also left the README's own counts inconsistent (agent list says 12, tier lines still add to 11).

This PR makes the Tier-1 claim real and enforced, because a "supported integration" that no gate exercises is a claim with nothing behind it. Refs #1952.

## What changed

Promotes **DeepSeek Harness** to Tier-1: the fifth agent whose real binary must pass a real task before a release can tag.

#1952 landed DSH with a first-class setup flow, docs and 13 tests — but **zero automated coverage**. It was in neither tier, absent from `HARNESS_PROFILES`, and absent from the release gate. Nothing would have caught an rc.8 schema break. (It was also left out of the README's own counts: the agent list says 12, the tier lines still added to 11.)

### Release gate — `tests/integrations/agent_smoke.sh`

- `run_dsh()` drives the real `dsh` binary through the same factorial bug-fix task as the other four, graded by re-running the repo's own test suite.
- `DSH_HOME` joins the throwaway-home guard loop with its own `~/.dsh` realpath case. This matters **more** than for codex/hermes: `agents dsh --setup` also writes `.credentials.yaml`, so an un-redirected run touches a credential store, not just a provider block. `_real_fingerprint` therefore covers both files.
- **Grading deliberately ignores exit status.** Measured on rc.7: `dsh` pointed at an unregistered provider prints `NO_ADAPTER: ...` and still **exits 0**. Recorded in `known_issues`, commented at the call site, and pinned by a test so nobody "tidies" it into an exit-code check.

### Harness tier

- `HARNESS_PROFILES` 5 → 6, **appended** so existing positional assertions (`HARNESS_PROFILES[1:]`, the exact-tuple pin) keep their meaning. Mirror in `release_check_m3_random.py` and G7b wording updated in lock-step.
- `community-benchmarks/schema.json`: `harness_result` is `additionalProperties: false`, so a 6-adapter payload would not have validated. Added to `properties` but **deliberately not to `required`** — 8 historical submissions carry exactly five adapters, and requiring the sixth would retroactively invalidate them and reject every older client. The asymmetry is documented in the schema and pinned by a test.

### Matrix

`TestDeepSeekHarness` wire cell. Its DeepSeek column joins the R1-Distill architectural tool-emission xfail set — being DeepSeek's own client buys no exemption from its own checkpoint's gap — and its Hy3 column joins the Ultra-only set. Strict-xfail snapshot 24 → 26.

### Timeouts

Recomputed, not bumped by feel. Worst case grows by one more `2×480s` agent: `~78 → ~94 min`. Preserving the existing headroom margins gives `tier1-agent-gate` 105 → **125** and `agent-gate` 75 → **90**.

## Operational prerequisite

`dsh` was **not installed** on the Studio runner. I installed it globally (`npm i -g @deepseek-ai/dsh`, now `0.1.0-rc.7`) and re-qualified against that exact binary — npm blocks its transitive install scripts (`node-pty`, `koffi`, `protobufjs`) by default, and DSH still works, so the gate does not need `--allow-scripts`.

## Validation — verified on the Studio, not asserted

- **Tier-1 task:** `dsh 0.1.0-rc.7` on `qwen3.6-35b-8bit` — first attempt, **64 s cold / 17 s warm** against a 480 s budget. Real multi-turn: ran the failing test, diagnosed the off-by-one, edited `calc.py`, re-ran to confirm.
- `rapid-mlx agents dsh --test` → **13/13**.
- `bench --tier harness` scoped to the new profile → **PASS**, 13 tests, 34.9 s.
- Matrix cell **strict-PASS on real weights** for `qwen36` (`qwen3.6-35b-8bit`) and `gptoss` (`gpt-oss-20b-MXFP4-Q8`). The gemma4/muse columns are recorded from the shared `_run_openai_tool_smoke` code path rather than an independent run — stated explicitly in a `†` footnote in `tests/integrations/README.md` rather than passed off as measured.
- **rc.6 → rc.7 contract check:** all 8 schema keys we write still exist in rc.7's pi-ai plugin; `--profile headless` and `$DSH_HOME` unchanged; `engines` still undeclared, so our Node/Zstd diagnostic is still needed. Docs pin corrected rc.6 → rc.7.
- **All three `DSH_HOME` guards proven to abort** — blank-once-resolved, resolves-to-real-`~/.dsh`, and a symlink spelling of it.
- **Six mutations of the new guards each produce exactly one red**, and the source restores byte-identical. A guard that cannot fail is not a guard.
- Full suite: **17,731 passed, 1 failed** — the single failure is `test_no_routing_shaped_rapid_mlx_env_vars`, which is **pre-existing red on main** (`a5f9004f`) from #1969 and is fixed by **#1980**. This branch introduces zero failures; CI here stays red until #1980 lands.
- `ruff check` / `ruff format` clean; `bash -n` on both shell files; YAML/JSON parse checks on the workflows, schema and profile.

## Related

- **#1980** — fixes the pre-existing red main that gates this PR's CI.
- **#1981** — `_test_e2e_chat` false-green found during this work (`"4" in output` passes when the agent never reached the server). Filed, not fixed here: it is independent, affects all 13 profiles, and does **not** affect this gate, which grades on a real test suite run.
- Companion site PR: `raullenchai/rapidmlx.com#85`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
