### PR TITLE
fix(upgrade): prefer rapidmlx.com for upgrade, fall back to github.io

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,7 +19,7 @@ installs) the right Python automatically. Upgrade later with
 ## One-liner install script
 
 ```bash
-curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash
+curl -fsSL https://rapidmlx.com/install.sh | bash
 ```
 
 Auto-installs Python if needed, then `pipx install rapid-mlx`. Good fallback

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -10,6 +10,7 @@ laptop.
 from __future__ import annotations
 
 import json
+import os
 import urllib.parse
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -513,6 +514,23 @@ def test_detect_install_method_install_sh(tmp_path, monkeypatch):
     info = vc.detect_install_method()
     assert info.method == "install_sh"
     assert "install.sh" in info.upgrade_command
+    # Upgrade prefers the canonical rapidmlx.com host and falls back to the
+    # raullenchai.github.io Pages mirror — both present, primary first, wired
+    # with ``||`` so the mirror is only reached if rapidmlx.com fails.
+    cmd = info.upgrade_command
+    assert "https://rapidmlx.com/install.sh" in cmd
+    assert "https://raullenchai.github.io/Rapid-MLX/install.sh" in cmd
+    assert cmd.index("rapidmlx.com") < cmd.index("github.io")
+    assert "||" in cmd
+    # Fetch to a temp file and run only a complete download (never ``| bash``):
+    # guards against a false-success on total outage and a partial/hybrid script.
+    assert "mktemp" in cmd
+    assert "set -e" in cmd
+    assert "| bash" not in cmd
+    # Bounded timeouts so a blackholed primary fails fast into the fallback
+    # instead of hanging forever.
+    assert "--connect-timeout" in cmd
+    assert "--max-time" in cmd
 
 
 def test_detect_install_method_install_sh_via_symlink(tmp_path, monkeypatch):
@@ -539,8 +557,130 @@ def test_detect_install_method_install_sh_via_symlink(tmp_path, monkeypatch):
     info = vc.detect_install_method()
     assert info.method == "install_sh"
     assert "install.sh" in info.upgrade_command
+    cmd = info.upgrade_command
+    assert "https://rapidmlx.com/install.sh" in cmd
+    assert "https://raullenchai.github.io/Rapid-MLX/install.sh" in cmd
+    assert cmd.index("rapidmlx.com") < cmd.index("github.io")
+    assert "||" in cmd
     # Pipe needs a shell — wrapped as ``bash -c <pipe>``, never `shell=True`.
     assert info.upgrade_argv[:2] == ["bash", "-c"]
+    # The executed argv carries the same primary-first fallback pipeline.
+    argv_cmd = info.upgrade_argv[2]
+    assert "https://rapidmlx.com/install.sh" in argv_cmd
+    assert argv_cmd.index("rapidmlx.com") < argv_cmd.index("github.io")
+
+
+def _run_install_sh_upgrade(
+    tmp_path, monkeypatch, *, primary_ok, mirror_ok, primary_stall=False
+):
+    """Execute the real install_sh upgrade_argv with a stub ``curl`` on PATH.
+
+    The stub writes a host-tagged marker script to the ``-o`` target and exits 0
+    for an "ok" host, or exits non-zero (writing nothing) for a "down" host —
+    letting us assert the shell's fetch-to-temp-then-run semantics end to end.
+    With ``primary_stall`` the primary first asserts the bounded-timeout flags
+    reached it, then exits 28 (curl's timeout code) after a short sleep,
+    simulating a blackholed host hitting ``--max-time``.
+    Returns ``(returncode, sentinel_text_or_None)``.
+    """
+    import subprocess
+
+    home = tmp_path / "home"
+    (home / ".local" / "bin").mkdir(parents=True)
+    fake_binary = str(home / ".local" / "bin" / "rapid-mlx")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("shutil.which", lambda _name: fake_binary)
+    monkeypatch.setattr("os.path.realpath", lambda p: p)
+    argv = vc.detect_install_method().upgrade_argv
+
+    sentinel = tmp_path / "ran.txt"
+    primary_flags = tmp_path / "primary_flags.txt"
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    curl = stub_dir / "curl"
+    # ``curl -fsSL --connect-timeout N --max-time N <url> -o <file>`` — capture
+    # the whole argv, find the url + -o target, decide ok/fail by host, and
+    # (on ok) drop a script that records which host served it. Every primary
+    # invocation records whether the bounded-timeout flags were present to
+    # ``primary_flags`` — a signal independent of the fallback path, so a test
+    # can assert the flags actually reached curl rather than inferring it from a
+    # mirror run (which happens on *any* primary failure). In stall mode the
+    # primary then times out (exit 28), emulating a blackholed host.
+    curl.write_text(
+        "#!/bin/bash\n"
+        'argv="$*"; url=""; out=""\n'
+        "while [ $# -gt 0 ]; do\n"
+        '  case "$1" in -o) out="$2"; shift 2;; https://*) url="$1"; shift;;'
+        " *) shift;; esac\n"
+        "done\n"
+        f'primary_ok="{int(primary_ok)}"; mirror_ok="{int(mirror_ok)}"\n'
+        f'primary_stall="{int(primary_stall)}"\n'
+        'case "$url" in\n'
+        "  *rapidmlx.com*)\n"
+        '    case "$argv" in *--connect-timeout*--max-time*)'
+        f" echo yes > {primary_flags};; *) echo no > {primary_flags};; esac\n"
+        '    if [ "$primary_stall" = 1 ]; then sleep 0.2; exit 28; fi\n'
+        '    [ "$primary_ok" = 1 ] || exit 22;'
+        f" printf 'printf primary > {sentinel}\\n' > \"$out\";;\n"
+        '  *github.io*) [ "$mirror_ok" = 1 ] || exit 22;'
+        f" printf 'printf mirror > {sentinel}\\n' > \"$out\";;\n"
+        "  *) exit 22;;\n"
+        "esac\n"
+    )
+    curl.chmod(0o755)
+
+    env = dict(os.environ, PATH=f"{stub_dir}:{os.environ['PATH']}")
+    proc = subprocess.run(argv, env=env, capture_output=True, text=True)
+    got = sentinel.read_text() if sentinel.exists() else None
+    return proc.returncode, got
+
+
+def test_install_sh_upgrade_prefers_primary(tmp_path, monkeypatch):
+    """Primary reachable → run the rapidmlx.com script; mirror untouched."""
+    rc, ran = _run_install_sh_upgrade(
+        tmp_path, monkeypatch, primary_ok=True, mirror_ok=True
+    )
+    assert rc == 0
+    assert ran == "primary"
+
+
+def test_install_sh_upgrade_falls_back_to_mirror(tmp_path, monkeypatch):
+    """Primary down → transparently run the github.io mirror script."""
+    rc, ran = _run_install_sh_upgrade(
+        tmp_path, monkeypatch, primary_ok=False, mirror_ok=True
+    )
+    assert rc == 0
+    assert ran == "mirror"
+
+
+def test_install_sh_upgrade_total_outage_fails_loudly(tmp_path, monkeypatch):
+    """Both hosts down → non-zero exit and NO installer runs. Regression for a
+    naive ``curl A || curl B | bash`` that returns bash's status and would
+    falsely report success (running nothing) when both fetches fail.
+    """
+    rc, ran = _run_install_sh_upgrade(
+        tmp_path, monkeypatch, primary_ok=False, mirror_ok=False
+    )
+    assert rc != 0
+    assert ran is None
+
+
+def test_install_sh_upgrade_stalled_primary_times_out_to_mirror(tmp_path, monkeypatch):
+    """A blackholed primary that hangs (rather than returning a clean HTTP
+    error) must not stall the upgrade forever: the bounded ``--connect-timeout``
+    /``--max-time`` flags reach the primary curl, it aborts (exit 28), and the
+    github.io mirror serves the install.
+    """
+    rc, ran = _run_install_sh_upgrade(
+        tmp_path, monkeypatch, primary_ok=True, mirror_ok=True, primary_stall=True
+    )
+    assert rc == 0
+    assert ran == "mirror"
+    # Assert the flags reached the *primary* invocation directly — not inferred
+    # from the mirror run, which fires on any primary failure. Drop either flag
+    # from the production command and this records "no" and the test fails.
+    flags = (tmp_path / "primary_flags.txt").read_text().strip()
+    assert flags == "yes"
 
 
 def test_detect_install_method_pip_uses_sys_executable(monkeypatch):

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -457,13 +457,44 @@ def detect_install_method() -> InstallInfo:
         local_bin = str(Path.home() / ".local" / "bin")
         rapid_mlx_dir = str(Path.home() / ".rapid-mlx")
         if binary.startswith(local_bin) or normalized.startswith(rapid_mlx_dir):
+            # Prefer the canonical rapidmlx.com host (the same domain the
+            # website, docs, and the update poll ``CLI_UPDATE_ENDPOINT`` use),
+            # falling back to the raullenchai.github.io Pages mirror when it
+            # can't be reached. Two independent hosts, no single point of
+            # failure: if rapidmlx.com is down the mirror still upgrades, and —
+            # because ``*.github.io`` is frequently unreachable from mainland
+            # China — trying rapidmlx.com (Cloudflare) first keeps that path
+            # working there.
+            #
+            # Download to a temp file and execute only a *complete* fetch,
+            # rather than ``curl ... | bash``: a naive pipe (a) reports the
+            # pipeline's ``bash`` status, so if BOTH hosts fail bash reads empty
+            # input and exits 0 — a false "upgrade succeeded"; and (b) streams
+            # bytes as they arrive, so a mid-transfer primary failure could feed
+            # a partial script to bash before the fallback even runs. ``set -e``
+            # + ``curl -o`` fixes both: ``curl -f`` exits non-zero on any HTTP
+            # error (the primary's stderr silenced so a clean fallback is quiet;
+            # the mirror keeps its stderr), ``||`` reaches the mirror only when
+            # the primary fails, ``curl -o`` overwrites the temp file so the two
+            # candidates never concatenate, and ``set -e`` aborts (non-zero,
+            # before ``bash``) when both fail. The trap cleans up on every exit.
+            # Bounded timeouts (``--connect-timeout``/``--max-time``) are what
+            # make the fallback actually reachable: a blocked or blackholed host
+            # frequently hangs the connection rather than returning a clean HTTP
+            # error, and without a cap the primary ``curl`` would wait forever
+            # and never reach the mirror. 5s to connect + 30s overall is ample
+            # for a few-KB script while failing fast when rapidmlx.com stalls.
+            _curl = "curl -fsSL --connect-timeout 5 --max-time 30"
             install_sh_pipe = (
-                "curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh | bash"
+                'set -e; t="$(mktemp)"; trap \'rm -f "$t"\' EXIT; '
+                f'{_curl} https://rapidmlx.com/install.sh -o "$t" 2>/dev/null || '
+                f'{_curl} https://raullenchai.github.io/Rapid-MLX/install.sh -o "$t"; '
+                'bash "$t"'
             )
             return InstallInfo(
                 method="install_sh",
                 upgrade_command=install_sh_pipe,
-                # Pipe needs a shell — use bash -c explicitly rather than
+                # The script needs a shell — use bash -c explicitly rather than
                 # ``shell=True`` (no ambient $SHELL coupling, no PATH-based
                 # shell-injection surface beyond the literal string we control).
                 upgrade_argv=["bash", "-c", install_sh_pipe],


### PR DESCRIPTION
## Why

`rapid-mlx upgrade` for install.sh-class installs re-runs the installer solely from **`raullenchai.github.io/Rapid-MLX/install.sh`**, while the website, docs, and the update poll `CLI_UPDATE_ENDPOINT` all use **`rapidmlx.com`**. Found while dogfooding CLI auto-upgrade on 0.12.15.

Rather than swap one single-source-of-truth for another, this makes the upgrade resilient on **both** axes that actually matter:

- **Availability** — if rapidmlx.com is unreachable, the github.io Pages mirror still upgrades. No single point of failure ("website down → can't upgrade").
- **Reach** — `*.github.io` is frequently DNS-blocked from mainland China, whereas rapidmlx.com (Cloudflare, overseas PoPs) is generally reachable there. Trying rapidmlx.com **first** keeps upgrades working for those users; the mirror covers everyone else.

(The package layer already does this — install.sh falls back PyPI → GitHub `git+`. This brings the same primary+fallback resilience to the bootstrap-script fetch.)

## What

`_version_check.detect_install_method()` — install.sh-class upgrade becomes:

```
(curl -fsSL https://rapidmlx.com/install.sh 2>/dev/null || curl -fsSL https://raullenchai.github.io/Rapid-MLX/install.sh) | bash
```

- `curl -f` exits non-zero on any HTTP error, so `||` only reaches the mirror when the primary genuinely fails.
- The primary's stderr is silenced (`2>/dev/null`) so a successful fallback is quiet — no alarming `curl: (56) … 404` — while the **mirror keeps its stderr**, so a total outage surfaces a real error instead of a silent no-op.
- Both the cosmetic `upgrade_command` and the executed `upgrade_argv` derive from one string.
- Also fixes the lone `github.io` one-liner in `docs/getting-started/installation.md` to the canonical host (docs stay a clean single-host copy — matches the website).

## Tests

- `tests/test_version_check.py` + `tests/test_upgrade_cli.py` → **66 passed**; `ruff check`/`format` clean.
- Tightened `test_detect_install_method_install_sh` + `_via_symlink`: both hosts present, **rapidmlx.com before github.io**, `||` wiring — asserted in both the cosmetic string and the executed argv.
- **Fallback semantics verified live**: a 404 on the primary silently falls through to the mirror, which serves the script; primary-down no longer prints curl noise.

## Notes

Existing installed clients hardcode the github.io URL in their own `detect_install_method`, so **the Pages copy must stay reachable regardless** — this change makes *new* clients prefer the canonical host while keeping the mirror as a genuine fallback. Turning the Pages copy into a thin forwarder to rapidmlx.com is a possible later infra step, but no longer required for correctness since the mirror is still a first-class fallback here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-assisted: authored with Claude Code (Opus 4.8); human-reviewed before merge.