### PR TITLE
fix(gui-golden): press the audio buttons instead of a click that never landed

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3688,7 +3688,15 @@ flow_audio_readiness() {
                      and .text == "golden speech controls"' \
         "Generate Speech did not send the selected voice and text"
     wait_identifier Audio.Speech.Play "$OUT/speech-result.json"
-    "$AX_DRIVER" click-center "$APP_PID" Audio.Speech.Save \
+    # AXPress, not a synthesized mouse click. `click-center` (added with this
+    # flow) read the button's AX bounds, posted a CGEvent down/up pair at the
+    # centre, and returned success as soon as the EVENTS were created — it never
+    # observed whether the button fired. Measured on an M3 Ultra: the click
+    # reported `{"success": true}` and no WAV was ever written; the identical
+    # flow with AXPress wrote all 64,044 bytes. That is why the gate could merge
+    # red and still look like a product bug ("Save speech did not write the
+    # generated WAV") rather than a harness that never pressed anything.
+    "$AX_DRIVER" press "$APP_PID" Audio.Speech.Save \
         > "$OUT/speech-save-click.json" \
         || die "Save speech is not clickable"
     local speech_saved=0
@@ -3701,7 +3709,7 @@ flow_audio_readiness() {
     [[ "$speech_saved" == 1 ]] \
         || die "Save speech did not write the generated WAV"
     see_main "$OUT/speech-before-play.json"
-    "$AX_DRIVER" click-center "$APP_PID" Audio.Speech.Play \
+    "$AX_DRIVER" press "$APP_PID" Audio.Speech.Play \
         > "$OUT/speech-play-click.json" \
         || die "Play speech is not clickable"
     local playback_started=0

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -111,7 +111,7 @@ if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
 
 guard CommandLine.arguments.count >= 3,
       let pid = pid_t(CommandLine.arguments[2]) else {
-    fail("usage: rapid-ax <dump|press|click-center|increment|decrement|set-value|paste-file|close-window|trust> <pid> [identifier-or-window-title] [value]")
+    fail("usage: rapid-ax <dump|press|increment|decrement|set-value|paste-file|close-window|trust> <pid> [identifier-or-window-title] [value]")
 }
 
 let command = CommandLine.arguments[1]
@@ -314,24 +314,6 @@ switch command {
 case "press":
     let result = AXUIElementPerformAction(target, kAXPressAction as CFString)
     guard result == .success else { fail("AXPress \(identifier) failed: \(result.rawValue)") }
-case "click-center":
-    guard let origin = point(target, kAXPositionAttribute as CFString),
-          let extent = size(target, kAXSizeAttribute as CFString)
-    else { fail("click-center \(identifier) has no readable bounds") }
-    guard let running = NSRunningApplication(processIdentifier: pid) else {
-        fail("target application is no longer running")
-    }
-    running.activate(options: [.activateAllWindows])
-    usleep(100_000)
-    let center = CGPoint(x: origin.x + extent.width / 2, y: origin.y + extent.height / 2)
-    guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown,
-                             mouseCursorPosition: center, mouseButton: .left),
-          let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp,
-                           mouseCursorPosition: center, mouseButton: .left)
-    else { fail("could not create click-center events") }
-    down.post(tap: .cghidEventTap)
-    up.post(tap: .cghidEventTap)
-    usleep(100_000)
 case "increment":
     let result = AXUIElementPerformAction(target, kAXIncrementAction as CFString)
     guard result == .success else { fail("AXIncrement \(identifier) failed: \(result.rawValue)") }


### PR DESCRIPTION
## What does this PR do?

`gui-golden-flows` has been **red on main since #2005**, reporting

```
[gui-golden] FAIL: Save speech did not write the generated WAV
```

which reads as a broken Save button. It is not. The button works.

`click-center` — the primitive #2005 introduced for exactly these two buttons —
reads the element's AX bounds, posts a `CGEvent` down/up pair at the centre, and
returns success **as soon as the two events were constructed**. It never
observes whether the button fired, so a click that lands nowhere is
indistinguishable from a working one.

Measured on an M3 Ultra — same flow, same build, one line different:

| Save step | result |
|---|---|
| `click-center` | `{"success": true}`, then a 10s timeout, no file |
| `press` (AXPress) | `saved-speech.wav`, **64,044 bytes** — the fake sidecar's exact payload |

With AXPress the whole flow runs to `PASS`, writing both `saved-speech.wav` and
`saved-transcription.txt`. The two call sites now use AXPress, like the ~50
other interactions in this harness already do.

## Why `click-center` is removed, not left in place

It has no callers after this change, and a primitive that reports success
unconditionally is a trap: it converts *"the harness never pressed anything"*
into what looks like a product defect. That is precisely how a red gate came to
be merged — the failure named a user-facing symptom, so it read as a known app
bug rather than a broken test.

Anything that genuinely needs a synthesized click should re-add it **with a
verification step**, not inherit this one.

`increment` / `decrement` from the same PR are untouched — those are real
`AXUIElementPerformAction` calls with checked results, and the speech-speed step
depends on them.

## Scope

Harness only. `git diff --name-only` against main touches **zero** files under
`Sources/` or `vllm_mlx/` — nothing that ships changes.

## Test plan

- `audio-readiness` end to end on an M3 Ultra: **PASS**, with both artifacts
  written (`saved-speech.wav` 64,044 bytes, `saved-transcription.txt`).
- A/B recorded above isolates the cause to the primitive, not the app.
- `bash -n` on the flow script, `swiftc -parse` on the driver.
- `tests/test_gui_preflight_contract.py` + `tests/test_rapid_mac_ax_identifiers.py`:
  78 passed.

## Not fixed here

The same CI run also failed `re-onboarding confirmation Cancel is not pressable`
(a `#if DEBUG`-only panel, absent from release builds). That one is still under
investigation on a debug build and is deliberately not bundled into this fix, so
the harness repair can land on its own evidence.

## Checklist

- [x] Tests pass locally
- [x] Verified end-to-end on real hardware
- [x] No product code touched
- [x] No breaking changes to existing API