### PR TITLE
fix(mac): make folder prompt golden flow reachable

### DIFF
--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -510,6 +510,11 @@ python3 scripts/ax-baseline.py normalize --scrub fake-alias /tmp/…/steady.json
 ## Why this is not coordinate automation
 
 The checked-in `rapid-ax.swift` helper talks directly to macOS Accessibility.
+Actions normally target an accessibility identifier. Native SwiftUI alerts
+are the exception: macOS can discard a `TextField` identifier while retaining
+the surrounding button identifiers. After waiting for an identified alert
+button, a flow may use `sheet-role:AXTextField` to address the first text field
+strictly inside the open `AXSheet`.
 It finds controls by stable `AXIdentifier`, performs `AXPress`, sets native text
 values, and serializes roles/descriptions/values for assertions. Peekaboo is
 kept for permission checks, window discovery, menu interaction, and screenshots.

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1679,8 +1679,12 @@ flow_chat_restore() {
     wait_identifier Sidebar.Conversation.Action.MoveToNewFolder "$OUT/folder-menu.json"
     press "$OUT/folder-menu.json" Sidebar.Conversation.Action.MoveToNewFolder \
         "$OUT/folder-new-press.json"
-    wait_identifier Sidebar.Folder.NameField "$OUT/folder-prompt.json"
-    "$AX_DRIVER" set-value "$APP_PID" Sidebar.Folder.NameField "Golden Work" \
+    # SwiftUI `.alert` button identifiers survive the macOS AX bridge, but its
+    # TextField identifier does not. Wait for the identified confirm button so
+    # the sheet is definitely present, then address the anonymous field by its
+    # role inside that sheet (never an unrelated field in the main window).
+    wait_identifier Sidebar.Folder.Prompt.Confirm "$OUT/folder-prompt.json"
+    "$AX_DRIVER" set-value "$APP_PID" sheet-role:AXTextField "Golden Work" \
         > "$OUT/folder-name.json"
     see_main "$OUT/folder-name-set.json"
     press "$OUT/folder-name-set.json" Sidebar.Folder.Prompt.Confirm \

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -2,6 +2,9 @@
 // Minimal native Accessibility driver for deterministic Rapid GUI journeys.
 // It deliberately exposes only semantic operations: dump, press, set-value,
 // paste-file, and closing a named native window through its AXCloseButton.
+// Most targets are accessibility identifiers. A `sheet-role:<AXRole>` target
+// is also available for native alert controls whose SwiftUI identifier is
+// discarded by macOS before the control reaches the accessibility tree.
 import AppKit
 import ApplicationServices
 import Foundation
@@ -149,6 +152,13 @@ var windowTitles = [String]()
 var windowListComplete = true
 var windowElements = [AXUIElement]()
 let wanted = CommandLine.arguments.count > 3 ? CommandLine.arguments[3] : nil
+let sheetRolePrefix = "sheet-role:"
+let wantedSheetRole: String? = wanted.flatMap { target in
+    guard target.hasPrefix(sheetRolePrefix) else { return nil }
+    let role = String(target.dropFirst(sheetRolePrefix.count))
+    guard !role.isEmpty else { fail("sheet-role selector requires an AX role") }
+    return role
+}
 
 func attribute(_ element: AXUIElement, _ name: CFString) -> AnyObject? {
     var value: CFTypeRef?
@@ -182,7 +192,7 @@ func size(_ element: AXUIElement, _ name: CFString) -> CGSize? {
     return result
 }
 
-func walk(_ element: AXUIElement, depth: Int) {
+func walk(_ element: AXUIElement, depth: Int, insideSheet: Bool = false) {
     guard depth <= 40, records.count < 12_000 else {
         elementWalkComplete = false
         return
@@ -191,6 +201,10 @@ func walk(_ element: AXUIElement, depth: Int) {
 
     let identifier = string(element, kAXIdentifierAttribute as CFString)
     let role = string(element, kAXRoleAttribute as CFString)
+    let elementIsInsideSheet = insideSheet || role == kAXSheetRole as String
+    let matchesSheetRole = wantedSheetRole.map {
+        elementIsInsideSheet && role == $0
+    } ?? false
     // Action commands only need one element. Building a complete 12k-node
     // dump after finding it leaves SwiftUI several seconds to replace the
     // backing accessibility object; AXPress then receives a stale reference
@@ -201,7 +215,8 @@ func walk(_ element: AXUIElement, depth: Int) {
         match = element
         return
     }
-    if command != "dump", match == nil, identifier == wanted {
+    if command != "dump", match == nil,
+       identifier == wanted || matchesSheetRole {
         match = element
         return
     }
@@ -266,7 +281,7 @@ func walk(_ element: AXUIElement, depth: Int) {
         }
     }
     for child in children {
-        walk(child, depth: depth + 1)
+        walk(child, depth: depth + 1, insideSheet: elementIsInsideSheet)
         if command != "dump", match != nil { break }
     }
 }


### PR DESCRIPTION
Closes #2050.

## What changed

- add a `sheet-role:<AXRole>` target to the native AX driver for controls inside an `AXSheet` whose SwiftUI identifier is discarded by macOS
- wait for the folder prompt confirm button, whose identifier is preserved, before addressing its anonymous `AXTextField`
- document the narrowly scoped selector

## Root cause

On macOS, the SwiftUI `.alert` keeps accessibility identifiers on its buttons but drops the identifier on its `TextField`. The `chat-restore` flow therefore waited forever for `Sidebar.Folder.NameField` even though the prompt was present.

## Validation

- `swiftc scripts/rapid-ax.swift`
- 52 GUI harness contract tests passed
- 2,405 Swift tests passed
- release app build succeeded
- real `chat-restore` flow progressed through folder creation and observed `Golden Work (1)`; later stopped at the separate native export-panel close race