### PR TITLE
fix(agents): stop e2e_chat passing on an agent that never answered (#1981)

### DIFF
--- a/tests/test_agent_e2e_chat_false_green.py
+++ b/tests/test_agent_e2e_chat_false_green.py
@@ -136,6 +136,63 @@ def test_e2e_chat_rejects_the_expected_answer_inside_a_longer_number():
     )
 
 
+def test_a_failed_run_gets_no_credit_for_what_it_printed_on_stderr():
+    """The same false green from the other side (codex review, round 1).
+
+    Evidence beats a non-zero exit — so a failure diagnostic that happens to
+    quote the expected token would buy a PASS if diagnostics counted as
+    evidence. They do not: a process that reported failure is credited only
+    with what it wrote to stdout, where every profile's CLI writes its answer.
+    """
+    result = _test_e2e_chat(
+        sys.executable,
+        _fake_cli(
+            stderr=f"ERROR: expected {E2E_CHAT_EXPECTED}; request failed\n",
+            exit_code=1,
+        ),
+        _TIMEOUT_S,
+    )
+
+    assert result.status is TestStatus.ERROR, (
+        f"a failed run passed because its own error message mentioned the "
+        f"expected answer; got {result.status} / {result.message!r}"
+    )
+
+
+def test_a_failed_run_gets_no_credit_for_a_sentinel_on_stderr():
+    """Same rule for the sibling probes — one place decides, not three."""
+    file_read = _test_e2e_file_read(
+        sys.executable,
+        _fake_cli(stderr=f"ERROR: never found {E2E_FIRST_LINE}\n", exit_code=1),
+        _TIMEOUT_S,
+    )
+    marker = "rapidmlx_codex_test"
+    terminal = _test_e2e_terminal(
+        sys.executable,
+        _fake_cli(stderr=f"ERROR: could not run echo {marker}\n", exit_code=1),
+        _TIMEOUT_S,
+        "codex",
+    )
+
+    assert file_read.status is TestStatus.ERROR, file_read.message
+    assert terminal.status is TestStatus.ERROR, terminal.message
+
+
+def test_e2e_chat_rejects_a_signed_or_fractional_near_miss():
+    """ "-777777" and "777777.5" are different numbers, not sloppy right ones."""
+    for reply in ("-777777\n", "777777.5\n", "12.777777\n"):
+        result = _test_e2e_chat(sys.executable, _fake_cli(stdout=reply), _TIMEOUT_S)
+        assert result.status is TestStatus.FAIL, (
+            f"{reply.strip()!r} was accepted as the answer to "
+            f"{E2E_CHAT_QUERY!r}: {result.status}"
+        )
+    # ...while a sentence-ending period is punctuation, not a decimal point.
+    ok = _test_e2e_chat(
+        sys.executable, _fake_cli(stdout="The answer is 777777.\n"), _TIMEOUT_S
+    )
+    assert ok.status is TestStatus.PASS, ok.message
+
+
 def test_e2e_chat_is_not_satisfied_by_a_cli_echoing_the_prompt():
     """Why the expected value is derived, not a sentinel handed to the agent.
 
@@ -187,6 +244,10 @@ def test_e2e_chat_passes_when_the_agent_answered_then_exited_nonzero():
     Some CLIs answer and then exit non-zero on their way out. Making a
     non-zero exit fatal would turn those into a red release gate, so evidence
     wins — the exit status only decides what an evidence-LESS run is called.
+
+    The answer is on stdout and the noise on stderr, which is the split
+    `_agent_query` relies on: see the stderr-diagnostic test above for the
+    other half of this rule.
     """
     result = _test_e2e_chat(
         sys.executable,

--- a/tests/test_agent_e2e_chat_false_green.py
+++ b/tests/test_agent_e2e_chat_false_green.py
@@ -172,22 +172,14 @@ def test_a_failed_run_gets_no_credit_for_what_it_printed_on_stderr():
 
 
 def test_a_failed_run_gets_no_credit_for_a_sentinel_on_stderr():
-    """Same rule for the sibling probes — one place decides, not three."""
+    """Same rule for the file-read probe — one place decides, not two."""
     file_read = _test_e2e_file_read(
         sys.executable,
         _fake_cli(stderr=f"ERROR: never found {E2E_FIRST_LINE}\n", exit_code=1),
         _TIMEOUT_S,
     )
-    marker = "rapidmlx_codex_test"
-    terminal = _test_e2e_terminal(
-        sys.executable,
-        _fake_cli(stderr=f"ERROR: could not run echo {marker}\n", exit_code=1),
-        _TIMEOUT_S,
-        "codex",
-    )
 
     assert file_read.status is TestStatus.ERROR, file_read.message
-    assert terminal.status is TestStatus.ERROR, terminal.message
 
 
 def test_a_hung_run_gets_no_credit_for_what_it_printed_on_stderr():
@@ -195,27 +187,23 @@ def test_a_hung_run_gets_no_credit_for_what_it_printed_on_stderr():
 
     ``TIMEOUT`` is the other err that loses to evidence, so if a hung CLI's
     stderr counted, the stderr-diagnostic false green would simply move here.
-    Both e2e probes with a marker-style assertion are checked, because
-    `_test_e2e_terminal` only gained its carve-out in this change.
     """
-    marker = "rapidmlx_codex_test"
     chat = _test_e2e_chat(
         sys.executable,
         _hanging_cli(stderr=f"ERROR: expected {E2E_CHAT_EXPECTED}\n"),
         timeout=1,
     )
-    terminal = _test_e2e_terminal(
+    file_read = _test_e2e_file_read(
         sys.executable,
-        _hanging_cli(stderr=f"ERROR: could not run echo {marker}\n"),
-        1,
-        "codex",
+        _hanging_cli(stderr=f"ERROR: never found {E2E_FIRST_LINE}\n"),
+        timeout=1,
     )
 
     assert chat.status is TestStatus.ERROR, (
         f"a hung run passed on its own error text: {chat.message!r}"
     )
-    assert terminal.status is TestStatus.ERROR, (
-        f"a hung run passed on its own error text: {terminal.message!r}"
+    assert file_read.status is TestStatus.ERROR, (
+        f"a hung run passed on its own error text: {file_read.message!r}"
     )
 
 
@@ -235,7 +223,7 @@ def test_e2e_chat_rejects_a_malformed_digit_grouping():
     Deleting every separator that sat between two digits also turned "7777 77"
     into the expected sum — a fresh way to pass without answering.
     """
-    for reply in ("7777 77\n", "77 7777\n", "7,77777\n"):
+    for reply in ("7777 77\n", "77 7777\n", "7,77777\n", "1,777777\n", "777777,000\n"):
         result = _test_e2e_chat(sys.executable, _fake_cli(stdout=reply), _TIMEOUT_S)
         assert result.status is TestStatus.FAIL, (
             f"{reply.strip()!r} was normalized into the expected answer: "
@@ -344,16 +332,37 @@ def test_file_read_still_passes_when_the_cli_exits_nonzero_with_the_sentinel():
     assert result.status is TestStatus.PASS, result.message
 
 
-def test_terminal_still_passes_when_the_cli_exits_nonzero_with_the_marker():
+def test_terminal_keeps_a_broken_run_fatal_because_its_marker_is_in_the_prompt():
+    """The terminal probe gets no evidence carve-out, and that is on purpose.
+
+    Its marker is handed to the agent in the prompt ("Run 'echo <marker>'"),
+    so a CLI that echoes the prompt on its way out prints the marker without
+    ever opening a shell. Letting that overrule a crash would be the #1981
+    false green again, one probe over (codex review, round 4).
+    """
     marker = "rapidmlx_codex_test"
-    result = _test_e2e_terminal(
+    echoed = _test_e2e_terminal(
+        sys.executable, _echoing_cli(exit_code=1), _TIMEOUT_S, "codex"
+    )
+    printed = _test_e2e_terminal(
         sys.executable,
         _fake_cli(stdout=f"{marker}\n", exit_code=1),
         _TIMEOUT_S,
         "codex",
     )
 
-    assert result.status is TestStatus.PASS, result.message
+    assert echoed.status is TestStatus.ERROR, (
+        f"a CLI that echoed the prompt and died passed the terminal probe: "
+        f"{echoed.message!r}"
+    )
+    assert printed.status is TestStatus.ERROR, (
+        f"a broken run must stay fatal for the terminal probe: {printed.message!r}"
+    )
+    # ...while a healthy run that echoes the marker is still a PASS.
+    healthy = _test_e2e_terminal(
+        sys.executable, _fake_cli(stdout=f"{marker}\n"), _TIMEOUT_S, "codex"
+    )
+    assert healthy.status is TestStatus.PASS, healthy.message
 
 
 def test_file_read_reports_the_launch_failure_instead_of_a_wrong_answer():
@@ -387,7 +396,7 @@ def test_plain_chat_wants_the_number_four_not_the_digit(monkeypatch):
     Same family as the e2e false green: grading a digit rather than a number
     lets an unrelated value satisfy the assertion (codex review, round 3).
     """
-    for wrong in ("1234", "0.4", "-4", "4.5", "The id is a4b."):
+    for wrong in ("1234", "0.4", "-4", "4.5", "The id is a4b.", "4,000"):
         assert _plain_chat_verdict(wrong, monkeypatch) is TestStatus.FAIL, (
             f"{wrong!r} was accepted as the answer to 2+2"
         )

--- a/tests/test_agent_e2e_chat_false_green.py
+++ b/tests/test_agent_e2e_chat_false_green.py
@@ -75,6 +75,17 @@ def _fake_cli(stdout: str = "", stderr: str = "", exit_code: int = 0) -> str:
     return f"{shlex.quote(sys.executable)} -c {shlex.quote(script)} '{{query}}'"
 
 
+def _hanging_cli(stdout: str = "", stderr: str = "") -> str:
+    """A CLI that prints, flushes, and then never terminates."""
+    script = (
+        "import sys, time; "
+        f"sys.stdout.write({stdout!r}); sys.stdout.flush(); "
+        f"sys.stderr.write({stderr!r}); sys.stderr.flush(); "
+        "time.sleep(30)"
+    )
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(script)} '{{query}}'"
+
+
 def _echoing_cli(exit_code: int = 1) -> str:
     """A CLI that prints the prompt back and never answers it."""
     script = "import sys; sys.stdout.write('> ' + sys.argv[1] + chr(10)); "
@@ -176,6 +187,63 @@ def test_a_failed_run_gets_no_credit_for_a_sentinel_on_stderr():
 
     assert file_read.status is TestStatus.ERROR, file_read.message
     assert terminal.status is TestStatus.ERROR, terminal.message
+
+
+def test_a_hung_run_gets_no_credit_for_what_it_printed_on_stderr():
+    """The timeout carve-out obeys the same rule (codex review, round 2).
+
+    ``TIMEOUT`` is the other err that loses to evidence, so if a hung CLI's
+    stderr counted, the stderr-diagnostic false green would simply move here.
+    Both e2e probes with a marker-style assertion are checked, because
+    `_test_e2e_terminal` only gained its carve-out in this change.
+    """
+    marker = "rapidmlx_codex_test"
+    chat = _test_e2e_chat(
+        sys.executable,
+        _hanging_cli(stderr=f"ERROR: expected {E2E_CHAT_EXPECTED}\n"),
+        timeout=1,
+    )
+    terminal = _test_e2e_terminal(
+        sys.executable,
+        _hanging_cli(stderr=f"ERROR: could not run echo {marker}\n"),
+        1,
+        "codex",
+    )
+
+    assert chat.status is TestStatus.ERROR, (
+        f"a hung run passed on its own error text: {chat.message!r}"
+    )
+    assert terminal.status is TestStatus.ERROR, (
+        f"a hung run passed on its own error text: {terminal.message!r}"
+    )
+
+
+def test_a_hung_run_still_passes_on_evidence_it_printed_on_stdout():
+    """...and #1598's carve-out itself must survive that narrowing."""
+    result = _test_e2e_chat(
+        sys.executable, _hanging_cli(stdout=f"{E2E_CHAT_EXPECTED}\n"), timeout=1
+    )
+
+    assert result.status is TestStatus.PASS, result.message
+    assert "did not terminate" in result.message, result.message
+
+
+def test_e2e_chat_rejects_a_malformed_digit_grouping():
+    """Separator tolerance must not manufacture the answer out of other digits.
+
+    Deleting every separator that sat between two digits also turned "7777 77"
+    into the expected sum — a fresh way to pass without answering.
+    """
+    for reply in ("7777 77\n", "77 7777\n", "7,77777\n"):
+        result = _test_e2e_chat(sys.executable, _fake_cli(stdout=reply), _TIMEOUT_S)
+        assert result.status is TestStatus.FAIL, (
+            f"{reply.strip()!r} was normalized into the expected answer: "
+            f"{result.status}"
+        )
+    # Real thousands grouping still counts.
+    for reply in ("777 777\n", "777,777\n"):
+        ok = _test_e2e_chat(sys.executable, _fake_cli(stdout=reply), _TIMEOUT_S)
+        assert ok.status is TestStatus.PASS, f"{reply.strip()!r}: {ok.message}"
 
 
 def test_e2e_chat_rejects_a_signed_or_fractional_near_miss():

--- a/tests/test_agent_e2e_chat_false_green.py
+++ b/tests/test_agent_e2e_chat_false_green.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pin that `_test_e2e_chat` cannot pass on an agent that never answered (#1981).
+
+The e2e chat probe asked "What is 2+2?" and accepted a bare ``4`` anywhere in
+the agent CLI's stdout+stderr, while `_agent_query` never looked at the child's
+exit status. A CLI that never reached the server therefore reported PASS:
+
+    dsh: request failed: connect ECONNREFUSED 127.0.0.1:8477   ->  PASS
+                                                       ^ this "4"
+
+An HTTP 404, a timestamp, a token count or a version string does it just as
+well, on all 13 agent profiles, including the release gate's
+``bench --tier harness`` sweep.
+
+Both halves of the fix need their own coverage, because neither is sufficient:
+
+* **the assertion** — dsh exits 0 even when it fails outright (its profile's
+  ``known_issues`` records this), so for that CLI the exit status carries no
+  signal at all and only the expected answer can decide;
+* **the exit status** — an agent whose failure text happens to contain the
+  expected token would otherwise still pass, and an evidence-less run deserves
+  to be reported as the launch failure it is rather than as a wrong answer.
+
+And the fix must not overshoot: an agent that produced the evidence and *then*
+exited non-zero has still demonstrated the capability (#1598 established the
+same for an agent that never terminates), so the sibling file-read and terminal
+probes are exercised here too.
+
+Everything below drives a REAL subprocess. The bug is at the subprocess
+boundary — an unread ``returncode`` — and a mock asserting we read the
+attribute would only restate the diff.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+
+from vllm_mlx.agents.testing import (
+    E2E_CHAT_EXPECTED,
+    E2E_CHAT_QUERY,
+    E2E_FIRST_LINE,
+    TestStatus,
+    _agent_query,
+    _err_to_status,
+    _test_e2e_chat,
+    _test_e2e_file_read,
+    _test_e2e_terminal,
+)
+
+# Long enough that a slow machine never flakes, short enough that a regression
+# fails the suite in seconds instead of hanging it.
+_TIMEOUT_S = 8
+
+# The proven reproducer from #1981, verbatim: the whole of what a dsh that
+# cannot reach the server prints. Its only "4"s live in the port number.
+CONNECT_REFUSED = "dsh: request failed: connect ECONNREFUSED 127.0.0.1:8477\n"
+
+# The other shape, and the reason an exit-code check alone is not the fix:
+# dsh returns 0 here. The "4"s come from an HTTP status and a version string.
+NO_ADAPTER = (
+    'NO_ADAPTER: no adapter registered for provider "rapid-mlx" '
+    "(dsh 0.1.0-rc.4, HTTP 404)\n"
+)
+
+
+def _fake_cli(stdout: str = "", stderr: str = "", exit_code: int = 0) -> str:
+    """A stand-in agent CLI with a scripted answer and exit status."""
+    script = (
+        "import sys; "
+        f"sys.stdout.write({stdout!r}); "
+        f"sys.stderr.write({stderr!r}); "
+        f"sys.exit({exit_code})"
+    )
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(script)} '{{query}}'"
+
+
+def _echoing_cli(exit_code: int = 1) -> str:
+    """A CLI that prints the prompt back and never answers it."""
+    script = "import sys; sys.stdout.write('> ' + sys.argv[1] + chr(10)); "
+    script += f"sys.exit({exit_code})"
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(script)} '{{query}}'"
+
+
+# --------------------------------------------------------------------------- #
+# The reported false green                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_e2e_chat_fails_when_the_cli_never_reached_the_server():
+    """The #1981 reproducer: a connection refusal must not read as an answer."""
+    result = _test_e2e_chat(
+        sys.executable, _fake_cli(stderr=CONNECT_REFUSED, exit_code=1), _TIMEOUT_S
+    )
+
+    assert result.status is not TestStatus.PASS, (
+        "an agent CLI that never reached the server reported PASS — the port "
+        "number in its error text satisfied the assertion"
+    )
+    assert result.status is TestStatus.ERROR, (
+        f"a CLI that exited non-zero without answering is a launch failure, "
+        f"not a wrong answer; got {result.status} / {result.message!r}"
+    )
+    assert "ECONNREFUSED" in result.message, (
+        f"the report must name what actually went wrong: {result.message!r}"
+    )
+
+
+def test_e2e_chat_fails_on_a_zero_exit_failure_whose_text_contains_a_four():
+    """The half an exit-code check cannot cover: dsh fails and still returns 0.
+
+    If this test can be made to pass by looking at ``returncode``, the fix is
+    in the wrong place — for dsh the exit status is a constant.
+    """
+    result = _test_e2e_chat(
+        sys.executable, _fake_cli(stdout=NO_ADAPTER, exit_code=0), _TIMEOUT_S
+    )
+
+    assert result.status is TestStatus.FAIL, (
+        f"a provider error that never produced an answer passed the chat probe; "
+        f"got {result.status} / {result.message!r}"
+    )
+
+
+def test_e2e_chat_rejects_the_expected_answer_inside_a_longer_number():
+    """A timestamp that merely contains the digits is not an answer."""
+    result = _test_e2e_chat(
+        sys.executable,
+        _fake_cli(stderr="[1777777923] dsh: request failed\n", exit_code=0),
+        _TIMEOUT_S,
+    )
+
+    assert result.status is TestStatus.FAIL, (
+        f"the expected answer was accepted as a fragment of a longer number — "
+        f"exactly the failure mode being fixed; got {result.status}"
+    )
+
+
+def test_e2e_chat_is_not_satisfied_by_a_cli_echoing_the_prompt():
+    """Why the expected value is derived, not a sentinel handed to the agent.
+
+    A sentinel word in the prompt would also be un-guessable from an error
+    string — and would be echoed straight back by any CLI that prints the
+    prompt it was given (``codex exec`` does), which is the same false green
+    wearing a different hat.
+    """
+    assert E2E_CHAT_EXPECTED not in E2E_CHAT_QUERY, (
+        "the expected answer appears in the prompt; every prompt-echoing CLI "
+        "now passes the chat probe without answering"
+    )
+
+    result = _test_e2e_chat(sys.executable, _echoing_cli(exit_code=1), _TIMEOUT_S)
+
+    assert result.status is not TestStatus.PASS, (
+        f"a CLI that only echoed the prompt passed: {result.message!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ...without breaking the honest cases                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_e2e_chat_passes_on_a_correct_answer():
+    """The guard has to let the working case through, or it is just a red X."""
+    result = _test_e2e_chat(
+        sys.executable, _fake_cli(stdout=f"{E2E_CHAT_EXPECTED}\n"), _TIMEOUT_S
+    )
+
+    assert result.status is TestStatus.PASS, result.message
+
+
+def test_e2e_chat_accepts_a_digit_grouped_answer():
+    """Models write long numbers with separators; that is still the answer."""
+    result = _test_e2e_chat(
+        sys.executable,
+        _fake_cli(stdout="123456 + 654321 = 777,777\n"),
+        _TIMEOUT_S,
+    )
+
+    assert result.status is TestStatus.PASS, result.message
+
+
+def test_e2e_chat_passes_when_the_agent_answered_then_exited_nonzero():
+    """Exit status describes how the process ended, not whether it worked.
+
+    Some CLIs answer and then exit non-zero on their way out. Making a
+    non-zero exit fatal would turn those into a red release gate, so evidence
+    wins — the exit status only decides what an evidence-LESS run is called.
+    """
+    result = _test_e2e_chat(
+        sys.executable,
+        _fake_cli(
+            stdout=f"{E2E_CHAT_EXPECTED}\n", stderr="warning: session\n", exit_code=3
+        ),
+        _TIMEOUT_S,
+    )
+
+    assert result.status is TestStatus.PASS, (
+        f"an agent that answered correctly was failed for its exit code: "
+        f"{result.message!r}"
+    )
+    assert "exited non-zero" in result.message, (
+        f"the non-zero exit must still be reported on the PASS: {result.message!r}"
+    )
+
+
+def test_file_read_still_passes_when_the_cli_exits_nonzero_with_the_sentinel():
+    """The exit-code signal must not regress the already-correct siblings."""
+    result = _test_e2e_file_read(
+        sys.executable, _fake_cli(stdout=f"{E2E_FIRST_LINE}\n", exit_code=1), _TIMEOUT_S
+    )
+
+    assert result.status is TestStatus.PASS, result.message
+
+
+def test_terminal_still_passes_when_the_cli_exits_nonzero_with_the_marker():
+    marker = "rapidmlx_codex_test"
+    result = _test_e2e_terminal(
+        sys.executable,
+        _fake_cli(stdout=f"{marker}\n", exit_code=1),
+        _TIMEOUT_S,
+        "codex",
+    )
+
+    assert result.status is TestStatus.PASS, result.message
+
+
+def test_file_read_reports_the_launch_failure_instead_of_a_wrong_answer():
+    """No evidence and a non-zero exit is an ERROR, not a FAIL, everywhere."""
+    result = _test_e2e_file_read(
+        sys.executable, _fake_cli(stderr=CONNECT_REFUSED, exit_code=1), _TIMEOUT_S
+    )
+
+    assert result.status is TestStatus.ERROR, (
+        f"got {result.status} / {result.message!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The err sentinel itself                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_agent_query_keeps_the_output_alongside_the_exit_err():
+    """The err is soft: callers must still be able to grade what was printed."""
+    out, err = _agent_query(
+        sys.executable,
+        _fake_cli(stdout="partial work\n", exit_code=2),
+        "unused",
+        timeout=_TIMEOUT_S,
+    )
+
+    assert out is not None and "partial work" in out, (
+        "dropping the output on a non-zero exit would break every "
+        "evidence-beats-exit-status grader"
+    )
+    assert err is not None and err.startswith("EXIT:2"), err
+
+
+def test_agent_query_reports_a_clean_exit_as_before():
+    out, err = _agent_query(
+        sys.executable, _fake_cli(stdout="ok\n"), "unused", timeout=_TIMEOUT_S
+    )
+
+    assert err is None, f"a clean run must stay err-free: {err!r}"
+    assert out == "ok\n"
+
+
+def test_exit_err_is_not_misrouted_to_skip_by_the_childs_own_words():
+    """The EXIT err carries the child's text, and that text is not ours.
+
+    ``_err_to_status`` maps any err containing "not found" to SKIP (the
+    binary-missing case). A child that printed "command not found" would
+    otherwise vanish from the report as a skip.
+    """
+    err = "EXIT:127 agent CLI exited non-zero — dsh: command not found"
+
+    assert _err_to_status(err) is TestStatus.ERROR, (
+        "a failed agent run was reported as a skip because its own error text "
+        "said 'not found'"
+    )

--- a/tests/test_agent_e2e_chat_false_green.py
+++ b/tests/test_agent_e2e_chat_false_green.py
@@ -46,6 +46,7 @@ from vllm_mlx.agents.testing import (
     _test_e2e_chat,
     _test_e2e_file_read,
     _test_e2e_terminal,
+    _test_plain_chat,
 )
 
 # Long enough that a slow machine never flakes, short enough that a regression
@@ -364,6 +365,39 @@ def test_file_read_reports_the_launch_failure_instead_of_a_wrong_answer():
     assert result.status is TestStatus.ERROR, (
         f"got {result.status} / {result.message!r}"
     )
+
+
+# --------------------------------------------------------------------------- #
+# The API-level sibling                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _plain_chat_verdict(content: str, monkeypatch) -> TestStatus:
+    """Grade `content` as `_test_plain_chat` would, without a live server."""
+    monkeypatch.setattr(
+        "vllm_mlx.agents.testing._api_call",
+        lambda *_a, **_k: {"choices": [{"message": {"content": content}}]},
+    )
+    return _test_plain_chat("http://localhost:8000/v1", "model").status
+
+
+def test_plain_chat_wants_the_number_four_not_the_digit(monkeypatch):
+    """ "1234", "0.4", "-4" and "4.5" are not answers to "what is 2+2".
+
+    Same family as the e2e false green: grading a digit rather than a number
+    lets an unrelated value satisfy the assertion (codex review, round 3).
+    """
+    for wrong in ("1234", "0.4", "-4", "4.5", "The id is a4b."):
+        assert _plain_chat_verdict(wrong, monkeypatch) is TestStatus.FAIL, (
+            f"{wrong!r} was accepted as the answer to 2+2"
+        )
+
+
+def test_plain_chat_still_accepts_a_real_answer(monkeypatch):
+    for right in ("4", "4.", "2+2 = 4", "The answer is **4**"):
+        assert _plain_chat_verdict(right, monkeypatch) is TestStatus.PASS, (
+            f"{right!r} was rejected — plain_chat must stay the easy control"
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_agent_query_stdin_and_trust.py
+++ b/tests/test_agent_query_stdin_and_trust.py
@@ -46,6 +46,7 @@ import pytest
 
 from vllm_mlx.agents import get_profile
 from vllm_mlx.agents.testing import (
+    E2E_CHAT_EXPECTED,
     E2E_FIRST_LINE,
     TestStatus,
     _agent_query,
@@ -244,9 +245,9 @@ def test_each_e2e_test_gets_its_own_workspace(tmp_path):
     reads back the directories they actually ran in.
     """
     log = tmp_path / "cwds.txt"
-    # One reply that satisfies both assertions: "4" for chat, the sentinel
-    # for file-read.
-    cmd = _recording_agent(log, f"4 {E2E_FIRST_LINE}")
+    # One reply that satisfies both assertions: the expected sum for chat,
+    # the sentinel for file-read.
+    cmd = _recording_agent(log, f"{E2E_CHAT_EXPECTED} {E2E_FIRST_LINE}")
 
     # ALL THREE entry points, not a sample of them: `_test_e2e_terminal`
     # could regress to a shared or inherited cwd while a test that only

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -43,6 +43,12 @@ _ANTHROPIC_REMOTE_ENV = (
     "CLAUDE_CODE_USE_FOUNDRY",
 )
 
+# Prefix of the err sentinel ``_agent_query`` returns when the agent CLI exits
+# non-zero. Sentinel-prefixed like the ``SKIP:`` one so classification stays a
+# property of the string the subprocess boundary produced, not a guess made
+# from the child's own prose.
+_EXIT_ERR_PREFIX = "EXIT:"
+
 
 # ---------------------------------------------------------------------------
 # Test result types
@@ -235,7 +241,20 @@ def _test_plain_chat(base_url: str, model_id: str) -> TestResult:
             [{"role": "user", "content": "What is 2+2? Reply with just the number."}],
         )
         content = r["choices"][0]["message"]["content"]
-        if "4" in content:
+        # A standalone "4", not the digit anywhere in the string: "1234",
+        # "0.4" or a request id ending in 4 are not answers to "what is
+        # 2+2" (#1981, sibling of the `_test_e2e_chat` false green).
+        #
+        # The question itself stays 2+2, unlike its e2e sibling, and the
+        # threat models are why. This grades ``choices[0].message.content``
+        # from a response that already passed ``raise_for_status`` — a
+        # parsed answer field, not the raw stdout+stderr of a CLI that may
+        # never have reached the server, so there is no error prose here to
+        # be mistaken for an answer. That leaves this the cheapest possible
+        # probe of "the server answers coherently", which is what makes it
+        # a useful control: when e2e_chat fails and plain_chat passes, the
+        # fault is in the agent CLI path, not the model.
+        if re.search(r"(?<!\d)4(?!\d)", content):
             return TestResult(
                 "plain_chat", TestStatus.PASS, duration_ms=(time.time() - t0) * 1000
             )
@@ -733,6 +752,43 @@ E2E_FIRST_LINE_TOKEN = "rapid-mlx-e2e-first-line-sentinel"
 E2E_FIRST_LINE = f"{E2E_FIRST_LINE_TOKEN} = true"
 
 
+# `_test_e2e_chat` grades whatever the agent CLI wrote to stdout+stderr, and
+# that text is not always an answer — a CLI that never reached the server
+# still prints something.  The old probe asked for 2+2 and accepted a bare
+# "4" anywhere in that text, so a pure launch failure reported PASS:
+#
+#     dsh: request failed: connect ECONNREFUSED 127.0.0.1:8477
+#                                                        ^ this "4"
+#
+# An HTTP 404, a timestamp, a token count or a version string does it just as
+# well (#1981).  The expected answer therefore has to be a value that cannot
+# plausibly fall out of a failure message — the same reasoning that made
+# `_test_e2e_file_read` demand a sentinel instead of the word "build".
+#
+# Why an arithmetic result rather than a sentinel word: the expected token must
+# NOT appear in the prompt, or every CLI that echoes its prompt (`codex exec`
+# does) becomes a new false green.  The operands below are chosen so that no
+# column carries — this is as easy as multi-digit arithmetic gets, so a small
+# quantized model is not being asked for a new capability — while the answer is
+# longer than any port number (max 65535) or status code, and is accepted only
+# as a standalone number so it can never be a fragment of an epoch, a request
+# id or a hash.
+E2E_CHAT_QUERY = "What is 123456 + 654321? Reply with just the number."
+E2E_CHAT_EXPECTED = "777777"
+_E2E_CHAT_EXPECTED_RE = re.compile(rf"(?<!\d){E2E_CHAT_EXPECTED}(?!\d)")
+# Models group long numbers ("777,777", "777 777").  Join digit groups before
+# matching — a single separator BETWEEN two digits only, never a newline, so
+# unrelated numbers on adjacent lines cannot be welded into the expected one.
+_DIGIT_GROUP_SEP_RE = re.compile("(?<=\\d)[,\u00a0\u202f ](?=\\d)")
+
+
+def _e2e_chat_answered(out: str | None) -> bool:
+    """True only when the agent came back with the expected sum itself."""
+    if not out:
+        return False
+    return bool(_E2E_CHAT_EXPECTED_RE.search(_DIGIT_GROUP_SEP_RE.sub("", out)))
+
+
 @contextlib.contextmanager
 def _e2e_workspace():
     """A throwaway directory for the agent to work in.
@@ -971,6 +1027,29 @@ def _agent_query(
                 f"SKIP: agent refused init — served model's context window "
                 f"is below the harness minimum{detail}"
             )
+        # The one signal the OS gives us that the run did not complete. A CLI
+        # that never reached the server prints its complaint and exits
+        # non-zero; without this the caller sees only the complaint text and
+        # grades it as if it were an answer (#1981).
+        #
+        # Deliberately a SOFT err — carried alongside the output, not instead
+        # of it — because exit status can neither pass nor fail a test on its
+        # own here:
+        #   * dsh exits 0 even when it fails outright (a bad provider prints
+        #     NO_ADAPTER and still returns 0; see its profile known_issues),
+        #     so a zero exit proves nothing;
+        #   * an agent may answer correctly and then exit non-zero on its way
+        #     out, which #1598 already established is not grounds for failing
+        #     a test whose evidence is on stdout.
+        # Capability evidence therefore still wins; this only decides what an
+        # evidence-LESS run gets called, and turns a silent "wrong answer"
+        # FAIL into an ERROR naming the launch failure.
+        if proc.returncode != 0:
+            tail = " ".join(output.split())[-160:]
+            detail = f" — {tail}" if tail else ""
+            return output, (
+                f"{_EXIT_ERR_PREFIX}{proc.returncode} agent CLI exited non-zero{detail}"
+            )
         return output, None
     except subprocess.TimeoutExpired as exc:
         # A headless agent can finish the capability under test, print the
@@ -992,8 +1071,13 @@ def _agent_query(
 def _err_to_status(err: str | None) -> TestStatus:
     """Map an ``_agent_query`` err string to the right TestStatus.
 
-    Three buckets, in priority order:
+    Four buckets, in priority order:
 
+    - ``"EXIT:"`` prefix → ERROR. The agent CLI exited non-zero (#1981).
+      Checked FIRST because this err carries a tail of the child's own
+      output, and that text is not ours: a child that printed "command
+      not found" or "model not found" would otherwise be misrouted to
+      SKIP by the substring rule below and vanish from the report.
     - ``"not found"`` → SKIP. Harness binary isn't installed; we can't
       run the e2e gate and shouldn't pretend to.
     - ``"SKIP:"`` prefix → SKIP. ``_agent_query`` propagates this for
@@ -1003,11 +1087,35 @@ def _err_to_status(err: str | None) -> TestStatus:
     """
     if not err:
         return TestStatus.PASS  # caller shouldn't pass empty err but stay safe
+    if err.startswith(_EXIT_ERR_PREFIX):
+        return TestStatus.ERROR
     if "not found" in err:
         return TestStatus.SKIP
     if err.startswith("SKIP:"):
         return TestStatus.SKIP
     return TestStatus.ERROR
+
+
+def _err_loses_to_evidence(err: str | None) -> bool:
+    """True for errs that must not overrule evidence the agent already gave.
+
+    An agent can do the work, print the proof, and only *then* misbehave:
+    never terminate (#1598) or exit non-zero on its way out (#1981). Both
+    describe how the process ended, not whether the capability worked, so
+    a caller holding the expected evidence keeps its PASS. Every other err
+    — binary missing, init refusal, server error, crash — means the output
+    cannot be trusted at all and wins outright.
+    """
+    return bool(err) and (err == "TIMEOUT" or err.startswith(_EXIT_ERR_PREFIX))
+
+
+def _evidence_note(err: str | None, evidence: str) -> str:
+    """Message for a PASS whose CLI misbehaved after producing the evidence."""
+    if err == "TIMEOUT":
+        return f"{evidence} observed; agent CLI did not terminate before timeout"
+    if err and err.startswith(_EXIT_ERR_PREFIX):
+        return f"{evidence} observed; {err}"
+    return ""
 
 
 def _test_e2e_chat(
@@ -1040,12 +1148,16 @@ def _test_e2e_chat(
         out, err = _agent_query(
             binary,
             query_cmd,
-            "What is 2+2? Reply with just the number.",
+            E2E_CHAT_QUERY,
             timeout,
             workdir,
             env_overrides,
         )
-    if err:
+    # Evidence first, exactly as `_test_e2e_file_read` does: an agent that
+    # answered and then failed to terminate (#1598) or exited non-zero
+    # (#1981) still demonstrated the capability under test.
+    answered = _e2e_chat_answered(out)
+    if err and not (_err_loses_to_evidence(err) and answered):
         status = _err_to_status(err)
         return TestResult(
             "e2e_chat",
@@ -1054,18 +1166,19 @@ def _test_e2e_chat(
             message=err,
             category="e2e",
         )
-    if "4" in (out or ""):
+    if answered:
         return TestResult(
             "e2e_chat",
             TestStatus.PASS,
             duration_ms=(time.time() - t0) * 1000,
+            message=_evidence_note(err, "answer"),
             category="e2e",
         )
     return TestResult(
         "e2e_chat",
         TestStatus.FAIL,
         duration_ms=(time.time() - t0) * 1000,
-        message=f"Expected '4': {(out or '')[:80]}",
+        message=f"Expected '{E2E_CHAT_EXPECTED}': {(out or '')[:80]}",
         category="e2e",
     )
 
@@ -1108,7 +1221,9 @@ def _test_e2e_file_read(
             workdir,
             env_overrides,
         )
-    if err and not (err == "TIMEOUT" and E2E_FIRST_LINE_TOKEN in (out or "")):
+    if err and not (
+        _err_loses_to_evidence(err) and E2E_FIRST_LINE_TOKEN in (out or "")
+    ):
         status = _err_to_status(err)
         return TestResult(
             "e2e_file_read",
@@ -1124,11 +1239,7 @@ def _test_e2e_file_read(
             "e2e_file_read",
             TestStatus.PASS,
             duration_ms=(time.time() - t0) * 1000,
-            message=(
-                "file-read evidence observed; agent CLI did not terminate before timeout"
-                if err == "TIMEOUT"
-                else ""
-            ),
+            message=_evidence_note(err, "file-read evidence"),
             category="e2e",
         )
     return TestResult(
@@ -1177,7 +1288,7 @@ def _test_e2e_terminal(
             workdir,
             env_overrides,
         )
-    if err:
+    if err and not (_err_loses_to_evidence(err) and marker in (out or "")):
         status = _err_to_status(err)
         return TestResult(
             "e2e_terminal",
@@ -1191,6 +1302,7 @@ def _test_e2e_terminal(
             "e2e_terminal",
             TestStatus.PASS,
             duration_ms=(time.time() - t0) * 1000,
+            message=_evidence_note(err, "terminal-marker evidence"),
             category="e2e",
         )
     return TestResult(

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -775,25 +775,42 @@ E2E_FIRST_LINE = f"{E2E_FIRST_LINE_TOKEN} = true"
 # id or a hash.
 E2E_CHAT_QUERY = "What is 123456 + 654321? Reply with just the number."
 E2E_CHAT_EXPECTED = "777777"
+# One separator character models actually use for thousands: comma, no-break
+# space, narrow no-break space, plain space.
+_DIGIT_GROUP_SEP = "[,\u00a0\u202f ]"
+
+
+def _grouped_number_pattern(digits: str) -> str:
+    """``777777`` → ``(?:777777|777<sep>777)`` — bare or thousands-grouped.
+
+    Only these two shapes. An earlier version stripped every separator that
+    sat between two digits before matching, which also turned malformed or
+    entirely different numbers ("7777 77") into the expected one — a fresh
+    way to pass without answering, which is the bug this module exists to
+    prevent (codex review round 2).
+    """
+    head = len(digits) % 3 or 3
+    groups = [digits[:head]] + [digits[i : i + 3] for i in range(head, len(digits), 3)]
+    return f"(?:{digits}|{_DIGIT_GROUP_SEP.join(groups)})"
+
+
 # Boundaries are numeric, not merely non-digit: a leading sign or a decimal
 # point makes the number a DIFFERENT number, so "-777777", "12.777777" and
 # "777777.5" are all wrong answers rather than sloppy right ones. A trailing
 # period is still fine — that is a sentence ending, not a decimal, which is
 # why only ``.<digit>`` is rejected on the right.
 _E2E_CHAT_EXPECTED_RE = re.compile(
-    "(?<![\\d.\\-−–])" + E2E_CHAT_EXPECTED + "(?!\\d)(?!\\.\\d)"
+    "(?<![\\d.\\-−–])"
+    + _grouped_number_pattern(E2E_CHAT_EXPECTED)
+    + "(?!\\d)(?!\\.\\d)"
 )
-# Models group long numbers ("777,777", "777 777").  Join digit groups before
-# matching — a single separator BETWEEN two digits only, never a newline, so
-# unrelated numbers on adjacent lines cannot be welded into the expected one.
-_DIGIT_GROUP_SEP_RE = re.compile("(?<=\\d)[,\u00a0\u202f ](?=\\d)")
 
 
 def _e2e_chat_answered(out: str | None) -> bool:
     """True only when the agent came back with the expected sum itself."""
     if not out:
         return False
-    return bool(_E2E_CHAT_EXPECTED_RE.search(_DIGIT_GROUP_SEP_RE.sub("", out)))
+    return bool(_E2E_CHAT_EXPECTED_RE.search(out))
 
 
 @contextlib.contextmanager
@@ -1061,9 +1078,9 @@ def _agent_query(
         # to stderr; the failure text is not discarded, it is summarized into
         # the err below, which is what gets reported.
         #
-        # The TIMEOUT path deliberately keeps its combined stdout+stderr
-        # capture: that behavior is #1598's and predates this change, and
-        # narrowing it is not needed to close #1981.
+        # The TIMEOUT branch below applies the same rule, for the same reason:
+        # both are runs that misbehaved, and it would be incoherent for a hung
+        # CLI to get credit for stderr text a failed one does not.
         if proc.returncode != 0:
             tail = " ".join(output.split())[-160:]
             detail = f" — {tail}" if tail else ""
@@ -1082,7 +1099,12 @@ def _agent_query(
                 return ""
             return value.decode(errors="replace") if isinstance(value, bytes) else value
 
-        partial = _timeout_text(exc.stdout) + _timeout_text(exc.stderr)
+        # STDOUT only, exactly as on the non-zero-exit path: a hung CLI's
+        # diagnostics ("ERROR: expected 777777", "could not run echo <marker>")
+        # are not evidence that it did the work, and this err is one of the two
+        # that lose to evidence. Nothing is lost from the report — the timeout
+        # err carries no child text in either form.
+        partial = _timeout_text(exc.stdout)
         return partial or None, "TIMEOUT"
     except Exception as e:
         return None, str(e)

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -78,9 +78,20 @@ def _exact_number_re(digits: str, *, grouped: bool = False) -> re.Pattern[str]:
     the "4" in a request id like "a4b" is not an answer to anything. A
     trailing period stays fine: that is a sentence ending, which is why only
     ``.<digit>`` is rejected on the right.
+
+    A group separator with a digit on its far side is rejected as well, or
+    the tolerance for "777,777" would accept "4,000", "1,777777" and
+    "777777,000" — each a different number that merely starts or ends with
+    the expected digits.
     """
     body = _grouped_number_pattern(digits) if grouped else digits
-    return re.compile("(?<![\\w.\\-−–])" + body + "(?!\\w)(?!\\.\\d)")
+    return re.compile(
+        "(?<![\\w.\\-−–])"
+        + f"(?<!\\d{_DIGIT_GROUP_SEP})"
+        + body
+        + f"(?!{_DIGIT_GROUP_SEP}\\d)"
+        + "(?!\\w)(?!\\.\\d)"
+    )
 
 
 # `_test_plain_chat` asks for 2+2 over HTTP; see the comment at its assertion
@@ -1171,9 +1182,12 @@ def _err_loses_to_evidence(err: str | None) -> bool:
     — binary missing, init refusal, server error, crash — means the output
     cannot be trusted at all and wins outright.
 
-    What counts as evidence is narrowed at the source: on a non-zero exit
-    ``_agent_query`` returns stdout only, so a failure diagnostic quoting
-    the expected token back at us on stderr cannot buy a PASS here.
+    What counts as evidence is narrowed at the source: on a non-zero exit or
+    a timeout ``_agent_query`` returns stdout only, so a failure diagnostic
+    quoting the expected token back at us on stderr cannot buy a PASS here.
+
+    Callers may only use this where their evidence cannot be produced by
+    echoing the prompt — `_test_e2e_terminal` deliberately does not.
     """
     return bool(err) and (err == "TIMEOUT" or err.startswith(_EXIT_ERR_PREFIX))
 
@@ -1357,7 +1371,18 @@ def _test_e2e_terminal(
             workdir,
             env_overrides,
         )
-    if err and not (_err_loses_to_evidence(err) and marker in (out or "")):
+    # NO evidence carve-out here, unlike the chat and file-read probes, and
+    # the difference is the marker itself: it is handed to the agent IN THE
+    # PROMPT ("Run 'echo <marker>'"), so any CLI that echoes its prompt prints
+    # it without having run anything. That is fine while the run is otherwise
+    # healthy — a healthy run that echoed the prompt and stopped would also
+    # have to survive `err is None` — but it is exactly what a broken CLI does
+    # on its way out, so letting a marker overrule a crash or a hang would
+    # hand a PASS to an agent that never opened a shell (codex review round 4).
+    # Chat and file-read can afford the carve-out because their evidence — a
+    # derived sum, a sentinel that lives only in the workspace file — cannot
+    # be produced by echoing the question.
+    if err:
         status = _err_to_status(err)
         return TestResult(
             "e2e_terminal",
@@ -1371,7 +1396,6 @@ def _test_e2e_terminal(
             "e2e_terminal",
             TestStatus.PASS,
             duration_ms=(time.time() - t0) * 1000,
-            message=_evidence_note(err, "terminal-marker evidence"),
             category="e2e",
         )
     return TestResult(

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -49,6 +49,44 @@ _ANTHROPIC_REMOTE_ENV = (
 # from the child's own prose.
 _EXIT_ERR_PREFIX = "EXIT:"
 
+# One separator character models actually use for thousands: comma, no-break
+# space, narrow no-break space, plain space.
+_DIGIT_GROUP_SEP = "[,\u00a0\u202f ]"
+
+
+def _grouped_number_pattern(digits: str) -> str:
+    """``777777`` → ``(?:777777|777<sep>777)`` — bare or thousands-grouped.
+
+    Only these two shapes. An earlier version stripped every separator that
+    sat between two digits before matching, which also turned malformed or
+    entirely different numbers ("7777 77") into the expected one — a fresh
+    way to pass without answering, which is the bug this module exists to
+    prevent (codex review round 2).
+    """
+    head = len(digits) % 3 or 3
+    groups = [digits[:head]] + [digits[i : i + 3] for i in range(head, len(digits), 3)]
+    return f"(?:{digits}|{_DIGIT_GROUP_SEP.join(groups)})"
+
+
+def _exact_number_re(digits: str, *, grouped: bool = False) -> re.Pattern[str]:
+    """Match `digits` as that number, not as a run of digits inside another.
+
+    Boundaries are numeric rather than merely non-digit: a leading sign or a
+    decimal point makes it a DIFFERENT number, so "-4", "0.4", "4.5",
+    "12.777777" and "777777.5" are wrong answers rather than sloppy right
+    ones. Word characters are excluded on both sides for the same reason —
+    the "4" in a request id like "a4b" is not an answer to anything. A
+    trailing period stays fine: that is a sentence ending, which is why only
+    ``.<digit>`` is rejected on the right.
+    """
+    body = _grouped_number_pattern(digits) if grouped else digits
+    return re.compile("(?<![\\w.\\-−–])" + body + "(?!\\w)(?!\\.\\d)")
+
+
+# `_test_plain_chat` asks for 2+2 over HTTP; see the comment at its assertion
+# for why its question stays easy while the e2e sibling's does not.
+_PLAIN_CHAT_EXPECTED_RE = _exact_number_re("4")
+
 
 # ---------------------------------------------------------------------------
 # Test result types
@@ -241,9 +279,10 @@ def _test_plain_chat(base_url: str, model_id: str) -> TestResult:
             [{"role": "user", "content": "What is 2+2? Reply with just the number."}],
         )
         content = r["choices"][0]["message"]["content"]
-        # A standalone "4", not the digit anywhere in the string: "1234",
-        # "0.4" or a request id ending in 4 are not answers to "what is
-        # 2+2" (#1981, sibling of the `_test_e2e_chat` false green).
+        # The number 4, not the digit anywhere in the string: "1234", "0.4",
+        # "-4", "4.5" and a request id ending in 4 are none of them answers to
+        # "what is 2+2" (#1981, sibling of the `_test_e2e_chat` false green).
+        # Same matcher as the e2e probe so the two cannot drift apart.
         #
         # The question itself stays 2+2, unlike its e2e sibling, and the
         # threat models are why. This grades ``choices[0].message.content``
@@ -254,7 +293,7 @@ def _test_plain_chat(base_url: str, model_id: str) -> TestResult:
         # probe of "the server answers coherently", which is what makes it
         # a useful control: when e2e_chat fails and plain_chat passes, the
         # fault is in the agent CLI path, not the model.
-        if re.search(r"(?<!\d)4(?!\d)", content):
+        if _PLAIN_CHAT_EXPECTED_RE.search(content):
             return TestResult(
                 "plain_chat", TestStatus.PASS, duration_ms=(time.time() - t0) * 1000
             )
@@ -775,35 +814,9 @@ E2E_FIRST_LINE = f"{E2E_FIRST_LINE_TOKEN} = true"
 # id or a hash.
 E2E_CHAT_QUERY = "What is 123456 + 654321? Reply with just the number."
 E2E_CHAT_EXPECTED = "777777"
-# One separator character models actually use for thousands: comma, no-break
-# space, narrow no-break space, plain space.
-_DIGIT_GROUP_SEP = "[,\u00a0\u202f ]"
-
-
-def _grouped_number_pattern(digits: str) -> str:
-    """``777777`` → ``(?:777777|777<sep>777)`` — bare or thousands-grouped.
-
-    Only these two shapes. An earlier version stripped every separator that
-    sat between two digits before matching, which also turned malformed or
-    entirely different numbers ("7777 77") into the expected one — a fresh
-    way to pass without answering, which is the bug this module exists to
-    prevent (codex review round 2).
-    """
-    head = len(digits) % 3 or 3
-    groups = [digits[:head]] + [digits[i : i + 3] for i in range(head, len(digits), 3)]
-    return f"(?:{digits}|{_DIGIT_GROUP_SEP.join(groups)})"
-
-
-# Boundaries are numeric, not merely non-digit: a leading sign or a decimal
-# point makes the number a DIFFERENT number, so "-777777", "12.777777" and
-# "777777.5" are all wrong answers rather than sloppy right ones. A trailing
-# period is still fine — that is a sentence ending, not a decimal, which is
-# why only ``.<digit>`` is rejected on the right.
-_E2E_CHAT_EXPECTED_RE = re.compile(
-    "(?<![\\d.\\-−–])"
-    + _grouped_number_pattern(E2E_CHAT_EXPECTED)
-    + "(?!\\d)(?!\\.\\d)"
-)
+# Grouped as well as bare: a model that writes "777,777" has answered the
+# question. `_exact_number_re` explains the boundaries.
+_E2E_CHAT_EXPECTED_RE = _exact_number_re(E2E_CHAT_EXPECTED, grouped=True)
 
 
 def _e2e_chat_answered(out: str | None) -> bool:
@@ -1087,6 +1100,16 @@ def _agent_query(
             return proc.stdout, (
                 f"{_EXIT_ERR_PREFIX}{proc.returncode} agent CLI exited non-zero{detail}"
             )
+        # A CLEAN exit keeps the combined capture, and that boundary is
+        # deliberate. Narrowing every run to stdout was considered (codex
+        # review round 3) and declined: it would change grading on the normal
+        # path for all 13 profiles to defend against a failure message that
+        # contains the expected six-digit sum, which a CLI has no way to know.
+        # The cost is not hypothetical — the Hermes binary writes user-facing
+        # text to STDERR (see the hard-wrap note in the refusal detection
+        # above), so stdout-only grading could fail a Tier-1 profile that
+        # answered correctly. Suppressing evidence is only justified once the
+        # run itself has reported that it went wrong.
         return output, None
     except subprocess.TimeoutExpired as exc:
         # A headless agent can finish the capability under test, print the

--- a/vllm_mlx/agents/testing.py
+++ b/vllm_mlx/agents/testing.py
@@ -775,7 +775,14 @@ E2E_FIRST_LINE = f"{E2E_FIRST_LINE_TOKEN} = true"
 # id or a hash.
 E2E_CHAT_QUERY = "What is 123456 + 654321? Reply with just the number."
 E2E_CHAT_EXPECTED = "777777"
-_E2E_CHAT_EXPECTED_RE = re.compile(rf"(?<!\d){E2E_CHAT_EXPECTED}(?!\d)")
+# Boundaries are numeric, not merely non-digit: a leading sign or a decimal
+# point makes the number a DIFFERENT number, so "-777777", "12.777777" and
+# "777777.5" are all wrong answers rather than sloppy right ones. A trailing
+# period is still fine — that is a sentence ending, not a decimal, which is
+# why only ``.<digit>`` is rejected on the right.
+_E2E_CHAT_EXPECTED_RE = re.compile(
+    "(?<![\\d.\\-−–])" + E2E_CHAT_EXPECTED + "(?!\\d)(?!\\.\\d)"
+)
 # Models group long numbers ("777,777", "777 777").  Join digit groups before
 # matching — a single separator BETWEEN two digits only, never a newline, so
 # unrelated numbers on adjacent lines cannot be welded into the expected one.
@@ -1044,10 +1051,23 @@ def _agent_query(
         # Capability evidence therefore still wins; this only decides what an
         # evidence-LESS run gets called, and turns a silent "wrong answer"
         # FAIL into an ERROR naming the launch failure.
+        #
+        # But a process that reported failure only gets credit for what it put
+        # on STDOUT: the returned output narrows to ``proc.stdout`` so a
+        # diagnostic that quotes the expected evidence back at us ("expected
+        # 777777; request failed", printed on stderr) cannot be mistaken for
+        # the answer and re-open this very bug from the other side. Every agent
+        # CLI the profiles drive writes its answer to stdout and its complaints
+        # to stderr; the failure text is not discarded, it is summarized into
+        # the err below, which is what gets reported.
+        #
+        # The TIMEOUT path deliberately keeps its combined stdout+stderr
+        # capture: that behavior is #1598's and predates this change, and
+        # narrowing it is not needed to close #1981.
         if proc.returncode != 0:
             tail = " ".join(output.split())[-160:]
             detail = f" — {tail}" if tail else ""
-            return output, (
+            return proc.stdout, (
                 f"{_EXIT_ERR_PREFIX}{proc.returncode} agent CLI exited non-zero{detail}"
             )
         return output, None
@@ -1105,6 +1125,10 @@ def _err_loses_to_evidence(err: str | None) -> bool:
     a caller holding the expected evidence keeps its PASS. Every other err
     — binary missing, init refusal, server error, crash — means the output
     cannot be trusted at all and wins outright.
+
+    What counts as evidence is narrowed at the source: on a non-zero exit
+    ``_agent_query`` returns stdout only, so a failure diagnostic quoting
+    the expected token back at us on stderr cannot buy a PASS here.
     """
     return bool(err) and (err == "TIMEOUT" or err.startswith(_EXIT_ERR_PREFIX))
 


### PR DESCRIPTION
## Why

Closes #1981.

`_test_e2e_chat` asked *"What is 2+2? Reply with just the number."* and graded the agent CLI's combined stdout+stderr with `if "4" in (out or "")`, while `_agent_query` never consulted `proc.returncode`. An agent that never reached the server therefore reported **PASS** — because any error text containing a `4` satisfies the assertion. This affected all 13 agent profiles, including the release gate's `bench --tier harness` sweep.

Proven reproducer — a fake CLI that prints only `dsh: request failed: connect ECONNREFUSED 127.0.0.1:8477` and exits 1, run against the grading module **before** this change:

```
_test_e2e_chat       -> PASS    <- WRONG, the port number 8477 contains a "4"
_test_e2e_file_read  -> FAIL    Unexpected: dsh: request failed: connect ECONNREFUSED 127.0.0.1:8477
_test_e2e_terminal   -> FAIL    Missing marker: dsh: request failed: connect ECONNREFUSED 127.0.0.1:8477
```

**After**, same fake CLI:

```
_test_e2e_chat       -> ERROR   EXIT:1 agent CLI exited non-zero - dsh: request failed: connect ECONNREFUSED 127.0.0.1:8477
_test_e2e_file_read  -> ERROR   EXIT:1 agent CLI exited non-zero - dsh: request failed: connect ECONNREFUSED 127.0.0.1:8477
_test_e2e_terminal   -> ERROR   EXIT:1 agent CLI exited non-zero - dsh: request failed: connect ECONNREFUSED 127.0.0.1:8477
```

## What changed

An exit-code check alone is **not** sufficient: `dsh` returns 0 even when it fails outright (a bad provider prints `NO_ADAPTER: no adapter registered for provider "rapid-mlx"` and still exits 0 — recorded in `deepseek-harness.yaml` `known_issues`). A stronger assertion alone is not sufficient either — an evidence-less run deserves to be named as the launch failure it is rather than reported as a wrong answer. So both:

**1. A stronger assertion.** The probe now asks `What is 123456 + 654321?` and requires `777777` as that *number* — not as a run of digits inside another. `_exact_number_re` rejects word characters, signs and decimal points on the boundaries, and accepts thousands grouping only in its valid shape, so `1777777923`, `-777777`, `777777.5`, `7777 77` and `777777,000` are all wrong answers.

Why a derived answer rather than a sentinel word handed to the agent: the expected token must **not** appear in the prompt, or every CLI that echoes its prompt (`codex exec` does) becomes a new false green. Same reasoning that made `_test_e2e_file_read` demand `E2E_FIRST_LINE_TOKEN` instead of the word "build".

Why this cannot turn a working gate red: the operands carry in no column, so this is as easy as multi-digit arithmetic gets — no new model capability is being demanded. Measured on the two models the sweep actually uses, both answer `777777`:

```
mlx-community/Qwen3.5-4B-MLX-4bit  -> PASS  ("... Final Check: ... 777777")
mlx-community/Qwen3.5-9B-4bit      -> PASS  ("... Final Output: 777777")
```

Cost on a reasoning 9B: 528 completion tokens vs 155 for the old 2+2 prompt — a few seconds against a 120 s query timeout.

**2. Exit-code awareness.** `_agent_query` returns an `EXIT:<code>` err sentinel (with a tail of the child's own output) when the CLI exits non-zero — **soft**, carried *alongside* the output, not instead of it:

* `dsh` exits 0 on failure, so a zero exit proves nothing and can never pass a test on its own;
* an agent may answer correctly and *then* exit non-zero, which #1598 already settled for the non-terminating case.

Capability evidence therefore still wins; the exit status only decides what an **evidence-less** run is called, turning a misleading `FAIL: Expected '4': dsh: request failed...` into an `ERROR` that names `ECONNREFUSED`. `_err_to_status` checks the `EXIT:` prefix **first**, so a child that printed "command not found" is not misrouted to SKIP and silently dropped from the report.

Two boundaries make that carve-out safe, both found in review and both pinned by tests:

* **A run that reported it went wrong is credited only with its stdout** (non-zero exit or timeout), so a diagnostic quoting the expected token back at us cannot buy a PASS. A *clean* exit keeps the combined capture — narrowing the normal path for 13 profiles would risk failing an agent that answered on stderr, and Hermes is known to put user-facing text there.
* **The carve-out only applies where the evidence cannot come from the prompt.** Chat (a derived sum) and file-read (a sentinel that exists only in the workspace file) qualify. `_test_e2e_terminal` does **not** — its marker is handed to the agent in the prompt (`Run 'echo <marker>'`), so a CLI that echoes the prompt while dying would print the evidence without opening a shell. That probe keeps treating any err as fatal, exactly as on main.

**3. `_test_plain_chat`** (separate hunk): now wants the number `4` via the same matcher, so `1234`, `0.4`, `-4`, `4.5`, `4,000` and the `4` inside an identifier no longer pass. Its question deliberately stays 2+2 — it grades `choices[0].message.content` from a response that already passed `raise_for_status`, i.e. a parsed answer field rather than CLI error prose, and keeping it the cheapest possible probe is what makes it a useful control: e2e_chat red + plain_chat green means the fault is in the agent CLI path, not the model.

## Proving the guard can fail

`tests/test_agent_e2e_chat_false_green.py` (21 tests) drives **real subprocesses** — the bug lives at the subprocess boundary (an unread `returncode`), and a mock asserting we read the attribute would only restate the diff.

Every load-bearing piece was reverted in turn; each one takes tests down with it:

| mutation | result |
| --- | --- |
| assertion reverted (bare `4`, 2+2 prompt) | **6 failed**, 15 passed |
| exit code reverted (`returncode` unread) | **7 failed**, 14 passed |
| both reverted (pre-fix behaviour) | **12 failed**, 9 passed |
| failed run keeps credit for stderr | **2 failed**, 19 passed |
| hung run keeps credit for stderr | **1 failed**, 20 passed |
| numeric boundaries reverted | **3 failed**, 18 passed |
| grouping validation reverted | **1 failed**, 20 passed |
| terminal probe given back the carve-out | **1 failed**, 20 passed |

## Tests

```
tests/test_agent_e2e_chat_false_green.py                                21 passed
test_deepseek_harness_profile / _tier1 / test_agent_first_class_setup /
test_agent_query_stdin_and_trust / test_agent_query_context_skip /
test_agent_test_runner_refresh_config / test_claude_code_profile /
test_codex_profile / test_bench_tier_harness /
test_hermes_harness_contract / test_http_auth                          124 passed
pr_validate full_unit                            17746 passed, 63 skipped
```

`python3.12 -m ruff check` and `ruff format` clean on the touched files. `pr_validate` verdict **MERGE-SAFE**, codex review 0 blocking after four rounds.

One existing test was updated, not weakened: `test_each_e2e_test_gets_its_own_workspace` scripted its stand-in agent to reply `4`, which is no longer an answer — it now replies with `E2E_CHAT_EXPECTED`.

Two review findings were **declined**, with the reasoning left in the code where the boundary is drawn: narrowing evidence to stdout on *clean* exits (would change grading on the normal path for all 13 profiles to defend against a failure message containing a sum no CLI can know), and re-widening the *timeout* capture to stdout+stderr (the inverse of an earlier finding — the two cannot both hold).

Not covered: no live agent CLI (codex/dsh/claude) was driven end-to-end against a running server in this change; the CLI-side behaviour is covered by fake CLIs, and the model-side answer was verified directly against both shipped models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
