### PR TITLE
fix(mac): keep the image progress sweep inside its track

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -1073,6 +1073,17 @@ private struct ShimmerProgressBar: View {
                     .offset(x: slideX)
                     .animation(indeterminate ? nil : .easeOut(duration: 0.3), value: fraction)
             }
+            // The indeterminate sweep deliberately travels from `-fillW` to
+            // `w`, i.e. it starts and ends OUTSIDE the track so the shuttle
+            // enters and leaves rather than popping into existence at the
+            // edges. Without a clip that overhang is drawn: the fill escapes
+            // the track and paints over the HUD card's padding — visible as an
+            // orange bar bleeding past the card's left/right edges during the
+            // "Finalizing image…" phase, which is indeterminate for its whole
+            // duration and therefore shows the bug on every single render.
+            // Clipping to the track's own capsule keeps the motion intact and
+            // confines the paint to the groove it belongs in.
+            .clipShape(Capsule())
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

  Clips `ShimmerProgressBar`'s fill to the track capsule in the Images progress HUD (`ImagesView.swift`). One line plus the comment explaining why the clip is load-bearing; no change to the sweep's geometry, timing, or Reduce Motion behaviour.

  ## Why is this needed?

  The indeterminate shuttle is deliberately offset from `-fillW` to `w` so it enters and leaves the track instead of popping into existence at the edges. The enclosing `ZStack` was never clipped, so that intentional overhang got drawn: the orange fill escaped the groove and painted across the HUD card's 18pt padding, bleeding past the card's left and right edges.

  It is not an edge case. The bar is indeterminate for the entire `Finalizing image…` phase (`indeterminate: !denoising || finalizing`), which every generation and every edit passes through, so the broken frame is on screen at the end of literally every render.