### PR TITLE
fix(install): require an arm64 Python and rebuild an incomplete venv (#1953)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,18 @@ jobs:
             bash "$t"
           done
 
+      # install.sh picks the interpreter and builds ~/.rapid-mlx, but it only
+      # runs end-to-end on Apple Silicon, so its arch-selection and venv-repair
+      # logic (see #1953) is covered offline against fake interpreters. Pure
+      # bash, no network/Python/real install — runs on the Linux CI leg.
+      - name: Installer offline tests
+        run: |
+          set -euo pipefail
+          for t in tests/install/test_*.sh; do
+            echo "── $t"
+            bash "$t"
+          done
+
       # Parser microbench — catches >10x regressions in tool-call
       # extraction. Pure Python (parsers don't import mlx); thresholds
       # are intentionally generous (3-5x measured M3 numbers) to

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,121 @@ download() {
     fi
 }
 
+# ── Interpreter + venv helpers (also sourced by tests/install) ────────────────
+
+# Echo the first python3.x (>= MIN_PYTHON_MINOR) on PATH that is a NATIVE arm64
+# build, else nothing. MLX ships arm64 wheels only: a uv/pyenv-managed x86_64
+# interpreter earlier in PATH would build a Rosetta venv that cannot import mlx
+# and, historically, left ~/.rapid-mlx half-built with no bin/pip (#1953). The
+# arch note goes to stderr so command substitution captures only the name.
+select_python() {
+    local py ver major minor pyarch
+    for py in python3.13 python3.12 python3.11 python3.10 python3; do
+        command -v "$py" >/dev/null 2>&1 || continue
+        ver=$("$py" -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")' 2>/dev/null || echo "0.0")
+        major="${ver%%.*}"; minor="${ver#*.}"
+        { [ "$major" -ge 3 ] && [ "$minor" -ge "$MIN_PYTHON_MINOR" ]; } || continue
+        pyarch=$("$py" -c 'import platform; print(platform.machine())' 2>/dev/null || echo "?")
+        if [ "$pyarch" != "arm64" ]; then
+            dim "Skipping $py (${pyarch}; Rapid-MLX needs a native arm64 Python)" >&2
+            continue
+        fi
+        printf '%s\n' "$py"
+        return 0
+    done
+    return 1
+}
+
+# A venv is reusable only if it is COMPLETE (python + pip present and runnable)
+# AND COMPATIBLE (a native arm64 interpreter, Python >= MIN_PYTHON_MINOR) — the
+# same contract fresh selection enforces. Anything else is treated as
+# not-installed and rebuilt under the newly selected interpreter:
+#   - missing bin/pip: an aborted earlier run left it out (the original #1953).
+#   - executable-but-broken pip: a ~/.vllm-mlx -> ~/.rapid-mlx migration leaves a
+#     stale shebang, so `-x` passes but running fails — hence the `--version` run.
+#   - wrong arch / too-old version: a venv built earlier under a Rosetta x86_64
+#     or a 3.9 Python still runs, so it would pass a liveness check and quietly
+#     survive the upgrade path even though mlx can never import there.
+venv_is_complete() {
+    local dir="$1" arch ver major minor
+    [ -x "$dir/bin/python" ] && [ -x "$dir/bin/pip" ] || return 1
+    "$dir/bin/python" -c 'import sys' >/dev/null 2>&1 || return 1
+    "$dir/bin/pip" --version >/dev/null 2>&1 || return 1
+    arch=$("$dir/bin/python" -c 'import platform; print(platform.machine())' 2>/dev/null || echo "?")
+    [ "$arch" = "arm64" ] || return 1
+    ver=$("$dir/bin/python" -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")' 2>/dev/null || echo "0.0")
+    major="${ver%%.*}"; minor="${ver#*.}"
+    [ "$major" -ge 3 ] && [ "$minor" -ge "$MIN_PYTHON_MINOR" ]
+}
+
+# Remove ONLY the virtual environment's own entries under $1, so a rebuild does
+# not touch the shared ~/.rapid-mlx state that pip and the desktop app also keep
+# here — telemetry-client-id, bench-install-id, agents/ profiles, launch.pid,
+# first-run markers. `python -m venv` then recreates bin/lib/... in place,
+# alongside that preserved state.
+reset_venv_dir() {
+    local dir="$1"
+    rm -rf "$dir/bin" "$dir/lib" "$dir/lib64" "$dir/include" "$dir/share" "$dir/pyvenv.cfg"
+}
+
+# Decide what a fresh install run should do with $1: "create" when nothing is
+# there, "upgrade" a compatible venv in place, or "rebuild" an incompatible one
+# (reset_venv_dir + recreate). Isolated from the actions it drives so the
+# decision is unit-testable.
+plan_venv_action() {
+    local dir="$1"
+    if [ ! -d "$dir" ]; then echo create; return; fi
+    if venv_is_complete "$dir"; then echo upgrade; else echo rebuild; fi
+}
+
+# Best-effort pip self-upgrade: a transient failure here must not abort install.
+upgrade_pip() {
+    "$INSTALL_DIR/bin/pip" install --upgrade pip -q 2>/dev/null || true
+}
+
+# Build the venv at $INSTALL_DIR under $PYTHON and verify it came out usable.
+create_venv() {
+    "$PYTHON" -m venv "$INSTALL_DIR"
+    if ! venv_is_complete "$INSTALL_DIR"; then
+        err "Could not create a working virtual environment at $INSTALL_DIR."
+        dim "Selected Python: $("$PYTHON" -c 'import platform, sys; print(platform.machine(), sys.version.split()[0])' 2>/dev/null || echo unknown)"
+        dim "Install an arm64 Python 3.10+ (e.g. 'brew install python@3.12') and re-run."
+        exit 1
+    fi
+    upgrade_pip
+}
+
+# Carry out a planned action. Kept as its own function (not an inline case) so
+# the create/upgrade/rebuild wiring is unit-testable with mocked actions.
+dispatch_venv() {
+    case "$1" in
+        upgrade)
+            info "Upgrading Rapid-MLX..."
+            upgrade_pip
+            ;;
+        rebuild)
+            warn "Existing $INSTALL_DIR has no usable virtual environment — rebuilding it."
+            dim "(shared state such as telemetry-client-id and agents/ is preserved)"
+            reset_venv_dir "$INSTALL_DIR"
+            info "Installing Rapid-MLX..."
+            dim "(this takes about a minute)"
+            create_venv
+            ;;
+        *)
+            info "Installing Rapid-MLX..."
+            dim "(this takes about a minute)"
+            create_venv
+            ;;
+    esac
+}
+
+# When sourced by the test harness we only want the definitions above, not the
+# installer itself. `return` succeeds only in a sourced context; the `|| exit 0`
+# keeps an accidental `RAPID_INSTALL_LIB=1 bash install.sh` from erroring out.
+if [ "${RAPID_INSTALL_LIB:-0}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
 # Validate target
 if [[ "$TARGET" != "stable" ]] && [[ "$TARGET" != "latest" ]] && [[ ! "$TARGET" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     echo "Usage: install.sh [stable|latest|VERSION]" >&2
@@ -118,17 +233,7 @@ dim "macOS $(sw_vers -productVersion) · Apple Silicon · ${RAM_GB} GB RAM"
 
 # ── 3. Find or install Python 3.10+ ─────────────────────────────────────────
 
-PYTHON=""
-for py in python3.13 python3.12 python3.11 python3.10 python3; do
-    if command -v "$py" >/dev/null 2>&1; then
-        ver=$("$py" -c "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')" 2>/dev/null || echo "0.0")
-        major="${ver%%.*}"; minor="${ver#*.}"
-        if [ "$major" -ge 3 ] && [ "$minor" -ge "$MIN_PYTHON_MINOR" ]; then
-            PYTHON="$py"
-            break
-        fi
-    fi
-done
+PYTHON="$(select_python || true)"
 
 if [ -z "$PYTHON" ]; then
     echo ""
@@ -136,7 +241,18 @@ if [ -z "$PYTHON" ]; then
     if command -v brew >/dev/null 2>&1; then
         info "Installing Python 3.12 via Homebrew..."
         brew install python@3.12
-        PYTHON="python3.12"
+        # Resolve the formula's OWN keg path, not the bare name and not the
+        # Homebrew root: python@3.12 is keg-only, so `$(brew --prefix)/bin` may
+        # not carry python3.12, while a bare `python3.12` could still hit the
+        # x86_64 build earlier on PATH (the reason we got here) and fail the
+        # arch check below. The lookup is best-effort (|| true) so it can't abort
+        # the install under set -e; fall back to the name if the keg path is gone.
+        keg="$(brew --prefix python@3.12 2>/dev/null || true)"
+        if [ -n "$keg" ] && [ -x "$keg/bin/python3.12" ]; then
+            PYTHON="$keg/bin/python3.12"
+        else
+            PYTHON="python3.12"
+        fi
     else
         STANDALONE_DIR="${HOME}/.rapid-mlx-python"
         PY_VERSION="3.12.13"
@@ -159,6 +275,18 @@ fi
 
 dim "Python: $("$PYTHON" --version 2>&1)"
 
+# Whatever interpreter we ended up with — found on PATH or auto-installed — must
+# be arm64. MLX has no x86_64 build, so a Rosetta Python cannot run Rapid-MLX at
+# all; fail here with a clear message instead of building a venv that breaks
+# later on the first `import mlx` (#1953).
+PY_ARCH=$("$PYTHON" -c 'import platform; print(platform.machine())' 2>/dev/null || echo "?")
+if [ "$PY_ARCH" != "arm64" ]; then
+    err "Selected Python is ${PY_ARCH}, but Apple Silicon needs a native arm64 Python."
+    dim "Interpreter: $PYTHON"
+    dim "Install an arm64 Python 3.10+ (e.g. 'brew install python@3.12') and re-run."
+    exit 1
+fi
+
 # ── 4. Migrate from old install location ─────────────────────────────────────
 
 OLD_DIR="${HOME}/.vllm-mlx"
@@ -170,15 +298,9 @@ fi
 # ── 5. Create or update venv + install ───────────────────────────────────────
 
 echo ""
-if [ -d "$INSTALL_DIR" ]; then
-    info "Upgrading Rapid-MLX..."
-    "$INSTALL_DIR/bin/pip" install --upgrade pip -q 2>/dev/null
-else
-    info "Installing Rapid-MLX..."
-    dim "(this takes about a minute)"
-    "$PYTHON" -m venv "$INSTALL_DIR"
-    "$INSTALL_DIR/bin/pip" install --upgrade pip -q 2>/dev/null
-fi
+# The directory doubles as shared state, so create-vs-upgrade turns on whether a
+# COMPATIBLE venv exists (plan_venv_action), not on whether the dir exists.
+dispatch_venv "$(plan_venv_action "$INSTALL_DIR")"
 
 # Use uv for resolution + parallel downloads when available — typically 3-10x
 # faster than pip on a fresh install. Falls back to the venv's pip.

--- a/tests/install/test_install_sh.sh
+++ b/tests/install/test_install_sh.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Offline regression tests for install.sh interpreter + venv handling (#1953).
+#
+# install.sh used to pick the first python3.x on PATH by name, ignoring its
+# architecture, so a uv/pyenv x86_64 python3.12 ahead of an arm64 python3.11
+# was chosen on Apple Silicon; the resulting venv was incomplete (no bin/pip)
+# and every re-run then died on the upgrade path calling the missing pip.
+#
+# We source install.sh in library mode (RAPID_INSTALL_LIB=1) so only the
+# helper functions load, then drive them against fake interpreters. No network,
+# no real Python, no real install — runs on any host (macOS dev + Linux CI).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+# Load install.sh's functions without running the installer. Do this BEFORE
+# defining the harness helpers below: install.sh also defines ok()/warn()/dim(),
+# so our definitions must win to keep the pass/fail counters correct.
+# shellcheck disable=SC1090
+RAPID_INSTALL_LIB=1 source "$INSTALL_SH"
+
+PASS=0 FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1"; printf '        want: %s\n        got:  %s\n' "$3" "$2"; fi; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+SYS_PATH="$PATH"   # keep coreutils for setup
+
+# A fake python that reports a given "python X.Y" version and machine arch.
+make_py() {   # make_py <path> <ver e.g. 3.12> <arch e.g. arm64>
+    local path="$1" ver="$2" arch="$3"
+    cat > "$path" <<EOF
+#!/bin/bash
+case "\$*" in
+  *version_info*)      echo "$ver" ;;
+  *platform.machine*)  echo "$arch" ;;
+  *"import sys"*)       exit 0 ;;
+  --version)           echo "Python $ver.0" ;;
+  *)                   exit 0 ;;
+esac
+EOF
+    chmod +x "$path"
+}
+
+# ── 1. arch-aware selection: skip x86_64, pick the native arm64 build ─────────
+BIN1="$WORK/bin1"; mkdir -p "$BIN1"
+make_py "$BIN1/python3.12" 3.12 x86_64     # earlier in loop order, WRONG arch
+make_py "$BIN1/python3.11" 3.11 arm64      # later in order, right arch
+sel="$(PATH="$BIN1" select_python 2>/dev/null)"
+check "picks the native arm64 python over an earlier x86_64 one" "$sel" "python3.11"
+
+# ── 2. selection fails cleanly when only an x86_64 python exists ──────────────
+BIN2="$WORK/bin2"; mkdir -p "$BIN2"
+make_py "$BIN2/python3.12" 3.12 x86_64
+if PATH="$BIN2" select_python >/dev/null 2>&1; then
+    bad "returns non-zero when no arm64 python is available"
+else
+    ok "returns non-zero when no arm64 python is available"
+fi
+
+# ── 3. version gate: a too-old arm64 python is not accepted ──────────────────
+# Only a 3.9 candidate is present, so selection MUST fail. (Pairing it with a
+# valid fallback would pass even if the version check were removed.)
+BIN3="$WORK/bin3"; mkdir -p "$BIN3"
+make_py "$BIN3/python3.11" 3.9 arm64       # 3.9 < MIN_PYTHON_MINOR, only candidate
+if PATH="$BIN3" select_python >/dev/null 2>&1; then
+    bad "rejects an arm64 python older than MIN_PYTHON_MINOR"
+else
+    ok "rejects an arm64 python older than MIN_PYTHON_MINOR"
+fi
+
+# ── 4. venv completeness: missing bin/pip is treated as incomplete ───────────
+VBAD="$WORK/venv_bad"; mkdir -p "$VBAD/bin"
+make_py "$VBAD/bin/python" 3.11 arm64      # python present, pip MISSING
+if PATH="$SYS_PATH" venv_is_complete "$VBAD"; then
+    bad "an existing venv without bin/pip is reported incomplete"
+else
+    ok "an existing venv without bin/pip is reported incomplete"
+fi
+
+# ── 5. venv completeness: python + working pip is complete ───────────────────
+VOK="$WORK/venv_ok"; mkdir -p "$VOK/bin"
+make_py "$VOK/bin/python" 3.11 arm64
+make_py "$VOK/bin/pip"    3.11 arm64
+if PATH="$SYS_PATH" venv_is_complete "$VOK"; then
+    ok "a venv with both bin/python and bin/pip is reported complete"
+else
+    bad "a venv with both bin/python and bin/pip is reported complete"
+fi
+
+# ── 6. venv completeness: a non-existent dir is incomplete ───────────────────
+if PATH="$SYS_PATH" venv_is_complete "$WORK/nope"; then
+    bad "a missing install dir is reported incomplete"
+else
+    ok "a missing install dir is reported incomplete"
+fi
+
+# ── 7. venv completeness: an executable-but-broken pip is incomplete ──────────
+# Mirrors a ~/.vllm-mlx → ~/.rapid-mlx migration where pip's shebang is stale:
+# the file is present and +x, but running it fails.
+VBROKEN="$WORK/venv_broken"; mkdir -p "$VBROKEN/bin"
+make_py "$VBROKEN/bin/python" 3.11 arm64
+printf '#!/bin/bash\nexit 1\n' > "$VBROKEN/bin/pip"   # +x but errors when run
+chmod +x "$VBROKEN/bin/pip"
+if PATH="$SYS_PATH" venv_is_complete "$VBROKEN"; then
+    bad "a pip that is executable but fails to run is reported incomplete"
+else
+    ok "a pip that is executable but fails to run is reported incomplete"
+fi
+
+# ── 8. venv completeness: a runnable but x86_64 venv is incompatible ──────────
+# An earlier Rosetta install: python/pip run fine, but mlx can never import.
+VX86="$WORK/venv_x86"; mkdir -p "$VX86/bin"
+make_py "$VX86/bin/python" 3.12 x86_64
+make_py "$VX86/bin/pip"    3.12 x86_64
+if PATH="$SYS_PATH" venv_is_complete "$VX86"; then
+    bad "an existing x86_64 venv is reported incomplete (must be rebuilt)"
+else
+    ok "an existing x86_64 venv is reported incomplete (must be rebuilt)"
+fi
+
+# ── 9. venv completeness: a runnable but too-old (3.9) venv is incompatible ───
+VOLD="$WORK/venv_old"; mkdir -p "$VOLD/bin"
+make_py "$VOLD/bin/python" 3.9 arm64
+make_py "$VOLD/bin/pip"    3.9 arm64
+if PATH="$SYS_PATH" venv_is_complete "$VOLD"; then
+    bad "an existing Python 3.9 venv is reported incomplete (must be rebuilt)"
+else
+    ok "an existing Python 3.9 venv is reported incomplete (must be rebuilt)"
+fi
+
+# ── 10. rebuild removes only venv entries, preserves shared ~/.rapid-mlx state ─
+# ~/.rapid-mlx doubles as the state dir (telemetry-client-id, bench-install-id,
+# agents/ profiles, launch.pid). A rebuild must not delete any of that.
+RVD="$WORK/rapid_state"; mkdir -p "$RVD/bin" "$RVD/lib" "$RVD/include" "$RVD/agents"
+make_py "$RVD/bin/python" 3.11 arm64
+printf 'x' > "$RVD/pyvenv.cfg"
+printf 'client-abc' > "$RVD/telemetry-client-id"
+printf 'bench-xyz'  > "$RVD/bench-install-id"
+printf '{}'         > "$RVD/agents/custom.json"
+printf '4242'       > "$RVD/launch.pid"
+reset_venv_dir "$RVD"
+venv_gone=yes; for e in bin lib include pyvenv.cfg; do [ -e "$RVD/$e" ] && venv_gone=no; done
+check "reset_venv_dir removes the venv's own entries" "$venv_gone" "yes"
+state_kept=yes
+for f in telemetry-client-id bench-install-id agents/custom.json launch.pid; do
+    [ -e "$RVD/$f" ] || state_kept=no
+done
+check "reset_venv_dir preserves shared ~/.rapid-mlx state" "$state_kept" "yes"
+
+# ── 11. create-vs-upgrade decision wires venv_is_complete correctly ──────────
+# Exercises the actual control flow: a missing dir creates, a compatible venv
+# upgrades, and an incomplete/incompatible one rebuilds. Reversing the branch
+# in install.sh would flip these.
+check "plan: a missing dir is created" \
+    "$(PATH="$SYS_PATH" plan_venv_action "$WORK/absent")" "create"
+
+PUP="$WORK/plan_ok"; mkdir -p "$PUP/bin"
+make_py "$PUP/bin/python" 3.11 arm64
+make_py "$PUP/bin/pip"    3.11 arm64
+check "plan: a complete arm64 venv is upgraded" \
+    "$(PATH="$SYS_PATH" plan_venv_action "$PUP")" "upgrade"
+
+PRB="$WORK/plan_rebuild"; mkdir -p "$PRB/bin"
+make_py "$PRB/bin/python" 3.11 arm64       # no bin/pip -> incomplete
+check "plan: an incomplete venv is rebuilt" \
+    "$(PATH="$SYS_PATH" plan_venv_action "$PRB")" "rebuild"
+
+PX86="$WORK/plan_x86"; mkdir -p "$PX86/bin"
+make_py "$PX86/bin/python" 3.12 x86_64
+make_py "$PX86/bin/pip"    3.12 x86_64
+check "plan: an x86_64 venv is rebuilt" \
+    "$(PATH="$SYS_PATH" plan_venv_action "$PX86")" "rebuild"
+
+# ── 12. dispatch_venv wires each action to the right operations ───────────────
+# Mock the side-effecting steps so we can assert the create/upgrade/rebuild
+# branches invoke the intended operations in order — a swapped or dropped branch
+# in install.sh would change this record.
+CALLS=""
+create_venv()    { CALLS="$CALLS create"; }
+upgrade_pip()    { CALLS="$CALLS upgrade"; }
+reset_venv_dir() { CALLS="$CALLS reset"; }
+info() { :; }; warn() { :; }; dim() { :; }   # silence banners during dispatch
+
+CALLS=""; dispatch_venv upgrade
+check "dispatch upgrade -> only pip upgrade" "$CALLS" " upgrade"
+CALLS=""; dispatch_venv create
+check "dispatch create -> only venv create" "$CALLS" " create"
+CALLS=""; dispatch_venv rebuild
+check "dispatch rebuild -> reset then create" "$CALLS" " reset create"
+
+echo
+printf 'passed %d, failed %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Why

On Apple Silicon, `install.sh` picked the first `python3.x` on `PATH` **by name, ignoring architecture** (`install.sh:122`). A uv/pyenv-managed **x86_64** `python3.12` sitting ahead of an arm64 `python3.11` was selected. MLX ships arm64 wheels only, so the venv it built was incomplete — `bin/python` existed, `bin/pip` did not. Every re-run then took the existing-directory **upgrade** path and died calling the missing `bin/pip`, leaving the user stuck until they manually `rm -rf ~/.rapid-mlx`. **Fixes #1953** (reported by @moinulmoin on an M4 Pro, with a clean repro).

## What

- **`select_python()`** — skips x86_64 candidates and keeps searching for a native **arm64** interpreter. A final hard check rejects a non-arm64 Python (e.g. from an x86_64 Homebrew) with an actionable message instead of building a doomed venv. Implements the reporter's suggestions 1–2.
- **`venv_is_complete()`** — gates create-vs-upgrade: an existing but **incomplete** `~/.rapid-mlx` is rebuilt rather than upgraded, and a freshly created venv still lacking a working `pip` fails loudly. Implements suggestions 3–4.
- pip-upgrade steps are now best-effort (`|| true`) so a transient failure there no longer aborts the install.
- Only the installer-owned venv dir is ever removed, and only when already broken.

## Tests

- New offline suite **`tests/install/test_install_sh.sh`** (6 checks): arch selection over an earlier x86_64, the no-arm64 failure path, the version gate, and venv-completeness (missing pip / complete / missing dir). It sources `install.sh` in **library mode** (`RAPID_INSTALL_LIB=1`) and drives the helpers against fake interpreters — no network, no real Python, no real install, so it runs on the Linux CI leg. New CI step **"Installer offline tests"** in `ci.yml`.
- Red/green: the pre-fix selection loop picks the x86_64 `python3.12` against the same fake interpreters; `select_python()` picks the arm64 `python3.11`. **6 passed, 0 failed.**
- `tests/test_ram_tier_recommendations_agree.py` (parses `install.sh`) still 21 passed — the RAM-tier block is untouched.
- `scripts/check_workflow_expressions.py` OK; `bash -n` clean. (`shellcheck` not installed locally.)

## Notes

`install.sh` only runs end-to-end on Apple Silicon, so this is the first automated coverage of its selection/repair logic. Website delivery is unaffected: `pages.yml` auto-syncs `install.sh` to `rapidmlx.com` on merge to main.

---
🤖 AI-assisted: implementation, tests, and review with Claude Code (Opus 4.8). Human-reviewed.
