### PR TITLE
chore: drop MachineFi / IoTeX as current-identity references

### DIFF
--- a/apps/rapid-mac/LICENSE
+++ b/apps/rapid-mac/LICENSE
@@ -1,5 +1,5 @@
 Rapid-MLX Desktop
-Copyright 2026 MachineFi Inc.
+Copyright 2026 the Rapid-MLX contributors
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this software except in compliance with the License. The full license

--- a/apps/rapid-mac/PRIVACY.md
+++ b/apps/rapid-mac/PRIVACY.md
@@ -247,4 +247,4 @@ distributions are out of scope but we will help triage.
 
 ## Contact
 
-privacy@machinefi.com
+privacy@rapidmlx.com

--- a/apps/rapid-mac/SECURITY.md
+++ b/apps/rapid-mac/SECURITY.md
@@ -9,7 +9,7 @@ surface matters.
 
 **Do not file a public GitHub issue for security reports.**
 
-Email **security@machinefi.com** with:
+Email **security@rapidmlx.com** with:
 
 - A description of the vulnerability
 - Steps to reproduce (a minimal Swift / shell snippet is ideal)

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -89,9 +89,10 @@ an injected Sparkle public key have no in-app update path at all.
 
 ## Assets
 
-* **Cheetah mascot** — derived from the `rapidmlx.com` landing-page
-  assets. © 2026 MachineFi. Embedded in the app bundle (not the
-  source tree under an OSS license).
+* **Cheetah mascot** — the Rapid-MLX project's own artwork, derived from
+  the project's `rapidmlx.com` landing-page assets. © 2026 the Rapid-MLX
+  project; all rights reserved. Embedded in the app bundle (not the source
+  tree under an OSS license).
 
 ## Bundled engine (the `rapid-mlx` sidecar)
 

--- a/docs/plans/telemetry-golden-profile.md
+++ b/docs/plans/telemetry-golden-profile.md
@@ -194,7 +194,7 @@ see §2.3 reasoning).
 
 Two-zone reality:
 - `rapidmlx.com` zone — owned by raullen, hosts Pages + `chat.…`.
-- `quicksilverpro.io` zone — Iotex-owned, hosts `rapidserver.…`.
+- `quicksilverpro.io` zone — separately owned, hosts `rapidserver.…`.
 
 Because the telemetry Worker has zero coupling to the share tunnel,
 it can attach to `rapidmlx.com` cleanly:


### PR DESCRIPTION
## Why

Remove **MachineFi** and **IoTeX** from the project's current-identity surfaces (copyright, contact, asset ownership), while keeping the references that are factual or historical.

## What

Changed:
- `apps/rapid-mac/LICENSE` — copyright line → `the Rapid-MLX contributors` (matches the root `LICENSE`/`NOTICE` collective form landed in #1968).
- `apps/rapid-mac/PRIVACY.md`, `apps/rapid-mac/SECURITY.md` — contact addresses → `privacy@` / `security@rapidmlx.com`.
- `apps/rapid-mac/THIRD_PARTY.md` — Cheetah mascot asset copyright → `© 2026 the Rapid-MLX project`.
- `docs/plans/telemetry-golden-profile.md` — `Iotex-owned` → `separately owned`.

**Deliberately left in place:**
- `PRIVACY.md`'s Apple Developer ID line — `MachineFi Inc. (73WQ7ZGSWC)` is a *factual* statement about the identity the app is signed and notarised under (`codesign -dv` reports it). It stays accurate until the signing account changes.
- Historical `machinefi/rapid-desktop` references in `CHANGELOG.md`, update-checker test fixtures, and source comments — these point at the app's prior development repo and are historical record. (The real update-URL allowlist in `RapidApp.swift` is host-based — `github.com` / `rapidmlx.com` — with no org dependency, so nothing functional relies on these.)

## Tests

Docs/text only — no code or test changes. Verified no test asserts any of the changed strings, and no remaining `machinefi.com` address or `IoTeX` occurrence outside the intentionally-kept factual/historical set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-assisted: authored with Claude Code (Opus 4.8); human-reviewed before merge.