### PR TITLE
fix(chat): expose prefix-cache privacy opt-out

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -251,6 +251,7 @@ rapid-mlx chat [model] [options]
 | `--ready-timeout` | Seconds to wait for the spawned server to become ready | 600 |
 | `--response-timeout` | Seconds to wait for a single response | 600 |
 | `--mcp-config` | Load MCP tools into this chat agent | *(none)* |
+| `--disable-prefix-cache` | Disable reusable on-disk prefix caching for a server spawned by `chat` | off |
 
 > The REPL defaults to `--no-think` because reasoning models (Qwen3.5, etc.)
 > otherwise leak raw chain-of-thought and can loop until `max-tokens`. Pass
@@ -274,7 +275,13 @@ rapid-mlx chat qwen3.5-4b-4bit --system "You are a terse, friendly Mac shell tut
 
 # Give the built-in chat agent tools from one or more MCP servers
 rapid-mlx chat qwen3.5-4b-4bit --mcp-config mcp.json
+
+# Keep sensitive prompts out of the reusable on-disk prefix cache
+rapid-mlx chat qwen3.5-4b-4bit --disable-prefix-cache
 ```
+
+`--disable-prefix-cache` applies only when `chat` spawns its own server. When
+using `--port` or `--base-url`, start that server with the corresponding flag.
 
 In-REPL slash commands: `/help`, `/reset` (alias `/clear`), `/model <alias>`,
 `/save <path>` (write conversation to markdown), `/exit` (alias `/quit`).

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -126,6 +126,21 @@ def test_chat_subcommand_registered_in_cli():
     assert exc.value.code == 0
 
 
+def test_chat_disable_prefix_cache_flag_is_registered():
+    captured: list = []
+    with (
+        patch.object(
+            sys,
+            "argv",
+            ["rapid-mlx", "chat", "qwen3.5-4b-4bit", "--disable-prefix-cache"],
+        ),
+        patch.object(cli, "chat_command", side_effect=captured.append),
+    ):
+        cli.main()
+
+    assert captured[0].disable_prefix_cache is True
+
+
 def test_chat_no_model_defaults_to_qwen35_4b():
     """`rapid-mlx chat` (no model) on a COLD cache routes chat_command with
     the first-run starter (qwen3.5-4b-4bit).

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -2609,6 +2609,44 @@ def test_spawn_chat_server_sets_chat_spawn_env(monkeypatch, tmp_path):
     assert "--mcp-config" not in captured["cmd"]
 
 
+def test_spawn_chat_server_forwards_disable_prefix_cache(monkeypatch, tmp_path):
+    captured: dict = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+
+        def poll(self):
+            return None
+
+    class _FakeSocket:
+        def __init__(self, *_, **__):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def bind(self, _addr):
+            pass
+
+        def getsockname(self):
+            return ("127.0.0.1", 54321)
+
+    monkeypatch.setattr("socket.socket", _FakeSocket)
+    monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+    cli._spawn_chat_server(
+        "qwen3.5-4b-4bit",
+        str(tmp_path / "fake.log"),
+        disable_prefix_cache=True,
+    )
+
+    assert captured["cmd"].count("--disable-prefix-cache") == 1
+
+
 def test_sigterm_handler_masks_second_sigterm(monkeypatch):
     """A second SIGTERM landing mid-cleanup must be silently dropped via
     ``signal.SIG_IGN``, not re-invoke ``_cleanup`` (which would block on

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6225,6 +6225,7 @@ def _spawn_chat_server(
     *,
     register_in: list | None = None,
     log_handle=None,
+    disable_prefix_cache: bool = False,
 ) -> tuple[object, str]:
     """Spawn a `serve` subprocess on an ephemeral port for chat REPL use.
 
@@ -6277,6 +6278,8 @@ def _spawn_chat_server(
     ]
     if served_name and served_name != model:
         cmd.extend(["--served-model-name", served_name])
+    if disable_prefix_cache:
+        cmd.append("--disable-prefix-cache")
     log = open(log_path, "w")  # noqa: SIM115 — kept open for proc lifetime
     # Tell the child main() that the parent already gated (or that this is
     # an internal spawn, where prompting would deadlock anyway because the
@@ -7241,12 +7244,18 @@ def chat_command(args):
             # If main() resolved an alias, expose the alias as the API model name
             # so the chat request body matches what the user typed.
             original = getattr(args, "_original_alias", None)
+            privacy_kwargs = (
+                {"disable_prefix_cache": True}
+                if getattr(args, "disable_prefix_cache", False)
+                else {}
+            )
             proc, base_url = _spawn_chat_server(
                 args.model,
                 log_path,
                 served_name=original,
                 register_in=_active_procs,
                 log_handle=_log_handle,
+                **privacy_kwargs,
             )
 
         try:
@@ -7526,12 +7535,18 @@ def chat_command(args):
             # readiness wait, before any further Python statement runs in
             # this scope. A SIGTERM/Ctrl-C during the (possibly multi-second)
             # load tears the child down via the cleanup walk.
+            privacy_kwargs = (
+                {"disable_prefix_cache": True}
+                if getattr(args, "disable_prefix_cache", False)
+                else {}
+            )
             new_proc, new_base_url = _spawn_chat_server(
                 resolved,
                 new_log_path,
                 served_name=new_alias,
                 register_in=_active_procs,
                 log_handle=_new_log_handle,
+                **privacy_kwargs,
             )
         try:
             _wait_for_chat_server(new_base_url, new_proc, timeout_s=args.ready_timeout)
@@ -10187,6 +10202,15 @@ Examples:
         help=(
             "Maximum tool-call rounds per turn when --mcp-config is set "
             "(default: 8). Multi-step tasks may need more."
+        ),
+    )
+    chat_parser.add_argument(
+        "--disable-prefix-cache",
+        action="store_true",
+        help=(
+            "Disable reusable prefix-cache persistence in the server spawned "
+            "by chat, so prompt token IDs are not written to disk. Has no "
+            "effect with --port or --base-url; configure that server directly."
         ),
     )
 


### PR DESCRIPTION
## Why

`serve` could disable reusable prefix caching, but `chat` could not forward that choice to its spawned server. Sensitive prompt token IDs could therefore be persisted without a chat-level opt-out.

## What

- Add `rapid-mlx chat --disable-prefix-cache`.
- Forward it to every server spawned by the session, including `/model` swaps.
- Keep attach mode explicit: users configure an already-running server directly.
- Add subprocess command regression coverage and CLI documentation.

Closes #2002.

## Validation

- `pytest -q tests/test_cli_chat.py` — 95 passed
- `git diff --check`