### PR TITLE
test(mtp): re-green two gates that #1987 left failing on main

### DIFF
--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -132,8 +132,20 @@ def test_models_listing_renders_ddtree_column(capsys) -> None:
     assert "DDTree" in captured.out
     lines = captured.out.splitlines()
 
+    # DDTree is the second-to-last column: #1987 appended a "Preset" column
+    # after it. The table pads by display width (wide glyphs like ✓/—/✗ are not
+    # one char), so a header-char-offset slice misaligns — index from the end of
+    # the whitespace-split row instead. For the rows checked here every cell is
+    # a single token (Size is "X.Y GiB", but it sits well before DDTree), so the
+    # last two tokens are DDTree then Preset. Guard that Preset is really last.
+    header = next((ln for ln in lines if "DDTree" in ln and "Alias" in ln), None)
+    assert header is not None, "models listing header with a DDTree column not found"
+    assert header.split()[-2:] == ["DDTree", "Preset"], (
+        f"DDTree is expected to be the second-to-last column: {header!r}"
+    )
+
     def ddtree_cell(row: str) -> str:
-        return row.split()[-1]
+        return row.split()[-2]
 
     eligible_row = next(
         (line for line in lines if line.strip().startswith("qwen3.5-9b-8bit ")),

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -1379,6 +1379,9 @@ def test_alias_profile_str_fields_are_explicitly_listed():
             "suffix_decoding_tier",  # one of VALID_SUFFIX_TIERS — non-routing data
             "dflash_draft_model",  # HF path for the spec-decode drafter
             "ddtree_draft_model",  # HF path for the DDTree/DFlash drafter
+            "mtp_draft_model",  # HF 'org/repo' path for the MTP drafter (#1987);
+            # validated as non-empty org/repo at JSON load in model_aliases.py,
+            # open-ended like the other *_draft_model paths, not a routing enum
             # PFlash long-prompt compression eligibility (#287). One of
             # VALID_PFLASH_TIERS ({"unknown", "verified"}). It IS a
             # routing decision in the sense that it flips the engine's


### PR DESCRIPTION
## Why

main HEAD (`d325f1f8`) fails two tests deterministically — a **release blocker** unrelated to any open PR. #1987 (opt-in Qwen3.8 MTP acceleration) added the `mtp_draft_model` field and a trailing `Preset` column but did not update the tests that pin those surfaces.

## What

- **test_alias_profile_str_fields_are_explicitly_listed** — register `mtp_draft_model` in `ALLOWED_STR_FIELDS`. It is an HF `org/repo` drafter path validated at JSON load (`model_aliases.py`), the same open-ended shape as `dflash_draft_model`/`ddtree_draft_model`, not a routing enum. This gate exists to force exactly this review when a str field is added.
- **test_models_listing_renders_ddtree_column** — DDTree is now the second-to-last column (#1987 appended `Preset`). The table pads by display width, so a header-char-offset slice misaligns on wide ✓/—/✗ glyphs; read the DDTree cell as the second-to-last token and assert `Preset` is last.

Product behaviour from #1987 is intentional; only the tests needed updating.

## Tests

- Both tests pass; full `test_ddtree_integration.py` + `test_no_out_of_band_routing.py` = 27 passed. `ruff check` clean.
- Confirmed both fail on clean main and pass with this change.

---
🤖 AI-assisted with Claude Code (Opus 4.8). Human-reviewed.