### PR TITLE
fix(mac): preserve cached state for curated quickstart models

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1700,10 +1700,15 @@ struct QuickstartView: View {
                         shortlistHeading("OR PICK A BIGGER ONE")
                         VStack(spacing: 9) {
                             ForEach(list.tradeUps) { choice in
+                                let cached = Self.cachedModel(
+                                    alias: choice.alias,
+                                    cachedModels: cachedModels
+                                )
                                 QuickstartCompactCard(
                                     choice: choice,
                                     selected: coordinator.selection.alias == choice.alias,
-                                    sizeText: Self.sizeText(for: choice),
+                                    sizeText: cached?.sizeOnDisk ?? Self.sizeText(for: choice),
+                                    isCached: cached != nil,
                                     onActivate: { activatePrimary(in: .shortlist) }
                                 ) { coordinator.select(choice) }
                             }

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
@@ -69,4 +69,25 @@ struct QuickstartCachedModelTests {
         )
         #expect(resolved?.hfRepo == "local/actual-cached-repo")
     }
+
+    @Test("curated trade-up keeps cached provenance past the six-row display cap")
+    func cachedTradeUpPastDisplayCap() {
+        let rows = (0..<6).map { entry("cached-\($0)") } + [
+            entry("qwen3.5-4b-4bit")
+        ]
+        let shortlist = QuickstartView.shortlist(
+            catalog: rows,
+            selection: "qwen3.5-4b-4bit"
+        )
+
+        #expect(shortlist.cached.count == 6)
+        #expect(QuickstartView.cachedModel(
+            alias: "qwen3.5-4b-4bit",
+            cachedModels: rows
+        )?.sizeOnDisk == "2.9 GiB")
+        #expect(QuickstartView.canStartWithoutDownload(
+            alias: "qwen3.5-4b-4bit",
+            cachedModels: rows
+        ))
+    }
 }

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -899,6 +899,10 @@ def _emit_catalog(subcommand, alias):
             # fixture, but fresh-install must exercise the real default
             # selection contract rather than falling back to fake-alias.
             print("lfm2.5-1b-4bit        hermes           none")
+        if _setting("FAKE_CACHED_CURATED_TRADEUP") == "1":
+            for index in range(6):
+                print(f"a-cached-{index}             hermes           none")
+            print("qwen3.5-4b-4bit       hermes           qwen3")
         print("fake-alias             hermes           qwen3")
         print("fake-external-alias    hermes           qwen3")
         if _setting("FAKE_SETTINGS_MTP") == "1":
@@ -940,6 +944,10 @@ def _emit_catalog(subcommand, alias):
         if _setting("FAKE_SETTINGS_MTP") != "1":
             print(f"fake-alias             {FAKE_REPO}        1.2 GB")
             print("(external)             fake-external-alias     2.4 GB")
+        if _setting("FAKE_CACHED_CURATED_TRADEUP") == "1":
+            for index in range(6):
+                print(f"a-cached-{index}             fake-org/a-cached-{index}        100 MB")
+            print("qwen3.5-4b-4bit       mlx-community/Qwen3.5-4B-MLX-4bit  2.9 GB")
         if _setting("FAKE_SETTINGS_MTP") == "1":
             print("qwen3.8-27b-4bit       rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX  15.2 GB")
         # Cached, so the Images tab resolves to it without a download path —

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -36,7 +36,7 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, cached-quickstart, download-progress, settings-persistence, settings-mtp, chat-restore, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
+Flows: fresh-install, cached-quickstart, cached-curated-tradeup, download-progress, settings-persistence, settings-mtp, chat-restore, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, window-close-prompt, no-dead-controls, catalog-integrity,
@@ -99,7 +99,7 @@ flow_requires_screen_recording() {
 # unattended without taking on any of that.
 flow_requires_peekaboo() {
     case "$FLOW" in
-        cached-quickstart|download-progress|settings-persistence|settings-mtp|chat-restore|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|launch-integrations) return 1 ;;
+        cached-quickstart|cached-curated-tradeup|download-progress|settings-persistence|settings-mtp|chat-restore|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|launch-integrations) return 1 ;;
         slow-stream-stop|model-crash-recovery|chat-document-attachment|image-generation|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
         *) return 0 ;;
     esac
@@ -1193,6 +1193,33 @@ flow_cached_quickstart() {
     fi
     cleanup_persona
     cleanup_operator_server
+}
+
+flow_cached_curated_tradeup() {
+    log "cached curated trade-up keeps its on-disk state past the six-row cap"
+    start_persona cached-curated-tradeup FAKE_CACHED_CURATED_TRADEUP=1
+    see_main "$OUT/consent.json"
+    if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
+        "$OUT/consent.json" >/dev/null; then
+        press "$OUT/consent.json" TelemetryConsent.DontShare "$OUT/consent-dismiss.json"
+    fi
+
+    # Six alphabetically earlier cached rows consume the bounded "Already on
+    # this Mac" presentation. Qwen remains a native curated trade-up, so this
+    # pins the exact seam where cached provenance used to be discarded.
+    wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
+    press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
+    wait_identifier Quickstart.Choice.qwen3.5-4b-4bit "$OUT/chooser.json"
+    jq -e '.data.ui_elements[]?
+            | select(.identifier == "Quickstart.Choice.qwen3.5-4b-4bit")
+            | select((.description // "") | contains("on disk 2.9 GB"))
+            | select(((.description // "") | contains("download")) | not)' \
+        "$OUT/chooser.json" >/dev/null \
+        || die "cached curated trade-up still advertises a download"
+    press "$OUT/chooser.json" Quickstart.Choice.qwen3.5-4b-4bit "$OUT/select.json"
+    see_main "$OUT/selected.json"
+    assert_tree_text "$OUT/selected.json" "Start existing model"
+    cleanup_persona
 }
 
 flow_download_progress() {
@@ -3276,6 +3303,7 @@ require_tools
 case "$FLOW" in
     fresh-install) flow_fresh_install ;;
     cached-quickstart) flow_cached_quickstart ;;
+    cached-curated-tradeup) flow_cached_curated_tradeup ;;
     download-progress) flow_download_progress ;;
     settings-persistence) flow_settings_persistence ;;
     settings-mtp) flow_settings_mtp ;;
@@ -3300,6 +3328,7 @@ case "$FLOW" in
     all)
         flow_fresh_install
         flow_cached_quickstart
+        flow_cached_curated_tradeup
         flow_download_progress
         flow_settings_persistence
         flow_settings_mtp

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -91,6 +91,7 @@ def test_peekaboo_requirement_is_default_deny():
     peekaboo_free = {
         "chat-restore",
         "cached-quickstart",
+        "cached-curated-tradeup",
         "download-progress",
         "settings-persistence",
         "settings-mtp",


### PR DESCRIPTION
## What changed
- preserve cached catalog provenance when a curated trade-up falls beyond the six-row cached display cap
- show the real on-disk size and start-only copy instead of advertising a redundant download
- add focused Swift and GUI golden-flow regression coverage

## Root cause
The onboarding shortlist bounded the visible cached section to six rows, then rendered curated trade-ups only from static recommendation metadata. A cached curated model outside that presentation slice therefore lost its cached state even though the action path still knew it was available locally.

## User impact
Users with many cached models now see an honest `on disk` state and `Start existing model` action for curated models already present on the Mac.

## Validation
- `swift test --filter QuickstartCachedModelTests`
- `python -m pytest -q tests/test_gui_preflight_contract.py`
- `bash scripts/gui-golden-flows.sh --flow cached-curated-tradeup`
- `bash scripts/gui-golden-flows.sh --flow cached-quickstart`
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `bash -n apps/rapid-mac/scripts/fake-rapid-mlx.sh`

Why: cached provenance is runtime truth; losing it at a presentation-only row cap causes a redundant-download prompt that contradicts the actual start path.