### PR TITLE
test(mac): stabilize semantic GUI actions in CI

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -106,6 +106,28 @@ enum DevSnapshot {
             )
         }
 
+        // LIVE mode must run before the static matrix. The matrix below
+        // renders ~200 full-size views and temporarily raises process memory;
+        // running live last can trip ServerManager's real pre-load safety
+        // gate even for a 0.6B model, leaving state=.idle and silently skipping
+        // the only end-to-end sidecar check. Use a separate non-persisting
+        // chat model so the real turn cannot leak into the static fixtures.
+        if let liveAlias = ProcessInfo.processInfo.environment["RAPID_DEV_SERVE_ALIAS"],
+           !liveAlias.isEmpty {
+            let liveChat = ChatViewModel(
+                sampling: sampling,
+                customInstructions: chat.customInstructions,
+                server: server,
+                persistsConversations: false
+            )
+            await runLiveChat(
+                alias: liveAlias, server: server, chat: liveChat,
+                downloads: downloads, quickstart: quickstart, dir: dir
+            )
+            await server.stop()
+            server.dismissTerminalState()
+        }
+
         // The Images tab, rendered standalone — ``ContentView`` owns its
         // ``SidebarSection`` privately, so (like ``launchView``) the detail
         // surface is captured directly rather than by driving navigation.
@@ -844,19 +866,6 @@ enum DevSnapshot {
         )
 
         log("wrote PNGs to \(dir)")
-
-        // LIVE mode: when RAPID_DEV_SERVE_ALIAS is set, actually start the
-        // sidecar (resolved by ServerLocator — the bundled engine unless
-        // RAPID_BIN overrides it), send one chat turn, and snapshot the
-        // REAL streamed output — the runtime path static renders can't
-        // reach. Then the normal terminate exercises clean teardown.
-        if let liveAlias = ProcessInfo.processInfo.environment["RAPID_DEV_SERVE_ALIAS"],
-           !liveAlias.isEmpty {
-            await runLiveChat(
-                alias: liveAlias, server: server, chat: chat,
-                downloads: downloads, quickstart: quickstart, dir: dir
-            )
-        }
 
         // One-shot: quit so the dogfood harness gets a clean exit.
         NSApp.terminate(nil)

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2376,11 +2376,14 @@ flow_no_dead_controls() {
             || die "Erase and restart is not pressable"
         wait_identifier Settings.Developer.CancelReonboard \
             "$OUT/dead-actions-developer-dialog.json"
-        press "$OUT/dead-actions-developer-dialog.json" Settings.Developer.CancelReonboard \
-            "$OUT/dead-actions-developer-cancel.json" \
-            || die "re-onboarding confirmation Cancel is not pressable"
         local dialog_closed=0
         for ((i=0; i<40; i++)); do
+            # SwiftUI can replace a confirmation-dialog AX element between a
+            # tree dump and AXPress. Re-resolve and retry the semantic action;
+            # the observable contract is that the dialog disappears.
+            "$AX_DRIVER" press "$APP_PID" Settings.Developer.CancelReonboard \
+                > "$OUT/dead-actions-developer-cancel.json" 2>/dev/null || true
+            sleep 0.1
             see_main "$OUT/dead-actions-developer-cancelled.json"
             if ! jq -e '.data.ui_elements[]?
                         | select(.identifier == "Settings.Developer.CancelReonboard")' \
@@ -3688,11 +3691,14 @@ flow_audio_readiness() {
                      and .text == "golden speech controls"' \
         "Generate Speech did not send the selected voice and text"
     wait_identifier Audio.Speech.Play "$OUT/speech-result.json"
-    "$AX_DRIVER" click-center "$APP_PID" Audio.Speech.Save \
-        > "$OUT/speech-save-click.json" \
-        || die "Save speech is not clickable"
     local speech_saved=0
     for ((i=0; i<40; i++)); do
+        # Re-resolve the dynamic result button for every AXPress. A real
+        # semantic action is required here; CGEvent coordinate clicks are not
+        # trustworthy on unattended runners and can report success while TCC
+        # discards the event.
+        "$AX_DRIVER" press "$APP_PID" Audio.Speech.Save \
+            > "$OUT/speech-save-press.json" 2>/dev/null || true
         if [[ -s "$OUT_ROOT/audio-readiness/saved-speech.wav" ]]; then
             speech_saved=1; break
         fi
@@ -3701,11 +3707,11 @@ flow_audio_readiness() {
     [[ "$speech_saved" == 1 ]] \
         || die "Save speech did not write the generated WAV"
     see_main "$OUT/speech-before-play.json"
-    "$AX_DRIVER" click-center "$APP_PID" Audio.Speech.Play \
-        > "$OUT/speech-play-click.json" \
-        || die "Play speech is not clickable"
     local playback_started=0
     for ((i=0; i<40; i++)); do
+        "$AX_DRIVER" press "$APP_PID" Audio.Speech.Play \
+            > "$OUT/speech-play-press.json" 2>/dev/null || true
+        sleep 0.05
         see_main "$OUT/speech-playing.json"
         if [[ "$(element_field "$OUT/speech-playing.json" Audio.Speech.Play description)" == "Stop playback" ]]; then
             playback_started=1; break
@@ -3841,11 +3847,15 @@ flow_audio_readiness() {
         || die "Transcription stayed behind Download & start after its model became ready"
 
     see_main "$OUT/transcription-controls-before.json"
-    press "$OUT/transcription-controls-before.json" Audio.Transcription.FilePicker \
-        "$OUT/transcription-file-press.json" \
-        || die "Choose File is not pressable"
     local file_selected=0
     for ((i=0; i<40; i++)); do
+        # AXPress can return success for a SwiftUI button whose backing object
+        # is replaced before its closure runs. Resolve the current button on
+        # every attempt and require the actual selection + enabled Transcribe
+        # state instead of treating the AX result as proof of user-visible work.
+        "$AX_DRIVER" press "$APP_PID" Audio.Transcription.FilePicker \
+            > "$OUT/transcription-file-press.json" 2>/dev/null || true
+        sleep 0.1
         see_main "$OUT/transcription-file-selected.json"
         if jq -e '((.data.ui_elements | tostring) | contains("assistant_bank_en.wav"))
                   and any(.data.ui_elements[]?;

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -111,11 +111,25 @@ if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
 
 guard CommandLine.arguments.count >= 3,
       let pid = pid_t(CommandLine.arguments[2]) else {
-    fail("usage: rapid-ax <dump|press|click-center|increment|decrement|set-value|paste-file|close-window|trust> <pid> [identifier-or-window-title] [value]")
+    fail("usage: rapid-ax <dump|press|increment|decrement|set-value|paste-file|close-window|trust> <pid> [identifier-or-window-title] [value]")
 }
 
 let command = CommandLine.arguments[1]
 let application = AXUIElementCreateApplication(pid)
+
+// A semantic action should model an actual user interacting with the app.
+// On unattended runners AXPress can return success for a background SwiftUI
+// window without dispatching the Button closure. Bring the target app forward
+// before reading its tree, then resolve the post-activation elements so the
+// action never holds a reference across the activation/layout transition.
+if command != "dump" {
+    guard let running = NSRunningApplication(processIdentifier: pid) else {
+        fail("target application is no longer running")
+    }
+    running.activate(options: [.activateAllWindows])
+    usleep(100_000)
+}
+
 var visited = Set<AXUIElement>()
 var records = [[String: Any]]()
 var match: AXUIElement?
@@ -176,6 +190,15 @@ func walk(_ element: AXUIElement, depth: Int) {
     guard visited.insert(element).inserted else { return }
 
     let identifier = string(element, kAXIdentifierAttribute as CFString)
+    // Action commands only need one element. Building a complete 12k-node
+    // dump after finding it leaves SwiftUI several seconds to replace the
+    // backing accessibility object; AXPress then receives a stale reference
+    // and fails with invalidUIElement/cannotComplete. Stop at the match. Dump
+    // still walks the complete tree because negative assertions depend on it.
+    if command != "dump", match == nil, identifier == wanted {
+        match = element
+        return
+    }
     var record: [String: Any] = ["depth": depth]
     if let identifier { record["identifier"] = identifier }
     if let role = string(element, kAXRoleAttribute as CFString) { record["role"] = role }
@@ -238,6 +261,7 @@ func walk(_ element: AXUIElement, depth: Int) {
     }
     for child in children {
         walk(child, depth: depth + 1)
+        if command != "dump", match != nil { break }
     }
 }
 
@@ -314,24 +338,6 @@ switch command {
 case "press":
     let result = AXUIElementPerformAction(target, kAXPressAction as CFString)
     guard result == .success else { fail("AXPress \(identifier) failed: \(result.rawValue)") }
-case "click-center":
-    guard let origin = point(target, kAXPositionAttribute as CFString),
-          let extent = size(target, kAXSizeAttribute as CFString)
-    else { fail("click-center \(identifier) has no readable bounds") }
-    guard let running = NSRunningApplication(processIdentifier: pid) else {
-        fail("target application is no longer running")
-    }
-    running.activate(options: [.activateAllWindows])
-    usleep(100_000)
-    let center = CGPoint(x: origin.x + extent.width / 2, y: origin.y + extent.height / 2)
-    guard let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown,
-                             mouseCursorPosition: center, mouseButton: .left),
-          let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp,
-                           mouseCursorPosition: center, mouseButton: .left)
-    else { fail("could not create click-center events") }
-    down.post(tap: .cghidEventTap)
-    up.post(tap: .cghidEventTap)
-    usleep(100_000)
 case "increment":
     let result = AXUIElementPerformAction(target, kAXIncrementAction as CFString)
     guard result == .success else { fail("AXIncrement \(identifier) failed: \(result.rawValue)") }


### PR DESCRIPTION
## What changed

- stop the AX walker as soon as an action target is found, avoiding stale SwiftUI accessibility objects
- retry semantic AXPress actions and verify their observable effects for Audio Save/Play and the Developer confirmation dialog
- run the real DevSnapshot sidecar/chat check before the large static render matrix so the test harness does not trip the production memory gate
- remove the unreliable coordinate-click fallback

## Why

The AX helper kept walking up to 12,000 nodes after locating an action target. SwiftUI could replace the backing element before AXPress, producing transient invalid-element/cannot-complete errors. The coordinate fallback could report success even when unattended-runner TCC discarded the injected CGEvent. Separately, DevSnapshot attempted its real model load only after rendering roughly 200 full-size views, so harness memory could block the sidecar startup.

## Validation

- `swiftc apps/rapid-mac/scripts/rapid-ax.swift`
- `gui-golden-flows.sh --flow audio-readiness` twice
- `gui-golden-flows.sh --flow no-dead-controls` twice
- `gui-golden-flows.sh --flow all`
- 93 focused Python GUI contract tests
- Swift test suite: 2,289/2,290 first run; the one unrelated timing test passed 5/5 on immediate focused rerun
- isolated real GUI live run with `qwen3-0.6b-4bit`: sidecar ready, real chat completed, live screenshot written, clean stop