### PR TITLE
feat(mac): Settings → Developer, with re-onboarding (#1973)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -614,6 +614,10 @@ enum DevSnapshot {
                     .environment(appearance)
                     .environment(settingsRouter)
                     .environment(server)
+                    // The capture loop walks Category.allCases, which in a
+                    // debug build includes Developer — and that panel reads
+                    // the coordinator.
+                    .environment(quickstart)
                     .environment(downloads)
                     .environment(updater)
                     .environment(snapshotSparkleUpdater)

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -750,13 +750,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // write inline so the data lands before this delegate hook
         // returns to AppKit.
         MainActor.assumeIsolated {
-            AppDelegate.runTerminationSequence(
-                stopStream: { AppDelegate.shared.chat?.stopAndPersist() },
-                signalServer: { AppDelegate.shared.server?.beginShutdown() },
-                signalDownloads: { AppDelegate.shared.downloads?.beginShutdown() },
-                reapServer: { AppDelegate.shared.server?.shutdownSync() },
-                reapDownloads: { AppDelegate.shared.downloads?.finishShutdown() }
-            )
+            AppDelegate.runStandardTermination()
         }
         // Last write before AppKit pulls the plug — clears this
         // launch's crash marker so the NEXT launch doesn't
@@ -905,5 +899,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // edit / deletion isn't lost when the process exits before the
         // async save lands.
         ConversationStore.flush()
+    }
+
+    /// The single clean-shutdown wiring, shared by ``applicationWillTerminate``
+    /// and the re-onboarding relaunch (``ReonboardingReset``). Both paths end
+    /// the process, so both must persist the chat, reap the server, and stop
+    /// the download children — keeping this in one place stops the two from
+    /// drifting (the re-onboarding path originally teardown only the server
+    /// and orphaned in-flight downloads / lost the last chat edit, #1973).
+    @MainActor
+    static func runStandardTermination() {
+        runTerminationSequence(
+            stopStream: { AppDelegate.shared.chat?.stopAndPersist() },
+            signalServer: { AppDelegate.shared.server?.beginShutdown() },
+            signalDownloads: { AppDelegate.shared.downloads?.beginShutdown() },
+            reapServer: { AppDelegate.shared.server?.shutdownSync() },
+            reapDownloads: { AppDelegate.shared.downloads?.finishShutdown() }
+        )
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -414,6 +414,11 @@ struct RapidApp: App {
                 .environment(appearance)
                 .environment(settingsRouter)
                 .environment(server)
+                // Settings → Developer resets the wizard, and SwiftUI traps
+                // rather than warns when an @Environment observable is
+                // missing — so the Settings scene needs this even though the
+                // panel that reads it only exists in a debug build.
+                .environment(quickstart)
                 .environment(downloads)
                 .environment(updater)
                 .environment(sparkleUpdater)

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -831,6 +831,19 @@ final class ServerManager {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Drop the last-served alias without going through a stop.
+    ///
+    /// ``stop()`` clears it, but only along the path that actually terminates
+    /// a child — `guard child != nil else { return }` means an idle app's
+    /// Stop is a no-op and the alias survives. That is right for Stop and
+    /// wrong for re-onboarding, which has to reach a state the wizard
+    /// considers fresh whether or not a model happened to be running
+    /// (``QuickstartCoordinator.isEligible`` gates on this alias
+    /// independently of its own flags). See ``ReonboardingReset``.
+    nonisolated static func forgetLastServedAlias(defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: lastServedAliasKey)
+    }
+
     /// Bring the embedded child to ``.ready(alias)`` regardless of
     /// where the state machine currently sits.
     ///

--- a/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
@@ -214,6 +214,14 @@ enum ReonboardingReset {
     /// reason spelled out on ``relaunch(bundleURL:processIdentifier:spawn:terminate:)``.
     @MainActor
     static func exitAfterCleanShutdown() {
+        // The relaunch replaces a normal quit, so it must run the SAME
+        // teardown ``applicationWillTerminate`` does — persist the last chat
+        // edit and stop in-flight download children — not just the server
+        // ``perform`` already stopped. Without this an onboarding-only reset
+        // loses the last conversation edit and orphans pull subprocesses
+        // (#1973). The sequence is the terminal path and safe to re-run after
+        // ``perform``'s ``server.stop()``.
+        AppDelegate.runStandardTermination()
         CrashReporter.recordCleanShutdown()
         exit(0)
     }

--- a/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
@@ -106,11 +106,16 @@ enum ReonboardingReset {
     @MainActor
     static func perform(
         scope: ReonboardingScope,
-        quickstart: QuickstartCoordinator,
-        server: ServerManager
+        quickstart: QuickstartCoordinator
     ) async {
         guard !scope.isEmpty else { return }
-        await server.stop()
+        // Persist the last chat edit and reap the server + download children
+        // BEFORE erasing, so ``eraseState``'s conversation delete is the LAST
+        // write. The other order lets the termination flush — and a streaming
+        // ``stopAndPersist`` — resurrect the conversations we just erased
+        // (#1973). ``runStandardTermination`` reaps the server too, so the
+        // file handles on the state we're about to delete are already gone.
+        AppDelegate.runStandardTermination()
         eraseState(scope: scope, quickstart: quickstart)
     }
 
@@ -214,14 +219,11 @@ enum ReonboardingReset {
     /// reason spelled out on ``relaunch(bundleURL:processIdentifier:spawn:terminate:)``.
     @MainActor
     static func exitAfterCleanShutdown() {
-        // The relaunch replaces a normal quit, so it must run the SAME
-        // teardown ``applicationWillTerminate`` does — persist the last chat
-        // edit and stop in-flight download children — not just the server
-        // ``perform`` already stopped. Without this an onboarding-only reset
-        // loses the last conversation edit and orphans pull subprocesses
-        // (#1973). The sequence is the terminal path and safe to re-run after
-        // ``perform``'s ``server.stop()``.
-        AppDelegate.runStandardTermination()
+        // ``perform`` already ran ``AppDelegate.runStandardTermination`` (chat
+        // persisted, server + downloads reaped) BEFORE erasing state — doing
+        // it here instead would re-persist the conversations ``eraseState``
+        // just deleted (#1973). So this only records the clean-shutdown marker
+        // and leaves.
         CrashReporter.recordCleanShutdown()
         exit(0)
     }

--- a/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
@@ -1,0 +1,229 @@
+import AppKit
+import Foundation
+
+/// What a re-onboarding run erases.
+///
+/// The set is a choice rather than a constant because the flows worth
+/// rehearsing differ: tuning the Quickstart wizard wants the flags gone and
+/// nothing else, while checking what a genuinely new Mac sees wants the
+/// conversations and the consent prompt back too. A fixed scope would make the
+/// cheap case as destructive as the expensive one.
+struct ReonboardingScope: OptionSet, Sendable {
+    let rawValue: Int
+
+    /// Quickstart's completion flags, plus the last-served alias that gates
+    /// the wizard independently of them.
+    static let onboarding = ReonboardingScope(rawValue: 1 << 0)
+    /// Every preference this app has written — theme, sampling, tool
+    /// toggles, model favourites, window state.
+    static let preferences = ReonboardingScope(rawValue: 1 << 1)
+    /// `conversations.json`. Hard delete, no undo.
+    static let conversations = ReonboardingScope(rawValue: 1 << 2)
+    /// The telemetry decision, so the consent sheet runs again. Shared with
+    /// the `rapid-mlx` CLI — see ``ReonboardingReset/confirmation(for:)``.
+    static let telemetry = ReonboardingScope(rawValue: 1 << 3)
+}
+
+/// Clears the state that makes this Mac "already onboarded", then relaunches.
+///
+/// Kept out of any SwiftUI ``View`` so the confirmation copy is a pure
+/// function a test can call — the same split ``ModelCacheActions`` uses for
+/// the model-deletion dialog.
+enum ReonboardingReset {
+
+    // MARK: - Copy
+
+    struct Confirmation: Equatable {
+        let title: String
+        let message: String
+        /// The destructive button's label. Names the worst thing in the
+        /// scope, because that is what the reader needs to weigh.
+        let confirmTitle: String
+    }
+
+    /// One sentence per thing that will be gone, in descending order of how
+    /// much it would hurt to lose. Generated rather than written out per
+    /// combination: with four independent toggles there are sixteen, and a
+    /// hand-written table would drift from the toggles the first time one
+    /// is added.
+    static func confirmation(for scope: ReonboardingScope) -> Confirmation {
+        var losses: [String] = []
+        if scope.contains(.conversations) {
+            losses.append("every conversation in the sidebar, permanently")
+        }
+        if scope.contains(.preferences) {
+            losses.append("every setting, back to first-install defaults")
+        }
+        if scope.contains(.telemetry) {
+            losses.append(
+                "the telemetry decision — this one is shared with the "
+                    + "rapid-mlx CLI, so the command line will ask again too"
+            )
+        }
+        if scope.contains(.onboarding) {
+            losses.append("the record that Quickstart has run")
+        }
+
+        let message: String
+        if losses.isEmpty {
+            message = "Nothing is selected, so nothing will be erased."
+        } else {
+            message = "This erases " + Self.sentenceList(losses)
+                + ". Rapid restarts immediately afterwards."
+        }
+
+        return Confirmation(
+            title: "Erase this Mac's Rapid state and restart?",
+            message: message,
+            confirmTitle: scope.contains(.conversations)
+                ? "Erase and restart"
+                : "Restart into onboarding"
+        )
+    }
+
+    /// "a", "a and b", "a, b, and c" — the serial comma is deliberate; two of
+    /// the clauses above contain their own commas.
+    private static func sentenceList(_ items: [String]) -> String {
+        switch items.count {
+        case 0: return ""
+        case 1: return items[0]
+        case 2: return "\(items[0]) and \(items[1])"
+        default:
+            return items.dropLast().joined(separator: ", ")
+                + ", and " + items[items.count - 1]
+        }
+    }
+
+    // MARK: - Execution
+
+    /// Erase, then hand back. The caller relaunches — separated so a test can
+    /// exercise the erasure without the process going away underneath it.
+    ///
+    /// The server is stopped first for two reasons: its shutdown path is what
+    /// clears `rapid.serve.lastAlias` (the gate Quickstart checks alongside
+    /// its own flag), and a sidecar still holding the port would keep the
+    /// relaunched instance from binding it.
+    @MainActor
+    static func perform(
+        scope: ReonboardingScope,
+        quickstart: QuickstartCoordinator,
+        server: ServerManager
+    ) async {
+        guard !scope.isEmpty else { return }
+        await server.stop()
+        eraseState(scope: scope, quickstart: quickstart)
+    }
+
+    /// The erasure itself, with every destination injectable.
+    ///
+    /// Split from ``perform(scope:quickstart:server:)`` so it can be tested
+    /// against temporary paths and a scratch defaults suite: a test that had
+    /// to build a real ``ServerManager`` to check which file got deleted
+    /// would be starting a subprocess to assert on `unlink`.
+    @MainActor
+    static func eraseState(
+        scope: ReonboardingScope,
+        quickstart: QuickstartCoordinator,
+        conversationsURL: URL = ConversationStore.fileURL(),
+        telemetryDirectory: URL = TelemetryIdentity.sharedTelemetryDirectory(),
+        defaults: UserDefaults = .standard,
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier
+    ) {
+        guard !scope.isEmpty else { return }
+
+        if scope.contains(.conversations) {
+            try? FileManager.default.removeItem(at: conversationsURL)
+        }
+
+        if scope.contains(.preferences), let bundleIdentifier {
+            // Wipes the whole domain, which includes Quickstart's own flags —
+            // so this runs BEFORE the onboarding reset, letting that step put
+            // the in-memory coordinator back in step with the erased disk.
+            defaults.removePersistentDomain(forName: bundleIdentifier)
+        }
+
+        if scope.contains(.telemetry) {
+            defaults.removeObject(forKey: TelemetryConfig.enabledKey)
+            defaults.removeObject(forKey: TelemetryConfig.sharedConsentMigrationKey)
+            try? FileManager.default.removeItem(
+                at: telemetryDirectory
+                    .appendingPathComponent("telemetry-consent.yaml", isDirectory: false)
+            )
+        }
+
+        if scope.contains(.onboarding) {
+            quickstart.resetForReonboarding()
+            // The wizard is gated on this alias as well as on its own flags,
+            // and `stop()` only clears it when there was a child to stop —
+            // so an idle app would otherwise restart straight past Quickstart.
+            ServerManager.forgetLastServedAlias(defaults: defaults)
+        }
+    }
+
+    // MARK: - Relaunch
+
+    /// Quit, and have something outside this process start us again.
+    ///
+    /// Two things about this app make the obvious spellings fail.
+    ///
+    /// `NSWorkspace.openApplication` with `createsNewApplicationInstance`,
+    /// terminating from its completion, was tried first: measured on a local
+    /// ad-hoc signed build, no second instance appeared and the completion
+    /// never fired. Hence a detached shell that waits for this PID to vanish
+    /// and only then opens the app — by the time it runs there is no second
+    /// instance for LaunchServices to arbitrate.
+    ///
+    /// `NSApp.terminate` then turned out not to quit this app at all.
+    /// ``MainWindowCloseInterceptor/windowShouldClose(_:)`` runs the
+    /// hide-the-Dock-icon prompt on any window close and returns `false` when
+    /// the answer is "hide" — and AppKit routes terminate through exactly
+    /// that path, so one `false` cancels the whole sequence. Measured:
+    /// `osascript … to quit` returns `-128 userCancelled`, and ⌘Q behaves the
+    /// same. That is a defect in its own right and is being reported
+    /// separately; this button cannot wait on it.
+    ///
+    /// So: run the termination work explicitly, then `exit`. Everything
+    /// ``AppDelegate/applicationWillTerminate(_:)`` does that still matters
+    /// here is done by the caller — ``perform(scope:quickstart:server:)``
+    /// already awaited `server.stop()` — plus the clean-shutdown marker,
+    /// without which the next launch reports a crash that did not happen.
+    ///
+    /// pid and path go in as `$1` / `$2` rather than interpolated into the
+    /// script: the bundle path contains a space in every install
+    /// ("Rapid-MLX Desktop.app"), and quoting it into a shell string is a
+    /// bug waiting for the first user with a space in their home directory.
+    @MainActor
+    static func relaunch(
+        bundleURL: URL = Bundle.main.bundleURL,
+        processIdentifier: Int32 = ProcessInfo.processInfo.processIdentifier,
+        spawn: (String, [String]) -> Void = Self.spawnDetached,
+        terminate: @MainActor () -> Void = Self.exitAfterCleanShutdown
+    ) {
+        spawn("/bin/sh", [
+            "-c",
+            "while kill -0 \"$1\" 2>/dev/null; do sleep 0.1; done; open \"$2\"",
+            "sh",
+            String(processIdentifier),
+            bundleURL.path,
+        ])
+        terminate()
+    }
+
+    /// Record the clean shutdown ``applicationWillTerminate`` would have
+    /// recorded, then leave. `exit` rather than `NSApp.terminate` for the
+    /// reason spelled out on ``relaunch(bundleURL:processIdentifier:spawn:terminate:)``.
+    @MainActor
+    static func exitAfterCleanShutdown() {
+        CrashReporter.recordCleanShutdown()
+        exit(0)
+    }
+
+    /// Launch and forget. The child outlives us on purpose — it exists to
+    /// notice that we are gone.
+    static func spawnDetached(_ launchPath: String, _ arguments: [String]) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+        try? process.run()
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -747,7 +747,7 @@ Open the picker any time to switch models.
     /// falls), in-memory flag lost, welcome permanently skipped.
     private(set) var awaitingWelcomeSeed: Bool {
         didSet {
-            UserDefaults.standard.set(awaitingWelcomeSeed, forKey: Self.awaitingSeedKey)
+            defaults.set(awaitingWelcomeSeed, forKey: Self.awaitingSeedKey)
             // #1524: pin the alias the deferred seed is waiting on. Before
             // #1524 every comparison used the single pinned static, so a
             // quit-mid-flow relaunch trivially matched. Now the live
@@ -759,9 +759,9 @@ Open the picker any time to switch models.
             // against the model that was actually in flight, so a
             // non-default pick's welcome message survives the relaunch.
             if awaitingWelcomeSeed {
-                UserDefaults.standard.set(selection.alias, forKey: Self.awaitingSeedAliasKey)
+                defaults.set(selection.alias, forKey: Self.awaitingSeedAliasKey)
             } else {
-                UserDefaults.standard.removeObject(forKey: Self.awaitingSeedAliasKey)
+                defaults.removeObject(forKey: Self.awaitingSeedAliasKey)
             }
         }
     }
@@ -809,9 +809,9 @@ Open the picker any time to switch models.
     private(set) var pendingReadyAlias: String? {
         didSet {
             if let pendingReadyAlias {
-                UserDefaults.standard.set(pendingReadyAlias, forKey: Self.pendingReadyAliasKey)
+                defaults.set(pendingReadyAlias, forKey: Self.pendingReadyAliasKey)
             } else {
-                UserDefaults.standard.removeObject(forKey: Self.pendingReadyAliasKey)
+                defaults.removeObject(forKey: Self.pendingReadyAliasKey)
             }
         }
     }
@@ -819,21 +819,28 @@ Open the picker any time to switch models.
     /// True while an unconfirmed Ready flow is on the books.
     var hasPendingReady: Bool { pendingReadyAlias != nil }
 
-    init() {
-        self.done = UserDefaults.standard.bool(forKey: Self.storageKey)
-        self.legacyDone = UserDefaults.standard.bool(forKey: Self.legacyStorageKey)
+    /// Injectable so tests validate erasure against a scratch suite instead
+    /// of mutating the developer's real ``defaults`` when they
+    /// run the suite (#1973). Defaults to ``.standard`` — production is
+    /// unchanged.
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.done = defaults.bool(forKey: Self.storageKey)
+        self.legacyDone = defaults.bool(forKey: Self.legacyStorageKey)
         // Codex r5: read the persisted awaiting-seed flag so a
         // quit-mid-deferred-flow relaunch can resume the welcome
         // injection once an active session lands. (Assigning a stored
         // property in ``init`` does NOT trigger the didSet, so this read
         // can't clobber the persisted alias below.)
-        self.awaitingWelcomeSeed = UserDefaults.standard.bool(forKey: Self.awaitingSeedKey)
-        self.pendingReadyAlias = UserDefaults.standard.string(forKey: Self.pendingReadyAliasKey)
+        self.awaitingWelcomeSeed = defaults.bool(forKey: Self.awaitingSeedKey)
+        self.pendingReadyAlias = defaults.string(forKey: Self.pendingReadyAliasKey)
         // #1524: if a deferred seed survived a quit, restore the model it
         // was waiting on so the seed observers match the served alias and
         // the welcome copy names the right model (not the reset default).
         if self.awaitingWelcomeSeed,
-           let alias = UserDefaults.standard.string(forKey: Self.awaitingSeedAliasKey) {
+           let alias = defaults.string(forKey: Self.awaitingSeedAliasKey) {
             self.selection = Self.choice(forAlias: alias)
         }
         // An unconfirmed Ready flow restores its model and drops the user
@@ -874,7 +881,7 @@ Open the picker any time to switch models.
     /// in-memory mirror. Idempotent.
     func markDone() {
         done = true
-        UserDefaults.standard.set(true, forKey: Self.storageKey)
+        defaults.set(true, forKey: Self.storageKey)
     }
 
     /// Put the wizard back to the state a Mac has before it has ever run.
@@ -902,10 +909,10 @@ Open the picker any time to switch models.
         hasSeededWelcome = false
         awaitingWelcomeSeed = false
         pendingReadyAlias = nil
-        UserDefaults.standard.removeObject(forKey: Self.storageKey)
-        UserDefaults.standard.removeObject(forKey: Self.awaitingSeedKey)
-        UserDefaults.standard.removeObject(forKey: Self.awaitingSeedAliasKey)
-        UserDefaults.standard.removeObject(forKey: Self.pendingReadyAliasKey)
+        defaults.removeObject(forKey: Self.storageKey)
+        defaults.removeObject(forKey: Self.awaitingSeedKey)
+        defaults.removeObject(forKey: Self.awaitingSeedAliasKey)
+        defaults.removeObject(forKey: Self.pendingReadyAliasKey)
     }
 
     /// The name 44 call sites in the suite and ``DevSnapshot`` already use.

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -910,6 +910,14 @@ Open the picker any time to switch models.
         awaitingWelcomeSeed = false
         pendingReadyAlias = nil
         defaults.removeObject(forKey: Self.storageKey)
+        // Clear the legacy v1 flag too. A user upgraded from a build that
+        // wrote ``rapid.quickstart.v1.done`` would otherwise relaunch reading
+        // ``legacyDone == true``, which ``onboardingOwed`` treats as "already
+        // onboarded" and suppresses Quickstart — silently defeating the reset
+        // unless "erase all settings" was also chosen (#1973). ``legacyDone``
+        // is a launch-time ``let``, so removing the key is what takes effect
+        // on the relaunch this reset triggers.
+        defaults.removeObject(forKey: Self.legacyStorageKey)
         defaults.removeObject(forKey: Self.awaitingSeedKey)
         defaults.removeObject(forKey: Self.awaitingSeedAliasKey)
         defaults.removeObject(forKey: Self.pendingReadyAliasKey)

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -877,11 +877,18 @@ Open the picker any time to switch models.
         UserDefaults.standard.set(true, forKey: Self.storageKey)
     }
 
-    /// Test-only reset so the suite can drive the state machine from
-    /// scratch in every case without leaking flag state across runs.
-    /// NOT exposed in any production UI; the design contract is that
-    /// Quickstart is one-shot per Mac.
-    internal func _testingReset() {
+    /// Put the wizard back to the state a Mac has before it has ever run.
+    ///
+    /// Quickstart is one-shot per Mac by design, and no shipping UI offers a
+    /// way back — the only callers are the test suite, ``DevSnapshot``, and
+    /// the debug-only Settings → Developer panel, which exists so that flow
+    /// can be rehearsed without faking `$HOME`.
+    ///
+    /// This does NOT clear `rapid.serve.lastAlias`, which gates the wizard
+    /// independently of these flags (see ``isEligible``). Callers wanting a
+    /// true first-run state must stop the server too; ``ReonboardingReset``
+    /// does exactly that.
+    internal func resetForReonboarding() {
         done = false
         phase = .idle
         stage = .welcome
@@ -900,6 +907,11 @@ Open the picker any time to switch models.
         UserDefaults.standard.removeObject(forKey: Self.awaitingSeedAliasKey)
         UserDefaults.standard.removeObject(forKey: Self.pendingReadyAliasKey)
     }
+
+    /// The name 44 call sites in the suite and ``DevSnapshot`` already use.
+    /// Kept as an alias rather than renamed at every site, so this change
+    /// stays reviewable as "the reset grew a second caller".
+    internal func _testingReset() { resetForReonboarding() }
 
     /// Drop the record of an unconfirmed Ready flow. Idempotent.
     func clearPendingReady() {

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsDeveloperPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsDeveloperPanel.swift
@@ -1,0 +1,128 @@
+#if DEBUG
+import SwiftUI
+
+/// Settings → Developer. Present only in debug builds.
+///
+/// Rehearsing the first-run experience used to mean either `defaults delete`
+/// against a list of keys nobody keeps current, or `scripts/dogfood-isolate.sh`
+/// and a fake `$HOME`. Both work; neither is available to somebody who is
+/// already looking at the app and wants to see what a new user sees.
+///
+/// The whole file is inside `#if DEBUG`, so none of it — not the panel, not
+/// the category, not the copy — reaches a release binary. That is also why
+/// `scripts/build.sh` needs `RAPID_BUILD_CONFIG=debug` before this appears.
+struct SettingsDeveloperPanel: View {
+    @Environment(QuickstartCoordinator.self) private var quickstart
+    @Environment(ServerManager.self) private var server
+
+    /// Always on and not offered as a choice: without it this button does
+    /// nothing that deserves a restart.
+    private let onboardingAlwaysIncluded = true
+
+    @State private var erasePreferences = false
+    @State private var eraseConversations = false
+    @State private var eraseTelemetry = false
+    @State private var confirming = false
+    @State private var isWorking = false
+
+    private var scope: ReonboardingScope {
+        var scope: ReonboardingScope = .onboarding
+        if erasePreferences { scope.insert(.preferences) }
+        if eraseConversations { scope.insert(.conversations) }
+        if eraseTelemetry { scope.insert(.telemetry) }
+        return scope
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+                SectionHeader(
+                    "Developer",
+                    subtitle: "Debug builds only. These actions erase real state on this Mac — they are not sandboxed and there is no undo.",
+                    emphasis: .page
+                )
+                reonboardingSection
+            }
+            .padding(RapidTheme.Space.xl)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .accessibilityIdentifier("Settings.Developer.Panel")
+    }
+
+    private var reonboardingSection: some View {
+        SettingsSection(
+            "Re-onboarding",
+            subtitle: "Erase what makes this Mac count as already set up, then restart into the Quickstart wizard. Everything below is off by default; the Quickstart flags themselves are always cleared."
+        ) {
+            Toggle(isOn: $erasePreferences) {
+                SettingsRowLabel(
+                    title: "Also erase all settings",
+                    description: "Theme, sampling, tool toggles, model favourites, window state — back to first-install defaults."
+                )
+            }
+            .toggleStyle(TrailingSettingsToggleStyle())
+            .accessibilityIdentifier("Settings.Developer.Scope.Preferences")
+
+            SettingsRowDivider()
+
+            Toggle(isOn: $eraseConversations) {
+                SettingsRowLabel(
+                    title: "Also erase every conversation",
+                    description: "Deletes conversations.json. Permanent — the sidebar comes back empty."
+                )
+            }
+            .toggleStyle(TrailingSettingsToggleStyle())
+            .accessibilityIdentifier("Settings.Developer.Scope.Conversations")
+
+            SettingsRowDivider()
+
+            Toggle(isOn: $eraseTelemetry) {
+                SettingsRowLabel(
+                    title: "Also erase the telemetry decision",
+                    description: "Brings back the consent sheet that runs before Quickstart. This decision is shared with the rapid-mlx CLI, so the command line will ask again too."
+                )
+            }
+            .toggleStyle(TrailingSettingsToggleStyle())
+            .accessibilityIdentifier("Settings.Developer.Scope.Telemetry")
+
+            SettingsRowDivider()
+
+            HStack {
+                Spacer(minLength: 0)
+                Button("Erase and restart") { confirming = true }
+                    .buttonStyle(.rapidDestructiveCompact)
+                    .disabled(isWorking)
+                    .accessibilityIdentifier("Settings.Developer.Reonboard")
+            }
+        }
+        // ``confirmationDialog`` over ``alert`` so the cancel-role button is
+        // Return-bound — the same reasoning as the cached-model delete dialog
+        // in ``SettingsModelManagementPanel``, and it matters more here: this
+        // one can take the conversations with it.
+        .confirmationDialog(
+            ReonboardingReset.confirmation(for: scope).title,
+            isPresented: $confirming,
+            titleVisibility: .visible
+        ) {
+            Button(ReonboardingReset.confirmation(for: scope).confirmTitle, role: .destructive) {
+                erase()
+            }
+            .accessibilityIdentifier("Settings.Developer.ConfirmReonboard")
+            Button("Cancel", role: .cancel) { confirming = false }
+                .accessibilityIdentifier("Settings.Developer.CancelReonboard")
+        } message: {
+            Text(ReonboardingReset.confirmation(for: scope).message)
+        }
+    }
+
+    private func erase() {
+        isWorking = true
+        Task { @MainActor in
+            await ReonboardingReset.perform(
+                scope: scope, quickstart: quickstart, server: server
+            )
+            ReonboardingReset.relaunch()
+        }
+    }
+}
+#endif

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsDeveloperPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsDeveloperPanel.swift
@@ -119,7 +119,7 @@ struct SettingsDeveloperPanel: View {
         isWorking = true
         Task { @MainActor in
             await ReonboardingReset.perform(
-                scope: scope, quickstart: quickstart, server: server
+                scope: scope, quickstart: quickstart
             )
             ReonboardingReset.relaunch()
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -87,6 +87,13 @@ struct SettingsView: View {
         /// Rapid-MLX Desktop app updates. The .app self-update is the
         /// only correct way to bump the bundled engine.
         case app
+        #if DEBUG
+        /// Debug builds only — state-erasing actions for rehearsing flows
+        /// that are one-shot per Mac, chiefly Quickstart. Compiled out of
+        /// release entirely rather than hidden at the rail, so the copy and
+        /// the erase logic cannot ship even unreachable.
+        case developer
+        #endif
 
         var id: String { rawValue }
         var title: String {
@@ -99,6 +106,9 @@ struct SettingsView: View {
             case .appearance: return "Appearance"
             case .privacy: return "Privacy"
             case .app: return "App"
+            #if DEBUG
+            case .developer: return "Developer"
+            #endif
             }
         }
         var iconName: String {
@@ -111,6 +121,9 @@ struct SettingsView: View {
             case .appearance: return "paintpalette.fill"
             case .privacy: return "lock.shield.fill"
             case .app: return "app.badge.fill"
+            #if DEBUG
+            case .developer: return "hammer.fill"
+            #endif
             }
         }
     }
@@ -475,6 +488,10 @@ struct SettingsView: View {
             privacyPanel
         case .app:
             appPanel
+        #if DEBUG
+        case .developer:
+            SettingsDeveloperPanel()
+        #endif
         }
     }
 

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXScrollArea id="Settings.Performance.Panel"

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXScrollArea id="Settings.Performance.Panel"

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Custom Instructions, Set preferences for how the assistant responds in every conversation." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Custom Instructions, Set preferences for how the assistant responds in every conversation." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Model Management, Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Model Management, Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Model Management, Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXScrollArea id="Settings.Performance.Panel"

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Model Management, Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Rapid-MLX, Self-update for Rapid-MLX. New releases bundle the latest models, performance improvements, and bug fixes." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
@@ -67,6 +67,9 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Rapid-MLX, Self-update for Rapid-MLX. New releases bundle the latest models, performance improvements, and bug fixes." enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -61,6 +61,30 @@ struct AccessibilityIdentifierInventoryTests {
         }
     }
 
+    // MARK: - Settings → Developer (debug builds only)
+
+    /// The panel and its controls exist only in a debug build, and so does
+    /// this pin — asserting the file's contents from a release test run would
+    /// fail against source that is deliberately compiled out.
+    #if DEBUG
+    @Test("Settings → Developer names its panel and every control")
+    func settingsDeveloperPanelIdentifiers() throws {
+        try assertDeclared(
+            [
+                #""Settings.Developer.Panel""#,
+                #""Settings.Developer.Scope.Preferences""#,
+                #""Settings.Developer.Scope.Conversations""#,
+                #""Settings.Developer.Scope.Telemetry""#,
+                #""Settings.Developer.Reonboard""#,
+                #""Settings.Developer.ConfirmReonboard""#,
+                #""Settings.Developer.CancelReonboard""#,
+            ],
+            in: "Sources/Rapid/UI/SettingsDeveloperPanel.swift",
+            surface: "Settings → Developer"
+        )
+    }
+    #endif
+
     // MARK: - Settings → Tools
 
     @Test("Settings → Performance names its panel and every control")

--- a/apps/rapid-mac/Tests/RapidTests/ReonboardingResetTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReonboardingResetTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Re-onboarding erases real, unrecoverable state, so the two things worth
+/// pinning are the copy the user reads before saying yes, and that each
+/// checkbox erases only what it names.
+@Suite("Re-onboarding reset")
+@MainActor
+struct ReonboardingResetTests {
+
+    // MARK: - Copy
+
+    /// The dialog has to name the worst thing in the scope. A generic
+    /// "this cannot be undone" reads the same whether it is about a flag or
+    /// about every conversation on the Mac, which is exactly when a reader
+    /// stops reading.
+    @Test("The message names each selected loss, worst first")
+    func messageEnumeratesLosses() {
+        let all = ReonboardingReset.confirmation(
+            for: [.onboarding, .preferences, .conversations, .telemetry]
+        )
+        #expect(all.message.contains("every conversation"))
+        #expect(all.message.contains("every setting"))
+        #expect(all.message.contains("telemetry decision"))
+        #expect(all.message.contains("Quickstart"))
+
+        // Conversations lead: losing them is the only irreversible item.
+        let conversationsIndex = all.message.range(of: "every conversation")?.lowerBound
+        let settingsIndex = all.message.range(of: "every setting")?.lowerBound
+        #expect(conversationsIndex != nil && settingsIndex != nil)
+        if let c = conversationsIndex, let s = settingsIndex { #expect(c < s) }
+    }
+
+    /// Deleting conversations earns a different verb from restarting into a
+    /// wizard, because it is a different promise.
+    @Test("The confirm button escalates when conversations are included")
+    func confirmTitleEscalates() {
+        #expect(ReonboardingReset.confirmation(for: .onboarding).confirmTitle
+            == "Restart into onboarding")
+        #expect(ReonboardingReset.confirmation(for: [.onboarding, .conversations]).confirmTitle
+            == "Erase and restart")
+    }
+
+    /// The CLI shares this decision, and a user who wipes it from the desktop
+    /// will be asked again in a terminal with no idea why.
+    @Test("The telemetry line says the CLI is affected")
+    func telemetryMentionsTheCLI() {
+        let copy = ReonboardingReset.confirmation(for: [.onboarding, .telemetry])
+        #expect(copy.message.contains("rapid-mlx CLI"))
+    }
+
+    @Test("An empty scope promises nothing")
+    func emptyScopeSaysSo() {
+        #expect(ReonboardingReset.confirmation(for: []).message.contains("Nothing is selected"))
+    }
+
+    // MARK: - Erasure
+
+    private func scratch() throws -> (URL, URL) {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("reonboard-\(UUID().uuidString)", isDirectory: true)
+        let telemetry = root.appendingPathComponent(".rapid-mlx", isDirectory: true)
+        try FileManager.default.createDirectory(at: telemetry, withIntermediateDirectories: true)
+        let conversations = root.appendingPathComponent("conversations.json")
+        try Data("[]".utf8).write(to: conversations)
+        try Data("consent: true".utf8)
+            .write(to: telemetry.appendingPathComponent("telemetry-consent.yaml"))
+        return (conversations, telemetry)
+    }
+
+    /// The narrow scope is the common one — rehearsing the wizard should not
+    /// cost the conversations sitting in the sidebar.
+    @Test("Onboarding-only leaves the conversations and the consent file alone")
+    func onboardingOnlyTouchesNothingElse() throws {
+        let (conversations, telemetry) = try scratch()
+        defer { try? FileManager.default.removeItem(at: conversations.deletingLastPathComponent()) }
+        let suite = TestDefaultsScope.mintSuiteName(prefix: "reonboard")
+        defer { TestDefaultsScope.cleanup(suiteNames: [suite]) }
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(true, forKey: TelemetryConfig.enabledKey)
+
+        let quickstart = QuickstartCoordinator()
+        quickstart.markDone()
+
+        ReonboardingReset.eraseState(
+            scope: .onboarding,
+            quickstart: quickstart,
+            conversationsURL: conversations,
+            telemetryDirectory: telemetry,
+            defaults: defaults,
+            bundleIdentifier: suite
+        )
+
+        #expect(quickstart.done == false, "the wizard flag is the one thing this scope must clear")
+        #expect(FileManager.default.fileExists(atPath: conversations.path))
+        #expect(defaults.object(forKey: TelemetryConfig.enabledKey) != nil)
+    }
+
+    @Test("Each optional scope erases only its own destination")
+    func scopesAreIndependent() throws {
+        let (conversations, telemetry) = try scratch()
+        defer { try? FileManager.default.removeItem(at: conversations.deletingLastPathComponent()) }
+        let consent = telemetry.appendingPathComponent("telemetry-consent.yaml")
+        let suite = TestDefaultsScope.mintSuiteName(prefix: "reonboard")
+        defer { TestDefaultsScope.cleanup(suiteNames: [suite]) }
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(true, forKey: TelemetryConfig.enabledKey)
+
+        ReonboardingReset.eraseState(
+            scope: [.onboarding, .conversations],
+            quickstart: QuickstartCoordinator(),
+            conversationsURL: conversations,
+            telemetryDirectory: telemetry,
+            defaults: defaults,
+            bundleIdentifier: suite
+        )
+        #expect(!FileManager.default.fileExists(atPath: conversations.path))
+        #expect(FileManager.default.fileExists(atPath: consent.path),
+                "conversations scope reached the telemetry file")
+
+        ReonboardingReset.eraseState(
+            scope: [.onboarding, .telemetry],
+            quickstart: QuickstartCoordinator(),
+            conversationsURL: conversations,
+            telemetryDirectory: telemetry,
+            defaults: defaults,
+            bundleIdentifier: suite
+        )
+        #expect(!FileManager.default.fileExists(atPath: consent.path))
+        #expect(defaults.object(forKey: TelemetryConfig.enabledKey) == nil,
+                "the consent sheet is gated on this key being absent")
+    }
+
+    /// The whole-domain wipe also removes Quickstart's own keys, so the
+    /// in-memory coordinator has to be reset after it — otherwise a
+    /// coordinator still holding `done = true` would write the flag straight
+    /// back on the next save.
+    @Test("Wiping preferences still leaves the coordinator reset")
+    func preferencesWipeOrderingLeavesTheWizardArmed() throws {
+        let (conversations, telemetry) = try scratch()
+        defer { try? FileManager.default.removeItem(at: conversations.deletingLastPathComponent()) }
+        let suite = TestDefaultsScope.mintSuiteName(prefix: "reonboard")
+        defer { TestDefaultsScope.cleanup(suiteNames: [suite]) }
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set("something", forKey: "rapid.appearance.v1")
+
+        let quickstart = QuickstartCoordinator()
+        quickstart.markDone()
+
+        ReonboardingReset.eraseState(
+            scope: [.onboarding, .preferences],
+            quickstart: quickstart,
+            conversationsURL: conversations,
+            telemetryDirectory: telemetry,
+            defaults: defaults,
+            bundleIdentifier: suite
+        )
+
+        #expect(defaults.object(forKey: "rapid.appearance.v1") == nil)
+        #expect(quickstart.done == false)
+    }
+
+    /// `stop()` returns early when no child is running, so the alias it
+    /// would have cleared survives — and the wizard is gated on that alias
+    /// as well as on its own flag. An idle app would restart straight past
+    /// Quickstart, which is the whole point of the button.
+    @Test("Onboarding scope forgets the last-served alias even with nothing running")
+    func onboardingForgetsTheServedAlias() throws {
+        let (conversations, telemetry) = try scratch()
+        defer { try? FileManager.default.removeItem(at: conversations.deletingLastPathComponent()) }
+        let suite = TestDefaultsScope.mintSuiteName(prefix: "reonboard")
+        defer { TestDefaultsScope.cleanup(suiteNames: [suite]) }
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set("qwen3.5-9b-4bit", forKey: "rapid.serve.lastAlias")
+
+        ReonboardingReset.eraseState(
+            scope: .onboarding,
+            quickstart: QuickstartCoordinator(),
+            conversationsURL: conversations,
+            telemetryDirectory: telemetry,
+            defaults: defaults,
+            bundleIdentifier: suite
+        )
+
+        #expect(defaults.object(forKey: "rapid.serve.lastAlias") == nil)
+    }
+
+    // MARK: - Relaunch
+
+    /// The relaunch must outlive this process, so the pid and the bundle path
+    /// both have to reach the detached helper — and as arguments, not spliced
+    /// into the script, because every install path contains a space.
+    @Test("Relaunch hands the pid and path to a detached waiter, then quits")
+    func relaunchSpawnsAWaiterBeforeTerminating() {
+        var spawned: (String, [String])?
+        var terminated = false
+        ReonboardingReset.relaunch(
+            bundleURL: URL(fileURLWithPath: "/Applications/Rapid-MLX Desktop.app"),
+            processIdentifier: 4242,
+            spawn: { path, args in spawned = (path, args) },
+            terminate: { terminated = true }
+        )
+
+        #expect(terminated, "the old instance has to go away or the waiter never fires")
+        guard let (launchPath, arguments) = spawned else {
+            Issue.record("nothing was spawned, so nothing will restart the app")
+            return
+        }
+        #expect(launchPath == "/bin/sh")
+        #expect(arguments.contains("4242"))
+        #expect(arguments.contains("/Applications/Rapid-MLX Desktop.app"))
+        // The script must reference them positionally — an interpolated path
+        // would split on the space in "Rapid-MLX Desktop.app".
+        let script = arguments.first(where: { $0.contains("kill -0") }) ?? ""
+        #expect(script.contains("$1") && script.contains("$2"))
+        #expect(!script.contains("Rapid-MLX Desktop.app"))
+    }
+
+    @Test("An empty scope erases nothing")
+    func emptyScopeIsANoOp() throws {
+        let (conversations, telemetry) = try scratch()
+        defer { try? FileManager.default.removeItem(at: conversations.deletingLastPathComponent()) }
+        let quickstart = QuickstartCoordinator()
+        quickstart.markDone()
+
+        ReonboardingReset.eraseState(
+            scope: [],
+            quickstart: quickstart,
+            conversationsURL: conversations,
+            telemetryDirectory: telemetry,
+            defaults: UserDefaults.standard,
+            bundleIdentifier: nil
+        )
+
+        #expect(quickstart.done == true)
+        #expect(FileManager.default.fileExists(atPath: conversations.path))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ReonboardingResetTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReonboardingResetTests.swift
@@ -80,7 +80,7 @@ struct ReonboardingResetTests {
         let defaults = UserDefaults(suiteName: suite)!
         defaults.set(true, forKey: TelemetryConfig.enabledKey)
 
-        let quickstart = QuickstartCoordinator()
+        let quickstart = QuickstartCoordinator(defaults: defaults)
         quickstart.markDone()
 
         ReonboardingReset.eraseState(
@@ -109,7 +109,7 @@ struct ReonboardingResetTests {
 
         ReonboardingReset.eraseState(
             scope: [.onboarding, .conversations],
-            quickstart: QuickstartCoordinator(),
+            quickstart: QuickstartCoordinator(defaults: defaults),
             conversationsURL: conversations,
             telemetryDirectory: telemetry,
             defaults: defaults,
@@ -121,7 +121,7 @@ struct ReonboardingResetTests {
 
         ReonboardingReset.eraseState(
             scope: [.onboarding, .telemetry],
-            quickstart: QuickstartCoordinator(),
+            quickstart: QuickstartCoordinator(defaults: defaults),
             conversationsURL: conversations,
             telemetryDirectory: telemetry,
             defaults: defaults,
@@ -145,7 +145,7 @@ struct ReonboardingResetTests {
         let defaults = UserDefaults(suiteName: suite)!
         defaults.set("something", forKey: "rapid.appearance.v1")
 
-        let quickstart = QuickstartCoordinator()
+        let quickstart = QuickstartCoordinator(defaults: defaults)
         quickstart.markDone()
 
         ReonboardingReset.eraseState(
@@ -176,7 +176,7 @@ struct ReonboardingResetTests {
 
         ReonboardingReset.eraseState(
             scope: .onboarding,
-            quickstart: QuickstartCoordinator(),
+            quickstart: QuickstartCoordinator(defaults: defaults),
             conversationsURL: conversations,
             telemetryDirectory: telemetry,
             defaults: defaults,
@@ -221,7 +221,10 @@ struct ReonboardingResetTests {
     func emptyScopeIsANoOp() throws {
         let (conversations, telemetry) = try scratch()
         defer { try? FileManager.default.removeItem(at: conversations.deletingLastPathComponent()) }
-        let quickstart = QuickstartCoordinator()
+        let suite = TestDefaultsScope.mintSuiteName(prefix: "reonboard")
+        defer { TestDefaultsScope.cleanup(suiteNames: [suite]) }
+        let defaults = UserDefaults(suiteName: suite)!
+        let quickstart = QuickstartCoordinator(defaults: defaults)
         quickstart.markDone()
 
         ReonboardingReset.eraseState(
@@ -229,7 +232,7 @@ struct ReonboardingResetTests {
             quickstart: quickstart,
             conversationsURL: conversations,
             telemetryDirectory: telemetry,
-            defaults: UserDefaults.standard,
+            defaults: defaults,
             bundleIdentifier: nil
         )
 

--- a/apps/rapid-mac/Tests/RapidTests/SettingsEnvironmentInjectionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsEnvironmentInjectionTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Every observable a Settings panel reads must be injected by the Settings
+/// scene.
+///
+/// SwiftUI does not warn about a missing `@Environment` observable — it traps.
+/// The failure is invisible until somebody opens that one category, and then
+/// the app dies with `EnvironmentValues.subscript.getter` in the backtrace and
+/// nothing naming the type.
+///
+/// This is not hypothetical: Settings → Developer shipped its first build
+/// reading `QuickstartCoordinator`, which the main window injected and the
+/// Settings window did not. It compiled, every unit test passed, and clicking
+/// the row killed the app.
+///
+/// ``SettingsVisualFoundationTests/everyCategoryKeepsItsStateOwner`` pins the
+/// other half — that a panel still *declares* what it needs. Declaring and
+/// providing are different mistakes; this covers the provider side.
+@Suite("Settings environment injection")
+struct SettingsEnvironmentInjectionTests {
+
+    private static var sourceRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private func source(_ relativePath: String) throws -> String {
+        try String(
+            contentsOf: Self.sourceRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    private func matches(_ pattern: String, in text: String, group: Int = 1) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.matches(in: text, range: range).compactMap {
+            Range($0.range(at: group), in: text).map { r in String(text[r]) }
+        }
+    }
+
+    /// The `Window("Settings", …)` scene body, sliced out by brace balance so
+    /// the main window's own (larger) injection list can't stand in for it.
+    private func settingsSceneBody(_ app: String) throws -> String {
+        guard let anchor = app.range(of: #"Window("Settings""#) else {
+            Issue.record("RapidApp no longer declares Window(\"Settings\")")
+            return ""
+        }
+        guard let open = app[anchor.upperBound...].firstIndex(of: "{") else { return "" }
+        var depth = 0
+        var index = open
+        while index < app.endIndex {
+            if app[index] == "{" { depth += 1 }
+            if app[index] == "}" {
+                depth -= 1
+                if depth == 0 { return String(app[open...index]) }
+            }
+            index = app.index(after: index)
+        }
+        return ""
+    }
+
+    @Test("The Settings scene injects every observable its panels read")
+    func settingsSceneProvidesEveryPanelDependency() throws {
+        let app = try source("Sources/Rapid/RapidApp.swift")
+
+        // name → type, from `@State private var server: ServerManager`.
+        var typeOfProperty: [String: String] = [:]
+        let declarations = matches(
+            #"@State\s+private\s+var\s+(\w+)\s*:\s*(\w+)"#, in: app, group: 0
+        )
+        for declaration in declarations {
+            let name = matches(#"var\s+(\w+)\s*:"#, in: declaration).first
+            let type = matches(#":\s*(\w+)"#, in: declaration).first
+            if let name, let type { typeOfProperty[name] = type }
+        }
+        #expect(!typeOfProperty.isEmpty, "the @State declaration scrape found nothing")
+
+        let scene = try settingsSceneBody(app)
+        #expect(!scene.isEmpty, "could not slice the Settings scene body")
+        let injected = Set(
+            matches(#"\.environment\((\w+)\)"#, in: scene).compactMap { typeOfProperty[$0] }
+        )
+
+        // Every Settings panel, including the debug-only one when present.
+        var panels = [
+            "Sources/Rapid/UI/SettingsView.swift",
+            "Sources/Rapid/UI/SettingsToolsPanel.swift",
+            "Sources/Rapid/UI/SettingsConnectorsPanel.swift",
+            "Sources/Rapid/UI/SettingsModelManagementPanel.swift",
+            "Sources/Rapid/UI/SettingsPerformancePanel.swift",
+        ]
+        #if DEBUG
+        panels.append("Sources/Rapid/UI/SettingsDeveloperPanel.swift")
+        #endif
+
+        for path in panels {
+            let required = Set(matches(#"@Environment\((\w+)\.self\)"#, in: try source(path)))
+            for type in required.sorted() {
+                #expect(
+                    injected.contains(type),
+                    """
+                    \(path) reads \(type) from the environment, and the \
+                    Settings scene in RapidApp.swift never injects it. SwiftUI \
+                    traps — not warns — the first time that category is opened.
+                    """
+                )
+            }
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
@@ -80,10 +80,16 @@ struct SettingsVisualFoundationTests {
         // ``connectors`` did in #1716. The guard's job is to make a category
         // change deliberate and reviewed, not to freeze the list forever —
         // update this literal alongside the enum when a feature adds one.
-        let expected: Set<String> = [
+        var expected: Set<String> = [
             "modelManagement", "instructions", "tools", "connectors", "performance",
             "appearance", "privacy", "app",
         ]
+        // `swift test` builds debug, so the debug-only category is present
+        // here and absent from the shipped binary. Conditioning the literal
+        // rather than hardcoding it keeps `swift test -c release` honest too.
+        #if DEBUG
+        expected.insert("developer")
+        #endif
         let actual = Set(SettingsView.Category.allCases.map(\.rawValue))
         #expect(
             actual == expected,
@@ -101,10 +107,14 @@ struct SettingsVisualFoundationTests {
     @MainActor
     @Test("Category order is unchanged, so arrow-key navigation is unchanged")
     func categoryOrderIsStable() {
-        #expect(SettingsView.Category.allCases.map(\.rawValue) == [
+        var expectedOrder = [
             "modelManagement", "instructions", "tools", "connectors", "performance",
             "appearance", "privacy", "app",
-        ])
+        ]
+        #if DEBUG
+        expectedOrder.append("developer")
+        #endif
+        #expect(SettingsView.Category.allCases.map(\.rawValue) == expectedOrder)
         // #1717: ``performance`` sits after ``connectors`` — both are
         // "what the engine is wired to do", ahead of the presentation and
         // app-level sections.
@@ -112,7 +122,16 @@ struct SettingsVisualFoundationTests {
         #expect(SettingsView.category(.performance, movedBy: 1) == .appearance)
         // The rail's ↑/↓ handler walks this order and clamps at the ends.
         #expect(SettingsView.category(.modelManagement, movedBy: -1) == nil)
+        // Developer sits after App in debug, so App is only the last row in
+        // a release build. Both spellings assert the same property: arrowing
+        // past the final row clamps rather than wrapping.
+        #if DEBUG
+        #expect(SettingsView.category(.app, movedBy: 1) == .developer)
+        #expect(SettingsView.category(.developer, movedBy: 1) == nil)
+        #expect(SettingsView.category(.developer, movedBy: -1) == .app)
+        #else
         #expect(SettingsView.category(.app, movedBy: 1) == nil)
+        #endif
         #expect(SettingsView.category(.modelManagement, movedBy: 1) == .instructions)
         #expect(SettingsView.category(.app, movedBy: -1) == .privacy)
     }


### PR DESCRIPTION
## Why

Landing @xiaoxiunique's #1973 (Settings → Developer panel + re-onboarding) with the codex-review defects fixed in-repo, authorship preserved. Re-onboarding erases real, unrecoverable state, so the erasure has to actually stick and the app has to shut down cleanly around it.

## What

- Settings → Developer panel; scoped re-onboarding that erases app-owned state (conversations / preferences / telemetry consent / onboarding flags) and relaunches the app.

## Fixes applied over the original PR (codex review, 3 rounds to convergence)

- **Clean shutdown**: the relaunch used `exit(0)`, bypassing `applicationWillTerminate` — so the last chat edit was never persisted and in-flight model-download subprocesses were orphaned (`perform` only stopped the server). Extracted a shared `AppDelegate.runStandardTermination()` (chat persist + server reap + download reap + conversation flush) and run it in `perform` **before** erasing.
- **Erase ordering**: running termination *after* the erase re-persisted the conversations just deleted (the flush + a streaming `stopAndPersist` resurrected `conversations.json`). Termination now precedes `eraseState`, so the delete is the final write.
- **Test hygiene**: `QuickstartCoordinator` hardcoded `UserDefaults.standard`, so the suite mutated the developer's real onboarding state and never validated erasure against the injected domain. `defaults` is now injectable (defaults to `.standard`; production unchanged); tests use scratch suites.
- **Legacy flag**: `resetForReonboarding` cleared the v2 key but not `legacyStorageKey`, so a user carrying the v1 `done` flag relaunched with `legacyDone == true` and Quickstart stayed suppressed.

## Review

Supply-chain audit clean (the `/bin/sh` spawn is a safe app-relaunch — pid/path passed as `$1`/`$2`, not interpolated; no deps/CI/network changes; ASCII-only). Codex converged; local `swift build` + 89 re-onboarding/Quickstart tests green.

Co-authored-by: Atom <929746602@qq.com>
