### PR TITLE
fix(mtp): serve the MTP sidecar an alias already declares (#1998)

### DIFF
--- a/tests/test_mtp_alias_declared_sidecar_1998.py
+++ b/tests/test_mtp_alias_declared_sidecar_1998.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""An alias that declares MTP must actually serve MTP (#1998).
+
+``rapid-mlx models`` renders ``✓ MTP`` and ``MTP@<repo>@<k>`` for any alias
+carrying ``mtp_draft_model``. Until this fix those two fields were read by that
+renderer and by nothing else, so the command the listing implies —
+
+    rapid-mlx serve qwen3.8-27b-mixed-3.5bpw --speculative-config '{"method":"mtp"}'
+
+— reached the injector with ``sidecar=None`` and hard-failed at boot, suggesting
+an unrelated model (``mlx-community/Qwen3.5-9B-MTP-4bit``) in the remedy. The
+declared depth was ignored too: the alias says 3, the controller ran ``max_k=1``.
+
+The fail-closed boot is correct and stays. What changes is that the serve path
+now reads the declaration the registry already advertises.
+
+Precedence is the substance of these tests: an explicit ``--speculative-config``
+must always win, and an alias with NO declaration must keep hard-failing rather
+than silently acquiring a sidecar.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+# Real registry entries: one that declares MTP, one that does not. Using the
+# real aliases (not fixtures) is deliberate — the bug was precisely that the
+# registry and the serve path disagreed, so the test has to read the registry.
+ALIAS_WITH_MTP = "qwen3.8-27b-mixed-3.5bpw"
+ALIAS_WITHOUT_MTP = "qwen3.6-35b-8bit"
+
+
+def _args(**overrides):
+    data = {
+        "model": None,
+        "speculative_config": None,
+        "enable_ddtree": False,
+        "enable_dflash": False,
+        "spec_decode": "none",
+        "dflash_drafter_path": "",
+        "mtp_num_draft_tokens": 1,
+        "mtp_optimistic": False,
+        "mtp_sidecar": None,
+        "mtp_max_k": None,
+        "mtp_disable_auto_k": False,
+        "force_spec_decode": False,
+        "suffix_decoding": False,
+        "suffix_max_draft": None,
+        "suffix_max_suffix_len": None,
+        "suffix_min_confidence": None,
+        "suffix_min_draft_len": None,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def _normalize(args):
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    _normalize_speculative_config_or_exit(args)
+    return args
+
+
+# --------------------------------------------------------------------- registry
+def test_registry_precondition_the_alias_still_declares_mtp():
+    """If this fails, the rest of the file is testing nothing."""
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile(ALIAS_WITH_MTP)
+    assert profile is not None
+    assert profile.mtp_draft_model, (
+        f"{ALIAS_WITH_MTP} no longer declares mtp_draft_model — update this test "
+        "to another declaring alias, or the #1998 wiring is now untested"
+    )
+    assert profile.mtp_speculative_tokens == 3
+
+    other = resolve_profile(ALIAS_WITHOUT_MTP)
+    assert other is not None
+    assert not other.mtp_draft_model
+
+
+# ------------------------------------------------------------------ the fix
+def test_alias_declaration_supplies_the_sidecar_and_depth():
+    from vllm_mlx.model_aliases import resolve_profile
+
+    declared = resolve_profile(ALIAS_WITH_MTP)
+    args = _normalize(
+        _args(model=ALIAS_WITH_MTP, speculative_config='{"method":"mtp"}')
+    )
+    assert args.spec_decode == "mtp"
+    assert args.mtp_sidecar == declared.mtp_draft_model
+    assert args.mtp_max_k == declared.mtp_speculative_tokens
+
+
+def test_alias_without_a_declaration_still_gets_no_sidecar():
+    """The injector's hard-fail must stay reachable — no silent acquisition."""
+    args = _normalize(
+        _args(model=ALIAS_WITHOUT_MTP, speculative_config='{"method":"mtp"}')
+    )
+    assert args.spec_decode == "mtp"
+    assert args.mtp_sidecar is None
+
+
+def test_unknown_model_is_left_alone():
+    args = _normalize(
+        _args(
+            model="not-a-real-org/not-a-real-model",
+            speculative_config='{"method":"mtp"}',
+        )
+    )
+    assert args.mtp_sidecar is None
+
+
+# --------------------------------------------------------------- precedence
+def test_explicit_model_beats_the_alias_declaration():
+    args = _normalize(
+        _args(
+            model=ALIAS_WITH_MTP,
+            speculative_config='{"method":"mtp","model":"org/explicit-sidecar"}',
+        )
+    )
+    assert args.mtp_sidecar == "org/explicit-sidecar"
+
+
+def test_explicit_depth_beats_the_alias_declaration():
+    args = _normalize(
+        _args(
+            model=ALIAS_WITH_MTP,
+            speculative_config='{"method":"mtp","num_speculative_tokens":7}',
+        )
+    )
+    assert args.mtp_max_k == 7
+    # …while the sidecar still comes from the alias: the two fill independently.
+    assert args.mtp_sidecar
+
+
+def test_alias_depth_beats_the_generic_force_spec_decode_default(monkeypatch):
+    """--force-spec-decode's K=3 is a generic fallback; the alias is specific.
+
+    The declared depth is forced to 5 here ON PURPOSE. The real alias declares
+    3, which is also the force-fallback value, so asserting against the real
+    registry would pass whether or not the alias is consulted at all — the
+    mutation run proved exactly that. 5 makes the two sources distinguishable.
+    """
+    import vllm_mlx.model_aliases as aliases
+
+    real = aliases.resolve_profile(ALIAS_WITH_MTP)
+    monkeypatch.setattr(
+        aliases,
+        "resolve_profile",
+        lambda _n: SimpleNamespace(
+            mtp_draft_model=real.mtp_draft_model, mtp_speculative_tokens=5
+        ),
+    )
+    args = _normalize(
+        _args(
+            model=ALIAS_WITH_MTP,
+            speculative_config='{"method":"mtp"}',
+            force_spec_decode=True,
+        )
+    )
+    assert args.mtp_max_k == 5
+
+
+def test_force_spec_decode_fallback_survives_for_undeclared_aliases():
+    args = _normalize(
+        _args(
+            model=ALIAS_WITHOUT_MTP,
+            speculative_config='{"method":"mtp"}',
+            force_spec_decode=True,
+        )
+    )
+    assert args.mtp_max_k == 3
+    assert args.mtp_sidecar is None
+
+
+# ------------------------------------------------------------- helper totality
+@pytest.mark.parametrize("model", [None, "", "org/unknown-model"])
+def test_declaration_lookup_is_total(model):
+    from vllm_mlx.cli import _alias_mtp_declaration
+
+    assert _alias_mtp_declaration(model) == (None, None)
+
+
+def test_declaration_lookup_never_raises_when_the_registry_is_broken(monkeypatch):
+    """A registry failure must degrade to "no default", not crash the serve."""
+    import vllm_mlx.model_aliases as aliases
+    from vllm_mlx.cli import _alias_mtp_declaration
+
+    def _boom(_name):
+        raise RuntimeError("registry unreadable")
+
+    monkeypatch.setattr(aliases, "resolve_profile", _boom)
+    assert _alias_mtp_declaration(ALIAS_WITH_MTP) == (None, None)
+
+
+def test_depth_without_a_sidecar_yields_neither(monkeypatch):
+    """A hand-edited registry could carry a depth alone; it is meaningless."""
+    import vllm_mlx.model_aliases as aliases
+    from vllm_mlx.cli import _alias_mtp_declaration
+
+    monkeypatch.setattr(
+        aliases,
+        "resolve_profile",
+        lambda _n: SimpleNamespace(mtp_draft_model=None, mtp_speculative_tokens=5),
+    )
+    assert _alias_mtp_declaration(ALIAS_WITH_MTP) == (None, None)
+
+
+# ------------------------------------------------------------------- labelling
+def test_info_reports_the_sidecar_lane_instead_of_disabled():
+    """`MTP path: disabled` was wrong for a model that decodes with MTP."""
+    from vllm_mlx.model_aliases import resolve_profile
+    from vllm_mlx.model_auto_config import _mtp_path_label
+
+    declaring = resolve_profile(ALIAS_WITH_MTP)
+    label = _mtp_path_label(declaring.hf_path, declaring)
+    assert "sidecar" in label and "--speculative-config" in label
+
+    plain = resolve_profile(ALIAS_WITHOUT_MTP)
+    assert _mtp_path_label(plain.hf_path, plain) == "disabled"

--- a/tests/test_mtp_alias_declared_sidecar_1998.py
+++ b/tests/test_mtp_alias_declared_sidecar_1998.py
@@ -194,6 +194,20 @@ def test_declaration_lookup_never_raises_when_the_registry_is_broken(monkeypatch
     assert _alias_mtp_declaration(ALIAS_WITH_MTP) == (None, None)
 
 
+@pytest.mark.parametrize("bad", [7, ["org/repo"], {"a": 1}, object()])
+def test_a_non_string_sidecar_does_not_raise(monkeypatch, bad):
+    """Totality has to survive the value being the wrong TYPE, not just absent."""
+    import vllm_mlx.model_aliases as aliases
+    from vllm_mlx.cli import _alias_mtp_declaration
+
+    monkeypatch.setattr(
+        aliases,
+        "resolve_profile",
+        lambda _n: SimpleNamespace(mtp_draft_model=bad, mtp_speculative_tokens=3),
+    )
+    assert _alias_mtp_declaration(ALIAS_WITH_MTP) == (None, None)
+
+
 def test_depth_without_a_sidecar_yields_neither(monkeypatch):
     """A hand-edited registry could carry a depth alone; it is meaningless."""
     import vllm_mlx.model_aliases as aliases

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1918,7 +1918,12 @@ def _alias_mtp_declaration(model_name) -> tuple[str | None, int | None]:
         return None, None
     if profile is None:
         return None, None
-    sidecar = (getattr(profile, "mtp_draft_model", None) or "").strip() or None
+    # Type-check BEFORE ``.strip()``: the value reaches us straight off a
+    # profile object, and a non-str there would raise ``AttributeError`` out of
+    # this helper — breaking the totality the docstring promises, in the exact
+    # hand-edited-registry case it promises it for (codex nit).
+    raw_sidecar = getattr(profile, "mtp_draft_model", None)
+    sidecar = raw_sidecar.strip() or None if isinstance(raw_sidecar, str) else None
     if sidecar is None:
         # Depth without a sidecar is meaningless — the injector has nothing to
         # load — so don't hand back a lone K either.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1893,6 +1893,42 @@ def _build_benchmark_context(target_tokens: int) -> str:
     return (block * repeats).strip()
 
 
+def _alias_mtp_declaration(model_name) -> tuple[str | None, int | None]:
+    """Return ``(mtp_draft_model, mtp_speculative_tokens)`` declared by an alias.
+
+    ``(None, None)`` when the model is not a known alias, declares no MTP
+    sidecar, or the registry cannot be read. Resolution is best-effort by
+    design: this only supplies DEFAULTS for a request that already asked for
+    MTP, so a registry problem must degrade to "no default" and let the
+    injector's own hard-fail speak — never turn a serve into a crash of its
+    own (#1998).
+
+    ``mtp_speculative_tokens`` is returned only when it is a positive int. The
+    alias schema already rejects the alternatives (``model_aliases`` requires
+    ``mtp_draft_model`` alongside it), so this is belt-and-braces against a
+    hand-edited registry rather than a live shape.
+    """
+    if not model_name:
+        return None, None
+    try:
+        from .model_aliases import resolve_profile as _resolve_alias
+
+        profile = _resolve_alias(model_name)
+    except Exception:  # noqa: BLE001 — see docstring: never fail the serve here
+        return None, None
+    if profile is None:
+        return None, None
+    sidecar = (getattr(profile, "mtp_draft_model", None) or "").strip() or None
+    if sidecar is None:
+        # Depth without a sidecar is meaningless — the injector has nothing to
+        # load — so don't hand back a lone K either.
+        return None, None
+    depth = getattr(profile, "mtp_speculative_tokens", None)
+    if not isinstance(depth, int) or isinstance(depth, bool) or depth <= 0:
+        depth = None
+    return sidecar, depth
+
+
 def _normalize_speculative_config_or_exit(args):
     """Parse ``--speculative-config`` and map methods to runtime fields."""
     import json
@@ -2201,9 +2237,23 @@ def _normalize_speculative_config_or_exit(args):
                 args.mtp_num_draft_tokens = config.num_speculative_tokens
             if legacy_mtp_optimistic_requested:
                 args.mtp_optimistic = True
-        args.mtp_sidecar = config.model
+        # #1998: an alias may DECLARE its own MTP sidecar and draft depth
+        # (``mtp_draft_model`` / ``mtp_speculative_tokens``). Those were
+        # rendered by ``rapid-mlx models`` as ``✓ MTP  MTP@<repo>@<k>`` and
+        # then read NOWHERE on the serve path, so the command that listing
+        # implies — ``serve <alias> --speculative-config '{"method":"mtp"}'``
+        # — reached the injector with ``sidecar=None`` and hard-failed at
+        # boot, quoting an unrelated model in the remedy. Fill ONLY what the
+        # request left unset; an explicit ``model`` /
+        # ``num_speculative_tokens`` in the JSON always wins.
+        alias_sidecar, alias_k = _alias_mtp_declaration(getattr(args, "model", None))
+        args.mtp_sidecar = config.model or alias_sidecar
         if config.num_speculative_tokens is not None:
             args.mtp_max_k = config.num_speculative_tokens
+        elif alias_k is not None:
+            # A depth the alias declares for THIS checkpoint beats the generic
+            # --force-spec-decode fallback below: it is the more specific fact.
+            args.mtp_max_k = alias_k
         elif getattr(args, "force_spec_decode", False):
             # User explicitly opted into spec-decode via --force-spec-decode
             # but didn't pin a draft depth. K=1 chain-of-1 carries draft

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2164,6 +2164,16 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
     Derivation is from the resolved profile only (no ``config.json``
     read), keeping the ``rapid-mlx info`` path weight-free.
     """
+    if (getattr(cfg, "mtp_draft_model", None) or "").strip():
+        # #1998: the alias DECLARES its own MTP sidecar, and that declaration
+        # now drives the serve path, so MTP genuinely runs for this checkpoint
+        # — including on a hybrid one, where ``supports_spec_decode`` is False.
+        # That flag gates the STANDARD spec-decode lane (hybrids cannot use
+        # it); the MTP sidecar lane is separate and was verified end-to-end on
+        # Qwen3.8-27B. Checked BEFORE the flag, because reporting "disabled"
+        # for a model that decodes with MTP is exactly the registry-vs-reality
+        # mismatch #1998 was about. Names the opt-in, mirroring the DFlash row.
+        return "sidecar (opt-in: --speculative-config)"
     if not cfg.supports_spec_decode:
         # Honest: the profile has spec decode gated off (hybrid arch, or
         # no MTP head/drafter registered for this alias). Even for a


### PR DESCRIPTION
## What does this PR do?

Fixes #1998. `rapid-mlx models` renders `✓ MTP` and `MTP@<repo>@<k>` for any
alias carrying `mtp_draft_model`. Those two fields were read by that renderer
and by **nothing else**, so the command the listing implies hard-failed:

```console
$ rapid-mlx serve qwen3.8-27b-mixed-3.5bpw --speculative-config '{"method":"mtp"}'
[MTP-vendored] dispatch_mtp_inject returned False ... sidecar=None
RuntimeError: MTP speculative-config was set but the family MTP injector rejected the model.
```

…while typing back the repo the alias already names worked fine. The declared
depth was ignored on that working path too: the alias says `3`, the controller
ran `max_k=1`.

The serve path now reads the declaration, filling **only what the request left
unset**:

```console
$ rapid-mlx serve qwen3.8-27b-mixed-3.5bpw --speculative-config '{"method":"mtp"}'
MTP: enabled via --speculative-config, max_k=3
Spec-decode: mtp (chain) +sidecar=rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX
[mtp.inject] Loaded 15/15 expected MTP weight tensors from model.safetensors
```

## Precedence

| source | wins over |
|---|---|
| explicit `model` in `--speculative-config` | alias `mtp_draft_model` |
| explicit `num_speculative_tokens` | alias `mtp_speculative_tokens` |
| alias `mtp_speculative_tokens` | `--force-spec-decode`'s generic K=3 |

The last row is a judgement call worth stating: a depth declared for *this
checkpoint* is more specific than a global fallback.

An alias with **no** declaration is untouched — the injector's hard-fail stays
reachable rather than being papered over by a guessed sidecar. That fail-closed
boot was correct behaviour and is not what this PR changes.

The lookup is best-effort by construction: it only supplies defaults to a request
that already asked for MTP, so an unreadable registry degrades to "no default"
and lets the injector's own error speak, instead of crashing a serve on its own.

## `rapid-mlx info` said `MTP path: disabled`

For the same aliases — because that label gates on `supports_spec_decode`, which
is `False` for a hybrid. But that flag governs the **standard** spec-decode lane;
the MTP **sidecar** lane is separate and runs fine on a hybrid (verified on
Qwen3.8-27B). Reporting `disabled` for a model that demonstrably decodes with MTP
is the same registry-vs-reality mismatch, so the row now names the opt-in, in the
style the DFlash row already uses:

```
│ MTP path         : sidecar (opt-in: --speculative-config)    │
```

A model with no declaration still reports `disabled`.

## Why is this needed?

MTP is the headline feature of this release window, and it failed on the path the
product's own model listing implies, with an error naming the wrong model.

## Test plan

- New `tests/test_mtp_alias_declared_sidecar_1998.py` (14 tests): the fill,
  both precedence directions, the undeclared-alias non-regression, the
  force-fallback interaction, helper totality (`None` / `""` / unknown model /
  raising registry / depth-without-sidecar), and the info label both ways.
- **Mutation-checked**, three ways — removing the sidecar fallback, ignoring the
  alias depth, and reverting the info label each turn the suite red.
  One test was **weak on the first pass and the mutation run caught it**: the
  real alias declares 3 and the force fallback is also 3, so the assertion held
  whether or not the alias was consulted. It now pins a declared depth of 5.
- Related suites green: `test_speculative_config`, `test_mtp_cli_wiring`,
  `test_mtp_spec_decode`, `test_ddtree_integration`, `test_dflash_integration`,
  `test_model_aliases`, `test_bench_spec_decode_mtp_gates` — 400 passed.
- **Live on an M3 Ultra**: the previously-failing command boots, takes sidecar
  and `max_k=3` from the alias, loads 15/15 MTP tensors, and answers correctly
  (`Tokyo`; a valid `reverse_string`; 1–20 counted).
- `ruff check` + `ruff format --check` clean.

## Checklist

- [x] Tests pass locally
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] New tests verified to FAIL without the fix (mutation, 3 variants)
- [x] Verified end-to-end on real hardware with a real model
- [x] No breaking changes to existing API