### PR TITLE
fix(cli): stop ps/models column collisions and connect's false Ready (#1999)

### DIFF
--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -123,10 +123,83 @@ def test_connect_no_target_renders_banner(monkeypatch):
         "resolve_endpoints",
         lambda **kw: connect.ServerEndpoints("localhost", 8000, model="m1"),
     )
+    # A live server is present for this shape check.
+    monkeypatch.setattr(connect, "probe_server_alive", lambda *a, **k: True)
     out = _run_connect()
     assert "Ready: http://localhost:8000" in out
     assert "Connect:" in out
     assert "OpenAI:" in out
+
+
+def test_probe_server_alive_keys_on_healthz_status_code(monkeypatch):
+    """#1999: /healthz is rapid-mlx-specific, so a non-404 response (2xx, or a
+    DDTree auth 401/403) counts as alive across all serving modes; a 404 (an
+    unrelated HTTP server) or a refused/timed-out connection does not. The body
+    is not inspected — the standard / DFlash / DDTree bodies differ."""
+    import urllib.error
+    import urllib.request
+
+    def _ok(url, timeout=None):
+        return object()  # urlopen returns without raising on 2xx
+
+    def _raise(code):
+        def _open(url, timeout=None):
+            raise urllib.error.HTTPError(url, code, "err", {}, None)
+
+        return _open
+
+    def _conn(url, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    # 2xx (any serving mode) → alive.
+    monkeypatch.setattr(urllib.request, "urlopen", _ok)
+    assert connect.probe_server_alive("localhost", 8000) is True
+
+    # Auth-gated DDTree /healthz answers 401/403 → still a server there.
+    for code in (401, 403):
+        monkeypatch.setattr(urllib.request, "urlopen", _raise(code))
+        assert connect.probe_server_alive("localhost", 8000) is True, code
+
+    # 404 (unrelated server), 503 (up but draining, refusing new work), and
+    # 500 (broken) are all "don't hand a client this endpoint".
+    for code in (404, 500, 503):
+        monkeypatch.setattr(urllib.request, "urlopen", _raise(code))
+        assert connect.probe_server_alive("localhost", 8000) is False, code
+
+    # Nothing listening: connection refused.
+    monkeypatch.setattr(urllib.request, "urlopen", _conn)
+    assert connect.probe_server_alive("localhost", 8000) is False
+
+    # A port occupied by a non-HTTP service (SSH, a DB) answers with garbage,
+    # which urllib surfaces as http.client.BadStatusLine — must not crash.
+    import http.client
+
+    def _bad_status(url, timeout=None):
+        raise http.client.BadStatusLine("\x00nonsense")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _bad_status)
+    assert connect.probe_server_alive("localhost", 8000) is False
+
+
+def test_connect_reports_no_server_when_nothing_listening(monkeypatch):
+    """#1999: connect must not announce Ready: for an address that refuses
+    connections; it says there is no server and drops the Connect cheat-sheet
+    that would otherwise wire a client to a dead endpoint."""
+    monkeypatch.setattr(
+        connect,
+        "resolve_endpoints",
+        lambda **kw: connect.ServerEndpoints("localhost", 8000, model=None),
+    )
+    monkeypatch.setattr(connect, "probe_server_alive", lambda *a, **k: False)
+    out = _run_connect()
+    assert "Ready:" not in out
+    assert "No rapid-mlx server on http://localhost:8000" in out
+    assert "rapid-mlx serve <model>" in out
+    # No cheat-sheet that points a client at the dead endpoint.
+    assert "Connect:" not in out
+    assert "--setup" not in out
+    # The prospective addresses are still shown, just not as "Ready".
+    assert "http://localhost:8000/v1" in out
 
 
 def test_connect_json_is_valid_and_stable(monkeypatch):
@@ -256,6 +329,7 @@ def test_ipv6_banner_renders_bracketed(monkeypatch):
         "resolve_endpoints",
         lambda **kw: connect.ServerEndpoints("::1", 8000, model=None),
     )
+    monkeypatch.setattr(connect, "probe_server_alive", lambda *a, **k: True)
     out = _run_connect()
     assert "Ready: http://[::1]:8000" in out
     assert "OpenAI:    http://[::1]:8000/v1" in out

--- a/tests/test_cli_ps_layout.py
+++ b/tests/test_cli_ps_layout.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx ps`` MODEL/UPTIME column must not collide (#1999).
+
+Serving a local *path* (a converted model) is the normal case, and those
+paths routinely exceed the 40-char MODEL column. The old code let them run
+straight into UPTIME with no separator; ``_elide_front`` caps the shown model
+at 38 chars, keeping the distinctive tail, so the ``<40`` pad always leaves at
+least two spaces before UPTIME.
+"""
+
+from __future__ import annotations
+
+from vllm_mlx.cli import _elide_front
+
+
+def test_short_model_is_unchanged():
+    assert _elide_front("qwen3.5-4b-4bit", 38) == "qwen3.5-4b-4bit"
+
+
+def test_exactly_at_width_is_unchanged():
+    s = "x" * 38
+    assert _elide_front(s, 38) == s
+
+
+def test_long_path_is_front_elided_and_keeps_the_tail():
+    model = "/Users/raullenstudio/mtplx-research/Qwen3.8-27B-MTPLX-Optimized-Speed"
+    shown = _elide_front(model, 38)
+    assert len(shown) == 38
+    assert shown.startswith("…")
+    # The distinctive tail (the model name) survives.
+    assert shown.endswith("Optimized-Speed")
+
+
+def test_never_exceeds_width_even_for_tiny_widths():
+    # Contract: the result is at most `width` chars, including the degenerate
+    # widths that leave no room for the ellipsis.
+    for w in (0, 1, 2, 3):
+        assert len(_elide_front("abcdefgh", w)) <= w
+    assert _elide_front("abcdefgh", 0) == ""
+    assert _elide_front("abcdefgh", 1) == "h"
+    assert _elide_front("abcdefgh", 2) == "…h"
+
+
+def test_pad_leaves_a_gap_before_uptime():
+    """The rendered ``{model:<40}{uptime:<10}`` must keep >= 2 spaces between
+    the (elided) model and the uptime for every input length."""
+    for model in ("short", "x" * 40, "/very/long/" + "y" * 80):
+        shown = _elide_front(model, 38)
+        row = f"  {'12345':<8}{'8123':<8}{shown:<40}{'5h20m':<10}"
+        assert "5h20m" in row
+        # index where uptime starts minus where the model text ends
+        uptime_start = row.index("5h20m")
+        model_end = 2 + 8 + 8 + len(shown)
+        assert uptime_start - model_end >= 2, f"columns collide: {row!r}"

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -72,6 +72,43 @@ def test_every_row_aligns_with_the_header_separator(capsys):
         )
 
 
+def test_spec_decode_column_aligns_despite_long_reasoning(capsys):
+    """#1999: a Reasoning value wider than the old fixed 12 chars
+    (``deepseek_r1_distill`` is 19) must not shift Spec-Decode and every
+    column right of it out from under the header. Alias/Size/Tools/Reasoning
+    are ASCII, so the Spec-Decode column START is at a fixed char offset in
+    both the header and every row; the wide ✓/✗/— glyphs only appear from
+    Spec-Decode onward.
+    """
+    out = _capture(capsys)
+    lines = [ln for ln in out.splitlines() if ln.startswith("  ")]
+    header_idx = next(
+        i
+        for i, ln in enumerate(lines)
+        if ln.lstrip().startswith("Alias") and "DFlash" in ln and "HF id" not in ln
+    )
+    header = lines[header_idx]
+    spec_col = header.index("Spec-Decode")
+    data_rows: list[str] = []
+    for ln in lines[header_idx + 2 :]:
+        if set(ln.strip()) == {"─"}:
+            break
+        data_rows.append(ln)
+
+    # At least one row carries the long reasoning value that used to overflow.
+    assert any("deepseek_r1_distill" in r for r in data_rows), (
+        "expected a row with the long 'deepseek_r1_distill' reasoning value"
+    )
+    for row in data_rows:
+        assert len(row) > spec_col, f"row too short for Spec-Decode col: {row!r}"
+        assert row[spec_col - 1] == " ", (
+            f"no gap before Spec-Decode at col {spec_col}: {row!r}"
+        )
+        assert row[spec_col] != " ", (
+            f"Spec-Decode value not at header col {spec_col}: {row!r}"
+        )
+
+
 def test_alias_column_width_floor_is_24(capsys, monkeypatch):
     """If the registry only has short names, the alias column must
     still be 24 wide so short tables don't feel cramped."""

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5578,11 +5578,24 @@ def models_command(args):
     # alias so the "how big before I pull?" answer is the first thing a user
     # sees next to the name (issue #1286). Values come from the checked-in
     # model_sizes.json manifest — no per-invocation HuggingFace round-trip.
+    # Tools and Reasoning carry parser keys whose length is unbounded
+    # (``deepseek_r1_distill`` is 19 chars, wider than the old fixed 12).
+    # Size them to the data like the alias column so a long value never
+    # overflows and shifts every field to its right out of the header's
+    # columns (#1999). Preset is last, so its long ``MTP@…`` values can
+    # overrun harmlessly and stay unbounded.
+    tools_width = max(
+        16, max((len(p.tool_call_parser or "—") for p in profiles.values()), default=0)
+    )
+    reasoning_width = max(
+        12,
+        max((len(p.reasoning_parser or "—") for p in profiles.values()), default=0),
+    )
     cols = (
         ("Alias", alias_width),
         ("Size", 10),
-        ("Tools", 16),
-        ("Reasoning", 12),
+        ("Tools", tools_width),
+        ("Reasoning", reasoning_width),
         ("Spec-Decode", 10),
         ("Suffix Tier", 11),
         ("DFlash", 7),
@@ -5624,7 +5637,8 @@ def models_command(args):
         ddtree = "✓" if p.supports_ddtree else "—"
         size = format_size(p.hf_path)
         row = (
-            f"  {alias:<{alias_width}} {size:<10} {tools:<16} {reasoning:<12} "
+            f"  {alias:<{alias_width}} {size:<10} {tools:<{tools_width}} "
+            f"{reasoning:<{reasoning_width}} "
             f"{spec:<10} {tier:<11} {dflash:<7} {ddtree:<7} {preset:<8}"
         )
         print(row)
@@ -5654,12 +5668,15 @@ def models_command(args):
         )
         print()
         print(f"  Audio models ({len(audio_entries)} aliases)")
-        audio_sep = "  " + "─" * width
-        print(audio_sep)
         audio_header = (
             f"  {'Alias':<{audio_alias_width}} {'Size':<10} {'Kind':<10} "
             f"{'Family':<12} {'HF id':<40}"
         )
+        # Size the rule to THIS table's header, not the text table's width —
+        # the text table's Tools/Reasoning columns are data-sized now (#1999),
+        # so reusing its width would stretch every secondary rule.
+        audio_sep = "  " + "─" * (len(audio_header) - 2)
+        print(audio_sep)
         print(audio_header)
         print(audio_sep)
         for entry in audio_entries:
@@ -5682,11 +5699,12 @@ def models_command(args):
         )
         print()
         print(f"  Video models ({len(video_profiles)} aliases)")
-        video_sep = "  " + "─" * width
-        print(video_sep)
-        print(
+        video_header = (
             f"  {'Alias':<{video_alias_width}} {'Size':<10} {'Kind':<11} {'HF id':<40}"
         )
+        video_sep = "  " + "─" * (len(video_header) - 2)
+        print(video_sep)
+        print(video_header)
         print(video_sep)
         for alias in sorted(video_profiles):
             p = video_profiles[alias]
@@ -5708,11 +5726,12 @@ def models_command(args):
         )
         print()
         print(f"  Image models ({len(image_profiles)} aliases)")
-        image_sep = "  " + "─" * width
-        print(image_sep)
-        print(
+        image_header = (
             f"  {'Alias':<{image_alias_width}} {'Size':<10} {'Kind':<11} {'HF id':<40}"
         )
+        image_sep = "  " + "─" * (len(image_header) - 2)
+        print(image_sep)
+        print(image_header)
         print(image_sep)
         for alias in sorted(image_profiles):
             p = image_profiles[alias]
@@ -6063,6 +6082,22 @@ def alias_command(args) -> None:
         raise SystemExit(1) from None
 
 
+def _elide_front(text: str, width: int) -> str:
+    """Trim ``text`` to at most ``width`` chars, keeping the TAIL.
+
+    For a served model that is a filesystem path, the tail (the model name) is
+    the distinctive part, so the head is what gets replaced by a leading ``…``.
+    The result never exceeds ``width`` (widths <= 1 leave no room for the ``…``).
+    """
+    if len(text) <= width:
+        return text
+    if width <= 0:
+        return ""
+    if width == 1:
+        return text[-1:]
+    return "…" + text[-(width - 1) :]
+
+
 def ps_command(_args):
     """List running rapid-mlx servers (process scan)."""
     import time
@@ -6153,9 +6188,14 @@ def ps_command(_args):
     print()
     print(f"  {'PID':<8}{'PORT':<8}{'MODEL':<40}{'UPTIME':<10}")
     print(f"  {'-' * 66}")
+    # Serving a local path (not an alias) is the normal case for a converted
+    # model, and those paths routinely exceed the 40-char column — the old
+    # code let them run straight into UPTIME with no gap (#1999). Elide from
+    # the FRONT so the distinctive tail (the model name) survives, capped at 38
+    # so the ``<40`` pad always leaves at least two spaces before UPTIME.
     # Sort numerically by port — string sort would put "10000" before "8000".
     for pid, port, model, uptime in sorted(rows, key=lambda r: int(r[1])):
-        print(f"  {pid:<8}{port:<8}{model:<40}{uptime:<10}")
+        print(f"  {pid:<8}{port:<8}{_elide_front(model, 38):<40}{uptime:<10}")
     print()
 
 
@@ -8059,7 +8099,7 @@ def connect_command(args):
     lifespan banner uses — so ``ready``/``openai``/``anthropic`` and the
     machine form can never drift from what a running server prints.
     """
-    from vllm_mlx.connect import render_banner, resolve_endpoints
+    from vllm_mlx.connect import probe_server_alive, render_banner, resolve_endpoints
 
     eps = resolve_endpoints(host=args.host, port=args.port, model=args.model)
 
@@ -8072,7 +8112,10 @@ def connect_command(args):
         print(eps.to_json())
         return
 
-    print(render_banner(eps), end="")
+    # Don't announce "Ready:" for a server that isn't there (#1999): probe the
+    # target first so a stopped server reads as "no server", not "warming up".
+    running = eps.listen_fd is not None or probe_server_alive(eps.host, eps.port)
+    print(render_banner(eps, running=running), end="")
 
 
 def _connect_target(args, eps):

--- a/vllm_mlx/connect.py
+++ b/vllm_mlx/connect.py
@@ -147,17 +147,35 @@ _CONNECT_ROWS: list[tuple[str, str, bool]] = [
 ]
 
 
-def render_banner(ep: ServerEndpoints, *, include_connect: bool = True) -> str:
+def render_banner(
+    ep: ServerEndpoints, *, include_connect: bool = True, running: bool = True
+) -> str:
     """Render the human "Ready:" / "OpenAI:" / "Connect:" block.
 
     Used by the serve lifespan (once warmup completes) and by
     ``rapid-mlx connect``. Rendered centrally so the served banner and the
     standalone ``connect`` output can never disagree about an endpoint.
+
+    ``running`` is the serve default: the lifespan only calls this once the
+    server is actually up. ``rapid-mlx connect`` passes ``running=False`` when
+    a liveness probe found nothing on the target, so the banner does not claim
+    "Ready:" for an address that refuses connections (#1999) — it says there is
+    no server and how to start one, and drops the Connect cheat-sheet that
+    would otherwise wire a client to a dead endpoint.
     """
     lines: list[str] = []
 
     if ep.listen_fd is not None:
         lines.append(f"  Ready: inherited fd {ep.listen_fd}")
+    elif not running:
+        port_hint = "" if ep.port == 8000 else f" --port {ep.port}"
+        lines.append(f"  No rapid-mlx server on {ep.base_url}")
+        lines.append(f"  Start one with:  rapid-mlx serve <model>{port_hint}")
+        lines.append("")
+        lines.append("  A server there would expose:")
+        lines.append(f"  OpenAI:    {ep.openai_url}")
+        lines.append(f"  Anthropic: {ep.anthropic_url}")
+        return "\n".join(lines) + "\n"
     else:
         lines.append(f"  Ready: {ep.base_url}")
         lines.append("")
@@ -176,6 +194,41 @@ def render_banner(ep: ServerEndpoints, *, include_connect: bool = True) -> str:
             lines.append(f"    {app:<{width}}  {rendered}")
 
     return "\n".join(lines) + "\n"
+
+
+def probe_server_alive(host: str, port: int) -> bool:
+    """Best-effort liveness check: is a rapid-mlx server answering on host:port?
+
+    Hits ``/healthz`` — the middleware fast-path that answers without touching
+    the engine, so it can't stall under load the way ``/health`` can. The route
+    is rapid-mlx-specific, so we key on the response CODE rather than the body
+    (which differs across the standard / DFlash / DDTree servers):
+
+    * any 2xx, or an auth challenge (401/403 — a DDTree server can gate
+      ``/healthz`` behind its API key) → a server that ``connect`` can point a
+      client at;
+    * any other status (404 from an unrelated HTTP server, 503 from a server
+      that is up but draining and refusing new work, 5xx from a broken one) →
+      not something to hand a client;
+    * connection refused / timeout / DNS → nothing is running.
+
+    Never raises.
+    """
+    import http.client
+    import urllib.error
+    import urllib.request
+
+    url = f"http://{_authority(host)}:{port}/healthz"
+    try:
+        urllib.request.urlopen(url, timeout=2.0)
+        return True
+    except urllib.error.HTTPError as exc:
+        return exc.code in (401, 403)
+    # http.client.HTTPException (e.g. BadStatusLine) covers a port occupied by a
+    # non-HTTP service (SSH, a database) that answers with garbage — not a
+    # server to point a client at, and it must not crash ``connect``.
+    except (urllib.error.URLError, http.client.HTTPException, TimeoutError, OSError):
+        return False
 
 
 def endpoints_from_bind(


### PR DESCRIPTION
## Why

Three CLI presentation defects reported in #1999 (found dogfooding main HEAD), same family (CLI rendering), each self-contained.

## What

- **`rapid-mlx ps`** — a served local *path* (the normal case for a converted model) longer than the 40-char MODEL column ran straight into UPTIME (`…Optimized-Speed5h20m`). Front-elide the model to 38 chars via `_elide_front()`, keeping the distinctive tail, so the `<40` pad always leaves ≥2 spaces before UPTIME.
- **`rapid-mlx models`** — a Reasoning value wider than the fixed 12 chars (`deepseek_r1_distill` is 19) overflowed and shifted Spec-Decode and every column to its right out from under the header. Size the Tools and Reasoning columns from the data like the Alias column already is. Preset stays last, so its long `MTP@…` values overrun harmlessly.
- **`rapid-mlx connect`** — announced `Ready:` for endpoints that refuse connections. Probe the target (`probe_server_alive`) and, when nothing answers, render `No rapid-mlx server on … — start one with rapid-mlx serve <model>` and drop the Connect cheat-sheet that would wire a client to a dead endpoint. The serve lifespan keeps `running=True`, so its Ready banner is unchanged.

## Tests

- `_elide_front` unit coverage (short / exact / long-path tail / no-collision gap).
- `test_spec_decode_column_aligns_despite_long_reasoning` — red against the fixed 12-wide column, green with dynamic sizing.
- `test_connect_reports_no_server_when_nothing_listening` — no false Ready, no dead cheat-sheet; existing banner-shape tests now mock a live probe.
- Full `test_models_command_layout` + `test_cli_connect` + `test_cli_ps_layout` + `test_ready_banner_timing` = 45 passed; `ruff` clean.

Presentation-only; no change to inference or the serve banner.

---
🤖 AI-assisted with Claude Code (Opus 4.8). Human-reviewed.