### PR TITLE
fix(gui-golden): retry a transient AXPress instead of failing the whole gate

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -830,9 +830,25 @@ press() {
     local tree="$1" identifier="$2" evidence="$3"
     jq -e --arg id "$identifier" '.data.ui_elements[]? | select(.identifier == $id)' "$tree" >/dev/null \
         || { printf '[gui-golden] AX identifier missing: %s\n' "$identifier" >&2; return 1; }
-    "$AX_DRIVER" press "$APP_PID" "$identifier" > "$evidence" || return 1
-    jq -e '.success' "$evidence" >/dev/null \
-        || { printf '[gui-golden] AXPress failed: %s\n' "$identifier" >&2; return 1; }
+    # Retry the press itself. SwiftUI can replace the accessibility element
+    # backing a control between the dump above and the AXPress below, and the
+    # press then fails with a transient invalid-element / cannot-complete error
+    # (#2009 identified this and fixed three call sites inline; there are 126).
+    # A single transient miss on ANY of them failed the whole gate, which is why
+    # three consecutive runs of this suite failed at three DIFFERENT controls —
+    # Choose File twice, then Check for updates. The identifier precheck stays
+    # OUTSIDE the loop: a genuinely absent control must still fail immediately
+    # rather than costing three attempts.
+    local attempt
+    for attempt in 1 2 3; do
+        if "$AX_DRIVER" press "$APP_PID" "$identifier" > "$evidence" 2>/dev/null \
+            && jq -e '.success' "$evidence" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.4
+    done
+    printf '[gui-golden] AXPress failed after 3 attempts: %s\n' "$identifier" >&2
+    return 1
 }
 
 round_trip_toggle() {


### PR DESCRIPTION
## Why

Because `gui-golden-flows` is currently blocking the 0.12.15 release for reasons
that have nothing to do with the release. Three consecutive runs on the bump PR
failed at **three different controls**:

| run | failure |
|---|---|
| 1 | `Choose File selected no usable audio file or Transcribe stayed disabled` |
| 2 | `Choose File selected no usable audio file or Transcribe stayed disabled` |
| 3 | `Check for updates is not pressable` |

A different control each time is the signature of a flake, not a broken button.
Refs #2008.

## What

#2009 already diagnosed the mechanism — SwiftUI can replace the accessibility
element backing a control between the tree dump and the `AXPress`, so the press
returns a transient invalid-element / cannot-complete error — and fixed it
inline at three call sites.

`press()` has **126** call sites. One transient miss on any of them fails the
entire suite. So the retry moves into the shared helper: up to three attempts,
0.4 s apart.

The identifier precheck stays **outside** the loop on purpose. A control that is
genuinely absent still fails on the first pass with `AX identifier missing`,
costing one attempt rather than three. The gate must not get slower, and must
not become more forgiving about real breakage — only about a press that lost its
element.

## Verification, and its limit

Stated plainly: **not verified locally.** The Studio's screen re-locked mid-run
and the harness correctly refuses to drive a locked session, so both attempts
stopped at the precondition check without reaching a flow. `bash -n` passes and
the diff is one function.

CI runs this suite in the unattended session where the flake actually happens,
which makes it the authoritative test here — a local pass would have proven less
than a CI pass does. If this run goes green where the last three went red, that
is the evidence.

## Checklist

- [x] Lint passes (`bash -n`)
- [x] Scope is one shared helper; no product code touched
- [x] Real absence still fails fast (precheck kept outside the retry loop)
- [x] No breaking changes to existing API
