### PR TITLE
fix(gui-golden): stop the FilePicker re-press storm cancelling its own selection

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3864,14 +3864,24 @@ flow_audio_readiness() {
 
     see_main "$OUT/transcription-controls-before.json"
     local file_selected=0
-    for ((i=0; i<40; i++)); do
+    for ((i=0; i<80; i++)); do
         # AXPress can return success for a SwiftUI button whose backing object
         # is replaced before its closure runs. Resolve the current button on
         # every attempt and require the actual selection + enabled Transcribe
         # state instead of treating the AX result as proof of user-visible work.
-        "$AX_DRIVER" press "$APP_PID" Audio.Transcription.FilePicker \
-            > "$OUT/transcription-file-press.json" 2>/dev/null || true
-        sleep 0.1
+        # Re-press only every ~2.5 s, not every iteration. Each press calls
+        # ``chooseAudioFile()`` → ``selectFile()``, which RESTARTS the file's
+        # async validation; on a busy unattended runner validation can outlast
+        # one 0.35 s loop period, so a per-iteration re-press keeps cancelling
+        # the work it is waiting for — a livelock. That is why this step kept
+        # failing in CI (3 of the last 5 runs) while passing on any warm local
+        # machine, and why the #2009 in-loop re-press did not cure it. One
+        # press per settle window keeps delivery-retry without the storm.
+        if (( i % 10 == 0 )); then
+            "$AX_DRIVER" press "$APP_PID" Audio.Transcription.FilePicker \
+                > "$OUT/transcription-file-press.json" 2>/dev/null || true
+            sleep 0.1
+        fi
         see_main "$OUT/transcription-file-selected.json"
         if jq -e '((.data.ui_elements | tostring) | contains("assistant_bank_en.wav"))
                   and any(.data.ui_elements[]?;


### PR DESCRIPTION
## Why

Because `gui-golden-flows` is the last red gate on the 0.12.15 bump (#2013), and
its failure is self-inflicted by the harness. The audio-readiness `Choose File`
step failed 3 of the last 5 unattended runs — twice AFTER #2009 added an in-loop
re-press and once after #2017 added driver-level press retries. Refs #2008.

## What

Each press of `Audio.Transcription.FilePicker` calls `chooseAudioFile()` →
`selectFile()`, which **restarts** the file's async validation. The loop
re-pressed every 0.35 s, so on a busy runner where validation outlasts one loop
period, the retry kept cancelling the very work it was polling for — a livelock.
Locally validation finishes inside the first iteration, which is why this step
passes on any warm machine and fails only in CI.

- Re-press only every 10th iteration (~2.5 s settle windows) — delivery retry is
  preserved, the storm is not.
- Budget widened 40 → 80 iterations so one slow validation fits.
- Save/Play keep their per-iteration re-press deliberately: writing a file is
  idempotent and restart-free, and those steps have passed every run since #2017.

## Verification, and its limit

Passes locally both before and after — by the same timing that hides the bug —
so a local run proves nothing here. `bash -n` clean. The unattended CI run on
this PR is the authoritative test; the failure history above is the baseline it
is judged against.

## Checklist

- [x] Lint passes (`bash -n`)
- [x] Harness-only; no product code touched
- [x] No breaking changes to existing API