### PR TITLE
test(mac): stabilize release GUI golden gates

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -83,6 +83,10 @@ AXApplication title="Rapid-MLX"
             AXRadioButton desc="TurboQuant V4" value=bool:false enabled=true
             AXRadioButton desc="TurboQuant K8V4" value=bool:false enabled=true
           AXStaticText value=text enabled=true
+          AXHeading desc="Speculative decoding, Drafts candidate tokens and verifies them with the full model." enabled=true
+          AXStaticText value=text enabled=false
+          AXCheckBox subrole=AXSwitch id="Settings.Performance.SpeculativeDecoding.Enabled" value=bool:false enabled=false
+          AXStaticText value=text enabled=true
           AXHeading desc="Prefix cache, Reuses computation for a prompt prefix the model has already seen. Speeds up multi-turn chat and repeated system prompts." enabled=true
           AXGroup id="Settings.Performance.PrefixCache" desc="Prefix cache" enabled=true
             AXButton id="Settings.Performance.Prefix.Default" desc="Engine default" enabled=true

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1213,7 +1213,14 @@ flow_download_progress() {
     press "$OUT/chooser.json" Quickstart.Footer.Primary "$OUT/review-open.json"
     wait_identifier Quickstart.Review.Alias "$OUT/review.json"
     assert_tree_text "$OUT/review.json" "Download & start"
-    press "$OUT/review.json" Quickstart.Footer.Primary "$OUT/download-start.json"
+    # AXPress is normally immediate, but AppKit can synchronously hold the
+    # accessibility action until the pull task yields.  In the full suite the
+    # fake pull can therefore finish before a synchronous `press` returns,
+    # making the harness miss the exact in-flight state it exists to verify.
+    # Drive the action concurrently with observation, then still require the
+    # action itself to have succeeded.
+    press "$OUT/review.json" Quickstart.Footer.Primary "$OUT/download-start.json" &
+    local press_pid=$!
 
     local observed=0
     for _ in {1..40}; do
@@ -1225,6 +1232,8 @@ flow_download_progress() {
         fi
         sleep 0.1
     done
+    wait "$press_pid" \
+        || die "AXPress failed while starting the download-progress fixture"
     [[ "$observed" == 1 ]] \
         || die "overrun fixture never reached a truthful bytes-downloaded state"
     if jq -e '(.data.ui_elements | tostring)


### PR DESCRIPTION
## What changed

- refresh the Settings persistence AX baseline for the speculative-decoding control added by #1987
- observe the download-progress UI concurrently with AXPress, because AppKit can hold the accessibility action until the fake pull finishes
- still wait for and validate the AX action result

## Why

Release dogfood on an 18 GB M3 Pro found two reproducible failures on current main: a stale intended baseline and a full-suite-only race where synchronous AXPress returned after the in-flight progress state had disappeared. The product pull did run; the harness started observing too late.

## Validation

- `make smoke`: 17,469 passed, 121 skipped, 6 xfailed
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `gui-golden-flows.sh --flow settings-persistence`
- `gui-golden-flows.sh --flow all`
- real main server + GUI dogfood with cached LFM2.5-1.2B on an 18 GB M3 Pro