### PR TITLE
test(routing): allowlist the RAPID_MLX_MIRROR_MIN_MBPS download knob

### DIFF
--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -266,6 +266,14 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # default R2 URL; power users override with any URL or "" to disable.
         # Never consulted by the engine, scheduler, or routing layer.
         "RAPID_MLX_MODEL_MIRROR",
+        # Throughput floor (MB/s, float) for the mirror-download guard in
+        # ``vllm_mlx/_mirror.py``. When a shard from ``RAPID_MLX_MODEL_MIRROR``
+        # sustains below this rate the download aborts and retries the same
+        # bytes via huggingface_hub. ``0`` or a negative value disables the
+        # guard; unset uses the built-in default. Purely a download-speed knob —
+        # it only changes *how fast / from where* bytes arrive, never which
+        # model alias loads, which parser fires, or which tier engages.
+        "RAPID_MLX_MIRROR_MIN_MBPS",
         # SIGTERM-grace budget (seconds, float) for the lifespan prefix-cache
         # flush in ``vllm_mlx/runtime/cache.py``. Defaults to 3.5s so a
         # multi-GB save commits its partial snapshot before downstream


### PR DESCRIPTION
## Why

`test_no_routing_shaped_rapid_mlx_env_vars` fails **deterministically on `main`** right now:

```
_mirror.py:106 references env var `RAPID_MLX_MIRROR_MIN_MBPS` —
not in ALLOWED_RAPID_MLX_ENV_VARS.
```

#2015 introduced the `RAPID_MLX_MIRROR_MIN_MBPS` download-throughput knob but did not register it in the allowlist. The guard test lives only in the non-required `full_unit` suite, so it slipped past #2015's required `tests` gate and left `main` red on a routing-security guard just before release.

## What

Add `RAPID_MLX_MIRROR_MIN_MBPS` to `ALLOWED_RAPID_MLX_ENV_VARS`, with a comment beside its sibling `RAPID_MLX_MODEL_MIRROR` following the file's documented convention.

The variable is a pure download-speed knob: it only changes *how fast / from where* bytes arrive (abort a throttled mirror shard and retry via huggingface_hub). It never selects which model alias loads, which parser fires, or which tier engages — so it is a non-routing knob and belongs on the allowlist.

## Tests

- `tests/test_no_out_of_band_routing.py` → **14 passed** (was 1 failed on `main`).

## Notes

Follow-up to #2015; restores `main` to green on the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-assisted: authored with Claude Code (Opus 4.8); human-reviewed before merge.