### PR TITLE
test(mac): align the semantic-audit contract with the evidence model

### DIFF
--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
 HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
@@ -34,16 +35,45 @@ def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():
     assert "image-generation audio-readiness" in diagnostic
 
 
+SNAPSHOTS = ROOT / "apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__"
+
+
 @pytest.mark.parametrize(
     "flow",
     ["no-dead-controls", "catalog-integrity", "update-state", "launch-integrations"],
 )
 def test_semantic_control_audits_are_blocking_gui_ci(flow: str):
+    """Each semantic audit is gated, and its failure leaves usable evidence.
+
+    What "evidence" means depends on whether the flow owns committed AX
+    baselines. update-state and launch-integrations do, so they belong in the
+    regenerate-on-failure diagnostic loop (whose exact membership is pinned by
+    test_failure_diagnostic_regenerates_every_ci_baseline_and_nothing_else:
+    gated flows WITH baselines, nothing else — a snapshot-less audit in that
+    loop has nothing to regenerate). no-dead-controls and catalog-integrity
+    carry no snapshots; their evidence is the flow's own output directory,
+    which must sit inside the artifact uploaded on failure.
+    """
     workflow = WORKFLOW.read_text()
 
     assert f"Golden flow: {flow}" in workflow
     assert f"--flow {flow}" in workflow
-    diagnostic = workflow.split("Regenerate baselines on this runner (diagnostic)", 1)[
-        1
-    ]
-    assert flow in diagnostic
+
+    if any(p.name.startswith(flow) for p in SNAPSHOTS.glob("*.txt")):
+        diagnostic = workflow.split(
+            "Regenerate baselines on this runner (diagnostic)", 1
+        )[1]
+        assert flow in diagnostic
+    else:
+        steps = yaml.safe_load(workflow)["jobs"]["gui-golden-flows"]["steps"]
+        audit = next(s for s in steps if s.get("name") == f"Golden flow: {flow}")
+        out = audit.get("env", {}).get("RAPID_GUI_GOLDEN_OUT", "")
+        assert out == "${{ runner.temp }}/golden/" + flow
+        upload = next(s for s in steps if s.get("name") == "Upload AX evidence")
+        assert upload.get("if") == "failure()"
+        paths = [
+            ln.strip()
+            for ln in str(upload.get("with", {}).get("path", "")).splitlines()
+            if ln.strip()
+        ]
+        assert "${{ runner.temp }}/golden" in paths


### PR DESCRIPTION
## Why

Closes #2031. main has been red on `test_semantic_control_audits_are_blocking_gui_ci[no-dead-controls]` / `[catalog-integrity]` since #2014, failing every pr_validate full_unit run (full_unit-only guard — the #2020 blind spot), because the contract as written is unsatisfiable: it demanded all four semantic audits in the regenerate-on-failure diagnostic loop, while `test_failure_diagnostic_regenerates_every_ci_baseline_and_nothing_else` pins that loop to exactly the gated flows WITH committed AX baselines. The two snapshot-less audits have nothing to regenerate, and their first-run output already lands in the uploaded evidence artifact — re-running them in the loop would be theater (my first attempt here did exactly that and correctly tripped the coverage contract).

## What

Test-only; no workflow change. The contract now branches on whether the flow owns committed snapshots (derived from `__Snapshots__/`, not hardcoded):
- **with baselines** (update-state, launch-integrations): must appear in the diagnostic regen loop — unchanged requirement;
- **snapshot-less** (no-dead-controls, catalog-integrity): their `RAPID_GUI_GOLDEN_OUT` must be exactly `${{ runner.temp }}/golden/<flow>` and the `Upload AX evidence` step (`if: failure()`) must list `${{ runner.temp }}/golden` as an exact path line (exact-line match, not substring — a substring check survived the mutation).

## Testing

- `test_gui_control_behavior_contract.py` + `test_gui_golden_ci_coverage.py` — 9 passed (was 2 failed on clean main tip 662c401d).
- Mutations: dropping update-state from the regen loop → red; renaming the uploaded golden path → red; both restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)