### PR TITLE
fix(mac): the status footer sheds readouts instead of squeezing six chips (#1974)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -199,6 +199,10 @@ enum DevSnapshot {
         // whether HF_HUB_CACHE points at a populated cache).
         render(contentView(width: 900, height: 640), to: "\(dir)/content-idle.png")
         render(contentView(width: 640, height: 560), to: "\(dir)/content-min.png")
+        // Narrow window: the status footer sheds its readouts through
+        // ViewThatFits rather than squeezing them to ellipses, and the version
+        // pill must stay on one line. Only a width this small exercises it.
+        render(contentView(width: 380, height: 560), to: "\(dir)/content-narrow.png")
         // Images tab (empty state — no results, catalog not yet resolved).
         render(imagesView(width: 700, height: 640), to: "\(dir)/images-empty.png")
         // Narrow composer: the canvas controls wrap to the two-row

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -890,6 +890,43 @@ struct ContentView: View {
 
     // MARK: - Status footer
 
+    /// The footer's right-hand readouts, widest arrangement first.
+    ///
+    /// ``ViewThatFits`` picks the first that does not overflow, so this is an
+    /// ordering of what to give up rather than a set of width breakpoints —
+    /// no magic numbers to re-tune when a chip's text changes length.
+    ///
+    /// What may be dropped follows the rule ``settingsContentIsCompact``
+    /// already states for Settings: shed readouts, never controls. The gear,
+    /// the log toggle and ``DesktopVersionPill`` are buttons — the version
+    /// pill routes to Settings → App — so all three survive every width and
+    /// sit outside this group. Everything inside is a number you read.
+    ///
+    /// The ambient system probes go first: CPU, GPU and memory describe the
+    /// Mac, not this app's work. Throughput goes next. ``ServerStatusPill``
+    /// is last because "is a model running" is the one piece of state the
+    /// rest of the footer is meaningless without — and even it is redundant
+    /// in the narrowest case, where ``ReadinessBanner`` is saying the same
+    /// thing in a full sentence directly above.
+    @ViewBuilder
+    private var footerReadouts: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                ServerStatusPill(state: server.state)
+                TokensPerSecondPill(messages: { chat.messages })
+                CPUPill()
+                GPUPill()
+                MemoryPill()
+            }
+            HStack(spacing: 8) {
+                ServerStatusPill(state: server.state)
+                TokensPerSecondPill(messages: { chat.messages })
+            }
+            ServerStatusPill(state: server.state)
+            EmptyView()
+        }
+    }
+
     private var statusFooter: some View {
         HStack(spacing: 8) {
             SettingsGearButton()
@@ -906,12 +943,8 @@ struct ContentView: View {
             .help(showLogs ? "Hide logs" : "Show logs")
             .accessibilityLabel(showLogs ? "Hide logs" : "Show logs")
             .accessibilityIdentifier("ContentView.ToggleLogs")
-            Spacer()
-            ServerStatusPill(state: server.state)
-            TokensPerSecondPill(messages: { chat.messages })
-            CPUPill()
-            GPUPill()
-            MemoryPill()
+            Spacer(minLength: 8)
+            footerReadouts
             DesktopVersionPill(updater: updater)
         }
         .padding(.horizontal, 14)
@@ -1428,6 +1461,13 @@ struct DesktopVersionPill: View {
                 label
             }
             .scaledSystemFont(11)
+            // One line, always. Without this the label wraps under
+            // compression — in a narrow window it became a five-line green
+            // block — and, worse, a view that wraps reports that it fits at
+            // any width, so the footer's ``ViewThatFits`` could never tell
+            // that the row had run out of room.
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
             .background(

--- a/apps/rapid-mac/Tests/RapidTests/StatusFooterCompressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StatusFooterCompressionTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// The status footer must shed readouts, never controls.
+///
+/// This is the rule `EnvironmentValues.settingsContentIsCompact` already
+/// states for Settings — "use this to DROP something optional …, never to hide
+/// a control — an unreachable control at a supported window size is the defect
+/// this exists to prevent" — applied to the one other row in the app that runs
+/// out of horizontal room.
+///
+/// Before this, a narrow window squeezed all six chips until they read
+/// "CPU…", "GPU 9…", "13.2 G…", and the version pill wrapped into a five-line
+/// block. ViewInspector is not in this target (#1492), so the wiring is pinned
+/// by a source guard in the same shape as
+/// ``AccessibilityIdentifierInventoryTests``.
+@Suite("Status footer compression")
+struct StatusFooterCompressionTests {
+
+    private func contentViewSource() throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Rapid/UI/ContentView.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// The droppable group, sliced out by brace balance.
+    private func readoutGroup(_ source: String) -> String {
+        guard let anchor = source.range(of: "private var footerReadouts: some View {") else {
+            Issue.record("ContentView no longer declares footerReadouts")
+            return ""
+        }
+        var depth = 0
+        var index = source.index(before: anchor.upperBound)
+        while index < source.endIndex {
+            if source[index] == "{" { depth += 1 }
+            if source[index] == "}" {
+                depth -= 1
+                if depth == 0 { return String(source[anchor.upperBound...index]) }
+            }
+            index = source.index(after: index)
+        }
+        return ""
+    }
+
+    /// A control inside the group would simply vanish at narrow widths with
+    /// no other way to reach it. Readouts are the only thing allowed to go.
+    @Test("Only readouts live in the droppable group")
+    func droppableGroupHoldsNoControls() throws {
+        let group = readoutGroup(try contentViewSource())
+        #expect(!group.isEmpty)
+        for control in ["SettingsGearButton", "DesktopVersionPill", "Button"] {
+            #expect(
+                !group.contains(control),
+                """
+                \(control) is inside footerReadouts, which ViewThatFits drops \
+                at narrow widths. A control that disappears at a supported \
+                window size is unreachable — move it out of the group.
+                """
+            )
+        }
+    }
+
+    /// The ambient system probes are the first thing a reader can spare, and
+    /// the server state is the last: the other numbers mean nothing without
+    /// knowing whether a model is running.
+    @Test("The widest arrangement is the only one carrying the system probes")
+    func systemProbesAreShedFirst() throws {
+        let group = readoutGroup(try contentViewSource())
+        for probe in ["CPUPill", "GPUPill", "MemoryPill"] {
+            #expect(
+                group.components(separatedBy: probe).count - 1 == 1,
+                "\(probe) should appear in exactly one arrangement — the widest"
+            )
+        }
+        // Server state survives into arrangements the probes do not.
+        let statusCount = group.components(separatedBy: "ServerStatusPill").count - 1
+        let cpuCount = group.components(separatedBy: "CPUPill").count - 1
+        #expect(statusCount > cpuCount)
+    }
+
+    /// A view that wraps reports that it fits at any width, so an unbounded
+    /// version label would keep ViewThatFits from ever choosing a shorter
+    /// arrangement — the pill's own bug and the row's, in one line of code.
+    @Test("The version pill is pinned to one line")
+    func versionPillCannotWrap() throws {
+        let source = try contentViewSource()
+        guard let anchor = source.range(of: "struct DesktopVersionPill") else {
+            Issue.record("DesktopVersionPill was renamed")
+            return
+        }
+        let body = String(source[anchor.lowerBound...])
+        #expect(body.contains(".lineLimit(1)"))
+        #expect(body.contains(".fixedSize(horizontal: true, vertical: false)"))
+    }
+}


### PR DESCRIPTION
## Why

Landing @xiaoxiunique's #1974 (cherry-picked in-repo so CI runs; authorship preserved). The status footer packed six readout chips into a fixed HStack, so in a narrow window they overflowed/wrapped instead of shedding — and a wrapping label reports it "fits" at any width, defeating any compression logic.

## What

- `footerReadouts` uses `ViewThatFits(in: .horizontal)` with an ordered set of arrangements (all 5 chips → status+throughput → status only → empty), shedding ambient system probes (CPU/GPU/Memory) first, throughput next, ServerStatusPill last. Controls (gear, log toggle, version pill) sit outside the group and always survive.
- `.lineLimit(1)` + `.fixedSize(horizontal:true, vertical:false)` stops the label wrapping so `ViewThatFits` can actually tell the row ran out of room.

## Review

Supply-chain audit clean (no deps/CI/network/process/trojan-source). Two codex rounds + manual review: code correct, shedding order and control preservation verified. One P3 test-strength note (the tests inspect `footerReadouts` but don't assert `statusFooter` uses it) left as a follow-up.

Co-authored-by: Atom <929746602@qq.com>
