### PR TITLE
feat(mac): web-search roster overhaul — Keenable keyless default, Parallel recommended, descriptor table, honest Brave billing copy [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/PRIVACY.md
+++ b/apps/rapid-mac/PRIVACY.md
@@ -246,8 +246,9 @@ distributions are out of scope but we will help triage.
   web-search tool, the search query (never your whole conversation)
   is sent to the configured provider per their own privacy policy.
   The default backend is Keenable's keyless endpoint
-  (`api.keenable.ai`) — no account, no API key, nothing identifying
-  beyond the request itself. You can switch to Parallel, Tavily,
+  (`api.keenable.ai`) — no account, no API key; the request carries
+  the query plus standard connection metadata (such as your IP
+  address), nothing more. You can switch to Parallel, Tavily,
   Brave, or the DuckDuckGo scrape — or add your own key — in
   Settings → Tools. When Keenable is unreachable the tool retries the
   query against DuckDuckGo. Rapid-MLX Desktop is a passthrough.

--- a/apps/rapid-mac/PRIVACY.md
+++ b/apps/rapid-mac/PRIVACY.md
@@ -6,15 +6,17 @@ Rapid-MLX Desktop ("the App") is a local-first SwiftUI Mac client for the
 `rapid-mlx` inference server. We designed it so that your prompts,
 attachments, and model responses **never leave your Mac** unless you
 explicitly send them somewhere (e.g. via the web-search tool, which
-calls a third-party search provider you configured).
+sends the search query to a third-party search provider — Keenable's
+keyless endpoint by default; you can switch the backend or add your
+own key in Settings → Tools).
 
 ## What stays on your Mac
 
 * Chat history (sessions, messages, attachments) — stored under
   `~/Library/Application Support/Rapid/sessions.json` and never
   transmitted off-device.
-* API keys for tools (Brave / Tavily / etc.) — stored in macOS
-  Keychain.
+* API keys for tools (Keenable / Parallel / Tavily / Brave) — stored
+  in macOS Keychain.
 * Server settings, picker state, window layout — stored in
   UserDefaults under `com.rapidmlx.rapid`.
 
@@ -240,10 +242,15 @@ distributions are out of scope but we will help triage.
   download the DMG from the
   [GitHub Releases page](https://github.com/raullenchai/Rapid-MLX/releases/latest)
   and verify its origin yourself before installing.
-* **Tool providers you configure** — when you call a search / file /
-  web tool, your prompt content is sent directly to that provider
-  (Brave, Tavily, etc.) per their own privacy policy. Rapid-MLX Desktop
-  is a passthrough.
+* **Search and tool providers** — when the model calls the
+  web-search tool, the search query (never your whole conversation)
+  is sent to the configured provider per their own privacy policy.
+  The default backend is Keenable's keyless endpoint
+  (`api.keenable.ai`) — no account, no API key, nothing identifying
+  beyond the request itself. You can switch to Parallel, Tavily,
+  Brave, or the DuckDuckGo scrape — or add your own key — in
+  Settings → Tools. When Keenable is unreachable the tool retries the
+  query against DuckDuckGo. Rapid-MLX Desktop is a passthrough.
 
 ## Contact
 

--- a/apps/rapid-mac/SECURITY.md
+++ b/apps/rapid-mac/SECURITY.md
@@ -52,8 +52,8 @@ Out of scope:
   fix belongs in the upstream project at
   [github.com/raullenchai/Rapid-MLX](https://github.com/raullenchai/Rapid-MLX).
 - Local privilege escalations that require root or full disk access
-- Vulnerabilities in third-party search providers (Brave, Tavily) the
-  user opts into for `web_search`
+- Vulnerabilities in third-party search providers (Keenable, Parallel,
+  Tavily, Brave) used by `web_search`
 
 ## Recognition
 

--- a/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
@@ -265,8 +265,10 @@ enum FailureDiagnoser {
             // endpoint per IP within a handful of searches, so the honest
             // remedy is a different backend, and the message has to say which
             // ones and where. Kept to one sentence of situation + one of
-            // remedy so it still reads inside the tool card.
-            message = "DuckDuckGo is rate-limiting web searches from this Mac. Switch to Brave Search or Tavily in Settings → Tools and add a free key."
+            // remedy so it still reads inside the tool card. Not Brave any
+            // more (#2043): Brave requires a card on file now, so pitching it
+            // as the free fix would steer the user into surprise billing.
+            message = "DuckDuckGo is rate-limiting web searches from this Mac. Switch to Keenable (no key) or add a free Parallel or Tavily key in Settings → Tools."
             action = .openWebSearchSettings
         case .browsePageTooLarge:
             message = "This page is too large for Rapid to read at once. Search it or open a smaller page instead."

--- a/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/BuiltinToolRegistry.swift
@@ -4,8 +4,9 @@ import Foundation
 /// surface exposes:
 ///
 ///   * ``weather`` — no approval, hits Open-Meteo over HTTPS
-///   * ``web_search`` — no approval, DuckDuckGo / Brave / Tavily per
-///     ``WebSearchConfig``
+///   * ``web_search`` — no approval, backend per ``WebSearchConfig``
+///     (Keenable keyless by default; Parallel / Tavily / Brave with a
+///     key; DuckDuckGo backstop)
 ///   * ``browse`` — USER-approved per fetch (``BrowseApprovalStore``),
 ///     SSRF-guarded, byte-capped
 ///

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchClients.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchClients.swift
@@ -230,3 +230,264 @@ enum TavilySearchClient {
         return out
     }
 }
+
+/// Keenable client (#2041) — the zero-setup default backend.
+///
+/// Keenable exposes two surfaces and we use both:
+///
+///   * **Keyless** — its public MCP endpoint accepts a bare
+///     JSON-RPC ``tools/call`` POST with no account, no key and no
+///     session handshake (verified live 2026-08-18: a cold
+///     ``tools/call`` with neither ``initialize`` nor a session
+///     header answers 200). Shared pool, 1 000 requests/hour per
+///     IP. This is NOT an MCP-client integration — it's one plain
+///     HTTPS POST; we never speak the rest of the protocol.
+///   * **Keyed** — ``POST /v1/search`` REST with an ``X-API-Key``
+///     header. Requires a (free) key; lifts the hourly cap and
+///     meters against the org's monthly credit allowance.
+///
+/// The keyless response arrives as a JSON-RPC envelope whose
+/// ``result.content[0].text`` is a plain-text block list
+/// (``Title:`` / ``URL:`` / ``Snippets:`` separated by ``---``);
+/// the keyed response is structured JSON. Both funnel into the
+/// engine-agnostic ``WebSearchTool.Result`` shape.
+enum KeenableSearchClient {
+    static let mcpEndpoint = "https://api.keenable.ai/mcp"
+    static let restEndpoint = "https://api.keenable.ai/v1/search"
+    static let timeout: TimeInterval = 15
+
+    /// One JSON-RPC ``tools/call`` against the public MCP endpoint.
+    /// The ``id`` is fixed: we send exactly one request per HTTP
+    /// call, so there is nothing to correlate.
+    static func buildKeylessRequest(query: String, snippetMaxLength: Int) -> URLRequest? {
+        guard let url = URL(string: mcpEndpoint) else { return nil }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.timeoutInterval = timeout
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // The MCP transport may answer either plain JSON or an SSE
+        // frame; advertise both so the server picks freely and
+        // ``parseKeylessResults`` handles either.
+        req.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+        let body: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": [
+                "name": "search_web_pages",
+                "arguments": [
+                    "query": query,
+                    // Server-side schema minimum is 180; we pass our
+                    // display cap so the upstream doesn't ship chars
+                    // we'd truncate anyway.
+                    "snippet_max_length": max(180, snippetMaxLength),
+                ] as [String: Any],
+            ] as [String: Any],
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return nil }
+        req.httpBody = data
+        return req
+    }
+
+    /// Keyed REST call. The key rides in ``X-API-Key`` — same
+    /// control-byte defence as every other header-borne key.
+    static func buildKeyedRequest(query: String, apiKey: String, snippetMaxLength: Int) -> URLRequest? {
+        guard let cleanKey = headerSafeKey(apiKey) else { return nil }
+        guard let url = URL(string: restEndpoint) else { return nil }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.timeoutInterval = timeout
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue(cleanKey, forHTTPHeaderField: "X-API-Key")
+        let body: [String: Any] = [
+            "query": query,
+            "snippet_max_length": max(180, snippetMaxLength),
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return nil }
+        req.httpBody = data
+        return req
+    }
+
+    /// Unwrap the JSON-RPC envelope (optionally SSE-framed) and parse
+    /// the tool text. ``nil`` means "malformed / error envelope" —
+    /// the caller degrades to the DuckDuckGo backstop; an empty array
+    /// is a genuine zero-hit search.
+    static func parseKeylessResults(_ data: Data, cap: Int) -> [WebSearchTool.Result]? {
+        struct Envelope: Decodable {
+            struct ResultBody: Decodable {
+                struct ContentItem: Decodable {
+                    let type: String?
+                    let text: String?
+                }
+                let content: [ContentItem]?
+                let isError: Bool?
+            }
+            struct RPCError: Decodable { let message: String? }
+            let result: ResultBody?
+            let error: RPCError?
+        }
+        var payload = data
+        // SSE frame: take the last ``data:`` line — the transport
+        // streams at most one JSON-RPC response per request here.
+        if let text = String(data: data, encoding: .utf8),
+           text.hasPrefix("event:") || text.hasPrefix("data:") || text.contains("\ndata:") {
+            let lines = text.split(separator: "\n", omittingEmptySubsequences: true)
+            if let last = lines.last(where: { $0.hasPrefix("data:") }) {
+                let json = last.dropFirst("data:".count).trimmingCharacters(in: .whitespaces)
+                payload = Data(json.utf8)
+            }
+        }
+        guard let env = try? JSONDecoder().decode(Envelope.self, from: payload) else { return nil }
+        guard env.error == nil, let result = env.result, result.isError != true else { return nil }
+        guard let text = result.content?.first(where: { $0.text != nil })?.text else { return nil }
+        return parseTextBlocks(text, cap: cap)
+    }
+
+    /// Parse the keyless tool text: blocks separated by ``---``
+    /// lines, each carrying ``Title:`` / ``URL:`` headers and a
+    /// free-text body after a ``Snippets:`` line. ``Published:`` /
+    /// ``Acquired:`` metadata lines are dropped — the model reads
+    /// title + URL + snippet, same as every other backend.
+    static func parseTextBlocks(_ text: String, cap: Int) -> [WebSearchTool.Result] {
+        var out: [WebSearchTool.Result] = []
+        for rawBlock in text.components(separatedBy: "\n---\n") {
+            if out.count >= cap { break }
+            var title = ""
+            var url = ""
+            var snippetLines: [String] = []
+            var inSnippets = false
+            for line in rawBlock.split(separator: "\n", omittingEmptySubsequences: false) {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if !inSnippets {
+                    if trimmed.hasPrefix("Title: ") {
+                        title = String(trimmed.dropFirst("Title: ".count))
+                    } else if trimmed.hasPrefix("URL: ") {
+                        url = String(trimmed.dropFirst("URL: ".count))
+                    } else if trimmed == "Snippets:" {
+                        inSnippets = true
+                    }
+                    // ``Published:`` / ``Acquired:`` fall through untouched.
+                } else if !trimmed.isEmpty {
+                    snippetLines.append(trimmed)
+                }
+            }
+            // Same boundary gate as every backend: only http(s)
+            // destinations reach the model.
+            guard WebSearchTool.isSafeHttpURL(url) else { continue }
+            out.append(WebSearchTool.Result(
+                title: title,
+                url: url,
+                snippet: snippetLines.joined(separator: " ")
+            ))
+        }
+        return out
+    }
+
+    /// Keyed REST response: ``{ "query", "results": [{ "title",
+    /// "url", "description", "snippet" }] }``. ``snippet`` carries
+    /// the query-relevant highlight; ``description`` is the static
+    /// page description — prefer the former, fall back to the
+    /// latter.
+    static func parseKeyedResults(_ data: Data, cap: Int) -> [WebSearchTool.Result]? {
+        struct Envelope: Decodable {
+            struct Item: Decodable {
+                let title: String?
+                let url: String?
+                let description: String?
+                let snippet: String?
+            }
+            let results: [Item]
+        }
+        guard let env = try? JSONDecoder().decode(Envelope.self, from: data) else { return nil }
+        var out: [WebSearchTool.Result] = []
+        for item in env.results {
+            if out.count >= cap { break }
+            let url = item.url ?? ""
+            guard WebSearchTool.isSafeHttpURL(url) else { continue }
+            out.append(WebSearchTool.Result(
+                title: item.title ?? "",
+                url: url,
+                snippet: item.snippet ?? item.description ?? ""
+            ))
+        }
+        return out
+    }
+}
+
+/// Parallel Search client (#2042) — the recommended keyed backend.
+/// ``POST /v1/search`` with the key in ``x-api-key``. We pin
+/// ``mode: "advanced"`` (the provider default and its
+/// strongest-measured tier) rather than inheriting a server-side
+/// default that could drift, and bound the response to our display
+/// budget via ``advanced_settings`` so extra excerpt characters are
+/// never fetched just to be truncated locally.
+enum ParallelSearchClient {
+    static let endpoint = "https://api.parallel.ai/v1/search"
+    static let timeout: TimeInterval = 15
+
+    static func buildRequest(
+        query: String,
+        apiKey: String,
+        maxResults: Int,
+        maxCharsPerResult: Int
+    ) -> URLRequest? {
+        guard let cleanKey = headerSafeKey(apiKey) else { return nil }
+        guard let url = URL(string: endpoint) else { return nil }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.timeoutInterval = timeout
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue(cleanKey, forHTTPHeaderField: "x-api-key")
+        // ``search_queries`` is the required field (an array);
+        // ``objective`` additionally carries the natural-language
+        // intent, which Parallel uses for ranking. Our tool has one
+        // query string, so it fills both.
+        let body: [String: Any] = [
+            "objective": query,
+            "search_queries": [query],
+            "mode": "advanced",
+            "advanced_settings": [
+                "max_results": maxResults,
+                "excerpt_settings": [
+                    "max_chars_per_result": maxCharsPerResult
+                ] as [String: Any],
+            ] as [String: Any],
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return nil }
+        req.httpBody = data
+        return req
+    }
+
+    /// Response: ``{ "results": [{ "url", "title", "excerpts": [str] }] }``.
+    /// ``excerpts`` is an array of markdown-formatted passages;
+    /// join them — ``formatOutput`` applies the display cap.
+    static func parseResults(_ data: Data, cap: Int) -> [WebSearchTool.Result]? {
+        struct Envelope: Decodable {
+            struct Item: Decodable {
+                let url: String?
+                let title: String?
+                let excerpts: [String]?
+            }
+            let results: [Item]
+        }
+        guard let env = try? JSONDecoder().decode(Envelope.self, from: data) else { return nil }
+        var out: [WebSearchTool.Result] = []
+        for item in env.results {
+            if out.count >= cap { break }
+            let url = item.url ?? ""
+            guard WebSearchTool.isSafeHttpURL(url) else { continue }
+            let snippet = (item.excerpts ?? [])
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .joined(separator: " … ")
+            out.append(WebSearchTool.Result(
+                title: item.title ?? "",
+                url: url,
+                snippet: snippet
+            ))
+        }
+        return out
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchClients.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchClients.swift
@@ -369,7 +369,12 @@ enum KeenableSearchClient {
                     }
                     // ``Published:`` / ``Acquired:`` fall through untouched.
                 } else if !trimmed.isEmpty {
-                    snippetLines.append(trimmed)
+                    // Codex r1: a metadata line emitted AFTER the
+                    // snippet body must not leak into the model-visible
+                    // snippet text.
+                    let isMetadata = ["Title: ", "URL: ", "Published: ", "Acquired: "]
+                        .contains { trimmed.hasPrefix($0) }
+                    if !isMetadata { snippetLines.append(trimmed) }
                 }
             }
             // Same boundary gate as every backend: only http(s)

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
@@ -114,7 +114,7 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
                 // card on file and overage is auto-billed. The
                 // subtitle must say so BEFORE the user follows the
                 // key link (issue #2043).
-                subtitle: "Requires a Brave API key and a card on file — usage past the monthly credit is auto-billed.",
+                subtitle: "Requires a Brave Search API key and a card on file — usage past the monthly credit is auto-billed.",
                 keyConsoleURL: URL(string: "https://brave.com/search/api/"),
                 // The dashboard host is separate from the API host;
                 // the API-serving host returns HTTP 403 for this UI
@@ -133,7 +133,7 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
             // for the problem must not be told the backend is fine.
             return WebSearchProviderDescriptor(
                 displayName: "DuckDuckGo",
-                subtitle: "No key. Backstop only — throttled after a few searches, and result quality is poor.",
+                subtitle: "No key required. Backstop only — throttled after a few searches, and result quality is poor.",
                 keyConsoleURL: nil,
                 keyDashboardURL: nil,
                 requiresKey: false,

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchProvider.swift
@@ -1,111 +1,157 @@
 import Foundation
 import Observation
 
-/// Which backend does ``web_search`` hit? v0.4.41 adds the two
-/// dominant paid options on top of the existing free DDG endpoint.
-///
-/// Why these three:
-///   * **DuckDuckGo** — no key, decent quality, the original
-///     v0.3 backend. Stays the default so a fresh install keeps
-///     working without any setup.
-///   * **Brave Search** — 2 000 queries/month free tier; high
-///     quality, fast, ad-free index.
-///   * **Tavily** — 1 000 queries/month free tier; explicitly
-///     designed for LLM agents (returns clean snippets + a
-///     ranked list, no SERP cruft).
-///
-/// Both paid options ask for a long-lived API key. Keys are
-/// stored in the macOS Keychain, NOT UserDefaults — leaking a
-/// Brave/Tavily key reads as a real privacy bug (the key is
-/// account-linked and per-call billing is metered against it).
-enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
-    case duckduckgo
-    case brave
-    case tavily
-
-    var id: String { rawValue }
-
-    var displayName: String {
-        switch self {
-        case .duckduckgo: return "DuckDuckGo"
-        case .brave:      return "Brave Search"
-        case .tavily:     return "Tavily"
-        }
-    }
-
+/// Static metadata for one ``web_search`` backend. One value per
+/// provider, produced by a single switch in
+/// ``WebSearchProvider/descriptor`` — adding a backend means writing
+/// ONE descriptor plus a client, not editing half a dozen scattered
+/// switches (issue #2040; the old shape needed 8 edits per provider).
+struct WebSearchProviderDescriptor: Sendable {
+    let displayName: String
     /// Plain-English subtitle for the Settings picker. Tells the
     /// user what they're trading off (cost / signup) without
     /// having to read the docs.
-    ///
-    /// The DuckDuckGo line used to end "works out of the box." It
-    /// doesn't: the free HTML endpoint throttles per IP after a
-    /// handful of searches (measured 2026-08-05 — one 200, then 202
-    /// non-results pages for every query after it). A user who hits
-    /// that throttle and comes here looking for the problem must not
-    /// be told the backend is fine.
-    var subtitle: String {
+    let subtitle: String
+    /// Marketing / landing page for the provider's API. Kept
+    /// distinct from ``keyDashboardURL`` — see that field.
+    let keyConsoleURL: URL?
+    /// Direct link to the API-keys dashboard — the page that lists
+    /// existing keys and offers a "create new key" affordance. The
+    /// Settings key row links here so the user lands one click from
+    /// a usable key instead of on a marketing page. Issue #193.
+    let keyDashboardURL: URL?
+    /// The provider cannot run without a key. At dispatch a
+    /// requiresKey provider with no stored key falls back to the
+    /// keyless chain (Keenable → DuckDuckGo).
+    let requiresKey: Bool
+    /// The provider can use a key at all. True for every
+    /// requiresKey provider, and for Keenable — where the key is
+    /// optional and lifts the shared keyless rate limit. Drives the
+    /// Settings key field + Keychain prefetch.
+    let acceptsKey: Bool
+    /// Keychain account label for this provider's API key. Distinct
+    /// per-provider so one provider's key never leaks into another's
+    /// call.
+    let keychainAccount: String?
+}
+
+/// Which backend does ``web_search`` hit?
+///
+/// The roster (2026-08, issues #2040–#2043; quality figures from the
+/// Artificial Analysis Search Index, 2026-08-18):
+///   * **Keenable** — the zero-setup default. No account, no key: the
+///     keyless pool allows 1 000 requests/hour per IP. An optional
+///     free key lifts the shared cap. Scores above both legacy keyed
+///     backends in independent agent-search benchmarking.
+///   * **Parallel** — the recommended keyed backend; strongest
+///     measured result quality of the providers benchmarked, with a
+///     recurring free monthly credit (≈1 000 searches).
+///   * **Tavily** — 1 000 queries/month free tier; agent-tuned
+///     snippets.
+///   * **Brave Search** — kept for existing keys. Brave dropped its
+///     card-free tier in Feb 2026: every plan now requires a card on
+///     file and auto-bills overage (issue #2043), so it is no longer
+///     pitched as a free upgrade.
+///   * **DuckDuckGo** — the original v0.3 scrape backend, demoted to
+///     backstop: its free HTML endpoint throttles per IP after a
+///     handful of searches (measured 2026-08-05) and result quality
+///     is poor. Kept because it needs nothing and never bills.
+///
+/// Keys are stored in the macOS Keychain, NOT UserDefaults — leaking
+/// a search key reads as a real privacy bug (the key is
+/// account-linked and per-call billing is metered against it).
+enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
+    // Case order == Settings radio order: the zero-setup default
+    // first, then the recommended keyed upgrade, then the rest.
+    case keenable
+    case parallel
+    case tavily
+    case brave
+    case duckduckgo
+
+    var id: String { rawValue }
+
+    /// The single source of provider metadata. Every legacy
+    /// per-property accessor below forwards here so existing call
+    /// sites didn't have to churn in the #2040 refactor.
+    var descriptor: WebSearchProviderDescriptor {
         switch self {
-        case .duckduckgo:
-            return "No key required. Best-effort — throttled after a few searches; the keyed backends aren't."
-        case .brave:
-            return "Requires a free Brave Search API key. 2 000 queries/month."
+        case .keenable:
+            return WebSearchProviderDescriptor(
+                displayName: "Keenable",
+                subtitle: "No key needed — the default. A free key lifts the shared hourly limit.",
+                keyConsoleURL: URL(string: "https://keenable.ai/"),
+                keyDashboardURL: URL(string: "https://keenable.ai/console"),
+                requiresKey: false,
+                acceptsKey: true,
+                keychainAccount: "rapid.web-search.keenable"
+            )
+        case .parallel:
+            return WebSearchProviderDescriptor(
+                displayName: "Parallel",
+                subtitle: "Recommended — the highest-quality backend in our testing. Free key covers about 1 000 searches a month.",
+                keyConsoleURL: URL(string: "https://parallel.ai/"),
+                keyDashboardURL: URL(string: "https://platform.parallel.ai/"),
+                requiresKey: true,
+                acceptsKey: true,
+                keychainAccount: "rapid.web-search.parallel"
+            )
         case .tavily:
-            return "Requires a free Tavily API key. 1 000 queries/month, agent-tuned snippets."
+            return WebSearchProviderDescriptor(
+                displayName: "Tavily",
+                subtitle: "Requires a free Tavily API key. 1 000 queries/month, agent-tuned snippets.",
+                keyConsoleURL: URL(string: "https://app.tavily.com/home"),
+                keyDashboardURL: URL(string: "https://app.tavily.com/home"),
+                requiresKey: true,
+                acceptsKey: true,
+                keychainAccount: "rapid.web-search.tavily"
+            )
+        case .brave:
+            return WebSearchProviderDescriptor(
+                displayName: "Brave Search",
+                // Not "a free key" any more: Brave dropped the
+                // card-free tier in Feb 2026 — every plan keeps a
+                // card on file and overage is auto-billed. The
+                // subtitle must say so BEFORE the user follows the
+                // key link (issue #2043).
+                subtitle: "Requires a Brave API key and a card on file — usage past the monthly credit is auto-billed.",
+                keyConsoleURL: URL(string: "https://brave.com/search/api/"),
+                // The dashboard host is separate from the API host;
+                // the API-serving host returns HTTP 403 for this UI
+                // route.
+                keyDashboardURL: URL(string: "https://api-dashboard.search.brave.com/app/keys"),
+                requiresKey: true,
+                acceptsKey: true,
+                keychainAccount: "rapid.web-search.brave"
+            )
+        case .duckduckgo:
+            // The subtitle used to end "works out of the box." It
+            // doesn't: the free HTML endpoint throttles per IP after
+            // a handful of searches (measured 2026-08-05 — one 200,
+            // then 202 non-results pages for every query after it).
+            // A user who hits that throttle and comes here looking
+            // for the problem must not be told the backend is fine.
+            return WebSearchProviderDescriptor(
+                displayName: "DuckDuckGo",
+                subtitle: "No key. Backstop only — throttled after a few searches, and result quality is poor.",
+                keyConsoleURL: nil,
+                keyDashboardURL: nil,
+                requiresKey: false,
+                acceptsKey: false,
+                keychainAccount: nil
+            )
         }
     }
 
-    /// Where the user goes to mint a key. Shown as an "Open
-    /// dashboard" link in Settings so the affordance is one click
-    /// instead of "Google for the right URL."
-    var keyConsoleURL: URL? {
-        switch self {
-        case .duckduckgo: return nil
-        case .brave:      return URL(string: "https://brave.com/search/api/")
-        case .tavily:     return URL(string: "https://app.tavily.com/home")
-        }
-    }
+    // MARK: Forwarding accessors (pre-#2040 API, unchanged call sites)
 
-    /// Direct link to the API-keys dashboard for the provider — the
-    /// page that lists existing keys and offers a "create new key"
-    /// affordance. Distinct from ``keyConsoleURL`` (the marketing
-    /// landing) because the "Upgrade to Brave" / "Upgrade to Tavily"
-    /// nudge in Settings + Onboarding wants to drop the user one
-    /// click closer to a usable key — landing on a marketing page
-    /// adds an extra "click Sign in / Get key" hop. Issue #193.
-    ///
-    /// For Tavily this resolves to the same /home page as
-    /// ``keyConsoleURL`` (the dashboard IS the home view). Brave
-    /// splits: ``keyConsoleURL`` points at the public API landing,
-    /// while ``keyDashboardURL`` uses the dedicated dashboard host
-    /// and jumps straight to /app/keys. The API-serving host returns
-    /// HTTP 403 for that UI route.
-    var keyDashboardURL: URL? {
-        switch self {
-        case .duckduckgo: return nil
-        case .brave:      return URL(string: "https://api-dashboard.search.brave.com/app/keys")
-        case .tavily:     return URL(string: "https://app.tavily.com/home")
-        }
-    }
-
-    /// True only when the provider needs an API key. Lets the
-    /// Settings panel hide the SecureField when DDG is selected.
-    var requiresKey: Bool {
-        switch self {
-        case .duckduckgo: return false
-        case .brave, .tavily: return true
-        }
-    }
-
-    /// Keychain account label used to store this provider's
-    /// API key. Distinct per-provider so a Brave key never
-    /// leaks into a Tavily call (and vice versa).
-    var keychainAccount: String? {
-        switch self {
-        case .duckduckgo: return nil
-        case .brave:      return "rapid.web-search.brave"
-        case .tavily:     return "rapid.web-search.tavily"
-        }
-    }
+    var displayName: String { descriptor.displayName }
+    var subtitle: String { descriptor.subtitle }
+    var keyConsoleURL: URL? { descriptor.keyConsoleURL }
+    var keyDashboardURL: URL? { descriptor.keyDashboardURL }
+    var requiresKey: Bool { descriptor.requiresKey }
+    var acceptsKey: Bool { descriptor.acceptsKey }
+    var keychainAccount: String? { descriptor.keychainAccount }
 }
 
 /// User-facing, persisted web-search configuration. Provider
@@ -117,8 +163,11 @@ enum WebSearchProvider: String, CaseIterable, Codable, Identifiable, Sendable {
 final class WebSearchConfig {
     /// Backed by ``UserDefaults`` under a single stable key so a
     /// reset-defaults action (or a corrupted prefs file) doesn't
-    /// need to sweep multiple keys. The default is ``.duckduckgo``
-    /// because that's the only zero-setup option.
+    /// need to sweep multiple keys. The default is ``.keenable``
+    /// (#2041): zero-setup like DuckDuckGo was, but with usable
+    /// result quality and no per-handful-of-searches throttle. A
+    /// user who ever picked a provider explicitly has a stored raw
+    /// value and keeps their choice.
     var provider: WebSearchProvider {
         didSet {
             guard oldValue != provider else { return }
@@ -159,7 +208,7 @@ final class WebSearchConfig {
            let p = WebSearchProvider(rawValue: raw) {
             self.provider = p
         } else {
-            self.provider = .duckduckgo
+            self.provider = .keenable
         }
     }
 
@@ -193,26 +242,24 @@ final class WebSearchConfig {
     /// "delete + tab" gesture removes the key instead of storing
     /// an empty record that pretends to be a key).
     ///
-    /// **Auto-promote on first key paste.** If the user is still on
-    /// the install-default ``.duckduckgo`` backend and pastes a key
-    /// for a paid provider (``.brave`` or ``.tavily``), we silently
-    /// flip ``provider`` to the keyed backend.
+    /// **Auto-promote on first key paste.** If the user is on a
+    /// keyless backend (the install-default ``.keenable``, or
+    /// ``.duckduckgo``) and pastes a key for a key-REQUIRING
+    /// provider, we silently flip ``provider`` to the keyed backend.
     ///
-    /// Why: DDG HTML scraping is silently rate-limited / anti-bot-
-    /// blocked in production today — the `cc=botnet` anomaly modal
-    /// returns 0 results without surfacing a real error, so the
-    /// tool appears to "work" while delivering nothing. When a user
-    /// goes to the trouble of pasting a Brave/Tavily key they have
-    /// explicitly opted into a more reliable backend; requiring them
-    /// to ALSO flip the provider picker is silent-broken UX (their
-    /// key is stored but never used).
+    /// Why: a user who goes to the trouble of pasting a
+    /// Parallel/Tavily/Brave key has explicitly opted into that
+    /// backend; requiring them to ALSO flip the provider picker is
+    /// silent-broken UX (their key is stored but never used).
     ///
-    /// We only auto-promote from the default DDG state. If the user
-    /// has already explicitly chosen a paid backend (say `.brave`)
-    /// and then pastes a key for the OTHER paid backend (`.tavily`),
+    /// We only auto-promote from a keyless state. If the user has
+    /// already explicitly chosen a keyed backend (say `.parallel`)
+    /// and then pastes a key for ANOTHER keyed backend (`.tavily`),
     /// the explicit prior choice wins — they're managing both keys
-    /// without re-selecting. Clearing a key never demotes; the user
-    /// can manually switch back to DDG in Settings.
+    /// without re-selecting. Pasting a Keenable key while on
+    /// Keenable is not a promotion either — the key is picked up in
+    /// place (it lifts the shared rate cap). Clearing a key never
+    /// demotes; the user can manually switch back in Settings.
     /// Returns ``true`` when the Keychain write/delete that backs the
     /// requested mutation actually succeeded. v0.6.7 added the
     /// return value to drive the inline "Saved" confirmation in
@@ -261,10 +308,12 @@ final class WebSearchConfig {
                 // Auto-promote happens AFTER a successful keychain
                 // write so the provider state can never get ahead of
                 // the stored key. Gate on ``provider.requiresKey``
-                // so a hypothetical future free provider can't
+                // so a key-optional provider (Keenable) can't
                 // trigger promotion via this path — the silent-
-                // broken UX only exists for keyed backends.
-                if self.provider == .duckduckgo && provider.requiresKey {
+                // broken UX only exists for key-REQUIRING backends,
+                // and a keyless backend keeps working when a key for
+                // it lands.
+                if !self.provider.requiresKey && provider.requiresKey {
                     self.provider = provider
                 }
                 return true
@@ -276,12 +325,9 @@ final class WebSearchConfig {
     /// True if the currently-selected provider has a usable key
     /// (or doesn't need one). Drives the "Effective backend" hint
     /// in Settings — when this is false, the tool will fall back
-    /// to DuckDuckGo at dispatch time.
+    /// to the keyless chain (Keenable) at dispatch time.
     var currentProviderUsable: Bool {
-        switch provider {
-        case .duckduckgo: return true
-        case .brave, .tavily: return apiKey(for: provider) != nil
-        }
+        !provider.requiresKey || apiKey(for: provider) != nil
     }
 
     // MARK: - Async prefetch (cycle-12 P3: Settings → Web Search blocked
@@ -388,7 +434,10 @@ final class WebSearchConfig {
     /// once, off the main actor, before the panel re-renders.
     func prefetchAllAPIKeys() async {
         await withTaskGroup(of: Void.self) { group in
-            for provider in WebSearchProvider.allCases where provider.requiresKey {
+            // ``acceptsKey``, not ``requiresKey``: Keenable's key is
+            // optional but still lives in the Keychain and still
+            // needs warming before the Settings key row renders.
+            for provider in WebSearchProvider.allCases where provider.acceptsKey {
                 group.addTask { await self.prefetchAPIKey(for: provider) }
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -422,6 +422,17 @@ enum WebSearchTool {
                     content: "\(toolName) error: the Keenable key's monthly credit allowance is used up (HTTP 402). Searches continue on the keyless pool if you clear the key.",
                     isError: true
                 )
+            case 429 where apiKey != nil:
+                // Codex r1 MAJOR: a keyed 429 is an account problem
+                // (the org's rate cap), not "Keenable was unavailable"
+                // — degrading here would hide and mislabel the quota
+                // state the user's own key is in. Same loud-surface
+                // contract as 401/402.
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: Keenable rate limit hit for this API key (HTTP 429). Wait a moment or check the plan's limits.",
+                    isError: true
+                )
             default:
                 // Keyless 429 (shared pool exhausted), 5xx, or any
                 // other transport-level answer: degrade.

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -1,15 +1,12 @@
 import Foundation
 
-/// Cheap web search via DuckDuckGo's HTML-only endpoint. No API key,
-/// no JS engine — we just GET the HTML page and pull the visible
-/// result links + snippets with regex. Brittle by design but the
-/// alternative (Google CSE / Bing API / SerpAPI) all require paid
-/// keys and an account, which Rapid's privacy-first stance doesn't
-/// want to ship with.
-///
-/// Returns the top N results as a plain-text bulleted list the
-/// model can quote from. No raw HTML, no link tracking — just
-/// title + URL + snippet per result.
+/// The ``web_search`` tool. Dispatches to the configured
+/// ``WebSearchProvider`` (Keenable keyless by default; Parallel /
+/// Tavily / Brave with a key; DuckDuckGo scrape as the backstop) and
+/// returns the top N results as a plain-text bulleted list the model
+/// can quote from. No raw HTML, no link tracking — just title + URL
+/// + snippet per result, identically shaped whatever backend
+/// answered.
 enum WebSearchTool {
     static let definition = ToolDefinition(
         name: "web_search",
@@ -41,20 +38,25 @@ enum WebSearchTool {
         await run(arguments: arguments, provider: .duckduckgo, apiKey: nil)
     }
 
-    /// v0.4.41 provider-aware entry point. Dispatches on the
-    /// configured ``WebSearchProvider``:
+    /// Provider-aware entry point. Dispatches on the configured
+    /// ``WebSearchProvider``:
     ///
-    ///   * ``.duckduckgo`` — HTML scrape, no key
-    ///   * ``.brave`` — JSON API, ``X-Subscription-Token`` header
+    ///   * ``.keenable`` — keyless JSON-RPC POST (default), or keyed
+    ///     REST when a key is stored
+    ///   * ``.parallel`` — JSON API, ``x-api-key`` header
     ///   * ``.tavily`` — JSON API, key in body
+    ///   * ``.brave`` — JSON API, ``X-Subscription-Token`` header
+    ///   * ``.duckduckgo`` — HTML scrape, no key (backstop)
     ///
-    /// When a paid provider is configured but the user hasn't
-    /// pasted a key yet, we silently fall back to DuckDuckGo with
-    /// a one-line hint appended to the model-visible result so the
-    /// assistant can tell the user what's going on (and so the
-    /// fallback isn't completely invisible). This matches the
-    /// "no broken state" promise the rest of the app makes — the
-    /// search keeps working even if the API key slot is empty.
+    /// When a key-requiring provider is configured but the user
+    /// hasn't pasted a key yet, we silently fall back to the keyless
+    /// Keenable pool with a one-line hint appended to the
+    /// model-visible result so the assistant can tell the user
+    /// what's going on (and so the fallback isn't completely
+    /// invisible). This matches the "no broken state" promise the
+    /// rest of the app makes — the search keeps working even if the
+    /// API key slot is empty. If Keenable itself is unreachable, the
+    /// DuckDuckGo scrape is the backstop of last resort.
     static func run(
         arguments: String,
         provider: WebSearchProvider,
@@ -82,20 +84,45 @@ enum WebSearchTool {
                 )
             ])
         }
-        var effectiveProvider = provider
-        var fallbackNote: String? = nil
-        if provider.requiresKey, apiKey == nil {
-            effectiveProvider = .duckduckgo
-            fallbackNote = "Note: \(provider.displayName) is selected but no API key is set — falling back to DuckDuckGo. Open Settings → Tools → Web search to paste a key."
-        }
-        switch effectiveProvider {
+        let plan = dispatchPlan(provider: provider, hasKey: apiKey != nil)
+        switch plan.effective {
+        case .keenable:
+            // ``apiKey`` belongs to the SELECTED provider. It only
+            // reaches the Keenable runner when Keenable is the
+            // selected provider — on a no-key fallback from a keyed
+            // backend it is nil by construction.
+            return await runKeenable(
+                query: q,
+                apiKey: plan.effective == provider ? apiKey : nil,
+                fallbackNote: plan.fallbackNote
+            )
         case .duckduckgo:
-            return await runDuckDuckGo(query: q, fallbackNote: fallbackNote)
+            return await runDuckDuckGo(query: q, fallbackNote: plan.fallbackNote)
+        case .parallel:
+            return await runParallel(query: q, apiKey: apiKey ?? "")
         case .brave:
             return await runBrave(query: q, apiKey: apiKey ?? "")
         case .tavily:
             return await runTavily(query: q, apiKey: apiKey ?? "")
         }
+    }
+
+    /// Pure dispatch decision, extracted so the fallback contract is
+    /// unit-testable without touching the network: a key-REQUIRING
+    /// provider with no stored key degrades to the keyless Keenable
+    /// pool, with a model-visible note naming both the situation and
+    /// the remedy.
+    static func dispatchPlan(
+        provider: WebSearchProvider,
+        hasKey: Bool
+    ) -> (effective: WebSearchProvider, fallbackNote: String?) {
+        guard provider.requiresKey, !hasKey else {
+            return (provider, nil)
+        }
+        return (
+            .keenable,
+            "Note: \(provider.displayName) is selected but no API key is set — falling back to Keenable. Open Settings → Tools → Web search to paste a key."
+        )
     }
 
     /// Turn relative "last week" language into the previous complete
@@ -305,9 +332,9 @@ enum WebSearchTool {
         web_search error: the DuckDuckGo backend rate-limited this Mac, so this query \
         returned no results. The web_search tool is enabled and working — DuckDuckGo \
         throttles its free endpoint per IP after a few searches, and usually recovers \
-        after a few minutes. The user can also switch the backend to Brave Search or \
-        Tavily in Settings → Tools → Web search (Brave: 2000 queries/month free; \
-        Tavily: 1000 queries/month free), which are not throttled this way.
+        after a few minutes. The user can switch the backend in Settings → Tools → \
+        Web search: Keenable needs no key, and Parallel or Tavily work with a free \
+        API key — none of them are throttled this way.
         """
 
     /// Wraps ``duckDuckGoThrottleContent`` with the stable UI classification.
@@ -326,6 +353,139 @@ enum WebSearchTool {
             isError: true,
             failureKind: .webSearchRateLimited
         )
+    }
+
+    /// Keenable runner (#2041). Keyless by default (public JSON-RPC
+    /// pool); keyed REST when the user stored a key. Unlike the
+    /// keyed backends, transport-level failure here does NOT surface
+    /// as an error: Keenable is the zero-setup default, so its
+    /// outages degrade to the DuckDuckGo backstop with a
+    /// model-visible note — the "no broken state" promise again.
+    /// Key problems (401/403 on the keyed path) still surface
+    /// loudly: the user pasted that key and must hear it's being
+    /// rejected rather than silently burning the keyless pool.
+    static func runKeenable(
+        query q: String,
+        apiKey: String?,
+        fallbackNote: String?
+    ) async -> ToolCallResult {
+        let toolName = "web_search"
+        let request: URLRequest?
+        if let apiKey {
+            request = KeenableSearchClient.buildKeyedRequest(
+                query: q, apiKey: apiKey, snippetMaxLength: snippetCharCap
+            )
+        } else {
+            request = KeenableSearchClient.buildKeylessRequest(
+                query: q, snippetMaxLength: snippetCharCap
+            )
+        }
+        guard let request else {
+            // Only reachable with a malformed (control-byte) key —
+            // an account-level problem, not an availability one.
+            return ToolCallResult(
+                toolCallID: "",
+                content: "\(toolName) error: could not build Keenable request — re-paste the API key in Settings → Tools → Web search.",
+                isError: true
+            )
+        }
+        do {
+            let (data, response) = try await cappedData(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return await duckDuckGoBackstop(query: q, fallbackNote: fallbackNote)
+            }
+            switch http.statusCode {
+            case 200..<300:
+                let parsed = apiKey != nil
+                    ? KeenableSearchClient.parseKeyedResults(data, cap: resultCap)
+                    : KeenableSearchClient.parseKeylessResults(data, cap: resultCap)
+                guard let results = parsed else {
+                    // Schema drift / error envelope — same degrade
+                    // path as unreachable: the user shouldn't eat an
+                    // error for a backend they never chose.
+                    return await duckDuckGoBackstop(query: q, fallbackNote: fallbackNote)
+                }
+                return formatOutput(query: q, provider: .keenable, results: results, fallbackNote: fallbackNote)
+            // NB: ``where`` binds per-pattern in Swift, so it must be
+            // repeated — ``case 401, 403 where …`` would guard only
+            // the 403 arm and let a keyless 401 surface as a key
+            // error for a key that doesn't exist.
+            case 401 where apiKey != nil, 403 where apiKey != nil:
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: Keenable rejected the API key (HTTP \(http.statusCode)). Re-paste it in Settings → Tools → Web search.",
+                    isError: true
+                )
+            case 402 where apiKey != nil:
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: the Keenable key's monthly credit allowance is used up (HTTP 402). Searches continue on the keyless pool if you clear the key.",
+                    isError: true
+                )
+            default:
+                // Keyless 429 (shared pool exhausted), 5xx, or any
+                // other transport-level answer: degrade.
+                return await duckDuckGoBackstop(query: q, fallbackNote: fallbackNote)
+            }
+        } catch {
+            return await duckDuckGoBackstop(query: q, fallbackNote: fallbackNote)
+        }
+    }
+
+    /// Last hop of the keyless chain: run the DuckDuckGo scrape and
+    /// tell the model why it's seeing the backstop.
+    private static func duckDuckGoBackstop(query q: String, fallbackNote: String?) async -> ToolCallResult {
+        let backstopNote = "Note: Keenable was unavailable for this search — the DuckDuckGo backstop answered instead."
+        let combined = [fallbackNote, backstopNote].compactMap { $0 }.joined(separator: "\n")
+        return await runDuckDuckGo(query: q, fallbackNote: combined)
+    }
+
+    /// Parallel runner (#2042). Standard keyed backend: account
+    /// problems surface with the remedy, everything else is a plain
+    /// error the model can relay.
+    static func runParallel(query q: String, apiKey: String) async -> ToolCallResult {
+        let toolName = "web_search"
+        guard let req = ParallelSearchClient.buildRequest(
+            query: q,
+            apiKey: apiKey,
+            maxResults: resultCap,
+            maxCharsPerResult: snippetCharCap
+        ) else {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: could not build Parallel request", isError: true)
+        }
+        do {
+            let (data, response) = try await cappedData(for: req)
+            guard let http = response as? HTTPURLResponse else {
+                return ToolCallResult(toolCallID: "", content: "\(toolName) error: Parallel returned no HTTP response", isError: true)
+            }
+            switch http.statusCode {
+            case 200..<300:
+                guard let results = ParallelSearchClient.parseResults(data, cap: resultCap) else {
+                    return ToolCallResult(
+                        toolCallID: "",
+                        content: "\(toolName) error: Parallel returned an invalid response",
+                        isError: true
+                    )
+                }
+                return formatOutput(query: q, provider: .parallel, results: results)
+            case 401, 403:
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: Parallel rejected the API key (HTTP \(http.statusCode)). Re-paste it in Settings → Tools → Web search.",
+                    isError: true
+                )
+            case 429:
+                return ToolCallResult(
+                    toolCallID: "",
+                    content: "\(toolName) error: Parallel rate limit hit (HTTP 429). Wait a few minutes or check your plan's monthly credit.",
+                    isError: true
+                )
+            default:
+                return ToolCallResult(toolCallID: "", content: "\(toolName) error: Parallel returned HTTP \(http.statusCode)", isError: true)
+            }
+        } catch {
+            return ToolCallResult(toolCallID: "", content: "\(toolName) error: \(error.localizedDescription)", isError: true)
+        }
     }
 
     static func runBrave(query q: String, apiKey: String) async -> ToolCallResult {

--- a/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/WebSearchTool.swift
@@ -361,9 +361,10 @@ enum WebSearchTool {
     /// as an error: Keenable is the zero-setup default, so its
     /// outages degrade to the DuckDuckGo backstop with a
     /// model-visible note — the "no broken state" promise again.
-    /// Key problems (401/403 on the keyed path) still surface
-    /// loudly: the user pasted that key and must hear it's being
-    /// rejected rather than silently burning the keyless pool.
+    /// Key problems (401/402/403/429 on the keyed path) still
+    /// surface loudly: the user pasted that key and must hear about
+    /// its rejection or quota state rather than silently burning
+    /// the keyless pool.
     static func runKeenable(
         query q: String,
         apiKey: String?,

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsToolsPanel.swift
@@ -241,7 +241,7 @@ struct SettingsToolsPanel: View {
         @Bindable var config = webSearch
         return SettingsSection(
             "Web search",
-            subtitle: "Which backend `web_search` queries. DuckDuckGo needs no account but is rate-limited; the keyed backends are more reliable."
+            subtitle: "Which backend `web_search` queries. Keenable works with no account; add a free key (Parallel recommended) for the best results. Keys stay in your Keychain."
         ) {
                 VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
                     // Native macOS radio group, kept native: radios are
@@ -287,7 +287,10 @@ struct SettingsToolsPanel: View {
                         .foregroundStyle(RapidTheme.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    if config.provider.requiresKey {
+                    // ``acceptsKey``, not ``requiresKey``: Keenable's
+                    // key is optional (it lifts the shared keyless
+                    // rate limit) but still needs the field.
+                    if config.provider.acceptsKey {
                         SettingsRowDivider()
                         keyField(for: config.provider)
                     }
@@ -344,7 +347,7 @@ struct SettingsToolsPanel: View {
                     .foregroundStyle(RapidTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             } else {
-                Text("No key stored — searches fall back to DuckDuckGo until you save one.")
+                Text(Self.noKeyCaption(for: provider))
                     .font(RapidFont.caption)
                     .foregroundStyle(RapidTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -352,6 +355,17 @@ struct SettingsToolsPanel: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear { resetKeyDraft() }
+    }
+
+    /// What an empty key slot means depends on the provider: a
+    /// key-REQUIRING backend silently degrades to the keyless chain
+    /// at dispatch, while Keenable just keeps using the shared pool.
+    /// Static + internal so the copy is pinned by tests.
+    static func noKeyCaption(for provider: WebSearchProvider) -> String {
+        if provider.requiresKey {
+            return "No key stored — searches fall back to Keenable until you save one."
+        }
+        return "No key stored — \(provider.displayName) works without one; a free key lifts the shared rate limit."
     }
 
     private func commitKey(for provider: WebSearchProvider) {

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchProviderRosterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchProviderRosterTests.swift
@@ -185,6 +185,7 @@ struct KeenableClientTests {
         Snippets:
         Chip Apple M3 Ultra CPU cores 28 or 32
         Memory bandwidth 819 GB/s
+        Published: 2026-07-24
 
         ---
 
@@ -249,10 +250,13 @@ struct KeenableClientTests {
         #expect(results[0].title.hasPrefix("Apple M3 Ultra"))
         #expect(results[0].url == "https://canitrun.dev/gpus/m3-ultra")
         #expect(results[0].snippet.contains("819 GB/s"))
-        // Multi-line snippet bodies join into one line.
+        // Multi-line snippet bodies join into one line, and metadata
+        // lines never leak into the snippet — whether they appear
+        // BEFORE the Snippets: header or trail AFTER the body (the
+        // fixture carries a trailing "Published:" line).
         #expect(results[1].snippet == "Chip Apple M3 Ultra CPU cores 28 or 32 Memory bandwidth 819 GB/s")
-        // Metadata lines never leak into the snippet.
         #expect(!results[0].snippet.contains("Acquired"))
+        #expect(!results[1].snippet.contains("Published"))
     }
 
     @Test("The result cap truncates the block list")

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchProviderRosterTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchProviderRosterTests.swift
@@ -1,0 +1,414 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+// Tests for the #2040–#2043 web-search roster overhaul: the
+// descriptor table, the Keenable keyless default + fallback chain,
+// the Parallel client, and the Brave billing-honesty copy.
+
+@Suite("Web-search provider descriptor table")
+struct WebSearchProviderDescriptorTests {
+    @Test("Roster order is the Settings radio order: default first, recommended second, backstop last")
+    func rosterOrder() {
+        #expect(WebSearchProvider.allCases.first == .keenable)
+        #expect(WebSearchProvider.allCases[1] == .parallel)
+        #expect(WebSearchProvider.allCases.last == .duckduckgo)
+    }
+
+    @Test("Keychain accounts are unique and present exactly for the key-accepting providers")
+    func keychainAccounts() {
+        let accounts = WebSearchProvider.allCases.compactMap(\.keychainAccount)
+        #expect(Set(accounts).count == accounts.count, "two providers sharing an account would leak one key into the other's calls")
+        for provider in WebSearchProvider.allCases {
+            #expect((provider.keychainAccount != nil) == provider.acceptsKey)
+        }
+    }
+
+    @Test("Every key-requiring provider also accepts a key")
+    func requiresImpliesAccepts() {
+        for provider in WebSearchProvider.allCases where provider.requiresKey {
+            #expect(provider.acceptsKey)
+        }
+    }
+
+    @Test("Keenable is keyless-capable but key-accepting; DuckDuckGo is neither")
+    func keylessMatrix() {
+        #expect(!WebSearchProvider.keenable.requiresKey)
+        #expect(WebSearchProvider.keenable.acceptsKey)
+        #expect(!WebSearchProvider.duckduckgo.requiresKey)
+        #expect(!WebSearchProvider.duckduckgo.acceptsKey)
+    }
+
+    @Test("Every key-accepting provider links a key dashboard")
+    func dashboardsPresent() {
+        for provider in WebSearchProvider.allCases where provider.acceptsKey {
+            #expect(provider.keyDashboardURL != nil, "\(provider.rawValue) has a key field but no way to mint a key")
+        }
+    }
+
+    @Test("Brave's subtitle discloses the card + auto-billing and never claims 'free' (#2043)")
+    func braveBillingHonesty() {
+        let subtitle = WebSearchProvider.brave.subtitle
+        #expect(subtitle.localizedCaseInsensitiveContains("card"))
+        #expect(subtitle.localizedCaseInsensitiveContains("auto-billed"))
+        #expect(!subtitle.localizedCaseInsensitiveContains("free"))
+    }
+
+    @Test("Parallel's subtitle carries the recommendation")
+    func parallelRecommended() {
+        #expect(WebSearchProvider.parallel.subtitle.localizedCaseInsensitiveContains("recommended"))
+    }
+
+    @Test("Raw values survive: a pre-roster stored choice still decodes")
+    func legacyRawValuesDecode() {
+        // These strings are persisted in UserDefaults on existing
+        // installs; renaming a case would silently reset users to
+        // the default.
+        #expect(WebSearchProvider(rawValue: "duckduckgo") == .duckduckgo)
+        #expect(WebSearchProvider(rawValue: "brave") == .brave)
+        #expect(WebSearchProvider(rawValue: "tavily") == .tavily)
+    }
+}
+
+@MainActor
+@Suite("Web-search config: default, promotion, usability")
+struct WebSearchConfigRosterTests {
+    private func freshDefaults() -> UserDefaults {
+        let name = "web-search-roster-tests-\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: name)!
+        d.removePersistentDomain(forName: name)
+        return d
+    }
+
+    @Test("A fresh install defaults to Keenable (#2041)")
+    func freshDefaultIsKeenable() {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: RosterInMemoryKeychain())
+        #expect(config.provider == .keenable)
+    }
+
+    @Test("An explicit pre-existing choice survives the default flip")
+    func persistedChoiceWins() {
+        let defaults = freshDefaults()
+        defaults.set("duckduckgo", forKey: "rapid.webSearch.provider")
+        let config = WebSearchConfig(defaults: defaults, keychain: RosterInMemoryKeychain())
+        #expect(config.provider == .duckduckgo)
+    }
+
+    @Test("A corrupted stored value falls back to the Keenable default")
+    func corruptedValueFallsBack() {
+        let defaults = freshDefaults()
+        defaults.set("altavista", forKey: "rapid.webSearch.provider")
+        let config = WebSearchConfig(defaults: defaults, keychain: RosterInMemoryKeychain())
+        #expect(config.provider == .keenable)
+    }
+
+    @Test("Pasting a keyed-provider key promotes from either keyless backend", arguments: [WebSearchProvider.keenable, .duckduckgo])
+    func autoPromoteFromKeyless(start: WebSearchProvider) {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: RosterInMemoryKeychain())
+        config.provider = start
+        #expect(config.setAPIKey("pk-123", for: .parallel))
+        #expect(config.provider == .parallel)
+    }
+
+    @Test("An explicit keyed choice is never overridden by another provider's key")
+    func explicitKeyedChoiceWins() {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: RosterInMemoryKeychain())
+        config.provider = .tavily
+        #expect(config.setAPIKey("BSA-abc", for: .brave))
+        #expect(config.provider == .tavily)
+    }
+
+    @Test("A Keenable key is stored in place without any promotion dance")
+    func keenableKeyStaysPut() {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: RosterInMemoryKeychain())
+        #expect(config.provider == .keenable)
+        #expect(config.setAPIKey("keen_xyz", for: .keenable))
+        #expect(config.provider == .keenable)
+        #expect(config.apiKey(for: .keenable) == "keen_xyz")
+    }
+
+    @Test("Keyless providers are always usable; key-requiring ones only with a key")
+    func usability() {
+        let config = WebSearchConfig(defaults: freshDefaults(), keychain: RosterInMemoryKeychain())
+        config.provider = .keenable
+        #expect(config.currentProviderUsable)
+        config.provider = .parallel
+        #expect(!config.currentProviderUsable)
+        #expect(config.setAPIKey("pk-123", for: .parallel))
+        #expect(config.currentProviderUsable)
+    }
+}
+
+@Suite("Web-search dispatch plan (fallback chain, no network)")
+struct WebSearchDispatchPlanTests {
+    @Test("A key-requiring provider without a key degrades to Keenable with a note", arguments: [WebSearchProvider.parallel, .tavily, .brave])
+    func keylessFallsBackToKeenable(provider: WebSearchProvider) {
+        let plan = WebSearchTool.dispatchPlan(provider: provider, hasKey: false)
+        #expect(plan.effective == .keenable)
+        let note = plan.fallbackNote ?? ""
+        #expect(note.contains(provider.displayName))
+        #expect(note.contains("Keenable"))
+        #expect(note.contains("Settings → Tools"))
+    }
+
+    @Test("Keyless providers run as themselves with no note", arguments: [WebSearchProvider.keenable, .duckduckgo])
+    func keylessRunsDirect(provider: WebSearchProvider) {
+        let plan = WebSearchTool.dispatchPlan(provider: provider, hasKey: false)
+        #expect(plan.effective == provider)
+        #expect(plan.fallbackNote == nil)
+    }
+
+    @Test("A keyed provider with its key runs as itself")
+    func keyedRunsDirect() {
+        let plan = WebSearchTool.dispatchPlan(provider: .parallel, hasKey: true)
+        #expect(plan.effective == .parallel)
+        #expect(plan.fallbackNote == nil)
+    }
+}
+
+@Suite("Keenable client request/response contracts")
+struct KeenableClientTests {
+    // Captured live 2026-08-18 from the public MCP endpoint (trimmed).
+    static let keylessText = """
+        Title: Apple M3 Ultra — 96–512 GB VRAM: Which LLMs Can It Run?
+        URL: https://canitrun.dev/gpus/m3-ultra
+        Published: 2026-08-01
+        Acquired: 2026-08-04
+        Snippets:
+        Apple M3 Ultra ships in 96–512 GB unified-memory configurations at 819 GB/s.
+
+        ---
+
+        Title: Mac Studio M3 Ultra: What AI Models Can It Run?
+        URL: https://modelpiper.com/mac-studio/m3-ultra
+        Acquired: 2026-08-01
+        Snippets:
+        Chip Apple M3 Ultra CPU cores 28 or 32
+        Memory bandwidth 819 GB/s
+
+        ---
+
+        Title: Block with no link is skipped
+        Snippets:
+        Body without a URL line.
+
+        ---
+
+        Title: Unsafe scheme is skipped
+        URL: javascript:alert(1)
+        Snippets:
+        Nope.
+        """
+
+    private static func rpcEnvelope(text: String) -> Data {
+        let obj: [String: Any] = [
+            "jsonrpc": "2.0", "id": 1,
+            "result": ["content": [["type": "text", "text": text]]],
+        ]
+        return try! JSONSerialization.data(withJSONObject: obj)
+    }
+
+    @Test("Keyless request is a single JSON-RPC tools/call POST with the snippet cap clamped to the server minimum")
+    func keylessRequestShape() throws {
+        let req = try #require(KeenableSearchClient.buildKeylessRequest(query: "hello world", snippetMaxLength: 100))
+        #expect(req.url?.absoluteString == KeenableSearchClient.mcpEndpoint)
+        #expect(req.httpMethod == "POST")
+        #expect(req.value(forHTTPHeaderField: "Accept")?.contains("text/event-stream") == true)
+        let body = try #require(req.httpBody)
+        let obj = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(obj["jsonrpc"] as? String == "2.0")
+        #expect(obj["method"] as? String == "tools/call")
+        let params = try #require(obj["params"] as? [String: Any])
+        #expect(params["name"] as? String == "search_web_pages")
+        let args = try #require(params["arguments"] as? [String: Any])
+        #expect(args["query"] as? String == "hello world")
+        // Schema minimum is 180 — a smaller local cap must clamp up,
+        // not send an invalid value.
+        #expect(args["snippet_max_length"] as? Int == 180)
+    }
+
+    @Test("Keyed request hits the REST endpoint with the key in X-API-Key")
+    func keyedRequestShape() throws {
+        let req = try #require(KeenableSearchClient.buildKeyedRequest(query: "q", apiKey: "keen_abc", snippetMaxLength: 240))
+        #expect(req.url?.absoluteString == KeenableSearchClient.restEndpoint)
+        #expect(req.value(forHTTPHeaderField: "X-API-Key") == "keen_abc")
+        let obj = try JSONSerialization.jsonObject(with: req.httpBody!) as? [String: Any]
+        #expect(obj?["query"] as? String == "q")
+        #expect(obj?["snippet_max_length"] as? Int == 240)
+    }
+
+    @Test("A key with a control byte refuses to build (header injection)")
+    func keyedRequestRejectsControlBytes() {
+        #expect(KeenableSearchClient.buildKeyedRequest(query: "q", apiKey: "keen\r\nX-Evil: 1", snippetMaxLength: 240) == nil)
+    }
+
+    @Test("Keyless text blocks parse into title + URL + joined snippet, skipping linkless and unsafe blocks")
+    func textBlockParsing() {
+        let results = KeenableSearchClient.parseTextBlocks(Self.keylessText, cap: 6)
+        #expect(results.count == 2)
+        #expect(results[0].title.hasPrefix("Apple M3 Ultra"))
+        #expect(results[0].url == "https://canitrun.dev/gpus/m3-ultra")
+        #expect(results[0].snippet.contains("819 GB/s"))
+        // Multi-line snippet bodies join into one line.
+        #expect(results[1].snippet == "Chip Apple M3 Ultra CPU cores 28 or 32 Memory bandwidth 819 GB/s")
+        // Metadata lines never leak into the snippet.
+        #expect(!results[0].snippet.contains("Acquired"))
+    }
+
+    @Test("The result cap truncates the block list")
+    func textBlockCap() {
+        let results = KeenableSearchClient.parseTextBlocks(Self.keylessText, cap: 1)
+        #expect(results.count == 1)
+    }
+
+    @Test("A plain JSON-RPC envelope parses end-to-end")
+    func keylessEnvelopeParses() {
+        let results = KeenableSearchClient.parseKeylessResults(Self.rpcEnvelope(text: Self.keylessText), cap: 6)
+        #expect(results?.count == 2)
+    }
+
+    @Test("An SSE-framed envelope parses identically")
+    func keylessSSEEnvelopeParses() {
+        let json = String(data: Self.rpcEnvelope(text: Self.keylessText), encoding: .utf8)!
+        let sse = "event: message\ndata: \(json)\n\n"
+        let results = KeenableSearchClient.parseKeylessResults(Data(sse.utf8), cap: 6)
+        #expect(results?.count == 2)
+    }
+
+    @Test("A JSON-RPC error envelope is nil (degrade), not an empty success")
+    func keylessErrorEnvelopeIsNil() {
+        let err = try! JSONSerialization.data(withJSONObject: [
+            "jsonrpc": "2.0", "id": 1,
+            "error": ["code": -32000, "message": "boom"],
+        ])
+        #expect(KeenableSearchClient.parseKeylessResults(err, cap: 6) == nil)
+    }
+
+    @Test("A tool-level isError result is nil (degrade)")
+    func keylessToolErrorIsNil() {
+        let err = try! JSONSerialization.data(withJSONObject: [
+            "jsonrpc": "2.0", "id": 1,
+            "result": ["isError": true, "content": [["type": "text", "text": "rate limited"]]],
+        ])
+        #expect(KeenableSearchClient.parseKeylessResults(err, cap: 6) == nil)
+    }
+
+    @Test("Malformed keyless bytes are nil, a resultless text is an empty success")
+    func keylessMalformedVsEmpty() {
+        #expect(KeenableSearchClient.parseKeylessResults(Data("not json".utf8), cap: 6) == nil)
+        let empty = KeenableSearchClient.parseKeylessResults(Self.rpcEnvelope(text: "No results."), cap: 6)
+        #expect(empty?.isEmpty == true)
+    }
+
+    @Test("Keyed REST results prefer the query snippet over the static description")
+    func keyedParsePrefersSnippet() {
+        let data = try! JSONSerialization.data(withJSONObject: [
+            "query": "q",
+            "results": [
+                ["title": "A", "url": "https://a.example/", "description": "static", "snippet": "relevant"],
+                ["title": "B", "url": "https://b.example/", "description": "static only"],
+                ["title": "C", "url": "file:///etc/passwd", "snippet": "unsafe"],
+            ],
+        ])
+        let results = KeenableSearchClient.parseKeyedResults(data, cap: 6)
+        #expect(results?.count == 2)
+        #expect(results?[0].snippet == "relevant")
+        #expect(results?[1].snippet == "static only")
+    }
+
+    @Test("Malformed keyed JSON is nil, not an empty success")
+    func keyedMalformedIsNil() {
+        #expect(KeenableSearchClient.parseKeyedResults(Data("{}".utf8), cap: 6) == nil)
+    }
+}
+
+@Suite("Parallel client request/response contracts")
+struct ParallelClientTests {
+    @Test("Request pins endpoint, auth header, mode and the local display budgets")
+    func requestShape() throws {
+        let req = try #require(ParallelSearchClient.buildRequest(
+            query: "swift concurrency",
+            apiKey: "pk-1",
+            maxResults: 6,
+            maxCharsPerResult: 240
+        ))
+        #expect(req.url?.absoluteString == ParallelSearchClient.endpoint)
+        #expect(req.httpMethod == "POST")
+        #expect(req.value(forHTTPHeaderField: "x-api-key") == "pk-1")
+        let obj = try #require(try JSONSerialization.jsonObject(with: req.httpBody!) as? [String: Any])
+        #expect(obj["objective"] as? String == "swift concurrency")
+        #expect(obj["search_queries"] as? [String] == ["swift concurrency"])
+        // Pinned, not inherited: the server default could drift.
+        #expect(obj["mode"] as? String == "advanced")
+        let advanced = try #require(obj["advanced_settings"] as? [String: Any])
+        #expect(advanced["max_results"] as? Int == 6)
+        let excerpts = try #require(advanced["excerpt_settings"] as? [String: Any])
+        #expect(excerpts["max_chars_per_result"] as? Int == 240)
+    }
+
+    @Test("A key with a control byte refuses to build")
+    func rejectsControlBytes() {
+        #expect(ParallelSearchClient.buildRequest(query: "q", apiKey: "pk\r\nX: y", maxResults: 6, maxCharsPerResult: 240) == nil)
+    }
+
+    @Test("Excerpts join into one snippet; unsafe URLs are filtered; empty results decode as empty")
+    func responseParsing() {
+        let data = try! JSONSerialization.data(withJSONObject: [
+            "search_id": "s1",
+            "results": [
+                ["url": "https://a.example/", "title": "A", "excerpts": ["first passage", "  second  "]],
+                ["url": "https://b.example/", "title": "B", "excerpts": []],
+                ["url": "javascript:alert(1)", "title": "evil", "excerpts": ["x"]],
+            ],
+        ])
+        let results = ParallelSearchClient.parseResults(data, cap: 6)
+        #expect(results?.count == 2)
+        #expect(results?[0].snippet == "first passage … second")
+        #expect(results?[1].snippet == "")
+
+        let empty = try! JSONSerialization.data(withJSONObject: ["search_id": "s2", "results": [] as [Any]])
+        #expect(ParallelSearchClient.parseResults(empty, cap: 6)?.isEmpty == true)
+        #expect(ParallelSearchClient.parseResults(Data("nope".utf8), cap: 6) == nil)
+    }
+}
+
+@MainActor
+@Suite("Settings web-search captions")
+struct WebSearchSettingsCaptionTests {
+    @Test("A key-requiring provider's empty slot names the Keenable fallback")
+    func requiredKeyCaption() {
+        let caption = SettingsToolsPanel.noKeyCaption(for: .parallel)
+        #expect(caption.contains("Keenable"))
+    }
+
+    @Test("Keenable's empty slot says it works without a key")
+    func optionalKeyCaption() {
+        let caption = SettingsToolsPanel.noKeyCaption(for: .keenable)
+        #expect(caption.contains("works without one"))
+        #expect(caption.contains("Keenable"))
+    }
+}
+
+/// Local in-memory keychain — mirrors the private one in
+/// ``BuiltinToolsTests`` (private types don't cross files).
+private final class RosterInMemoryKeychain: KeychainStoring, @unchecked Sendable {
+    private var store: [String: String] = [:]
+    private let lock = NSLock()
+
+    func read(account: String) -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return store[account]
+    }
+
+    func write(account: String, secret: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        store[account] = secret
+        return true
+    }
+
+    func delete(account: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        store.removeValue(forKey: account)
+        return true
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WebSearchThrottleTests.swift
@@ -122,9 +122,12 @@ struct WebSearchThrottleTests {
         let content = WebSearchTool.duckDuckGoThrottleContent
         #expect(content.contains("web_search tool is enabled and working"))
         #expect(content.contains("rate-limited"))
-        #expect(content.contains("Brave Search"))
-        #expect(content.contains("Tavily"))
+        #expect(content.contains("Keenable"))
+        #expect(content.contains("Parallel"))
         #expect(content.contains("Settings → Tools"))
+        // #2043: Brave's card-free tier is gone — the remedy list must
+        // not pitch it as the free fix any more.
+        #expect(!content.contains("Brave"))
     }
 
     @Test("A pending fallback note survives the throttle path")
@@ -143,9 +146,12 @@ struct WebSearchThrottleTests {
     func diagnosisCopyIsActionable() {
         let diagnosis = FailureDiagnoser.diagnosis(for: .webSearchRateLimited)
         #expect(diagnosis.message.contains("DuckDuckGo"))
-        #expect(diagnosis.message.contains("Brave Search"))
-        #expect(diagnosis.message.contains("Tavily"))
+        #expect(diagnosis.message.contains("Keenable"))
+        #expect(diagnosis.message.contains("Parallel"))
         #expect(diagnosis.message.contains("Settings → Tools"))
+        // #2043: no longer steer throttled users toward Brave — its
+        // "free" key now requires a card and auto-bills overage.
+        #expect(!diagnosis.message.contains("Brave"))
         // The dead end this replaced. Settings are not the problem when the
         // free backend throttles, so the copy must not send the user there to
         // "check" anything.


### PR DESCRIPTION
## Why

The Artificial Analysis Search Index (2026-08-18) benchmarked 7 search API providers for agent use; our two keyed backends came LAST (Tavily 66 = 10th/11, Brave 65 = 11th/11, vs Parallel 75 / Exa 74 / Firecrawl 73), and our zero-setup default (the DuckDuckGo HTML scrape) has unusable result quality plus a per-IP throttle after a handful of searches. Separately, Brave dropped its card-free tier in Feb 2026 — our UI still pitched it as a free upgrade, which can steer users into surprise auto-billed charges.

Because the out-of-box search experience should not be "unusable", and the recommended paid slot should hold the measured-best provider, not the measured-worst.

Closes #2040, #2041, #2042, #2043.

## What

- **Descriptor table (#2040)**: `WebSearchProvider` metadata collapses into one `WebSearchProviderDescriptor` switch; forwarding accessors keep every call site unchanged. Raw values preserved — stored user choices survive.
- **Keenable keyless default (#2041)**: fresh installs default to Keenable's public pool — a single JSON-RPC `tools/call` POST (no MCP client stack, no handshake; verified live 2026-08-18: 0.3–2.5 s, real query-relevant snippets, Chinese queries fine, AA score 67 > Tavily 66 > Brave 65). Optional `keen_` key switches to REST `/v1/search` and lifts the shared 1,000 req/h/IP cap. Transport failures degrade to the DuckDuckGo backstop with a model-visible note.
- **Parallel recommended (#2042)**: new keyed backend, `mode: advanced` pinned, `max_results`/`max_chars_per_result` bounded to our display caps server-side. Settings subtitle carries the recommendation; free key ≈ 1,000 searches/month.
- **Fallback chain**: key-requiring provider with no key → Keenable (was: throttled DDG). Extracted as pure `dispatchPlan()` for network-free unit tests.
- **Brave honesty (#2043)**: subtitle discloses card-on-file + auto-billed overage; throttle diagnosis and remedy copy stop recommending Brave as the free fix.
- **Docs**: PRIVACY.md names the default Keenable endpoint and the query-only payload; SECURITY.md provider list updated.
- **Tests**: 30 new swift-testing cases (descriptor invariants, config default/promotion/usability, dispatch plan, Keenable JSON-RPC + SSE + text-block parsing incl. unsafe-scheme filtering, keyed REST parsing, Parallel request/response pinning, settings captions); throttle-copy assertions updated to the new remedy set.

## Testing

- `swift build` green locally (54 s; this box is CLT-only so `swift test` can't resolve `import Testing` — rapid-mac CI is the swift-test judge, per the workflow header).
- Keenable keyless endpoint behavior verified live against the real service (cold call, SSE/JSON, snippet clamp ≥180).
- No golden-flow baselines touched: the Settings Tools panel has no committed AX baseline, and the `RAPID_GUI_WEB_SEARCH_FIXTURE` path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)