### PR TITLE
fix(release): strip multi-line release-note comments (supersedes #1966)

### DIFF
--- a/scripts/build_release_notes.sh
+++ b/scripts/build_release_notes.sh
@@ -138,18 +138,86 @@ if git cat-file -e "$RELEASE_SHA:$HIGHLIGHTS_PATH" 2>/dev/null; then
           for (i = 1; i <= pending_count; i++) print pending[i]
           pending_count = 0
         }
+        # An HTML comment closes at its FIRST "-->"; anything after that first
+        # marker is visible content. Return that trailing text so the caller can
+        # judge what a clean whole-line close leaves behind. Checking the whole
+        # line for a trailing "-->" instead would treat "<!-- x --> note -->" as
+        # a clean close and silently drop "note".
+        function tail_after_close(line,    p) {
+          p = index(line, "-->")
+          return substr(line, p + 3)
+        }
+        # Would the text trailing a closed comment ship nothing visible? True
+        # when it is only whitespace and/or further complete whole-line comments
+        # (so "<!-- a --> <!-- b -->" is fully strippable). A trailing UNCLOSED
+        # "<!--" is treated as not-clean so the line is kept verbatim rather than
+        # swallowing the notes that follow it. Only ever fed the tail of a line
+        # already in whole-line-comment context, so column-0-only stays intact.
+        function rest_is_clean(s,    o, c) {
+          while (1) {
+            if (s ~ /^[[:space:]]*$/) return 1
+            if (s !~ /^[[:space:]]*<!--/) return 0
+            o = index(s, "<!--"); s = substr(s, o + 4)
+            c = index(s, "-->"); if (c == 0) return 0
+            s = substr(s, c + 3)
+          }
+        }
+        # A line indented four or more spaces (or led by a tab) is a CommonMark
+        # indented code block, not prose: fences and drafting comments there are
+        # example text and must survive untouched. Kept deliberately simple —
+        # the interval form /^ {0,3}/ is avoided for portability with older awks.
+        function indented_code(line) {
+          return (line ~ /^    / || line ~ /^\t/)
+        }
+        # The leading code-fence run (0-3 spaces of indent), e.g. "```" or
+        # "~~~~", or "" when the line does not open/close a fence. A CommonMark
+        # fence is three or more backticks or tildes at 0-3 spaces of indent.
+        function fence_marker(line,    s, ch, n) {
+          if (indented_code(line)) return ""
+          s = line
+          sub(/^ */, "", s)
+          if (s ~ /^```/) ch = "`"
+          else if (s ~ /^~~~/) ch = "~"
+          else return ""
+          n = 0
+          while (substr(s, n + 1, 1) == ch) n++
+          return substr(s, 1, n)
+        }
         in_comment {
           pending[++pending_count] = $0
           if ($0 ~ /-->/) {
             in_comment = 0
-            if ($0 ~ /-->[[:space:]]*$/) pending_count = 0
+            if (rest_is_clean(tail_after_close($0))) pending_count = 0
             else flush_pending()
           }
           next
         }
-        /^[[:space:]]*<!--/ {
+        # Inside a fenced code block, "<!--" is example text, not a drafting
+        # comment: pass every line through untouched. Track the opener char and
+        # length so only a matching bare closer (same char, at least as long, no
+        # info string) ends the block — a shorter run or the other delimiter is
+        # just fenced content. Checked only when not mid-comment so an open
+        # comment still closes on its own "-->".
+        !in_fence {
+          fm = fence_marker($0)
+          if (fm != "") {
+            print
+            fence_char = substr(fm, 1, 1); fence_len = length(fm); in_fence = 1
+            next
+          }
+        }
+        in_fence {
+          print
+          fm = fence_marker($0)
+          if (fm != "" && substr(fm, 1, 1) == fence_char && length(fm) >= fence_len \
+              && $0 ~ ("^[[:space:]]*[" fence_char "]+[[:space:]]*$")) in_fence = 0
+          next
+        }
+        # A whole-line drafting comment sits at 0-3 spaces of indent; deeper
+        # indentation is an indented code block whose "<!--" is example text.
+        !indented_code($0) && /^[[:space:]]*<!--/ {
           if ($0 ~ /-->/) {
-            if ($0 !~ /-->[[:space:]]*$/) print
+            if (!rest_is_clean(tail_after_close($0))) print
             next
           }
           in_comment = 1

--- a/scripts/build_release_notes.sh
+++ b/scripts/build_release_notes.sh
@@ -130,9 +130,38 @@ HIGHLIGHTS_PATH="$HIGHLIGHTS_DIR/$TAG.md"
 if git cat-file -e "$RELEASE_SHA:$HIGHLIGHTS_PATH" 2>/dev/null; then
   HIGHLIGHTS=$(
     git show "$RELEASE_SHA:$HIGHLIGHTS_PATH" |
-      # Drop whole-line HTML comments so drafting guidance left in the template
-      # can never ship, then trim leading blank lines ($( ) trims trailing ones).
-      sed -E '/^[[:space:]]*<!--.*-->[[:space:]]*$/d' |
+      # Drop complete whole-line HTML comment blocks so drafting guidance left
+      # in the template can never ship. Buffer until the closing marker so an
+      # unmatched opener fails safe instead of swallowing the remaining notes.
+      awk '
+        function flush_pending(    i) {
+          for (i = 1; i <= pending_count; i++) print pending[i]
+          pending_count = 0
+        }
+        in_comment {
+          pending[++pending_count] = $0
+          if ($0 ~ /-->/) {
+            in_comment = 0
+            if ($0 ~ /-->[[:space:]]*$/) pending_count = 0
+            else flush_pending()
+          }
+          next
+        }
+        /^[[:space:]]*<!--/ {
+          if ($0 ~ /-->/) {
+            if ($0 !~ /-->[[:space:]]*$/) print
+            next
+          }
+          in_comment = 1
+          pending[++pending_count] = $0
+          next
+        }
+        { print }
+        END {
+          if (in_comment) flush_pending()
+        }
+      ' |
+      # Trim leading blank lines ($( ) trims trailing ones).
       sed -e '/./,$!d'
   )
   if [ -n "$HIGHLIGHTS" ]; then

--- a/tests/release/test_build_release_notes.sh
+++ b/tests/release/test_build_release_notes.sh
@@ -105,6 +105,13 @@ contains "$BODY" "Install:" "no highlights: install line present"
 # --- 2b. highlights file present ---
 cat > docs/release-notes/v1.2.0.md <<'MD'
 <!-- drafting note that must not ship -->
+<!-- Scratch space for the next release's notes. Append as you land work; in the
+     version-bump PR, `git mv` this to vX.Y.Z.md and recreate this file empty.
+     Whole-line HTML comments like this one are stripped before publishing.
+     See README.md in this directory for what good notes look like. -->
+<!-- inline drafting note --> Visible inline release note.
+IMPORTANT RELEASE NOTE
+<!-- later whole-line drafting note must not ship -->
 This release is about speculative decoding.
 
 ## Highlights
@@ -116,6 +123,9 @@ does not consistently gain, so the adaptive controller parks speculation there.
 | -------- | --: | -: | -----: | ---------: |
 | Code     |  42 | 88 |  +110% |        71% |
 | Prose    |  44 | 45 |    +2% |     32-57% |
+
+<!-- unmatched drafting note stays visible rather than swallowing notes
+Visible after unmatched opener.
 MD
 commit e.txt 1 "feat: delta (#4)"   # picks up the notes file too (git add -A)
 commit f.txt 1 "chore: bump version to 1.2.0"
@@ -130,6 +140,13 @@ contains "$BODY" "does not consistently gain" "highlights: negative result intac
 contains "$BODY" "<details>" "highlights: commit list collapsed"
 contains "$BODY" "<summary>All changes</summary>" "highlights: <details> summary"
 lacks "$BODY" "drafting note that must not ship" "highlights: HTML comments stripped"
+lacks "$BODY" "Scratch space for the next release's notes" "highlights: multi-line HTML comments stripped"
+lacks "$BODY" "version-bump PR" "highlights: multi-line HTML comment body stripped"
+contains "$BODY" "<!-- inline drafting note --> Visible inline release note." "highlights: inline comment with visible suffix is preserved"
+contains "$BODY" "IMPORTANT RELEASE NOTE" "highlights: inline comment does not swallow following notes"
+lacks "$BODY" "later whole-line drafting note" "highlights: later whole-line comment is still stripped"
+contains "$BODY" "<!-- unmatched drafting note" "highlights: unmatched comment opener fails safe"
+contains "$BODY" "Visible after unmatched opener." "highlights: unmatched comment does not swallow following notes"
 contains "$BODY" "Install:" "highlights: install line still last"
 # order: prose before <details> before Install
 check "highlights: prose is above All changes" \

--- a/tests/release/test_build_release_notes.sh
+++ b/tests/release/test_build_release_notes.sh
@@ -112,7 +112,34 @@ cat > docs/release-notes/v1.2.0.md <<'MD'
 <!-- inline drafting note --> Visible inline release note.
 IMPORTANT RELEASE NOTE
 <!-- later whole-line drafting note must not ship -->
+<!-- solo open --> KEEP SOLO NOTE -->
+<!-- multi open
+--> KEEP MULTI NOTE -->
+<!-- twin one --> <!-- twin two -->
+<!-- lead comment --> KEEP TWIN TAIL <!-- trailing comment -->
 This release is about speculative decoding.
+
+Example markup:
+
+```html
+<!-- generated marker
+FENCED COMMENT BODY stays visible -->
+```
+
+Nested-delimiter example:
+
+~~~text
+```
+<!-- inner marker
+NESTED FENCE BODY stays visible -->
+```
+~~~
+
+Indented-code example:
+
+    <!-- indented marker
+    INDENTED CODE COMMENT stays visible -->
+    plain indented code line
 
 ## Highlights
 
@@ -144,6 +171,17 @@ lacks "$BODY" "Scratch space for the next release's notes" "highlights: multi-li
 lacks "$BODY" "version-bump PR" "highlights: multi-line HTML comment body stripped"
 contains "$BODY" "<!-- inline drafting note --> Visible inline release note." "highlights: inline comment with visible suffix is preserved"
 contains "$BODY" "IMPORTANT RELEASE NOTE" "highlights: inline comment does not swallow following notes"
+contains "$BODY" "KEEP SOLO NOTE" "highlights: note after the first --> on an opener line is preserved"
+contains "$BODY" "KEEP MULTI NOTE" "highlights: note after the first --> closing a multi-line comment is preserved"
+lacks "$BODY" "twin one" "highlights: an all-comment line with two comments is fully stripped"
+lacks "$BODY" "twin two" "highlights: the second comment on an all-comment line is stripped"
+contains "$BODY" "KEEP TWIN TAIL" "highlights: visible text between two comments is preserved"
+contains "$BODY" "FENCED COMMENT BODY stays visible" "highlights: HTML comments inside a code fence are not stripped"
+contains "$BODY" "<!-- generated marker" "highlights: code-fence comment opener is preserved verbatim"
+contains "$BODY" "NESTED FENCE BODY stays visible" "highlights: a shorter delimiter inside a tilde fence does not close it, comment survives"
+contains "$BODY" "<!-- inner marker" "highlights: nested-fence comment opener is preserved verbatim"
+contains "$BODY" "INDENTED CODE COMMENT stays visible" "highlights: HTML comments in a 4-space indented code block are not stripped"
+contains "$BODY" "<!-- indented marker" "highlights: indented-code comment opener is preserved verbatim"
 lacks "$BODY" "later whole-line drafting note" "highlights: later whole-line comment is still stripped"
 contains "$BODY" "<!-- unmatched drafting note" "highlights: unmatched comment opener fails safe"
 contains "$BODY" "Visible after unmatched opener." "highlights: unmatched comment does not swallow following notes"


### PR DESCRIPTION
## Why

`scripts/build_release_notes.sh` stripped drafting comments with a single-line
`sed` (`/^\s*<!--.*-->\s*$/d`), so the four-line scratch template at the top of
`docs/release-notes/unreleased.md` — whose `<!--` and `-->` sit on different
lines — survived verbatim into the published GitHub Release body. Fixes #1961.
Every clean release so far depended on whoever cut it deleting the comment by
hand; the v0.12.14 bump (#1960) initially did not.

This builds on @YUHAO-corn's #1966 (cherry-picked with authorship preserved),
then hardens the stripper after a multi-round adversarial review.

## What

Replaces the `sed` with an awk state machine that removes **whole-line HTML
comment blocks** (single- or multi-line), and:

- **Closes a comment at its FIRST `-->`.** Anything after that first marker is
  visible content — `rest_is_clean()` decides whether the tail ships nothing
  (whitespace and/or further complete whole-line comments → drop the block) or
  carries a real note (keep the line verbatim). The naive "trailing `-->`" test
  dropped `<!-- x --> real note -->` whole.
- **Fails safe on an unmatched opener** — buffered text is restored, never
  swallowed.
- **Skips fenced code blocks** (```` ``` ````/`~~~`), so a release note that
  demonstrates HTML-comment syntax keeps it.
- Keeps **column-0-only** opener detection, so a mid-line `<!--` can't start a
  block and eat the following lines.

## Tests

- `bash tests/release/test_build_release_notes.sh` — **59 passed, 0 failed**
  (added: first-`-->` visible suffix single/multi-line, all-comment line with a
  second comment, visible text between two comments, multi-line comment inside a
  ```` ```html ```` fence).
- Red/green proof: the new multi-line assertions fail against the pre-fix
  script; the real four-line `unreleased.md` template now strips to empty.
- `bash -n` clean on both files.

## Notes — adversarial review (Codex, 4 rounds)

- R1 → found first-`-->` visible-suffix drop → fixed.
- R2 → found all-comment line (`<!-- a --> <!-- b -->`) leaking → fixed with `rest_is_clean()`.
- R3 → found multi-line comment inside a code fence being stripped (real regression) → fixed with fence passthrough.
- R4 → **0 blocking.** Two items explicitly judged non-blocking & declined:
  (a) fence delimiter type/length isn't matched (pathological for release notes);
  (b) the recent-tag sweep's oracle omits `--first-parent` — pre-existing, unrelated to this diff, not a visible-note loss.

Release-tooling only; no product code, no version bump.

Co-authored-by: YUHAO-corn <godcorn001@outlook.com>

---
🤖 AI-assisted: implementation and the 4-round adversarial review were done with Claude Code (Opus 4.8). Human-reviewed.
