### PR TITLE
fix(agents): report the served model's real reasoning capability to DSH

### DIFF
--- a/tests/test_deepseek_harness_profile.py
+++ b/tests/test_deepseek_harness_profile.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import stat
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -290,3 +293,142 @@ def test_dsh_reports_old_node_before_opaque_plugin_boot_failure():
     assert output is None
     assert "Node 22.15+" in error
     assert run.call_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# reasoningEfforts must describe the served model, not every model.
+# --------------------------------------------------------------------------- #
+#
+# DSH renders a reasoning-effort control from this block. Advertising the
+# off/low/medium/high ladder unconditionally gave users a selector that did
+# nothing on a model with no reasoning parser. pi-ai accepts
+# ``reasoningEfforts: false`` for exactly that case.
+
+
+def _models_payload(entries: list[dict]) -> bytes:
+    return json.dumps({"object": "list", "data": entries}).encode()
+
+
+@contextlib.contextmanager
+def _serving(entries: list[dict]):
+    """Run a throwaway /v1/models server and yield its base_url.
+
+    A real socket rather than a mocked urlopen: the thing under test is
+    "what do we conclude from what the server actually sent", and a mock
+    would let a wrong field name pass.
+    """
+    payload = _models_payload(entries)
+
+    class _H(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler API
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):  # keep pytest output clean
+            return
+
+    srv = HTTPServer(("127.0.0.1", 0), _H)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_port}/v1"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=5)
+
+
+def _dsh_model_entry(plan) -> dict:
+    return plan.after["llm-pi-ai"]["providers"]["rapid-mlx"]["models"][0]
+
+
+def _dsh_provider(plan) -> dict:
+    return plan.after["llm-pi-ai"]["providers"]["rapid-mlx"]
+
+
+def test_reasoning_support_is_three_state(tmp_path, monkeypatch):
+    """True / False / None must be distinguishable at the source."""
+    from vllm_mlx.agents.adapter import fetch_reasoning_support
+
+    with _serving([{"id": "m", "reasoning_parser": "qwen3"}]) as url:
+        assert fetch_reasoning_support(url, "m") is True
+    # Explicit null — the model has no reasoning parser.
+    with _serving([{"id": "m", "reasoning_parser": None}]) as url:
+        assert fetch_reasoning_support(url, "m") is False
+    # Key absent — a rapid-mlx too old to report it. NOT the same as False.
+    with _serving([{"id": "m"}]) as url:
+        assert fetch_reasoning_support(url, "m") is None
+    # Multi-model serve with no exact match must not describe another model.
+    with _serving(
+        [{"id": "a", "reasoning_parser": None}, {"id": "b", "reasoning_parser": None}]
+    ) as url:
+        assert fetch_reasoning_support(url, "missing") is None
+    # Unreachable server.
+    assert fetch_reasoning_support("http://127.0.0.1:9/v1", "m") is None
+
+
+def test_dsh_setup_declines_reasoning_for_a_model_without_a_parser(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DSH_HOME", str(tmp_path))
+    plan = build_setup_plan(
+        "dsh",
+        "http://127.0.0.1:8152/v1",
+        "no-think-1b",
+        65536,
+        supports_reasoning=False,
+    )
+    assert _dsh_model_entry(plan)["reasoningEfforts"] is False
+    assert _dsh_provider(plan)["compat"]["supportsReasoningEffort"] is False
+
+
+def test_dsh_setup_keeps_the_ladder_for_a_reasoning_model(tmp_path, monkeypatch):
+    monkeypatch.setenv("DSH_HOME", str(tmp_path))
+    plan = build_setup_plan(
+        "dsh",
+        "http://127.0.0.1:8152/v1",
+        "qwen3.6-35b-8bit",
+        65536,
+        supports_reasoning=True,
+    )
+    assert _dsh_model_entry(plan)["reasoningEfforts"]["off"] == "none"
+    assert _dsh_provider(plan)["compat"]["supportsReasoningEffort"] is True
+
+
+def test_dsh_setup_does_not_downgrade_on_unknown(tmp_path, monkeypatch):
+    """``None`` means we could not find out — never delete a real control on a guess."""
+    monkeypatch.setenv("DSH_HOME", str(tmp_path))
+    for unknown in (None,):
+        plan = build_setup_plan(
+            "dsh", "http://127.0.0.1:8152/v1", "m", 65536, supports_reasoning=unknown
+        )
+        assert _dsh_model_entry(plan)["reasoningEfforts"]["high"] == "high"
+        assert _dsh_provider(plan)["compat"]["supportsReasoningEffort"] is True
+    # Default argument must behave the same as an explicit None.
+    plan = build_setup_plan("dsh", "http://127.0.0.1:8152/v1", "m", 65536)
+    assert _dsh_model_entry(plan)["reasoningEfforts"]["high"] == "high"
+
+
+def test_dsh_declined_reasoning_survives_yaml_round_trip(tmp_path, monkeypatch):
+    """``false`` must reach the file as a YAML boolean, not the string 'False'.
+
+    pi-ai validates ``reasoningEfforts`` as ``false | {level: wire}``; a
+    quoted string would fail its schema and DSH would refuse the provider.
+    """
+    monkeypatch.setenv("DSH_HOME", str(tmp_path))
+    plan = build_setup_plan(
+        "dsh",
+        "http://127.0.0.1:8000/v1",
+        "no-think-1b",
+        65536,
+        supports_reasoning=False,
+    )
+    apply_setup_plan(plan)
+    written = yaml.safe_load((tmp_path / "settings.yaml").read_text())
+    entry = written["llm-pi-ai"]["providers"]["rapid-mlx"]["models"][0]
+    assert entry["reasoningEfforts"] is False
+    raw = (tmp_path / "settings.yaml").read_text()
+    assert "reasoningEfforts: false" in raw, raw

--- a/vllm_mlx/agents/adapter.py
+++ b/vllm_mlx/agents/adapter.py
@@ -381,6 +381,47 @@ def _detect_running_model(base_url: str) -> tuple[str | None, int | None]:
     return None, None
 
 
+def fetch_reasoning_support(base_url: str, model_id: str) -> bool | None:
+    """Whether *model_id* can emit reasoning, as a THREE-state answer.
+
+    ``True``  — the served model advertises a reasoning parser.
+    ``False`` — the entry was found and explicitly advertises none.
+    ``None``  — unknown: server unreachable, model not listed, or an
+                older rapid-mlx whose ``/v1/models`` predates the field.
+
+    The three states are not decoration. A client that is told a model
+    supports graded reasoning shows the user a control for it, so
+    guessing in either direction has a cost: claim support a model
+    doesn't have and the control is a lie, deny support it does have and
+    a working feature disappears. Callers are expected to leave their
+    current behaviour alone on ``None`` and only act on ``False``.
+
+    Distinguishing ``False`` from ``None`` relies on ``/v1/models``
+    serializing nulls — ``routes/models.py`` deliberately does not set
+    ``exclude_none`` "so the shape is stable", so a reasoning-less model
+    sends ``"reasoning_parser": null`` while a server too old to know
+    about the field omits the key entirely. If that ever changes, this
+    collapses to ``None`` (unknown) rather than to a wrong answer.
+    """
+
+    def _from_entry(entry: dict) -> bool | None:
+        if "reasoning_parser" not in entry:
+            return None
+        parser = entry.get("reasoning_parser")
+        return bool(isinstance(parser, str) and parser.strip())
+
+    models = _fetch_models(base_url)
+    for m in models:
+        if m.get("id") == model_id:
+            return _from_entry(m)
+    # Same single-model fallback rule as fetch_context_window: a
+    # multi-model serve must match exactly rather than describe some
+    # other model's capabilities.
+    if len(models) == 1:
+        return _from_entry(models[0])
+    return None
+
+
 def fetch_context_window(base_url: str, model_id: str) -> int | None:
     """Fetch ``context_window`` for a specific *model_id* from the server.
 

--- a/vllm_mlx/agents/profiles/deepseek-harness.yaml
+++ b/vllm_mlx/agents/profiles/deepseek-harness.yaml
@@ -7,6 +7,14 @@ stars: 1000
 # Its generic pi-ai adapter is the correct route for Rapid-MLX: using the
 # native deepseek-official adapter would require a fake API key and claim the
 # local endpoint has the official service's model/capacity contract.
+#
+# NOTE: `agents dsh --setup` does NOT render this template — it goes through
+# the first-class plan/apply flow in ``vllm_mlx/agents/setup.py``, which also
+# adapts ``reasoningEfforts`` to the served model's real capability (a model
+# with no reasoning parser gets ``false``, not the ladder below). This
+# template is what ``agents dsh --test`` writes into its throwaway home, where
+# the model is always a reasoning-capable one, so the ladder is correct there.
+# Change both if you change the provider contract.
 config:
   type: yaml
   path: "~/.dsh/settings.yaml"

--- a/vllm_mlx/agents/setup.py
+++ b/vllm_mlx/agents/setup.py
@@ -139,6 +139,7 @@ def build_setup_plan(
     base_url: str,
     model: str,
     context_length: int | None = None,
+    supports_reasoning: bool | None = None,
 ) -> SetupPlan:
     """Build a side-effect-free setup plan for a supported client."""
     if agent in {"claude", "claude-code"}:
@@ -163,6 +164,37 @@ def build_setup_plan(
         credentials_path = path.parent / ".credentials.yaml"
         credentials_before = _load_yaml_mapping(credentials_path)
         context = context_length if context_length and context_length > 0 else 32768
+        # Report the model's ACTUAL reasoning capability rather than
+        # asserting the graded ladder for everything we serve.
+        #
+        # Harness renders a reasoning-effort control from this block, so a
+        # model with no reasoning parser used to get an off/low/medium/high
+        # selector that changed nothing the user could observe. pi-ai
+        # accepts ``reasoningEfforts: false`` for exactly this case
+        # ("set false for a non-reasoning model").
+        #
+        # Only a definite ``False`` downgrades. ``None`` means we could not
+        # find out (server unreachable, model not listed, or a rapid-mlx too
+        # old to report the field), and silently deleting a working control
+        # on a guess is worse than the cosmetic over-claim this fixes — see
+        # ``fetch_reasoning_support`` for why the three states are kept apart.
+        reasoning_capable = supports_reasoning is not False
+        model_entry: dict[str, Any] = {
+            "id": model,
+            "name": f"{model} (Rapid-MLX)",
+            "contextWindow": context,
+            "maxTokens": 8192,
+            "reasoningEfforts": (
+                {
+                    "off": "none",
+                    "low": "low",
+                    "medium": "medium",
+                    "high": "high",
+                }
+                if reasoning_capable
+                else False
+            ),
+        }
         patch = {
             "llm-pi-ai": {
                 "providers": {
@@ -173,21 +205,8 @@ def build_setup_plan(
                         "baseURL": base_url.rstrip("/"),
                         "defaultContextWindow": context,
                         "defaultMaxTokens": 8192,
-                        "compat": {"supportsReasoningEffort": True},
-                        "models": [
-                            {
-                                "id": model,
-                                "name": f"{model} (Rapid-MLX)",
-                                "contextWindow": context,
-                                "maxTokens": 8192,
-                                "reasoningEfforts": {
-                                    "off": "none",
-                                    "low": "low",
-                                    "medium": "medium",
-                                    "high": "high",
-                                },
-                            }
-                        ],
+                        "compat": {"supportsReasoningEffort": reasoning_capable},
+                        "models": [model_entry],
                     }
                 }
             },

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7902,12 +7902,23 @@ def agents_command(args):
                 verify_server,
             )
 
+            # DSH renders a reasoning-effort control from what we write, so
+            # it needs the model's real capability, not a blanket claim.
+            # Scoped to the one profile that consumes it — the other
+            # first-class flows don't, and this is a second HTTP round trip.
+            supports_reasoning = None
+            if profile.name == "deepseek-harness":
+                from vllm_mlx.agents.adapter import fetch_reasoning_support
+
+                supports_reasoning = fetch_reasoning_support(base_url, model_id)
+
             try:
                 plan = build_setup_plan(
                     profile.name,
                     base_url,
                     model_id,
                     context_length=context_length,
+                    supports_reasoning=supports_reasoning,
                 )
             except (OSError, ValueError) as exc:
                 print(f"\n  {profile.display_name} setup failed: {exc}\n")


### PR DESCRIPTION
## Why

`agents dsh --setup` wrote the `off/low/medium/high` reasoning ladder into DSH's provider block **unconditionally** (`vllm_mlx/agents/setup.py:183`), regardless of whether the served model has a reasoning parser.

DeepSeek Harness renders a reasoning-effort control from that block, so serving a model with no reasoning parser gave the user a selector that changed nothing they could observe. pi-ai supports `reasoningEfforts: false` for exactly this case — its own error text says *"set false for a non-reasoning model"* — and we simply never used it. Found while promoting DSH to Tier-1 (#1982); filed here rather than folded into that PR because it is a behaviour change, not gate wiring.

## What changed

`fetch_reasoning_support(base_url, model_id)` returns a deliberate **three-state** answer:

| | meaning |
|---|---|
| `True` | model advertises a reasoning parser |
| `False` | entry found, explicitly advertises none |
| `None` | unknown — unreachable, not listed, or a rapid-mlx too old to report the field |

**Only a definite `False` downgrades.** Claiming reasoning a model lacks is a cosmetic lie; denying reasoning a model has deletes a working feature. `None` therefore preserves today's behaviour — the states are kept apart precisely so "unknown" cannot quietly become whichever answer is convenient.

`False` is distinguishable from `None` because `routes/models.py:925` deliberately does **not** set `exclude_none` "so the shape is stable": a reasoning-less model sends `"reasoning_parser": null`, while a server too old to know the field omits the key. If that ever changes, this degrades to `None` (unknown) rather than to a wrong answer.

Scoped to the `deepseek-harness` setup path — it is the only first-class flow that consumes the field, and it costs one extra `/v1/models` round trip.

## Validation

**Verified against the real client, not just our reading of the schema.** `dsh 0.1.0-rc.7`, provider pointed at a dead port so the config either registers or it doesn't:

```
reasoningEfforts: false  ->  dsh: TRANSPORT: Connection error.
reasoningEfforts: {}     ->  dsh: NO_ADAPTER: no adapter registered for provider "rapid-mlx"
```

The discrimination is the whole point. `{}` is documented-invalid and pi-ai rejects it at plugin load, so it never reaches dispatch. `false` **does** reach dispatch and fails only on the dead socket — which is proof pi-ai accepted the provider block we now write.

- New tests stand up a real throwaway HTTP server rather than mocking `urlopen`, so a wrong field name cannot pass.
- Covers all three states plus: multi-model serve with no exact match (must not describe some other model), unreachable server, the default argument, and a YAML round-trip asserting `reasoningEfforts: false` lands as a boolean rather than the string `"False"` (a quoted string would fail pi-ai's schema).
- **Mutation-checked**: forcing `reasoning_capable = True` turns two tests red; reverting restores green with the source byte-identical.
- 90 passed across the agent setup/profile suites; `ruff check` + `ruff format --check` clean.

## Note

The profile YAML still carries the full ladder, and that is correct: `--setup` does not render it (it uses the plan/apply flow), while `agents dsh --test` does — and that path always runs a reasoning-capable model in a throwaway home. Added a comment saying so, since two sources for one contract is otherwise a trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
