### PR TITLE
fix(tests): allowlist the mirror throughput-floor env knob (#2015)

### DIFF
--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -153,6 +153,12 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # these cannot alter emitted tokens either. Read only by
         # ``vllm_mlx.spec_decode.mtp.generator``.
         #
+        # ``RAPID_MLX_MIRROR_MIN_MBPS`` (#2015 / #2010) is the download
+        # throughput floor: below it a shard's R2 attempt is abandoned and the
+        # file is finished from HuggingFace. It selects a download SOURCE for
+        # identical bytes (sha256-verified either way), never a routing/decode
+        # path; 0 disables the guard.
+        "RAPID_MLX_MIRROR_MIN_MBPS",
         # ``RAPID_MLX_MTP_PROMPT_LOOKUP`` is the explicit opt-in (default
         # OFF) held until Qwen's hybrid SSM target path is proven
         # token-lossless across verification chunk boundaries; the other


### PR DESCRIPTION
## Why

Because main is red again on `test_no_routing_shaped_rapid_mlx_env_vars`: #2015
added `RAPID_MLX_MIRROR_MIN_MBPS` without allowlisting it — the identical miss
#1969 made with the MTP prompt-lookup knobs, fixed the identical way by #1980.
This guard does not run in the CI matrix, only in pr_validate's `full_unit`,
which is why #2015 merged green and every PR validated after it (including the
0.12.15 bump, #2013) now fails validation on a test it did not touch. Refs #2015, #2010.

## What

One allowlist entry with the required rationale comment. The knob selects the
download SOURCE for byte-identical files (R2 vs HuggingFace, sha256-verified
either way — verified in the #2015 review); it never influences a routing or
decode path, which is what the guard exists to forbid.

## Test plan

- `tests/test_no_out_of_band_routing.py` — 14 passed (was 1 failed on main).
- `ruff check` + `ruff format --check` clean.
- Reverting the allowlist entry reproduces the exact main failure.

## Checklist

- [x] Tests pass locally
- [x] Lint passes
- [x] No breaking changes to existing API