### PR TITLE
feat(mtp): warn when sidecar and base quantization differ (#1258)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -207,6 +207,11 @@ Pair each head with a base of the same size class: `Qwen3.6-27B-MTP-4bit`
 with a `qwen3.6-27b-*` base, and `Qwen3.6-35B-A3B-MTP-4bit` with a
 `qwen3.6-35b-*` base.
 
+Match the sidecar and base precision for performance. In
+[#1258](https://github.com/raullenchai/Rapid-MLX/issues/1258), a matched 4-bit
+base / 4-bit sidecar improved throughput by 14%, while a mixed 8-bit base /
+4-bit sidecar reduced throughput by 8% versus no speculation.
+
 ### MCP Options
 
 | Option | Description | Default |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -207,10 +207,14 @@ Pair each head with a base of the same size class: `Qwen3.6-27B-MTP-4bit`
 with a `qwen3.6-27b-*` base, and `Qwen3.6-35B-A3B-MTP-4bit` with a
 `qwen3.6-35b-*` base.
 
-Match the sidecar and base precision for performance. In
-[#1258](https://github.com/raullenchai/Rapid-MLX/issues/1258), a matched 4-bit
-base / 4-bit sidecar improved throughput by 14%, while a mixed 8-bit base /
-4-bit sidecar reduced throughput by 8% versus no speculation.
+Sidecar/base precision pairing effects are model-dependent: benchmark your
+pairing. On Qwen3.6
+([#1258](https://github.com/raullenchai/Rapid-MLX/issues/1258)), matched 4/4
+improved throughput by 14% while mixed 8/4 reduced it by 8% versus no
+speculation. On Qwen3.8-27B (M5 Max measurements in
+[#1216](https://github.com/raullenchai/Rapid-MLX/pull/1216)) the economics
+invert: mixed 8/4 gained 35-65% while matched 4/4 was roughly break-even,
+because an expensive base leaves more room for a cheap drafter.
 
 ### MCP Options
 

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1633,6 +1633,35 @@ def test_infer_sidecar_fc_quantization_full_precision_returns_none():
     assert _infer_sidecar_fc_quantization(flat, fc_out_dims, fc_in_dims) is None
 
 
+def test_mtp_quantization_pairing_warning_for_mismatch_only(caplog):
+    """Known mixed precision warns once; a matched pairing stays silent."""
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+        _warn_if_mtp_quantization_mismatch,
+    )
+
+    logger_name = "vllm_mlx.spec_decode.mtp.qwen3_5_inject"
+    with caplog.at_level("WARNING", logger=logger_name):
+        _warn_if_mtp_quantization_mismatch(
+            {"bits": 8, "group_size": 64},
+            {"bits": 4, "group_size": 64},
+        )
+
+    assert [record.getMessage() for record in caplog.records] == [
+        "[mtp.inject] MTP sidecar quantization (4-bit, group_size=64) "
+        "differs from base model (8-bit, group_size=64): mixed pairing "
+        "has been measured slower than no speculation (#1258). Matched "
+        "precision is recommended."
+    ]
+
+    caplog.clear()
+    with caplog.at_level("WARNING", logger=logger_name):
+        _warn_if_mtp_quantization_mismatch(
+            {"bits": 4, "group_size": 64},
+            {"bits": 4, "group_size": 64},
+        )
+    assert caplog.records == []
+
+
 def test_infer_sidecar_fc_quantization_raises_on_malformed_packing():
     """``fc.scales`` present but a packing we cannot interpret — an
     unsupported derived width, or a missing companion ``fc.weight`` —

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1648,9 +1648,9 @@ def test_mtp_quantization_pairing_warning_for_mismatch_only(caplog):
 
     assert [record.getMessage() for record in caplog.records] == [
         "[mtp.inject] MTP sidecar quantization (4-bit, group_size=64) "
-        "differs from base model (8-bit, group_size=64): mixed pairing "
-        "has been measured slower than no speculation (#1258). Matched "
-        "precision is recommended."
+        "differs from base model (8-bit, group_size=64): pairing effects "
+        "are model-dependent: slower than no speculation on Qwen3.6 "
+        "(#1258), faster on Qwen3.8-27B. Benchmark your pairing."
     ]
 
     caplog.clear()

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -150,9 +150,9 @@ def _warn_if_mtp_quantization_mismatch(
 
     logger.warning(
         "[mtp.inject] MTP sidecar quantization (%d-bit, group_size=%d) "
-        "differs from base model (%d-bit, group_size=%d): mixed pairing "
-        "has been measured slower than no speculation (#1258). Matched "
-        "precision is recommended.",
+        "differs from base model (%d-bit, group_size=%d): pairing effects "
+        "are model-dependent: slower than no speculation on Qwen3.6 "
+        "(#1258), faster on Qwen3.8-27B. Benchmark your pairing.",
         sidecar_quant["bits"],
         sidecar_quant["group_size"],
         base_quant["bits"],

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -141,6 +141,25 @@ def _detect_base_quantization(inner: Any) -> dict | None:
     return None
 
 
+def _warn_if_mtp_quantization_mismatch(
+    base_quant: dict | None, sidecar_quant: dict | None
+) -> None:
+    """Recommend matched MTP precision when both quantizations are known."""
+    if base_quant is None or sidecar_quant is None or base_quant == sidecar_quant:
+        return
+
+    logger.warning(
+        "[mtp.inject] MTP sidecar quantization (%d-bit, group_size=%d) "
+        "differs from base model (%d-bit, group_size=%d): mixed pairing "
+        "has been measured slower than no speculation (#1258). Matched "
+        "precision is recommended.",
+        sidecar_quant["bits"],
+        sidecar_quant["group_size"],
+        base_quant["bits"],
+        base_quant["group_size"],
+    )
+
+
 # MLX affine quantization's practical value set. Every mlx-community
 # checkpoint (base + MTP sidecar alike) uses one of these — the shipped
 # Qwen3.6 pairing is 4-/8-bit at group_size 64. A sidecar whose tensors
@@ -741,6 +760,9 @@ def inject_mtp_support(
             len(expected_keys),
             weights_file.name,
             f" (+{len(extra)} extra sidecar key(s) ignored)" if extra else "",
+        )
+        _warn_if_mtp_quantization_mismatch(
+            _detect_base_quantization(inner), sidecar_quant
         )
     else:
         # No sidecar.


### PR DESCRIPTION
Implements two of the outcomes discussed in #1258: the mismatch warning and the documentation note. The third outcome (adjusting automatic enablement) is a product decision I have deliberately left out.

### What is the new behavior?

- After a successful sidecar load, `inject_mtp_support` emits one warning when the detected sidecar quantization (bits, group_size) differs from the base model's, citing the measured mixed-pairing regression from #1258. Exact message:
  `[mtp.inject] MTP sidecar quantization (4-bit, group_size=64) differs from base model (8-bit, group_size=64): pairing effects are model-dependent: slower than no speculation on Qwen3.6 (#1258), faster on Qwen3.8-27B. Benchmark your pairing.`

  (Amended after my Qwen3.8-27B measurements in #1216 inverted the #1258 finding: mixed 8/4 gained 35-65% there while matched 4/4 was break-even. The docs note now states the model dependence with both datapoints.)
- Silent when either side's quantization metadata is unavailable, and when the pairing matches — no false alarms.
- `docs/reference/configuration.md` gains a short matched-precision recommendation citing the #1258 numbers (matched 4/4: +14%, mixed 8/4: -8%).
- One unit test: warning fires on mismatch, stays silent on matched pairing.

### Placement note

The check lives in `vllm_mlx/spec_decode/mtp/qwen3_5_inject.py`, right after the sidecar-load log line, because that is where both quantization dicts are in hand. I know `spec_decode/` is the core-team lane per #1216 — this is a 22-line additive warning, but happy to relocate the check to config level if you prefer.

### Validation

- Both changed modules compile; the injector imports and a dependency-free behavioral check produced the exact warning once on mismatch and nothing on match.
- `pytest`/`ruff` not run: fresh clone without the dev environment; no dependencies were installed. The added test follows the existing pattern in `tests/test_mtp_spec_decode.py`.
- Related cross-engine datapoint (mixed-precision draft pairing degrading under load on another engine) is in my comment on #1258.

*Implemented with the help of a coding agent (Claude Code) and reviewed locally by the author.*
