### PR TITLE
ci: run routing env guard before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
             tests/test_validate_release_subject.py \
             tests/test_check_gha_pinning.py \
             tests/test_check_mlx_upstream_calls.py \
+            tests/test_no_out_of_band_routing.py \
             tests/test_microbench_parsers.py \
             tests/test_telemetry_emit.py \
             tests/test_telemetry_consent.py \


### PR DESCRIPTION
## Why

The out-of-band routing environment-variable guard only ran in the post-merge/full validation path. Two unregistered variables therefore reached main before unrelated PRs exposed the failure.

## What

Run `tests/test_no_out_of_band_routing.py` in the normal Linux CI matrix before merge.

Closes #2020.

## Validation

- `pytest -q tests/test_no_out_of_band_routing.py` — 14 passed
- workflow YAML parsed successfully
- `git diff --check`