### PR TITLE
fix(chat): discover model when attaching to a server

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -276,6 +276,10 @@ rapid-mlx chat qwen3.5-4b-4bit --system "You are a terse, friendly Mac shell tut
 rapid-mlx chat qwen3.5-4b-4bit --mcp-config mcp.json
 ```
 
+When attaching with `--port` or `--base-url` and no model argument, `chat`
+discovers the model from the server's `/v1/models` response. An explicit model
+argument always wins.
+
 In-REPL slash commands: `/help`, `/reset` (alias `/clear`), `/model <alias>`,
 `/save <path>` (write conversation to markdown), `/exit` (alias `/quit`).
 Type `"""` on its own line to start/end a multi-line block (pasting code).

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -69,6 +69,7 @@ class _FakeChatHandler(BaseHTTPRequestHandler):
     # and round 2 returns the final answer.
     canned_rounds: list[list[dict]] = []
     received_payloads: list[dict] = []
+    advertised_models: list[str] = ["served-model"]
 
     def log_message(self, *_args, **_kwargs):  # silence stderr
         pass
@@ -95,6 +96,15 @@ class _FakeChatHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b"ok")
+        elif self.path == "/v1/models":
+            body = json.dumps(
+                {"object": "list", "data": [{"id": m} for m in self.advertised_models]}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
         else:
             self.send_response(404)
             self.end_headers()
@@ -159,6 +169,7 @@ def test_chat_no_model_defaults_to_qwen35_4b():
         args.model == "qwen3.5-4b-4bit"
         or getattr(args, "_original_alias", None) == "qwen3.5-4b-4bit"
     )
+    assert args._model_was_explicit is False
 
 
 def test_chat_with_alias_overrides_default():
@@ -175,6 +186,7 @@ def test_chat_with_alias_overrides_default():
         args.model == "smollm3-3b-4bit"
         or getattr(args, "_original_alias", None) == "smollm3-3b-4bit"
     )
+    assert args._model_was_explicit is True
 
 
 def test_chat_mcp_config_flag_is_scoped_to_chat():
@@ -667,6 +679,32 @@ def test_chat_command_repl_multi_turn(monkeypatch, capsys):
     assert payloads[0]["messages"] == [{"role": "user", "content": "hello"}]
     # After /reset and "again", history should NOT contain "hello".
     assert payloads[1]["messages"] == [{"role": "user", "content": "again"}]
+
+
+def test_chat_attach_without_model_discovers_server_model(monkeypatch, capsys):
+    with _fake_server([_delta("ok")]) as (port, payloads):
+        inputs = iter(["hello", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _prompt="": next(inputs))
+        ns = _ns_for_chat(port)
+        ns._model_was_explicit = False
+
+        cli.chat_command(ns)
+
+    assert payloads[0]["model"] == "served-model"
+    assert "Connected model: served-model" in capsys.readouterr().out
+
+
+def test_chat_attach_with_explicit_model_does_not_override_it(monkeypatch):
+    with _fake_server([_delta("ok")]) as (port, payloads):
+        inputs = iter(["hello", "exit"])
+        monkeypatch.setattr("builtins.input", lambda _prompt="": next(inputs))
+        ns = _ns_for_chat(port)
+        ns.model = "explicit-model"
+        ns._model_was_explicit = True
+
+        cli.chat_command(ns)
+
+    assert payloads[0]["model"] == "explicit-model"
 
 
 # ----------------------------------------------------------------------

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7188,6 +7188,8 @@ def chat_command(args):
         pass
     atexit.register(_cleanup)
 
+    attached_to_existing = bool(args.base_url or args.port is not None)
+
     if args.base_url:
         base_url = args.base_url.rstrip("/")
         if base_url.endswith("/v1"):
@@ -7255,6 +7257,37 @@ def chat_command(args):
             print(f"\n  {RED}Failed to start server:{RESET} {e}")
             sys.exit(1)
         print(f"  {GREEN}✓ Ready.{RESET}\n")
+
+    # When attaching without an explicit model, trust the server's advertised
+    # model instead of the client's independently configured starter alias.
+    # The latter commonly differs from a manually started server and turns the
+    # very first request into an avoidable 404. Direct callers predating this
+    # marker are treated as explicit to preserve their existing behavior.
+    if attached_to_existing and not getattr(args, "_model_was_explicit", True):
+        try:
+            import requests
+
+            response = requests.get(f"{base_url}/v1/models", timeout=2)
+            response.raise_for_status()
+            payload = response.json()
+            models = payload.get("data", []) if isinstance(payload, dict) else []
+            discovered = next(
+                (
+                    item.get("id")
+                    for item in models
+                    if isinstance(item, dict)
+                    and isinstance(item.get("id"), str)
+                    and item["id"].strip()
+                ),
+                None,
+            )
+        except (requests.RequestException, ValueError, TypeError):
+            discovered = None
+        if discovered:
+            args.model = discovered
+            if hasattr(args, "_original_alias"):
+                delattr(args, "_original_alias")
+            print(f"  Connected model: {discovered} (discovered from server)")
 
     from vllm_mlx._version_check import print_staleness_warning_if_any
 
@@ -10445,6 +10478,8 @@ def main():
     # Systematic serve-flag passthrough for ``share`` via the standard ``--``
     # end-of-options separator — see ``_parse_args_with_share_passthrough``.
     args = _parse_args_with_share_passthrough(parser, sys.argv[1:])
+    if getattr(args, "command", None) in ("chat", "run"):
+        args._model_was_explicit = getattr(args, "model", None) is not None
 
     # First-run consent prompt — fires at most once per machine, only on
     # interactive subcommands when stdin is a tty. Safe no-op otherwise.
@@ -10640,7 +10675,7 @@ def main():
         _cmd = getattr(args, "command", "chat")
         _sel_alias, _starter_cached = select_chat_default()
         args.model = _sel_alias
-        if sys.stdin.isatty():
+        if sys.stdin.isatty() and not (args.base_url or args.port is not None):
             if _starter_cached:
                 print(
                     f"  No model specified — using {_sel_alias} (already downloaded)."


### PR DESCRIPTION
## Why

`rapid-mlx chat --port N` selected the client starter alias even when the attached server served another model, so the documented quick-start could fail with HTTP 404.

## What

- Track whether the model argument was explicitly supplied.
- For attach mode without an explicit model, discover the first served model from `/v1/models`.
- Preserve explicit-model behavior and fall back to the existing default if discovery fails.
- Document the behavior and add end-to-end REPL coverage.

Closes #2035.

## Validation

- `pytest -q tests/test_cli_chat.py` — 96 passed
- `git diff --check`