### PR TITLE
fix(tools): stop the XML tool grammar truncating string arguments (#1996)

### DIFF
--- a/tests/test_gemma4_grammar_558.py
+++ b/tests/test_gemma4_grammar_558.py
@@ -1180,8 +1180,10 @@ def test_gemma4_key_safety_is_word_only_stricter_than_xml():
     for bad in ("my-key", "a.b", "a b", "a:b", "a,b", "x<y", "a{b"):
         assert g_rep({"properties": {bad: {"type": "string"}}}) is False, bad
     # XML allows ``-``/``.`` (its key wire tolerates them) — proves the divergence
-    # is intentional and the shared structural guard is otherwise identical.
-    assert x_rep({"properties": {"my-key": {"type": "string"}}}) is True
+    # is intentional and the shared structural guard is otherwise identical. The
+    # XML side probes an INTEGER property: since #1996 a top-level free-form
+    # string opts XML out regardless of the key, which would hide the key rule.
+    assert x_rep({"properties": {"my-key": {"type": "integer"}}}) is True
     assert g_rep({"properties": {"my-key": {"type": "string"}}}) is False
 
 

--- a/tests/test_qwen3coder_xml_freeform_string_1996.py
+++ b/tests/test_qwen3coder_xml_freeform_string_1996.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The XML tool wire must not constrain a top-level free-form string (#1996).
+
+Found by dogfooding ``qwen3.6-35b-8bit`` on a real server, not by reading the
+grammar. With the constraint ON, a ``write_file`` call came back with an 11-byte
+``content`` — ``"import time"`` — and nothing else: the model was forced to open
+a JSON string it had never been trained to open there, reached a newline it
+could not emit raw, and closed the string instead of escaping it. The file was
+silently truncated. The identical server with ``RAPID_MLX_CONSTRAIN_TOOLS=0``
+wrote all 710 bytes. Short values corrupted more quietly on the same run —
+``Tokyo`` became ``Toyo``, ``Osaka`` became ``osaka``.
+
+The cause is structural, not a tuning miss. On this wire the value is closed by
+``\\n</parameter>\\n``, which is ORDINARY TEXT, and the model emits the value
+BARE. No bare terminal can be lexed against that close: ``/[^<]*/`` munches the
+``\\n`` and then rejects the next token (real tokenizers emit ``\\n</`` as ONE
+token), and a lazy ``/(.|\\n)*?/`` never terminates, so it constrains nothing.
+That leaves ``%json`` — the quoted surface that causes the corruption. So the
+schema is genuinely NOT representable, and the fix routes it through the
+existing faithful-or-opt-out gate rather than emitting a grammar that mangles
+output.
+
+Scope matters as much as the opt-out: gemma4 frames its value with the
+``<|"|>`` special token the model natively emits, the JSON families are ``%json``
+end to end, and a NESTED string rides inside a ``%json`` object where quoting IS
+the native surface. All three must stay constrained — a blanket disable would
+have been the easy wrong fix.
+"""
+
+import importlib.util
+
+import pytest
+
+_HAS_LLGUIDANCE = importlib.util.find_spec("llguidance") is not None
+_requires_llguidance = pytest.mark.skipif(
+    not _HAS_LLGUIDANCE, reason="llguidance ([guided] extra) not installed"
+)
+
+
+# The exact shape that truncated the file on the live server.
+WRITE_FILE_PARAMS = {
+    "type": "object",
+    "properties": {
+        "path": {"type": "string", "description": "Repo-relative file path"},
+        "content": {"type": "string", "description": "Full file contents"},
+    },
+    "required": ["path", "content"],
+    "additionalProperties": False,
+}
+
+# Shapes that must KEEP the constraint — none of them emits a bare free-form
+# string, so none of them can hit the truncation.
+STILL_REPRESENTABLE = {
+    "string enum only": {
+        "type": "object",
+        "properties": {"unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}},
+        "required": ["unit"],
+        "additionalProperties": False,
+    },
+    "scalars only": {
+        "type": "object",
+        "properties": {"n": {"type": "integer"}, "b": {"type": "boolean"}},
+        "additionalProperties": False,
+    },
+    "nested string inside an object": {
+        "type": "object",
+        "properties": {
+            "loc": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "additionalProperties": False,
+            }
+        },
+        "additionalProperties": False,
+    },
+    "nested string inside an array": {
+        "type": "object",
+        "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+        "additionalProperties": False,
+    },
+    "no-argument tool": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+}
+
+
+def test_toplevel_freeform_string_is_not_representable_on_the_xml_wire():
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable
+
+    assert _xml_schema_representable(WRITE_FILE_PARAMS) is False
+
+
+@pytest.mark.parametrize("label", sorted(STILL_REPRESENTABLE))
+def test_shapes_without_a_bare_freeform_string_stay_constrained(label):
+    from vllm_mlx.api.tool_grammar import _xml_schema_representable
+
+    assert _xml_schema_representable(STILL_REPRESENTABLE[label]) is True, (
+        f"{label} lost its grammar constraint — the #1996 opt-out must be "
+        "confined to a TOP-LEVEL non-enum string"
+    )
+
+
+def test_gemma4_keeps_the_very_schema_the_xml_wire_now_refuses():
+    """gemma4 closes its value with a special token, so it is unaffected."""
+    from vllm_mlx.api.tool_grammar import _gemma4_schema_representable
+
+    assert _gemma4_schema_representable(WRITE_FILE_PARAMS) is True
+
+
+def test_the_opt_out_is_carried_by_the_wire_policy_not_hardcoded():
+    """The XML policy declares it; gemma4 keeps the permissive default."""
+    from vllm_mlx.api.tool_grammar import _GEMMA4_WIRE_POLICY, _XML_WIRE_POLICY
+
+    assert _XML_WIRE_POLICY.freeform_string_representable is False
+    assert _GEMMA4_WIRE_POLICY.freeform_string_representable is True
+
+
+# --------------------------------------------------------------------------
+# End to end through the public builder: the request must fall back to
+# free-form rather than compile a grammar.
+# --------------------------------------------------------------------------
+def _structure_info(arg_style):
+    from vllm_mlx.api.tool_grammar import StructureInfo
+
+    def _info(name):
+        if arg_style == "xml":
+            return StructureInfo(
+                begin=f"<tool_call>\n<function={name}>\n",
+                end="</function>\n</tool_call>",
+                trigger="<tool_call>",
+                sentinels=("<tool_call>", "</tool_call>"),
+                arg_style="xml",
+            )
+        return StructureInfo(
+            begin=f'<tool_call>\n{{"name": "{name}", "arguments": ',
+            end="}\n</tool_call>",
+            trigger="<tool_call>",
+            sentinels=("<tool_call>", "</tool_call>"),
+        )
+
+    return _info
+
+
+class _Parser:
+    """Minimal stand-in: the builder only needs these two attributes."""
+
+    def __init__(self, arg_style):
+        self._arg_style = arg_style
+        self.model_tokenizer = None
+
+    def structure_info(self):
+        return _structure_info(self._arg_style)
+
+
+@_requires_llguidance
+def test_xml_string_tool_falls_back_to_free_form():
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    tools = [{"name": "write_file", "parameters": WRITE_FILE_PARAMS}]
+    assert build_tool_grammar(tools, "required", _Parser("xml")) is None
+
+
+@_requires_llguidance
+def test_json_family_with_the_same_string_tool_still_compiles_a_grammar():
+    """hermes/qwen/harmony quote natively — they must not lose the constraint."""
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    tools = [{"name": "write_file", "parameters": WRITE_FILE_PARAMS}]
+    grammar = build_tool_grammar(tools, "required", _Parser("json"))
+    assert grammar is not None
+
+
+@_requires_llguidance
+def test_one_string_tool_opts_out_the_whole_request():
+    """Mixed tool-sets follow the existing faithful-or-opt-out gate."""
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    tools = [
+        {"name": "set_unit", "parameters": STILL_REPRESENTABLE["string enum only"]},
+        {"name": "write_file", "parameters": WRITE_FILE_PARAMS},
+    ]
+    assert build_tool_grammar(tools, "required", _Parser("xml")) is None
+
+
+@_requires_llguidance
+def test_enum_only_xml_tool_still_compiles_a_grammar():
+    from vllm_mlx.api.tool_grammar import build_tool_grammar
+
+    tools = [
+        {"name": "set_unit", "parameters": STILL_REPRESENTABLE["string enum only"]}
+    ]
+    assert build_tool_grammar(tools, "required", _Parser("xml")) is not None

--- a/tests/test_qwen3coder_xml_grammar_558.py
+++ b/tests/test_qwen3coder_xml_grammar_558.py
@@ -10,22 +10,23 @@ instead of a whole-object ``%json``. These tests prove that path WITHOUT a model
 or a decode loop:
 
   * ``build_tool_lark`` golden output for ``arg_style="xml"`` (function/parameter
-    frame, string values as the LAZY ``xml_param_value`` rule, enum alternation,
-    ``%json`` scalars with ``$defs``/``$ref`` propagation, required vs optional
-    ``( )?``);
-  * GAP #1 (the E3 fix): a string parameter value containing a literal ``<``
-    (a ``code`` arg such as ``a < b``, ``<html>...``, C++ ``vector<int>``) is
-    ACCEPTED and terminates at the real ``</parameter>`` — the pilot's
-    ``XMLSTR: /[^<]*/`` terminal SILENTLY TRUNCATED such a value at the first
-    ``<``. The fix ports llguidance's own ``[lazy]`` lexeme idiom (the one
-    ``StructTag.to_grammar`` uses for "text until a tag"), matching XGrammar's
-    ``qwen_xml`` semantics: value = any text up to the FIRST ``</parameter>``;
+    frame, enum alternation, ``%json`` values with ``$defs``/``$ref``
+    propagation, required vs optional ``( )?``);
+  * the #1996 boundary: a tool with a TOP-LEVEL free-form string is not
+    constrained at all. The value has no delimiter of its own and this wire's
+    close is ordinary text, so no terminal can be lexed against it — the value
+    rule this file once tested (first ``/[^<]*/``, then a lazy lexeme, finally
+    ``%json``) has no correct form, and forcing ``%json`` silently truncated real
+    output. Enforcement therefore drives ``XML_TOOLS_CONSTRAINABLE`` (enum +
+    scalars + frame, no free string); ``test_qwen3coder_xml_freeform_string_1996``
+    owns the opt-out itself;
   * grammar ENFORCEMENT via llguidance ``LLMatcher`` on the REAL Qwen3-Coder
     tokenizer: a valid XML call is accepted + terminal, prose before a forced
     call is masked at token 0, and a bad enum / off-schema scalar is rejected;
-  * ROUND-TRIP: the ``qwen3_coder_xml`` parser parses the constrained wire back
-    to ``{name, arguments}`` with correct types (str-with-``<`` / int / bool /
-    nested object);
+  * ROUND-TRIP: the ``qwen3_coder_xml`` parser parses the wire back to
+    ``{name, arguments}`` with correct types (str / int / bool / nested object).
+    The PARSER still accepts both the raw and the quoted surface — only the
+    grammar stopped forcing the quoted one;
   * REGRESSION GUARD: an ``arg_style="json"`` (hermes/qwen/harmony) build is
     byte-identical to before — it never emits the XML string constructs
     (``XML_PARAM_TEXT`` / ``xml_param_value``) and still uses ``%json``.
@@ -55,8 +56,10 @@ _TOKENIZER_MODEL = "mlx-community/Qwen3-Coder-Next-4bit"
 _TOKENIZER_REVISION = "7b9321eabb85ce79625cac3f61ea691e4ea984b5"
 
 # A representative XML tool: required string + required enum + optional int +
-# optional bool — exercises every ``_emit_xml_param_value`` branch (lazy string
-# rule, enum alternation, ``%json`` scalar) AND required-vs-optional framing.
+# optional bool — exercises every ``_emit_xml_param_value`` branch AND
+# required-vs-optional framing at the EMITTER level. Since #1996 its top-level
+# ``code`` string means the GUARD opts it out, so it drives the golden/emitter
+# tests and the opt-out test, never the enforcement tests.
 XML_TOOLS = [
     {
         "name": "run_code",
@@ -69,6 +72,28 @@ XML_TOOLS = [
                 "verbose": {"type": "boolean"},
             },
             "required": ["code", "language"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+# The same tool WITHOUT a top-level free-form string. Since #1996 that string is
+# what opts a tool out of grammar entirely (the wire cannot frame a bare value —
+# see ``test_qwen3coder_xml_freeform_string_1996.py``), so every ENFORCEMENT test
+# below drives this shape instead: it still exercises the required enum, the
+# optional ``%json`` scalars, and the call frame — everything the grammar can
+# still constrain.
+XML_TOOLS_CONSTRAINABLE = [
+    {
+        "name": "run_code",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "language": {"type": "string", "enum": ["python", "cpp"]},
+                "timeout": {"type": "integer"},
+                "verbose": {"type": "boolean"},
+            },
+            "required": ["language"],
             "additionalProperties": False,
         },
     },
@@ -100,11 +125,10 @@ XML_REF_TOOL = [
 ]
 
 
-# A tool whose ONLY property is a ``$ref`` resolving to a STRING (F3). Before the
-# fix, ``$defs`` were attached only AFTER the string-vs-``%json`` decision, so this
-# ``$ref`` fell through to ``%json`` and emitted QUOTED JSON the parser returned
-# with quotes preserved (``"\\"Paris\\""``). The fix resolves the ``$ref`` FIRST so
-# it takes the RAW lazy path and round-trips WITHOUT quotes.
+# A tool whose ONLY property is a ``$ref`` resolving to a STRING (F3). The fix
+# resolves the ``$ref`` BEFORE the string-vs-``%json`` decision, so it is treated
+# exactly like an inline string. Since #1996 that means it opts OUT of grammar —
+# resolution order still decides, it just now decides opt-out.
 XML_REF_STRING_TOOL = [
     {
         "name": "geo",
@@ -517,6 +541,20 @@ def _wire(code, *, language="python", timeout=None, verbose=None):
     return s
 
 
+def _wire_c(*, language="python", timeout=None, verbose=None):
+    """The ``XML_TOOLS_CONSTRAINABLE`` wire — same frame, no free-form string."""
+    s = (
+        "<tool_call>\n<function=run_code>\n"
+        f"<parameter=language>\n{language}\n</parameter>\n"
+    )
+    if timeout is not None:
+        s += f"<parameter=timeout>\n{timeout}\n</parameter>\n"
+    if verbose is not None:
+        s += f"<parameter=verbose>\n{verbose}\n</parameter>\n"
+    s += "</function>\n</tool_call>"
+    return s
+
+
 @_requires_llguidance
 def test_finding5_tokenizer_llguidance_integration_not_broken(tok):
     # FINDING 5: with llguidance importable AND the tokenizer loaded (cached), the
@@ -537,66 +575,36 @@ def test_finding5_tokenizer_llguidance_integration_not_broken(tok):
 
 @_requires_llguidance
 def test_xml_valid_call_accepted_and_terminates(tok, lltok):
-    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    grammar = _xml_grammar(XML_TOOLS_CONSTRAINABLE, "required", tok)
     assert grammar is not None
-    accepted, total, accepting = _consume(grammar, lltok, tok, _wire("print(1)"))
+    accepted, total, accepting = _consume(grammar, lltok, tok, _wire_c())
     assert accepted == total, f"valid XML call rejected ({accepted}/{total})"
     assert accepting, "valid complete XML call is not an accepting (terminal) state"
 
 
 @_requires_llguidance
-@pytest.mark.parametrize(
-    "code",
-    [
-        "a < b && c > d",
-        "<html><body>x</body></html>",
-        "vector<int> v",
-        "if (a < b) { return a; }",
-        "for (int i = 0; i < n; i++) x[i] <<= 1;",
-    ],
-)
-def test_xml_string_value_with_angle_bracket_is_accepted(code, tok, lltok):
-    # GAP #1 — the E3 fix. A ``code`` arg containing a literal ``<`` must be
-    # ACCEPTED in full and terminate at the real ``</parameter>``. The pilot's
-    # ``/[^<]*/`` terminal masked the first ``<`` and SILENTLY TRUNCATED here.
-    grammar = _xml_grammar(XML_TOOLS, "required", tok)
-    assert grammar is not None
-    accepted, total, accepting = _consume(grammar, lltok, tok, _wire(code))
-    assert accepted == total, (
-        f"`<`-containing code value rejected ({accepted}/{total}) for {code!r} — "
-        "gap #1 truncation is back (string value stops at the first `<`)"
-    )
-    assert accepting, f"`<`-containing value {code!r} is not a terminal state"
+def test_xml_tool_with_a_freeform_string_is_not_constrained_at_all(tok):
+    """#1996, on the real tokenizer through the real builder.
 
-
-@_requires_llguidance
-def test_xml_normal_value_still_round_trips_no_regression(tok, lltok):
-    # A plain value (no ``<``) must still be accepted + terminal — the lazy rule
-    # is a strict superset of the old raw terminal for non-``<`` values.
-    grammar = _xml_grammar(XML_TOOLS, "required", tok)
-    accepted, total, accepting = _consume(grammar, lltok, tok, _wire("Paris"))
-    assert accepted == total and accepting, (
-        f"plain value regressed ({accepted}/{total}, accepting={accepting})"
-    )
-
-
-@_requires_llguidance
-def test_xml_value_containing_close_tag_is_data_not_a_delimiter(tok, lltok):
-    grammar = _xml_grammar(XML_TOOLS, "required", tok)
-    wire = _wire("a</parameter>b")
-    accepted, total, accepting = _consume(grammar, lltok, tok, wire)
-    assert accepted == total and accepting
-    _, args = _parse(wire, XML_TOOLS)
-    assert args["code"] == "a</parameter>b"
+    ``XML_TOOLS`` carries a top-level free-form ``code`` string. The wire cannot
+    frame a bare value there and the ``%json`` surface silently truncated real
+    output, so the whole request must fall back to free-form. This supersedes the
+    three enforcement tests that used to drive string values through this
+    grammar (``<``-containing code, a plain value, an embedded ``</parameter>``):
+    those exercised a constrained string path that no longer exists — the
+    property they were protecting (a value is never truncated) is now held by
+    NOT constraining it. See ``test_qwen3coder_xml_freeform_string_1996.py``.
+    """
+    assert _xml_grammar(XML_TOOLS, "required", tok) is None
 
 
 @_requires_llguidance
 def test_xml_optional_and_scalar_params_enforced(tok, lltok):
     # Optional int/bool params present with valid scalar surface forms are
     # accepted + terminal; the enum on the required ``language`` is honored.
-    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    grammar = _xml_grammar(XML_TOOLS_CONSTRAINABLE, "required", tok)
     accepted, total, accepting = _consume(
-        grammar, lltok, tok, _wire("x=1", language="cpp", timeout=30, verbose="true")
+        grammar, lltok, tok, _wire_c(language="cpp", timeout=30, verbose="true")
     )
     assert accepted == total and accepting, (
         f"valid call with optional scalars rejected ({accepted}/{total})"
@@ -606,18 +614,17 @@ def test_xml_optional_and_scalar_params_enforced(tok, lltok):
 @_requires_llguidance
 def test_xml_bad_enum_value_is_rejected(tok, lltok):
     # ``language`` enum is {python, cpp}; "rust" must be masked.
-    grammar = _xml_grammar(XML_TOOLS, "required", tok)
-    accepted, total, _ = _consume(grammar, lltok, tok, _wire("x", language="rust"))
+    grammar = _xml_grammar(XML_TOOLS_CONSTRAINABLE, "required", tok)
+    accepted, total, _ = _consume(grammar, lltok, tok, _wire_c(language="rust"))
     assert accepted < total, "invalid enum value was NOT rejected by the grammar"
 
 
 @_requires_llguidance
 def test_xml_off_schema_scalar_is_rejected(tok, lltok):
     # ``timeout`` is an integer; a non-numeric value must be masked by ``%json``.
-    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    grammar = _xml_grammar(XML_TOOLS_CONSTRAINABLE, "required", tok)
     bad = (
         "<tool_call>\n<function=run_code>\n"
-        "<parameter=code>\nx\n</parameter>\n"
         "<parameter=language>\npython\n</parameter>\n"
         "<parameter=timeout>\nnot_an_int"
     )
@@ -629,9 +636,9 @@ def test_xml_off_schema_scalar_is_rejected(tok, lltok):
 def test_xml_forced_rejects_prose_before_the_call(tok, lltok):
     # Forced (required) non-reasoning: the first call sits AT the trigger with no
     # free prefix, so bare prose before it is masked at token 0.
-    grammar = _xml_grammar(XML_TOOLS, "required", tok)
+    grammar = _xml_grammar(XML_TOOLS_CONSTRAINABLE, "required", tok)
     assert grammar is not None
-    prose_then_call = "Sure, let me run that. " + _wire("print(1)")
+    prose_then_call = "Sure, let me run that. " + _wire_c()
     accepted, _total, _ = _consume(grammar, lltok, tok, prose_then_call)
     assert accepted == 0, (
         f"forced XML grammar accepted {accepted} prose token(s) before the "
@@ -718,11 +725,14 @@ def test_representable_common_and_noarg_schemas():
     # regression): typed properties, enums, required + optional, empty body.
     from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
 
-    assert rep(XML_TOOLS[0]["parameters"]) is True
+    assert rep(XML_TOOLS_CONSTRAINABLE[0]["parameters"]) is True
     assert rep(XML_REF_TOOL[0]["parameters"]) is True  # $ref -> object
-    assert rep(XML_REF_STRING_TOOL[0]["parameters"]) is True  # $ref -> string
     assert rep({"type": "object", "properties": {}, "additionalProperties": False})
     assert rep({}) is True  # allow-any / no-arg
+    # #1996: a top-level free-form string — direct or behind a ``$ref`` — is NOT
+    # representable on this wire, so these two are opt-outs, not regressions.
+    assert rep(XML_TOOLS[0]["parameters"]) is False
+    assert rep(XML_REF_STRING_TOOL[0]["parameters"]) is False
 
 
 def test_representable_rejects_f1_property_less_but_nontrivial():
@@ -785,10 +795,13 @@ def test_representable_rejects_f4_object_level_keywords():
 def test_representable_rejects_f5_delimiter_unsafe_keys():
     from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
 
+    # The property type is an INTEGER here on purpose: since #1996 a top-level
+    # string opts out on its own, which would make every case below pass for the
+    # wrong reason and the control unsatisfiable. An integer isolates KEY safety.
     for bad in ("x>y", "x<y", "a:b", "a,b", "a b", "a\nb", "a{b", "a}b"):
-        assert rep({"properties": {bad: {"type": "string"}}}) is False, bad
+        assert rep({"properties": {bad: {"type": "integer"}}}) is False, bad
     # A normal [\w-]+ key stays representable.
-    assert rep({"properties": {"my_key-1": {"type": "string"}}}) is True
+    assert rep({"properties": {"my_key-1": {"type": "integer"}}}) is True
 
 
 def test_representable_unresolvable_ref_opts_out():
@@ -806,21 +819,22 @@ def test_representable_unresolvable_ref_opts_out():
 # not in the allowlist), plus a positive control that the common case is intact.
 def test_representable_allowlist_positive_control():
     # The normal shape a blacklist would let through unchanged MUST still be fully
-    # constrained: typed scalars + string + enum + a nested OBJECT via `$ref` +
+    # constrained: typed scalars + enum + a nested OBJECT via `$ref` +
     # required ⊆ properties + closed additionalProperties. Guards against the
-    # allowlist over-opting-out the common case.
+    # allowlist over-opting-out the common case. A top-level free-form string is
+    # deliberately absent — #1996 made that the one shape this wire opts out of,
+    # and its own test owns that case.
     from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
 
     schema = {
         "type": "object",
         "properties": {
-            "code": {"type": "string"},
             "language": {"type": "string", "enum": ["python", "cpp"]},
             "retries": {"type": "integer"},
             "verbose": {"type": "boolean"},
             "origin": {"$ref": "#/$defs/point"},
         },
-        "required": ["code", "language"],
+        "required": ["language"],
         "additionalProperties": False,
         "$defs": {
             "point": {
@@ -893,7 +907,9 @@ def test_representable_rejects_round2_additional_properties_schema():
     # XML wire -> opt out; only a literal `False` is representable.
     from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
 
-    base = {"type": "object", "properties": {"a": {"type": "string"}}}
+    # Integer prop: a top-level string would opt out on its own (#1996) and the
+    # ``False`` control could never be True.
+    base = {"type": "object", "properties": {"a": {"type": "integer"}}}
     assert rep({**base, "additionalProperties": {"type": "string"}}) is False
     assert rep({**base, "additionalProperties": True}) is False
     assert rep({**base, "additionalProperties": False}) is True  # control
@@ -987,7 +1003,9 @@ def test_representable_total_required_guard_never_raises():
     # OUTSIDE the builder's exception handling -> a 500 on arbitrary client JSON.
     from vllm_mlx.api.tool_grammar import _xml_schema_representable as rep
 
-    base = {"type": "object", "properties": {"a": {"type": "string"}}}
+    # Integer prop for the same reason as above (#1996): the control at the end
+    # of this test asserts a well-formed ``required`` stays representable.
+    base = {"type": "object", "properties": {"a": {"type": "integer"}}}
     # ``required`` not a list -> opt out (no raise).
     assert rep({**base, "required": "a"}) is False
     assert rep({**base, "required": 123}) is False
@@ -1027,22 +1045,18 @@ def test_xml_ref_to_object_still_uses_json():
 
 
 @_requires_llguidance
-def test_xml_ref_to_string_roundtrips_without_quotes(tok, lltok):
-    # F3 end-to-end on the REAL tokenizer: the grammar for a `$ref` -> string
-    # param ACCEPTS a RAW unquoted value and is terminal (before the fix it forced
-    # a QUOTED `%json` string, so raw `Paris` would be rejected), and the parser
-    # round-trips it to the clean value `Paris` — NOT `"Paris"` (quotes preserved).
-    grammar = _xml_grammar(XML_REF_STRING_TOOL, "required", tok)
-    assert grammar is not None
+def test_xml_ref_to_string_opts_out_and_still_parses_raw(tok):
+    # F3 resolved the ``$ref`` BEFORE the string-vs-``%json`` decision so a
+    # ``$ref`` -> string takes the same path as an inline string. Since #1996
+    # that path is "not representable", so this tool opts out too — resolution
+    # order still matters, it just now decides opt-out rather than which value
+    # rule to emit. The PARSER half of F3 is unchanged and still asserted: a raw
+    # unquoted value round-trips to a clean ``Paris``, no quotes preserved.
+    assert _xml_grammar(XML_REF_STRING_TOOL, "required", tok) is None
     wire = (
         "<tool_call>\n<function=geo>\n"
-        '<parameter=city>\n"Paris"\n</parameter>\n'
+        "<parameter=city>\nParis\n</parameter>\n"
         "</function>\n</tool_call>"
-    )
-    accepted, total, accepting = _consume(grammar, lltok, tok, wire)
-    assert accepted == total and accepting, (
-        f"$ref->string raw value rejected ({accepted}/{total}, "
-        f"accepting={accepting}) — F3 regression (still on the quoted %json path)"
     )
     name, args = _parse(wire, XML_REF_STRING_TOOL)
     assert name == "geo"
@@ -1054,7 +1068,7 @@ def test_xml_ref_to_string_roundtrips_without_quotes(tok, lltok):
 def test_build_tool_grammar_opts_out_f1_toplevel_ref(tok):
     # Control: a representable XML tool DOES build a grammar (proves the opt-out
     # below is the guard, not a generic build failure).
-    assert _xml_grammar(XML_TOOLS, "required", tok) is not None
+    assert _xml_grammar(XML_TOOLS_CONSTRAINABLE, "required", tok) is not None
     # F1: a top-level `$ref` (no inline properties) would collapse to an EMPTY
     # body allowing `{}` even though the schema requires fields -> opt out.
     ref_tool = [
@@ -1152,13 +1166,17 @@ def test_build_tool_grammar_opts_out_r3_bad_enum(tok):
     # codex r3 #2/#3: an enum type-mismatch / unsupported sibling / delimiter-bearing
     # value each opt the whole request out of grammar; a clean string enum builds.
     def _tool(enum_schema):
+        # ``n`` is an INTEGER, not a string: since #1996 a top-level free-form
+        # string opts out on its own, which would make every assertion below pass
+        # for the wrong reason and the control unsatisfiable. The enum is the
+        # only thing under test here.
         return [
             {
                 "name": "run_code",
                 "parameters": {
                     "type": "object",
-                    "properties": {"code": {"type": "string"}, "e": enum_schema},
-                    "required": ["code"],
+                    "properties": {"n": {"type": "integer"}, "e": enum_schema},
+                    "required": ["n"],
                 },
             }
         ]

--- a/vllm_mlx/api/tool_grammar.py
+++ b/vllm_mlx/api/tool_grammar.py
@@ -703,6 +703,21 @@ class _ArgWirePolicy:
         five-string blacklist (codex r3 E4). Without a tokenizer it falls back to
         the five structural markers alone.
 
+      * ``freeform_string_representable`` — whether a TOP-LEVEL non-enum string
+        property can be constrained at all on this wire (#1996). A top-level
+        string is the one value the model emits with NO delimiter of its own, so
+        the wire must be able to end it. gemma4 CAN: its value is framed by the
+        ``<|"|>`` marker, a single special token the model natively emits, so the
+        lexer always knows where the value stops. The Qwen3-Coder XML wire CANNOT:
+        its close (``\\n</parameter>\\n``) is ORDINARY TEXT, and the model emits
+        the value BARE. A bare terminal cannot be lexed against that close —
+        ``/[^<]*/`` munches the ``\\n`` and then rejects the very next token
+        (real tokenizers emit ``\\n</`` as ONE token), and a lazy ``/(.|\\n)*?/``
+        never terminates, constraining nothing. That leaves ``%json`` — a QUOTED
+        surface the model was never trained to produce there — which is why it is
+        not representable rather than merely awkward. See the note on
+        ``_emit_xml_param_value``.
+
     Everything else (top-level key allowlist, ``additionalProperties`` /
     ``required`` totality, ``$ref`` resolution, scalar/object/array/string
     dispatch, string-facet allowlist) is wire-independent and SHARED — so the two
@@ -712,10 +727,22 @@ class _ArgWirePolicy:
 
     key_safe: Callable[[Any], bool]
     enum_wire_unsafe: Callable[[str], bool]
+    # Default True keeps every wire that CAN frame a bare value (gemma4) exactly
+    # as it was; only a wire that proves it cannot sets this False.
+    freeform_string_representable: bool = True
 
 
 _XML_WIRE_POLICY = _ArgWirePolicy(
-    key_safe=_xml_key_is_delimiter_safe, enum_wire_unsafe=_xml_enum_wire_unsafe
+    key_safe=_xml_key_is_delimiter_safe,
+    enum_wire_unsafe=_xml_enum_wire_unsafe,
+    # #1996: measured on a real server, not reasoned about. With the constraint
+    # ON, ``qwen3.6-35b-8bit`` answered a ``write_file`` call with an 11-byte
+    # ``content`` ("import time") — the model opened the forced JSON string, hit
+    # a newline it could not emit raw, and closed the string instead of escaping
+    # it, silently truncating the file. The same server with
+    # ``RAPID_MLX_CONSTRAIN_TOOLS=0`` wrote all 710 bytes. Short values corrupt
+    # more quietly: ``Tokyo`` came back as ``Toyo`` and ``Osaka`` as ``osaka``.
+    freeform_string_representable=False,
 )
 _GEMMA4_WIRE_POLICY = _ArgWirePolicy(
     key_safe=_gemma4_key_is_safe, enum_wire_unsafe=_gemma4_enum_wire_unsafe
@@ -899,8 +926,15 @@ def _xml_property_representable(
         return False
     t = prop_type.strip().lower()
     if t == "string":
-        # Only annotation keys may accompany a string; any facet the raw lazy
-        # value path cannot enforce (or an unknown key) opts out.
+        # A TOP-LEVEL free-form string is the one value this wire family emits
+        # with no delimiter of its own, so a wire that cannot frame a bare value
+        # cannot represent it at all (#1996 — see ``freeform_string_representable``).
+        # NESTED strings are unaffected: they ride inside a ``%json`` object or
+        # array, where quoting IS the surface the model emits.
+        if not policy.freeform_string_representable:
+            return False
+        # Only annotation keys may accompany a string; any facet the value path
+        # cannot enforce (or an unknown key) opts out.
         return set(resolved.keys()) <= _XML_ALLOWED_STRING_KEYS
     if t in _XML_SCALAR_TERMINAL_TYPES:
         return True
@@ -1052,6 +1086,12 @@ def _emit_xml_param_value(subschema: Any, defs: dict[str, Any]) -> str:
         ``\\n</parameter>\\n`` close.
       * STRING (non-enum) -> a ``%json`` string. Its quoting/escaping layer makes
         delimiter-looking text payload rather than XML structure (#1542).
+        UNREACHABLE for the XML wire since #1996: the representability guard opts
+        a tool with a top-level non-enum string OUT of grammar entirely, because
+        the model emits that value BARE and the forced quoted surface silently
+        truncated/mangled it. The branch stays because the emitter is shared and
+        ``policy.freeform_string_representable`` is what decides — flip that back
+        only together with a value rule this wire can actually lex.
       * EVERYTHING ELSE (number / integer / boolean / object / array / null) ->
         JSON-constrained via ``%json`` (these surface forms match the parser's
         int / float / bool / ``json.loads`` paths), then the ``\\n</parameter>\\n``


### PR DESCRIPTION
## What does this PR do?

Fixes #1996. On the Qwen3-Coder XML tool wire the default-ON grammar constraint
forced every free-form string argument into a `%json` (quoted) surface. The
model emits that value **bare**, so it was pushed off-distribution and the value
came back wrong — most severely as a **silent truncation** at the first newline.

Measured on the Studio, same server, same prompt, only `RAPID_MLX_CONSTRAIN_TOOLS`
differing:

| prompt | constraint ON (default) | constraint OFF |
|---|---|---|
| `write_file(path, content)` | `content` = `"import time"`, **11 bytes** | the full **710-byte** file |
| weather in Tokyo | `{"city": "Toyo"}` | `{"city": "Tokyo"}` |
| weather in Osaka | `{"city": "osaka"}` | `{"city": "Osaka"}` |

The truncation is invisible to a caller: `finish_reason` is `tool_calls` and the
arguments are valid JSON. Any coding agent driving a Qwen3-Coder-XML model —
the Qwen3.5 / 3.6 family, i.e. the default recommendation — writes truncated
files.

## Why not just emit the value unquoted?

Because the close, `\n</parameter>\n`, is ordinary text, a bare value terminal
has to be lexed against it, and neither candidate works. Both were checked with
`LLMatcher` against the real tokenizer, not reasoned about:

- `/[^<]*/` (the rule this file originally shipped) munches the `\n` and then
  rejects the very next token — real tokenizers emit `\n</` as **one** token. It
  rejected at token 11 of a 12-token *valid* call.
- a lazy `/(.|\n)*?/` compiles, accepts the close as payload, and never reaches
  an accepting state — it constrains nothing at all.

So the schema is genuinely not representable on this wire, and the fix routes it
through the **existing** faithful-or-opt-out gate rather than inventing a new
mechanism.

## Scope

Only a **top-level non-enum string** opts out. Everything else keeps the
constraint:

- enum strings, integers, booleans, objects, arrays, no-arg tools;
- **nested** strings — they ride inside a `%json` object/array where quoting *is*
  the native surface;
- **gemma4**, wholesale: its value is framed by `<|"|>`, a single special token
  the model natively emits, so its lexer always knows where the value ends;
- every **JSON-body family** (hermes / qwen / harmony), which is `%json` end to
  end.

A blanket disable would have been the easy wrong fix; the new test file asserts
each of those four stay constrained.

## Why is this needed?

It is a release blocker. It corrupts the default tool-calling path for the
default model family whenever `llguidance` is installed — which is a plain
dependency, so it resolves for everyone.

## Test plan

- New `tests/test_qwen3coder_xml_freeform_string_1996.py` (12 tests): the opt-out,
  the four scopes that must NOT change, the policy carrier, and end-to-end
  `build_tool_grammar` fallback including a mixed tool-set.
- **Mutation-checked**: flipping `freeform_string_representable` back to `True`
  turns 4 of the 12 red while the 8 scope-guarding tests stay green.
- `tests/test_qwen3coder_xml_grammar_558.py` updated — enforcement now drives
  `XML_TOOLS_CONSTRAINABLE` (enum + `%json` scalars + call frame, no free-form
  string). Three tests that drove string VALUES through the grammar are
  superseded by the opt-out test; the property they protected (a value is never
  truncated) is now held by not constraining it. Controls that incidentally used
  a string property moved to an integer so each tests what it names.
- Grammar + tool suites green: `test_qwen3coder_xml_grammar_558`,
  `test_gemma4_grammar_558`, `test_deepseek_v3_grammar_558`, `test_tool_parsers`,
  `test_tool_calling`, `test_qwen3coder_tool_parser_streaming` — 446 passed.
- **Live re-verification** on `qwen3.6-35b-8bit` after the change: `Tokyo` /
  `Osaka` and the 710-byte file now match the unconstrained control exactly.
- Full local functional sweep against the fixed server: 20/20 (streaming,
  reasoning, tools + round-trip + streaming tools, json_schema, json_object,
  `/v1/completions`, Anthropic `/v1/messages`, metrics, error handling, prefix
  cache, 8-way concurrency).
- `ruff check` + `ruff format --check` clean.

## Checklist

- [x] Tests pass locally
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] New tests verified to FAIL without the fix (mutation)
- [x] Verified end-to-end on real hardware with a real model
- [x] No breaking changes to existing API