### PR TITLE
Security hardening: fix reviewed findings (trust_remote_code, python artifact SHA256, Host allow-listing, SA3 weights_only, share key warning)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -261,7 +261,10 @@ if [ -z "$PYTHON" ]; then
         # the concrete build this line ships against; bump it deliberately.
         PY_BUILD="20260408"
         PY_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PY_BUILD}/cpython-${PY_VERSION}+${PY_BUILD}-aarch64-apple-darwin-install_only.tar.gz"
-        PY_TAR_BASE="cpython-${PY_VERSION}+${PY_BUILD}-aarch64-apple-darwin-install_only.tar.gz"
+        # Publisher SHA256SUMS, reviewed and pinned with the release rather
+        # than downloaded beside the artifact. Fetching both bytes and digest
+        # from the same compromised release would not add a trust boundary.
+        PY_SHA256="6000d09545602d3704bdff943f37663b3148b7c1a3a8a1fcc6c1ebd505a3cfc3"
         info "Downloading Python ${PY_VERSION} (build ${PY_BUILD}) + verifying SHA256..."
         mkdir -p "$STANDALONE_DIR"
         # Verify the tarball against the publisher-published SHA256SUMS for this
@@ -270,19 +273,12 @@ if [ -z "$PYTHON" ]; then
         # "trust whatever bytes came back" gap so a tampered / mis-served
         # download fails closed instead of silently installing.
         TMP_TAR="$(mktemp "${TMPDIR:-/tmp}/rapidmlx-py.XXXXXX.tar.gz")"
+        trap 'rm -f "$TMP_TAR"' EXIT
         download "$PY_URL" > "$TMP_TAR"
-        EXPECTED="$(download "https://github.com/astral-sh/python-build-standalone/releases/download/${PY_BUILD}/SHA256SUMS" \
-            | awk -v f="$PY_TAR_BASE" '$2 == f || $2 == "./" f {print $1}' | head -1 || true)"
-        if [ -z "$EXPECTED" ]; then
-            err "Could not fetch SHA256 for ${PY_TAR_BASE} from the Python build server."
-            dim "Download not verified; aborted to avoid installing an unverified runtime."
-            rm -f "$TMP_TAR"
-            exit 1
-        fi
         ACTUAL="$(shasum -a 256 "$TMP_TAR" | awk '{print $1}')"
-        if [ "$ACTUAL" != "$EXPECTED" ]; then
+        if [ "$ACTUAL" != "$PY_SHA256" ]; then
             err "SHA256 mismatch for Python standalone tarball."
-            dim "Expected $EXPECTED"
+            dim "Expected $PY_SHA256"
             dim "Got      $ACTUAL"
             dim "Refusing to extract an unverified runtime."
             rm -f "$TMP_TAR"
@@ -291,6 +287,7 @@ if [ -z "$PYTHON" ]; then
         dim "SHA256 verified."
         tar xzf "$TMP_TAR" -C "$STANDALONE_DIR" --strip-components=1
         rm -f "$TMP_TAR"
+        trap - EXIT
         PYTHON="${STANDALONE_DIR}/bin/python3"
         if ! "$PYTHON" --version >/dev/null 2>&1; then
             err "Failed to install standalone Python."

--- a/install.sh
+++ b/install.sh
@@ -256,13 +256,41 @@ if [ -z "$PYTHON" ]; then
     else
         STANDALONE_DIR="${HOME}/.rapid-mlx-python"
         PY_VERSION="3.12.13"
-        # Fetch latest build tag dynamically
-        PY_BUILD=$(download "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" \
-            | grep -o '"tag_name":"[^"]*"' | head -1 | cut -d'"' -f4 2>/dev/null || echo "20260408")
+        # Pin to a FIXED release tag (not the moving "latest" API) so the
+        # tarball we fetch is a stable, reviewable artifact. The tag below is
+        # the concrete build this line ships against; bump it deliberately.
+        PY_BUILD="20260408"
         PY_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PY_BUILD}/cpython-${PY_VERSION}+${PY_BUILD}-aarch64-apple-darwin-install_only.tar.gz"
-        info "Downloading Python ${PY_VERSION}..."
+        PY_TAR_BASE="cpython-${PY_VERSION}+${PY_BUILD}-aarch64-apple-darwin-install_only.tar.gz"
+        info "Downloading Python ${PY_VERSION} (build ${PY_BUILD}) + verifying SHA256..."
         mkdir -p "$STANDALONE_DIR"
-        download "$PY_URL" | tar xz -C "$STANDALONE_DIR" --strip-components=1
+        # Verify the tarball against the publisher-published SHA256SUMS for this
+        # exact release BEFORE anything is extracted. A curl|bash install trusts
+        # the transport (HTTPS) for integrity; verifying the checksum removes the
+        # "trust whatever bytes came back" gap so a tampered / mis-served
+        # download fails closed instead of silently installing.
+        TMP_TAR="$(mktemp "${TMPDIR:-/tmp}/rapidmlx-py.XXXXXX.tar.gz")"
+        download "$PY_URL" > "$TMP_TAR"
+        EXPECTED="$(download "https://github.com/astral-sh/python-build-standalone/releases/download/${PY_BUILD}/SHA256SUMS" \
+            | awk -v f="$PY_TAR_BASE" '$2 == f || $2 == "./" f {print $1}' | head -1 || true)"
+        if [ -z "$EXPECTED" ]; then
+            err "Could not fetch SHA256 for ${PY_TAR_BASE} from the Python build server."
+            dim "Download not verified; aborted to avoid installing an unverified runtime."
+            rm -f "$TMP_TAR"
+            exit 1
+        fi
+        ACTUAL="$(shasum -a 256 "$TMP_TAR" | awk '{print $1}')"
+        if [ "$ACTUAL" != "$EXPECTED" ]; then
+            err "SHA256 mismatch for Python standalone tarball."
+            dim "Expected $EXPECTED"
+            dim "Got      $ACTUAL"
+            dim "Refusing to extract an unverified runtime."
+            rm -f "$TMP_TAR"
+            exit 1
+        fi
+        dim "SHA256 verified."
+        tar xzf "$TMP_TAR" -C "$STANDALONE_DIR" --strip-components=1
+        rm -f "$TMP_TAR"
         PYTHON="${STANDALONE_DIR}/bin/python3"
         if ! "$PYTHON" --version >/dev/null 2>&1; then
             err "Failed to install standalone Python."

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -121,6 +121,15 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
     {
         "RAPID_MLX_DISABLE_VERSION_CHECK",  # opt-out of version check
         "RAPID_MLX_PROFILE_VERBOSE",  # debug verbosity for profile logs
+        # Security policy knobs, none of which selects a model, parser, tier,
+        # or engine route. TRUST_REMOTE_CODE only constrains whether an
+        # already-selected checkpoint may import repository Python;
+        # TRUSTED_HOSTS filters HTTP Host headers; ALLOW_UNSAFE_SA3_PICKLE is
+        # an explicit compatibility escape hatch after safe tensor loading
+        # rejects a legacy audio checkpoint.
+        "RAPID_MLX_TRUST_REMOTE_CODE",
+        "RAPID_MLX_TRUSTED_HOSTS",
+        "RAPID_MLX_ALLOW_UNSAFE_SA3_PICKLE",
         # Opt-out of the fused top-p/top-k/temperature sampler fast path
         # (PR #542). Same shape as DISABLE_VERSION_CHECK — a perf shortcut
         # toggle, not a routing decision. The math collapses to mlx-lm's

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -35,6 +35,48 @@ def test_remote_code_opt_out_is_authoritative_and_non_mutating(monkeypatch, valu
     assert original["trust_remote_code"] is True
 
 
+def test_mllm_remote_code_optout_reaches_model_and_config_loaders(monkeypatch):
+    """The process-wide opt-out must cover every MLLM repository read."""
+    import types
+
+    from vllm_mlx.models import mllm as mllm_mod
+
+    calls = {}
+    model = SimpleNamespace(config=SimpleNamespace())
+    processor = SimpleNamespace(tokenizer=SimpleNamespace())
+
+    def fake_load(model_name, **kwargs):
+        calls["model"] = (model_name, kwargs)
+        return model, processor
+
+    def fake_load_config(model_name, **kwargs):
+        calls["config"] = (model_name, kwargs)
+        return {}
+
+    monkeypatch.setenv("RAPID_MLX_TRUST_REMOTE_CODE", "0")
+    monkeypatch.setattr(mllm_mod, "_require_mlx_vlm", lambda: None)
+    monkeypatch.setitem(sys.modules, "mlx_vlm", types.SimpleNamespace(load=fake_load))
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.utils",
+        types.SimpleNamespace(load_config=fake_load_config),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.utils.tokenizer.augment_eos_token_ids_from_generation_config",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.utils.tokenizer.repair_byte_level_decoder",
+        lambda *_args, **_kwargs: None,
+    )
+
+    instance = mllm_mod.MLXMultimodalLM("org/model")
+    instance.load()
+
+    assert calls["model"] == ("org/model", {"trust_remote_code": False})
+    assert calls["config"] == ("org/model", {"trust_remote_code": False})
+
+
 def test_trusted_hosts_default_off_and_cli_comma_normalization(monkeypatch):
     import vllm_mlx.server as server
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for PR #2011 security boundaries."""
+
+from __future__ import annotations
+
+import pickle
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_remote_code_policy_preserves_historical_unset_default(monkeypatch):
+    from vllm_mlx.utils.tokenizer import apply_remote_code_policy
+
+    monkeypatch.delenv("RAPID_MLX_TRUST_REMOTE_CODE", raising=False)
+    config, enabled = apply_remote_code_policy(None)
+    assert config is None
+    assert enabled is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "NO", " off "])
+def test_remote_code_opt_out_is_authoritative_and_non_mutating(monkeypatch, value):
+    from vllm_mlx.utils.tokenizer import apply_remote_code_policy
+
+    original = {"trust_remote_code": True, "eos_token": "<eos>"}
+    monkeypatch.setenv("RAPID_MLX_TRUST_REMOTE_CODE", value)
+    config, enabled = apply_remote_code_policy(original)
+
+    assert enabled is False
+    assert config == {"trust_remote_code": False, "eos_token": "<eos>"}
+    assert original["trust_remote_code"] is True
+
+
+def test_trusted_hosts_default_off_and_cli_comma_normalization(monkeypatch):
+    import vllm_mlx.server as server
+
+    monkeypatch.delenv("RAPID_MLX_TRUSTED_HOSTS", raising=False)
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        return {"ok": True}
+
+    monkeypatch.setattr(server, "app", app)
+    assert server.configure_trusted_hosts(None) == []
+    assert (
+        TestClient(app).get("/health", headers={"host": "anything.test"}).status_code
+        == 200
+    )
+
+    app = FastAPI()
+
+    @app.get("/health")
+    async def protected_health():
+        return {"ok": True}
+
+    monkeypatch.setattr(server, "app", app)
+    assert server.configure_trusted_hosts(["localhost,127.0.0.1"]) == [
+        "localhost",
+        "127.0.0.1",
+    ]
+    client = TestClient(app)
+    assert client.get("/health", headers={"host": "localhost"}).status_code == 200
+    assert client.get("/health", headers={"host": "evil.test"}).status_code == 400
+
+
+def test_trusted_hosts_env_is_used_when_cli_absent(monkeypatch):
+    import vllm_mlx.server as server
+
+    app = FastAPI()
+    monkeypatch.setattr(server, "app", app)
+    monkeypatch.setenv("RAPID_MLX_TRUSTED_HOSTS", "localhost, 127.0.0.1")
+    assert server.configure_trusted_hosts(None) == ["localhost", "127.0.0.1"]
+
+
+def test_sa3_checkpoint_refuses_automatic_unsafe_pickle(monkeypatch):
+    from vllm_mlx.audio.sa3.models.defs.checkpoint_security import (
+        load_torch_checkpoint,
+    )
+
+    calls: list[bool] = []
+
+    def fake_load(_path, *, map_location, weights_only):
+        assert map_location == "cpu"
+        calls.append(weights_only)
+        raise pickle.UnpicklingError("legacy pickle")
+
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(load=fake_load))
+    monkeypatch.delenv("RAPID_MLX_ALLOW_UNSAFE_SA3_PICKLE", raising=False)
+    with pytest.raises(RuntimeError, match="Refusing unsafe pickle fallback"):
+        load_torch_checkpoint("model.ckpt")
+    assert calls == [True]
+
+
+def test_sa3_checkpoint_unsafe_fallback_requires_explicit_opt_in(monkeypatch):
+    from vllm_mlx.audio.sa3.models.defs.checkpoint_security import (
+        load_torch_checkpoint,
+    )
+
+    calls: list[bool] = []
+
+    def fake_load(_path, *, map_location, weights_only):
+        calls.append(weights_only)
+        if weights_only:
+            raise pickle.UnpicklingError("legacy pickle")
+        return {"state_dict": {}}
+
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(load=fake_load))
+    monkeypatch.setenv("RAPID_MLX_ALLOW_UNSAFE_SA3_PICKLE", "1")
+    assert load_torch_checkpoint("model.ckpt") == {"state_dict": {}}
+    assert calls == [True, False]
+
+
+def test_installer_pins_reviewed_python_artifact_digest():
+    installer = (Path(__file__).resolve().parents[1] / "install.sh").read_text()
+    assert 'PY_BUILD="20260408"' in installer
+    assert (
+        'PY_SHA256="6000d09545602d3704bdff943f37663b3148b7c1a3a8a1fcc6c1ebd505a3cfc3"'
+        in installer
+    )
+    assert (
+        'download "https://github.com/astral-sh/python-build-standalone/releases/download/${PY_BUILD}/SHA256SUMS"'
+        not in installer
+    )

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -131,15 +131,28 @@ def test_share_command_happy_path(capsys):
     ):
         share_cli.share_command(_make_args())
 
-    out = capsys.readouterr().out
+    captured = capsys.readouterr()
+    out = captured.out
     # Banner pieces that protect users from leaking the key:
     assert "PUBLIC INTERNET" in out
     assert "Do NOT screenshot" in out
     # URL surfaced verbatim (the worker route, not a bare host).
     assert "https://rapidserver.quicksilverpro.io/r/testabc1234567890abcd" in out
+    assert "public internet" in captured.err
+    assert "generated share URL/key" in captured.err
     # Ctrl-C path tears down the tunnel and the serve child.
     tunnel.stop.assert_called_once()
     serve_proc.terminate.assert_called_once()
+
+
+def test_share_warns_when_configured_server_key_is_replaced(monkeypatch, capsys):
+    monkeypatch.setenv("RAPID_MLX_API_KEY", "operator-key")
+    _drive_share_capture(_make_args())
+
+    warning = capsys.readouterr().err
+    assert "does not reuse it" in warning
+    assert "fresh per-share key" in warning
+    assert "operator-key" not in warning
 
 
 def test_share_command_aborts_when_serve_exits_before_ready():

--- a/vllm_mlx/audio/sa3/models/defs/checkpoint_security.py
+++ b/vllm_mlx/audio/sa3/models/defs/checkpoint_security.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Safe-by-default loading for legacy SA3 PyTorch checkpoints."""
+
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_UNSAFE_ENV = "RAPID_MLX_ALLOW_UNSAFE_SA3_PICKLE"
+
+
+def load_torch_checkpoint(path: str | Path) -> Any:
+    """Load tensors safely, requiring explicit consent for pickle fallback."""
+    import torch
+
+    try:
+        return torch.load(path, map_location="cpu", weights_only=True)
+    except pickle.UnpicklingError as exc:
+        allowed = os.environ.get(_UNSAFE_ENV, "").strip().lower() in _TRUE_VALUES
+        if not allowed:
+            raise RuntimeError(
+                f"Refusing unsafe pickle fallback for SA3 checkpoint {path}. "
+                f"Use a tensor-only checkpoint, or set {_UNSAFE_ENV}=1 only "
+                "if you trust this checkpoint's source."
+            ) from exc
+        logger.warning(
+            "Unsafe SA3 pickle fallback explicitly enabled for %s via %s; "
+            "checkpoint loading may execute arbitrary Python code.",
+            path,
+            _UNSAFE_ENV,
+        )
+        return torch.load(path, map_location="cpu", weights_only=False)

--- a/vllm_mlx/audio/sa3/models/defs/dit_mlx.py
+++ b/vllm_mlx/audio/sa3/models/defs/dit_mlx.py
@@ -10,13 +10,12 @@ Forward signature matches dit_torch.py:
 """
 
 import math
-import logging
 from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
 
-logger = logging.getLogger(__name__)
+from .checkpoint_security import load_torch_checkpoint
 
 
 # Constants (sa3-sm-music)
@@ -274,25 +273,9 @@ class DiT(nn.Module):
 
 def convert_weights_from_torch_ckpt(ckpt_path):
     """Load sa3-sm-music ckpt (torch.load), strip 'model.model.' prefix, remap to MLX layout."""
-    import torch
     import numpy as np
-    import pickle
 
-    # SA3-PIPE-01: default to ``weights_only=True`` so a crafted ckpt cannot
-    # execute arbitrary Python during unpickling (RCE via pickled
-    # ``__reduce__``). The file is only ever read for its tensor
-    # ``state_dict``. If a legacy ckpt needs non-tensor metadata, fall back
-    # to ``weights_only=False`` only on failure, with a warning.
-    try:
-        raw = torch.load(ckpt_path, map_location="cpu", weights_only=True)
-    except pickle.UnpicklingError:
-        logger.warning(
-            "SA3 DiT ckpt %s uses a legacy non-tensor format; falling back "
-            "to unsafe unpickling (weights_only=False). Prefer a "
-            ".safetensors checkpoint.",
-            ckpt_path,
-        )
-        raw = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    raw = load_torch_checkpoint(ckpt_path)
     sd = raw["state_dict"] if isinstance(raw, dict) and "state_dict" in raw else raw
 
     prefix = "model.model."

--- a/vllm_mlx/audio/sa3/models/defs/dit_mlx.py
+++ b/vllm_mlx/audio/sa3/models/defs/dit_mlx.py
@@ -10,10 +10,13 @@ Forward signature matches dit_torch.py:
 """
 
 import math
+import logging
 from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
 
 
 # Constants (sa3-sm-music)
@@ -273,8 +276,23 @@ def convert_weights_from_torch_ckpt(ckpt_path):
     """Load sa3-sm-music ckpt (torch.load), strip 'model.model.' prefix, remap to MLX layout."""
     import torch
     import numpy as np
+    import pickle
 
-    raw = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    # SA3-PIPE-01: default to ``weights_only=True`` so a crafted ckpt cannot
+    # execute arbitrary Python during unpickling (RCE via pickled
+    # ``__reduce__``). The file is only ever read for its tensor
+    # ``state_dict``. If a legacy ckpt needs non-tensor metadata, fall back
+    # to ``weights_only=False`` only on failure, with a warning.
+    try:
+        raw = torch.load(ckpt_path, map_location="cpu", weights_only=True)
+    except pickle.UnpicklingError:
+        logger.warning(
+            "SA3 DiT ckpt %s uses a legacy non-tensor format; falling back "
+            "to unsafe unpickling (weights_only=False). Prefer a "
+            ".safetensors checkpoint.",
+            ckpt_path,
+        )
+        raw = torch.load(ckpt_path, map_location="cpu", weights_only=False)
     sd = raw["state_dict"] if isinstance(raw, dict) and "state_dict" in raw else raw
 
     prefix = "model.model."

--- a/vllm_mlx/audio/sa3/models/defs/sa3_pipeline.py
+++ b/vllm_mlx/audio/sa3/models/defs/sa3_pipeline.py
@@ -14,13 +14,12 @@ channels=2 stereo, cond_token_dim=768.
 
 from __future__ import annotations
 import math
-import logging
 from typing import Optional
 
 import numpy as np
 import mlx.core as mx
 
-logger = logging.getLogger(__name__)
+from .checkpoint_security import load_torch_checkpoint
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -200,23 +199,7 @@ def load_conditioner_from_sa3_ckpt(ckpt_path: str) -> tuple[mx.array, SecondsTot
         sd = st.load_file(str(ckpt_path))
         get = lambda k: sd[k].cpu().float().numpy()
     else:
-        import torch
-        import pickle
-        # SA3-PIPE-01: default to ``weights_only=True`` so a crafted ckpt
-        # cannot execute arbitrary Python during unpickling (RCE via pickled
-        # ``__reduce__``). The file is only ever read for its tensor
-        # ``state_dict``. If a legacy ckpt needs non-tensor metadata, fall
-        # back to ``weights_only=False`` only on failure, with a warning.
-        try:
-            ck = torch.load(str(ckpt_path), map_location="cpu", weights_only=True)
-        except pickle.UnpicklingError:
-            logger.warning(
-                "SA3 ckpt %s uses a legacy non-tensor format; falling back "
-                "to unsafe unpickling (weights_only=False). Prefer a "
-                ".safetensors checkpoint.",
-                ckpt_path,
-            )
-            ck = torch.load(str(ckpt_path), map_location="cpu", weights_only=False)
+        ck = load_torch_checkpoint(str(ckpt_path))
         sd = ck.get("state_dict", ck) if isinstance(ck, dict) else ck
         get = lambda k: sd[k].cpu().float().numpy()
 

--- a/vllm_mlx/audio/sa3/models/defs/sa3_pipeline.py
+++ b/vllm_mlx/audio/sa3/models/defs/sa3_pipeline.py
@@ -14,10 +14,13 @@ channels=2 stereo, cond_token_dim=768.
 
 from __future__ import annotations
 import math
+import logging
 from typing import Optional
 
 import numpy as np
 import mlx.core as mx
+
+logger = logging.getLogger(__name__)
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -198,7 +201,22 @@ def load_conditioner_from_sa3_ckpt(ckpt_path: str) -> tuple[mx.array, SecondsTot
         get = lambda k: sd[k].cpu().float().numpy()
     else:
         import torch
-        ck = torch.load(str(ckpt_path), map_location="cpu", weights_only=False)
+        import pickle
+        # SA3-PIPE-01: default to ``weights_only=True`` so a crafted ckpt
+        # cannot execute arbitrary Python during unpickling (RCE via pickled
+        # ``__reduce__``). The file is only ever read for its tensor
+        # ``state_dict``. If a legacy ckpt needs non-tensor metadata, fall
+        # back to ``weights_only=False`` only on failure, with a warning.
+        try:
+            ck = torch.load(str(ckpt_path), map_location="cpu", weights_only=True)
+        except pickle.UnpicklingError:
+            logger.warning(
+                "SA3 ckpt %s uses a legacy non-tensor format; falling back "
+                "to unsafe unpickling (weights_only=False). Prefer a "
+                ".safetensors checkpoint.",
+                ckpt_path,
+            )
+            ck = torch.load(str(ckpt_path), map_location="cpu", weights_only=False)
         sd = ck.get("state_dict", ck) if isinstance(ck, dict) else ck
         get = lambda k: sd[k].cpu().float().numpy()
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -735,6 +735,8 @@ def _serve_audio_mode(args, entry) -> None:
 
     # CORS — same friendly default the text path uses.
     server.configure_cors_from_env(args.cors_origins)
+    # WH-1: OPT-IN Host-header allowlist (DNS-rebinding hardening).
+    server.configure_trusted_hosts(args.trusted_hosts)
     if args.rate_limit > 0:
         server._rate_limiter = configure_rate_limiter(args.rate_limit, enabled=True)
 
@@ -3196,6 +3198,9 @@ def serve_command(args):
     # when ``*`` is in the origin list. Operators who need cookie /
     # ``Authorization`` auto-forwarding must pin to specific origins.
     cors_origins = server.configure_cors_from_env(args.cors_origins)
+
+    # WH-1: OPT-IN Host-header allowlist (DNS-rebinding hardening).
+    server.configure_trusted_hosts(args.trusted_hosts)
 
     # Request logging middleware — installed AFTER CORS so it is the
     # outermost layer (Starlette prepends, so last install runs first).
@@ -6140,6 +6145,7 @@ def ps_command(_args):
             "--log-level",
             "--mcp-config",
             "--cors-origins",
+            "--trusted-hosts",
             "--served-model-name",
             "--max-tokens",
             "--gpu-memory-utilization",
@@ -9239,6 +9245,21 @@ Examples:
         help=(
             "Allowed CORS origins (default: * for all origins). "
             "Example: --cors-origins http://localhost:3000 https://myapp.com"
+        ),
+    )
+    serve_parser.add_argument(
+        "--trusted-hosts",
+        type=str,
+        nargs="+",
+        default=None,
+        metavar="HOST",
+        help=(
+            "OPT-IN Host-header allowlist (DNS-rebinding hardening): only "
+            "requests whose Host header matches one of these values are "
+            "accepted; everything else gets 400. Off by default so "
+            "rapid-mlx share and LAN access keep working. Example: "
+            "--trusted-hosts localhost 127.0.0.1 (also settable via "
+            "RAPID_MLX_TRUSTED_HOSTS)."
         ),
     )
     serve_parser.add_argument(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -736,7 +736,7 @@ def _serve_audio_mode(args, entry) -> None:
     # CORS — same friendly default the text path uses.
     server.configure_cors_from_env(args.cors_origins)
     # WH-1: OPT-IN Host-header allowlist (DNS-rebinding hardening).
-    server.configure_trusted_hosts(args.trusted_hosts)
+    server.configure_trusted_hosts(getattr(args, "trusted_hosts", None))
     if args.rate_limit > 0:
         server._rate_limiter = configure_rate_limiter(args.rate_limit, enabled=True)
 
@@ -3200,7 +3200,7 @@ def serve_command(args):
     cors_origins = server.configure_cors_from_env(args.cors_origins)
 
     # WH-1: OPT-IN Host-header allowlist (DNS-rebinding hardening).
-    server.configure_trusted_hosts(args.trusted_hosts)
+    server.configure_trusted_hosts(getattr(args, "trusted_hosts", None))
 
     # Request logging middleware — installed AFTER CORS so it is the
     # outermost layer (Starlette prepends, so last install runs first).
@@ -9257,8 +9257,9 @@ Examples:
             "OPT-IN Host-header allowlist (DNS-rebinding hardening): only "
             "requests whose Host header matches one of these values are "
             "accepted; everything else gets 400. Off by default so "
-            "rapid-mlx share and LAN access keep working. Example: "
-            "--trusted-hosts localhost 127.0.0.1 (also settable via "
+            "rapid-mlx share and LAN access keep working. Values may be "
+            "space- or comma-separated. Example: --trusted-hosts localhost "
+            "127.0.0.1 (also settable via "
             "RAPID_MLX_TRUSTED_HOSTS)."
         ),
     )

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1314,7 +1314,28 @@ class BatchedEngine(BaseEngine):
         from ..utils.tokenizer import load_model_with_fallback
 
         # Build tokenizer config
-        tokenizer_config = {"trust_remote_code": self._trust_remote_code}
+        # Security hardening (opt-out): remote-code execution is on by default
+        # for community-model compatibility, but an operator may disable it
+        # process-wide with RAPID_MLX_TRUST_REMOTE_CODE=0. When disabled, drop
+        # trust_remote_code so no repo model/tokenizer Python is downloaded and
+        # executed. The default stays on (no behavior change unless opted out).
+        import os as _os
+
+        _trust_remote_code = self._trust_remote_code
+        _env_trust = _os.environ.get("RAPID_MLX_TRUST_REMOTE_CODE")
+        if _env_trust is not None and _env_trust.lower() in (
+            "0",
+            "false",
+            "no",
+            "off",
+        ):
+            _trust_remote_code = False
+            logger.warning(
+                "RAPID_MLX_TRUST_REMOTE_CODE=%s: remote model/tokenizer code "
+                "execution disabled; loading only with trust_remote_code=False.",
+                _env_trust,
+            )
+        tokenizer_config = {"trust_remote_code": _trust_remote_code}
 
         # Qwen3 fix
         if "qwen3" in self._model_name.lower() or "Qwen3" in self._model_name:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1313,29 +1313,10 @@ class BatchedEngine(BaseEngine):
         from ..scheduler import SchedulerConfig
         from ..utils.tokenizer import load_model_with_fallback
 
-        # Build tokenizer config
-        # Security hardening (opt-out): remote-code execution is on by default
-        # for community-model compatibility, but an operator may disable it
-        # process-wide with RAPID_MLX_TRUST_REMOTE_CODE=0. When disabled, drop
-        # trust_remote_code so no repo model/tokenizer Python is downloaded and
-        # executed. The default stays on (no behavior change unless opted out).
-        import os as _os
-
-        _trust_remote_code = self._trust_remote_code
-        _env_trust = _os.environ.get("RAPID_MLX_TRUST_REMOTE_CODE")
-        if _env_trust is not None and _env_trust.lower() in (
-            "0",
-            "false",
-            "no",
-            "off",
-        ):
-            _trust_remote_code = False
-            logger.warning(
-                "RAPID_MLX_TRUST_REMOTE_CODE=%s: remote model/tokenizer code "
-                "execution disabled; loading only with trust_remote_code=False.",
-                _env_trust,
-            )
-        tokenizer_config = {"trust_remote_code": _trust_remote_code}
+        # The shared loader applies RAPID_MLX_TRUST_REMOTE_CODE=0 across every
+        # text-model entry point. Keep the engine's explicit request here so
+        # the default serve behavior remains unchanged.
+        tokenizer_config = {"trust_remote_code": self._trust_remote_code}
 
         # Qwen3 fix
         if "qwen3" in self._model_name.lower() or "Qwen3" in self._model_name:

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1093,9 +1093,22 @@ class MLXMultimodalLM:
             from mlx_vlm import load
             from mlx_vlm.utils import load_config
 
+            from ..utils.tokenizer import apply_remote_code_policy
+
             logger.info(f"Loading MLLM: {self.model_name}")
 
-            self.model, self.processor = load(self.model_name)
+            _, trust_remote_code = apply_remote_code_policy(
+                {"trust_remote_code": self.trust_remote_code}
+            )
+            if trust_remote_code:
+                # Preserve mlx-vlm's historical call shape (and compatibility
+                # with older versions/wrappers) unless the operator opts out.
+                self.model, self.processor = load(self.model_name)
+            else:
+                self.model, self.processor = load(
+                    self.model_name,
+                    trust_remote_code=False,
+                )
             self.config = load_config(self.model_name)
 
             # Augment the wrapped tokenizer's EOS set with the chat-

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1104,12 +1104,20 @@ class MLXMultimodalLM:
                 # Preserve mlx-vlm's historical call shape (and compatibility
                 # with older versions/wrappers) unless the operator opts out.
                 self.model, self.processor = load(self.model_name)
+                self.config = load_config(self.model_name)
             else:
                 self.model, self.processor = load(
                     self.model_name,
                     trust_remote_code=False,
                 )
-            self.config = load_config(self.model_name)
+                # mlx-vlm 0.6.x currently reads config.json directly, but
+                # forwarding the policy here makes the process-wide opt-out
+                # explicit and prevents a future/config-loader implementation
+                # from silently re-enabling repository code.
+                self.config = load_config(
+                    self.model_name,
+                    trust_remote_code=False,
+                )
 
             # Augment the wrapped tokenizer's EOS set with the chat-
             # template terminator ids from ``generation_config.json``.

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1175,6 +1175,41 @@ def _parse_csv(value: str) -> list[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
+def configure_trusted_hosts(cli_hosts: list[str] | None = None) -> None:
+    """OPT-IN Host-header allowlist (DNS-rebinding / Host-header-spoofing
+    hardening) via Starlette's ``TrustedHostMiddleware``.
+
+    Resolution:
+      1. ``--trusted-hosts`` CLI flag (comma-separated) — takes precedence.
+      2. ``RAPID_MLX_TRUSTED_HOSTS`` env var (comma-separated).
+      3. Unset / empty → middleware is NOT registered. This is the default:
+         restricting the Host header would break ``rapid-mlx share`` (which
+         forwards the public-facing Host header into the local server) and
+         LAN access via machine hostname, so an operator opts in deliberately.
+
+    ``allowed_hosts`` (Starlette) values cross-match the request ``Host``
+    header against glob patterns; ``*`` and ``localhost``/``127.0.0.1`` are
+    typical. A request whose Host matches nothing is rejected with 400.
+    """
+    hosts: list[str] = []
+    if cli_hosts:
+        hosts = list(cli_hosts)
+    else:
+        env_raw = os.environ.get("RAPID_MLX_TRUSTED_HOSTS")
+        if env_raw:
+            hosts = _parse_csv(env_raw)
+    if not hosts:
+        return
+    from starlette.middleware.trustedhost import TrustedHostMiddleware
+
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=hosts)
+    logger.info(
+        "TrustedHostMiddleware enabled (allowed_hosts=%s): requests with a "
+        "non-matching Host header are rejected.",
+        hosts,
+    )
+
+
 def configure_cors_from_env(
     cli_origins: list[str] | None = None,
 ) -> list[str]:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1175,7 +1175,7 @@ def _parse_csv(value: str) -> list[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
-def configure_trusted_hosts(cli_hosts: list[str] | None = None) -> None:
+def configure_trusted_hosts(cli_hosts: list[str] | None = None) -> list[str]:
     """OPT-IN Host-header allowlist (DNS-rebinding / Host-header-spoofing
     hardening) via Starlette's ``TrustedHostMiddleware``.
 
@@ -1192,14 +1192,16 @@ def configure_trusted_hosts(cli_hosts: list[str] | None = None) -> None:
     typical. A request whose Host matches nothing is rejected with 400.
     """
     hosts: list[str] = []
-    if cli_hosts:
-        hosts = list(cli_hosts)
+    if cli_hosts is not None:
+        # argparse's nargs="+" accepts both ``a b`` and values users commonly
+        # write as ``a,b``. Normalize each entry so CLI and env semantics match.
+        hosts = [host for entry in cli_hosts for host in _parse_csv(entry)]
     else:
         env_raw = os.environ.get("RAPID_MLX_TRUSTED_HOSTS")
         if env_raw:
             hosts = _parse_csv(env_raw)
     if not hosts:
-        return
+        return []
     from starlette.middleware.trustedhost import TrustedHostMiddleware
 
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=hosts)
@@ -1208,6 +1210,7 @@ def configure_trusted_hosts(cli_hosts: list[str] | None = None) -> None:
         "non-matching Host header are rejected.",
         hosts,
     )
+    return hosts
 
 
 def configure_cors_from_env(

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -586,6 +586,24 @@ def share_command(args: argparse.Namespace) -> None:
         extra_serve_args.extend(passthrough)
 
     api_key = secrets.token_hex(24)
+    # SH-1: if the operator has configured a serve API key (the standard
+    # path is RAPID_MLX_API_KEY, which server._resolve_api_key consumes),
+    # it does NOT protect this share. share mints its own fresh single-use
+    # bearer key below and overwrites that env var in the spawned serve, so
+    # the operator's configured key is ignored. More importantly, a live
+    # share tunnel forwards public-internet requests onto the loopback-bound
+    # serve, so any assumption that the serve is only reachable from this
+    # machine is broken while sharing.
+    if os.environ.get("RAPID_MLX_API_KEY"):
+        print(
+            "warning: RAPID_MLX_API_KEY is set, but `rapid-mlx share` "
+            "ignores it and mints a fresh single-use key (shown below). "
+            "The share tunnel also exposes this machine's loopback serve "
+            "to the public internet, so your configured API-key auth does "
+            "NOT protect the share — anyone holding the fresh key below can "
+            "use your compute. Press Ctrl-C to abort.",
+            file=sys.stderr,
+        )
     # Port parsing is lazy on purpose: validating RAPID_MLX_SHARE_PORT at
     # parser-build time crashes ``rapid-mlx models`` (and every other
     # unrelated subcommand) when the env var is set to garbage.

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -557,7 +557,7 @@ def share_command(args: argparse.Namespace) -> None:
                 "reachable only through the tunnel; --host would re-expose "
                 "it on your LAN"
             ),
-            "--api-key": "share mints its own single-use bearer key",
+            "--api-key": "share mints its own per-share bearer key",
             "--port": "use `rapid-mlx share --port` instead",
             "--listen-fd": "share owns the serve process lifecycle",
             "--log-level": "share sets the serve log level",
@@ -588,20 +588,23 @@ def share_command(args: argparse.Namespace) -> None:
     api_key = secrets.token_hex(24)
     # SH-1: if the operator has configured a serve API key (the standard
     # path is RAPID_MLX_API_KEY, which server._resolve_api_key consumes),
-    # it does NOT protect this share. share mints its own fresh single-use
+    # it does NOT protect this share. share mints its own fresh per-share
     # bearer key below and overwrites that env var in the spawned serve, so
     # the operator's configured key is ignored. More importantly, a live
     # share tunnel forwards public-internet requests onto the loopback-bound
     # serve, so any assumption that the serve is only reachable from this
     # machine is broken while sharing.
+    print(
+        "warning: `rapid-mlx share` exposes this model to the public internet. "
+        "Anyone holding the generated share URL/key can use your compute. "
+        "Press Ctrl-C to stop sharing.",
+        file=sys.stderr,
+    )
     if os.environ.get("RAPID_MLX_API_KEY"):
         print(
             "warning: RAPID_MLX_API_KEY is set, but `rapid-mlx share` "
-            "ignores it and mints a fresh single-use key (shown below). "
-            "The share tunnel also exposes this machine's loopback serve "
-            "to the public internet, so your configured API-key auth does "
-            "NOT protect the share — anyone holding the fresh key below can "
-            "use your compute. Press Ctrl-C to abort.",
+            "does not reuse it; a fresh per-share key is generated instead. "
+            "Your configured key does not grant access to this share.",
             file=sys.stderr,
         )
     # Port parsing is lazy on purpose: validating RAPID_MLX_SHARE_PORT at

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1043,6 +1043,22 @@ def load_model_with_fallback(
     # or fallback loader runs.  Remote repository ids are intentionally a no-op
     # here; see validate_local_model_file for the containment boundary.
     validate_local_model_file(model_name)
+
+    # Security hardening: when remote-code execution is enabled (the default,
+    # for maximal community-model compatibility) and this model actually needs
+    # it (its config declares ``auto_map``), say so BEFORE any repo code is
+    # downloaded and run. This turns silent code execution into an informed
+    # choice; opt out process-wide with RAPID_MLX_TRUST_REMOTE_CODE=0 (see
+    # BatchedEngine). A probe failure is silent — never breaks loading.
+    if _model_requires_remote_code(model_name):
+        logger.warning(
+            "Security: model %r declares auto_map (custom Python code). "
+            "Loading will DOWNLOAD AND EXECUTE that repo's code locally. "
+            "Only continue if you trust this model's source. Disable with "
+            "RAPID_MLX_TRUST_REMOTE_CODE=0 if you do not need it.",
+            model_name,
+        )
+
     if lazy:
         from mlx_lm import load as _mlx_lm_load
 
@@ -1191,6 +1207,59 @@ def _read_tokenizer_config_json(model_name: str) -> dict | None:
     except Exception as e:  # noqa: BLE001 — a probe must not break loading
         logger.debug("tokenizer_config.json probe failed for %s: %s", model_name, e)
         return None
+
+
+def _read_model_config_json(model_name: str) -> dict | None:
+    """Best-effort read of a model's ``config.json``.
+
+    Mirrors :func:`_read_tokenizer_config_json` (local dir first, cache-only
+    hub fetch with a network fallback for a fresh ``serve <repo-id>``). Any
+    failure returns ``None`` so callers fall through to the unmodified load
+    path — this is a pre-load probe and must never itself break loading.
+    """
+    try:
+        local = Path(model_name)
+        if local.is_dir():
+            cfg_path = local / "config.json"
+            if not cfg_path.is_file():
+                return None
+        else:
+            from huggingface_hub import hf_hub_download
+
+            try:
+                cfg_path = Path(
+                    hf_hub_download(model_name, "config.json", local_files_only=True)
+                )
+            except Exception:
+                cfg_path = Path(hf_hub_download(model_name, "config.json"))
+        with open(cfg_path) as f:
+            return json.load(f)
+    except Exception as e:  # noqa: BLE001 — a probe must not break loading
+        logger.debug("config.json probe failed for %s: %s", model_name, e)
+        return None
+
+
+def _model_requires_remote_code(model_name: str) -> bool:
+    """Return True if the model's ``config.json`` / ``tokenizer_config.json``
+    declares ``auto_map`` custom code.
+
+    ``auto_map`` is HF transformers' opt-in for executing model/tokenizer
+    Python shipped inside a repo (the remote-code execution gate). When a
+    model declares it, loading with ``trust_remote_code=True`` will download
+    and run that code locally — so surfacing it lets operators make an
+    informed choice before the code executes. Any probe failure returns
+    ``False`` (no warning) so loading is never broken by the probe.
+    """
+    try:
+        tok_cfg = _read_tokenizer_config_json(model_name)
+        if tok_cfg and tok_cfg.get("auto_map"):
+            return True
+        model_cfg = _read_model_config_json(model_name)
+        if model_cfg and model_cfg.get("auto_map"):
+            return True
+    except Exception as e:  # noqa: BLE001 — a probe must never break loading
+        logger.debug("remote-code probe failed for %s: %s", model_name, e)
+    return False
 
 
 def _neutralize_unbundled_template_types(

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -9,12 +9,36 @@ directly from tokenizer.json.
 
 import json
 import logging
+import os
 from pathlib import Path
 
 from .chat_templates import DEFAULT_CHATML_TEMPLATE, NEMOTRON_CHAT_TEMPLATE
 from .model_file_guard import validate_local_model_file
 
 logger = logging.getLogger(__name__)
+
+_FALSE_ENV_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def apply_remote_code_policy(
+    tokenizer_config: dict | None,
+) -> tuple[dict | None, bool]:
+    """Apply the process-wide remote-code opt-out without changing defaults.
+
+    ``None`` remains ``None`` when the environment variable is unset, which
+    preserves the loader's historical defaults for non-serve call sites.  An
+    explicit false value is authoritative across every caller of the shared
+    loader, including bench and disk-stream paths.
+    """
+    configured = tokenizer_config is not None
+    config = dict(tokenizer_config or {})
+    requested = bool(config.get("trust_remote_code", True))
+    raw = os.environ.get("RAPID_MLX_TRUST_REMOTE_CODE")
+    if raw is not None and raw.strip().lower() in _FALSE_ENV_VALUES:
+        config["trust_remote_code"] = False
+        return config, False
+    return (config if configured else None), requested
+
 
 # Install the per-layer Indexer gate for REAP-pruned DeepseekV32 configs
 # (e.g. mlx-community/pipenetwork-GLM-5.2-REAP50-MLX-4bit). The hook is
@@ -1044,6 +1068,8 @@ def load_model_with_fallback(
     # here; see validate_local_model_file for the containment boundary.
     validate_local_model_file(model_name)
 
+    tokenizer_config, trust_remote_code = apply_remote_code_policy(tokenizer_config)
+
     # Security hardening: when remote-code execution is enabled (the default,
     # for maximal community-model compatibility) and this model actually needs
     # it (its config declares ``auto_map``), say so BEFORE any repo code is
@@ -1051,13 +1077,20 @@ def load_model_with_fallback(
     # choice; opt out process-wide with RAPID_MLX_TRUST_REMOTE_CODE=0 (see
     # BatchedEngine). A probe failure is silent — never breaks loading.
     if _model_requires_remote_code(model_name):
-        logger.warning(
-            "Security: model %r declares auto_map (custom Python code). "
-            "Loading will DOWNLOAD AND EXECUTE that repo's code locally. "
-            "Only continue if you trust this model's source. Disable with "
-            "RAPID_MLX_TRUST_REMOTE_CODE=0 if you do not need it.",
-            model_name,
-        )
+        if trust_remote_code:
+            logger.warning(
+                "Security: model %r declares auto_map (custom Python code). "
+                "Loading may DOWNLOAD AND EXECUTE that repo's code locally. "
+                "Only continue if you trust this model's source. Disable with "
+                "RAPID_MLX_TRUST_REMOTE_CODE=0 if you do not need it.",
+                model_name,
+            )
+        else:
+            logger.warning(
+                "Model %r declares auto_map custom code, but remote code is "
+                "disabled; loading will continue with trust_remote_code=False.",
+                model_name,
+            )
 
     if lazy:
         from mlx_lm import load as _mlx_lm_load


### PR DESCRIPTION
## Summary

Security hardening for five audited boundaries, with compatibility-preserving defaults where safe and explicit fail-closed behavior for unsafe checkpoint deserialization.

### 1. Remote model code visibility and opt-out
- Historical default remains enabled for community-model compatibility.
- Models declaring custom `auto_map` code emit an explicit warning.
- `RAPID_MLX_TRUST_REMOTE_CODE=0` is enforced across text, benchmark, disk-stream, and multimodal model/config loading paths.

### 2. Standalone Python supply-chain integrity
- The pinned arm64 Python artifact is verified against its exact SHA256 committed in `install.sh` before extraction.
- A mismatch aborts installation; temporary artifacts are cleaned on every exit path.

### 3. Opt-in Host-header allow-listing
- `--trusted-hosts` / `RAPID_MLX_TRUSTED_HOSTS` installs Starlette `TrustedHostMiddleware`.
- Default remains off so LAN and `rapid-mlx share` behavior is unchanged.
- Comma- and space-separated host input is normalized consistently.

### 4. Fail-closed SA3 checkpoint loading
- SA3 checkpoints load with `weights_only=True` by default.
- Unsafe legacy pickle fallback is refused unless the operator explicitly sets `RAPID_MLX_ALLOW_UNSAFE_SA3_PICKLE=1`; the opt-in path emits a warning.

### 5. Share exposure warning
- `rapid-mlx share` always warns that the tunnel exposes compute publicly to holders of its generated URL/key.
- When `RAPID_MLX_API_KEY` is configured, it explains that share does not reuse that key and instead generates a fresh per-share key.

## Regression validation

- Full local suite: **17,712 passed, 241 skipped, 45 deselected, 6 xfailed, 1 xpassed**
- Focused security / audio / share regressions: **238 passed**
- MLLM policy regressions: **55 passed**
- `ruff check .` and `ruff format --check vllm_mlx tests`
- installer shell syntax + installer suite: **18 passed**
- No GUI code changed; GUI golden-flow coverage is not applicable.

Closes the reviewed security findings.
