### PR TITLE
chore: bump version to 0.12.15

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,12 +13,56 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.15] — 2026-08-17
+
+Fixes a bug that could silently truncate files your coding agent writes, adds a
+Developer section to Settings, and brings MTP acceleration to the Qwen 3.8
+models that ship with it.
+
+### Fixed
+
+- **Coding agents no longer get truncated file writes.** When an agent asked a
+  Qwen 3.5 or 3.6 model to write a file, the file could be cut off at the first
+  line break — a 700-byte file arriving as 11 bytes — with no error shown
+  anywhere. Short values could come back subtly misspelled (`Tokyo` as `Toyo`).
+  This affected versions 0.12.5 through 0.12.14; if you ran a coding agent on
+  those, it is worth re-checking files it wrote.
+- Downloading a model no longer crawls when our mirror slows down. Each file
+  now watches its own speed and switches to Hugging Face if the transfer
+  collapses, instead of waiting it out — one 335 MB model took 8 minutes before.
+- Voice transcription no longer invents words when a clip is short or silent.
+  A brief silent recording now returns nothing instead of a made-up sentence.
+- Images and other visual input work correctly again on hybrid vision models,
+  which could previously answer from the wrong cached state.
+- Media-only models (image, audio, video) no longer appear as things you can
+  launch for chat.
+
 ### Added
 
-- Qwen3.8-27B users can explicitly opt into MTP acceleration from
-  Settings → Performance. It remains off by default because the measured
-  speedup varies by Mac, and is available for both Rapid's standard 4-bit and
-  mixed-precision builds.
+- **Settings → Developer**, in development builds only: rehearse the first-run
+  experience without touching your real setup. You choose what gets erased —
+  conversations, settings, and the telemetry decision are each opt-in, and the
+  confirmation names every item before anything is removed.
+- **MTP acceleration for Qwen 3.8**, opt-in from Settings → Performance. It is
+  off by default because the speedup varies by machine. Models that ship an MTP
+  head now carry everything needed to run it, so turning it on just works; a
+  model without one refuses to start rather than quietly running unaccelerated.
+- DeepSeek Harness joins Claude Code, Codex, Hermes and Aider as a fully
+  supported coding agent — including in the gate that every release must pass.
+
+### Security
+
+- Model files downloaded from the internet are treated as untrusted by default:
+  code shipped inside a model repository no longer runs implicitly, downloaded
+  Python components are checksum-verified, and the audio checkpoint loader
+  refuses formats that can execute code unless you opt in.
+
+### Changed
+
+- The status footer drops readouts it cannot fit instead of squeezing six
+  indicators into the width of four.
+- Installing on Apple Silicon now insists on a matching Python and repairs a
+  half-built environment, instead of leaving an installation that never worked.
 
 ## [0.12.14] — 2026-08-15
 

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.14</string>
+	<string>0.12.15</string>
 	<key>CFBundleVersion</key>
-	<string>158</string>
+	<string>159</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.12.15.md
+++ b/docs/release-notes/v0.12.15.md
@@ -1,0 +1,113 @@
+## Highlights
+
+### Tool calls no longer truncate what your agent writes
+
+If you drive a coding agent against a Qwen3.5 or Qwen3.6 model, this is the
+release to take.
+
+Constrained tool calling — on by default — was forcing every free-form string
+argument into a JSON-quoted form on the Qwen3-Coder XML wire, where the model
+writes those values bare. Pushed off-distribution, the model would open the
+forced quote, reach a newline it could not write raw, and close the string
+instead of escaping it. The argument was cut at the first newline.
+
+Concretely, on `qwen3.6-35b-8bit`, a `write_file` call meant to produce a
+710-byte helper returned **11 bytes** — `"import time"` — and nothing else.
+Nothing looked wrong from the caller's side: `finish_reason` was `tool_calls`
+and the arguments were valid JSON. Short values corrupted more quietly on the
+same run: `Tokyo` came back as `Toyo`, `Osaka` as `osaka`.
+
+Fixed. A tool parameter that the wire cannot frame is no longer constrained at
+all, rather than constrained into the wrong shape. Enum values, numbers,
+booleans, objects, arrays and nested strings keep their guarantee, as do Gemma 4
+and every JSON-body model family — those quote natively, so they were never
+affected.
+
+This regressed in **0.12.5** and was present through **0.12.14**. If you ran a
+coding agent on a Qwen3-Coder-family model on any of those versions, re-check
+files it wrote: the truncation left no error behind. Nothing else needs doing —
+upgrading is enough.
+
+### DeepSeek Harness joins the Tier-1 agents
+
+`dsh` is now a first-class supported agent alongside Claude Code, Codex, Hermes
+and Aider. That means it is wired into the release gate: every release now boots
+a real server and drives all five agents through a genuine multi-step bug-fix
+task, and a regression in any one of them blocks the release.
+
+```bash
+rapid-mlx agents dsh --setup
+```
+
+Rapid-MLX also now tells `dsh` the truth about whether the model you are serving
+can reason, so a model without a reasoning parser stops showing an
+off/low/medium/high control that does nothing.
+
+### MTP acceleration for Qwen3.8
+
+Qwen3.8-27B can now decode with a multi-token-prediction head. It is opt-in, and
+the aliases that ship an MTP head now carry everything needed to run it:
+
+```bash
+rapid-mlx serve qwen3.8-27b-mixed-3.5bpw --speculative-config '{"method":"mtp"}'
+```
+
+That command previously failed, because the sidecar and draft depth an alias
+declares were shown by `rapid-mlx models` and read nowhere else. Both are now
+honoured, and an explicit `--speculative-config` still overrides them. Desktop
+users get the same switch under Settings → Performance.
+
+It stays off by default: the measured speedup varies by machine, and a model
+without an MTP head still refuses to start rather than quietly serving without
+acceleration.
+
+### Whisper stops inventing words in silence
+
+A short clip is padded to Whisper's 30-second window, and the padding was being
+transcribed as speech. A 0.4-second silent clip now returns an empty
+transcript instead of a hallucinated sentence.
+
+### Fixes
+
+- **`install.sh` on Apple Silicon** — it could select an x86_64 Python and leave
+  a venv that never worked. It now requires an arm64 interpreter and rebuilds an
+  incomplete environment. Thanks to @moinulmoin for the report.
+- **Vision on hybrid models** — multimodal requests on hybrid VLM checkpoints
+  now get the right cache, fixing wrong or empty answers.
+- **Model listings** — media-only models no longer appear as launchable chat
+  models, and the desktop status footer sheds readouts instead of squeezing six
+  chips into the width of four.
+- **MTP sidecars** — loading a sidecar whose quantization differs from the base
+  checkpoint now warns instead of silently degrading quality.
+
+### Downloads no longer crawl when the mirror throttles
+
+`rapid-mlx pull` fetches from the project's own mirror, which sometimes serves a
+fast first stretch and then drops to a trickle. The client only noticed a
+*silent* stall, not a slow one — bytes kept arriving, so it waited. A 335 MB
+model measured **8 minutes** that way; the same files from HuggingFace take
+seconds.
+
+Each file now watches its own transfer rate. If it collapses and stays down, that
+file is abandoned and finished from HuggingFace instead, per file, mid-pull. A
+healthy download is untouched: the check ignores connection start-up and needs
+two consecutive slow windows before it acts, so only a sustained stall triggers
+it. `RAPID_MLX_MIRROR_MIN_MBPS=0` disables it.
+
+The underlying mirror throughput is being investigated separately.
+
+### Security hardening
+
+A pass over the paths where a downloaded artifact gets to influence execution:
+
+- Remote code in a model repository is no longer trusted implicitly when
+  loading tokenizers and multimodal models.
+- Downloaded Python artifacts are verified by SHA256.
+- The SA3 audio checkpoint loader refuses pickled weights unless explicitly
+  allowed, and `rapid-mlx share` warns before a key leaves the machine.
+- `rapid-mlx serve` can restrict which HTTP `Host` headers it answers
+  (`--trusted-hosts`); off by default, so a normal local serve is unchanged.
+
+### Removed
+
+- `rapid-mlx jlens` — an unused subcommand.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.14"
+version = "0.12.15"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Because 0.12.5 through 0.12.14 — nine released tags — silently truncated tool
call string arguments on the model family we recommend by default, and users
have no way to notice: the call reports success with valid JSON. Shipping the
fix is the point of this release. Refs #1996, #1998, #1999.

Cuts the release carrying the tool-argument truncation fix, DeepSeek Harness as
a Tier-1 agent, MTP acceleration for Qwen 3.8, the Whisper padded-tail fix, and
a security-hardening pass. 35 commits since `v0.12.14`.

Carries all four required pieces: the pyproject version, the desktop app's
`CFBundleShortVersionString` + `CFBundleVersion` (158 → 159), the CHANGELOG
section the release job pre-checks, and the promoted release notes.

## What this release is really about

`#1996` — constrained tool calling silently truncated string arguments on the
Qwen3-Coder XML wire. A `write_file` call meant to produce a 710-byte file
returned **11 bytes**, with `finish_reason: tool_calls` and valid JSON
arguments, so nothing surfaced as an error. It affected **every release from
0.12.5 through 0.12.14** — nine tags — on the model family we recommend by
default. The notes tell users to re-check files their agents wrote.

## Dogfood behind this cut

On the Studio (M3 Ultra), against this exact tree unless noted:

- **Fresh user path**: real `install.sh` into an empty `$HOME`, GitHub HEAD →
  installs clean, `doctor` reports 0 issues, `pull` downloads and caches.
- **Server sweep, 20/20**: streaming, reasoning split, tool round-trip,
  streaming tool calls, `json_schema` / `json_object`, `/v1/completions`,
  Anthropic `/v1/messages`, metrics, error handling, prefix cache, 8-way
  concurrency. Re-run after the security-hardening commit landed.
- **The #1996 regression, directly**: 710-byte file, valid Python.
- **Qwen3.8-27B**: writes code that executes and passes 4 cases, answers a trap
  reasoning question, emits a tool call with correct fields, recalls a needle.
- **MTP on Qwen3.8-27B**: 38.9 → 44.1 tok/s mean (**1.13×**, up to 1.23× on
  structured output), and **byte-identical output** — same sha256 across all
  four prompts, so the lossless claim holds on real hardware.
- **Image generation**: 1024×1024 in 34.7 s, and the image matches the prompt.
- **Vision / STT**: gemma-4-26b answers about a real chart; a 0.4 s silent clip
  transcribes to nothing instead of a hallucinated sentence.
- **GUI**: 25 golden flows pass; `gui-golden-flows` is green on main again
  after #2007's evidence and #2009's fix.
- **Unit suite**: 17,723 passed on a clean checkout.

## Known, filed, not blocking

- **#2010** — the R2 mirror is the slowest part of the new-user path. Root-caused
  to our own Worker: R2 direct serves 18-31 MB/s, the same object through
  `models.rapidmlx.com` measured 0.12-0.39 MB/s. Infrastructure, not a code
  regression, and unchanged by this release.
- **#2008** — CI runs 12 of the 25 GUI golden flows.
- **#2001** — the XML tool wire could regain its grammar constraint via
  `rule[lazy]`; #1996 chose the safe option for the release window.

## Checklist

- [x] Tests pass locally
- [x] Lint passes
- [x] Verified end-to-end on real hardware
- [x] All four bump pieces present
- [x] No breaking changes to existing API