### PR TITLE
feat(mtp): support self-contained model repositories

### DIFF
--- a/tests/test_mtp_self_contained_repo.py
+++ b/tests/test_mtp_self_contained_repo.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from vllm_mlx.spec_decode.mtp.qwen3_5_inject import _find_mtp_weights_file
+
+
+def test_finds_nested_mtp_sidecar_in_self_contained_repo(tmp_path: Path):
+    sidecar = tmp_path / "mtp" / "model.safetensors"
+    sidecar.parent.mkdir()
+    sidecar.touch()
+
+    assert _find_mtp_weights_file(tmp_path) == sidecar
+
+
+def test_explicit_root_sidecar_wins_over_nested_layout(tmp_path: Path):
+    explicit = tmp_path / "model-mtp.safetensors"
+    nested = tmp_path / "mtp" / "model.safetensors"
+    nested.parent.mkdir()
+    explicit.touch()
+    nested.touch()
+
+    assert _find_mtp_weights_file(tmp_path) == explicit
+
+
+def test_nested_sidecar_wins_over_target_root_weights(tmp_path: Path):
+    target = tmp_path / "model.safetensors"
+    sidecar = tmp_path / "mtp" / "model.safetensors"
+    sidecar.parent.mkdir()
+    target.touch()
+    sidecar.touch()
+
+    assert _find_mtp_weights_file(tmp_path) == sidecar

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -261,7 +261,8 @@ def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
     Accepts:
 
     * An absolute / relative path to a directory containing a
-      ``model.safetensors`` or ``model-mtp.safetensors`` file
+      ``model.safetensors``, ``model-mtp.safetensors``, or
+      ``mtp/model.safetensors`` file
       (operators with a pre-downloaded HF snapshot).
     * An absolute / relative path to a ``*.safetensors`` file
       directly (operators with a hand-assembled sidecar; the
@@ -269,7 +270,9 @@ def _resolve_sidecar_file(mtp_sidecar: str | Path) -> Path | None:
       names).
     * An HF Hub repo name like ``mlx-community/Qwen3.5-9B-MTP-4bit``
       (downloaded via ``snapshot_download`` to the HF cache, then
-      probed for ``model.safetensors`` / ``model-mtp.safetensors``).
+      probed for the layouts above). The nested ``mtp/`` layout lets a
+      single repository contain target and drafter weights without
+      ``mlx_lm.load`` mistaking the drafter for a target-model shard.
 
     Returns ``None`` if the reference cannot be resolved — caller
     treats this as a soft failure and logs.
@@ -314,6 +317,7 @@ def _find_mtp_weights_file(sidecar_dir: Path) -> Path | None:
     """
     candidates = (
         sidecar_dir / "model-mtp.safetensors",
+        sidecar_dir / "mtp" / "model.safetensors",
         sidecar_dir / "model.safetensors",
     )
     for c in candidates:
@@ -449,8 +453,9 @@ def inject_mtp_support(
                 "[mtp.inject] sidecar %r could not be resolved to a "
                 "safetensors file; skipping MTP injection. "
                 "Pass either a repo id (mlx-community/Qwen3.5-9B-MTP-4bit), "
-                "a directory containing model.safetensors / "
-                "model-mtp.safetensors, or the file path directly.",
+                "a directory containing model-mtp.safetensors, "
+                "mtp/model.safetensors, or model.safetensors, or the "
+                "file path directly.",
                 mtp_sidecar,
             )
             return False


### PR DESCRIPTION
## Summary
- resolve MTP drafter weights from `mtp/model.safetensors` inside a target model repo
- prefer an explicit root sidecar, then the nested self-contained layout, then legacy standalone `model.safetensors`
- add regression coverage for all precedence cases

## Why
Putting `model-mtp.safetensors` beside target shards makes `mlx_lm.load()` ingest it as target weights and fail strict loading. A nested `mtp/` directory preserves one-repo/one-download UX without contaminating the target loader.

## Validation
- `64 passed` (`test_mtp_self_contained_repo.py` + `test_mtp_cli_wiring.py`)
- Studio E2E with assembled Qwen3.8-27B 4-bit repo: base load succeeds; AR 39.69 tok/s, Rapid MTP 44.51 tok/s (1.122x); emitted token hashes exact