### PR TITLE
feat(recommendations): AA-Index policy — qwen3.8-27b-4bit is the smart pick for every Mac from 32 GB up [skip-version-bump]

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ or Homebrew — prebuilt bottle straight from homebrew-core:
 brew install rapid-mlx
 ```
 
-Both land the same `rapid-mlx` CLI. The curl installer additionally installs Python 3.10+ if missing, creates an isolated venv at `~/.rapid-mlx/`, symlinks the `rapid-mlx` CLI into `~/.local/bin/`, and prints a serve command sized to your Mac (8–15 GB → `lfm2.5-2.6b-4bit`; 16–17 GB → `qwen3.5-4b-4bit`; 18–23 GB → `qwen3.5-9b-4bit`; 24–31 GB → `bonsai-27b-2bit`; 32–63 GB → `gemma-4-26b-4bit`; 64–95 GB → `qwen3.6-35b-8bit`; 96 GB+ → `qwen3.5-122b-mxfp4`).
+Both land the same `rapid-mlx` CLI. The curl installer additionally installs Python 3.10+ if missing, creates an isolated venv at `~/.rapid-mlx/`, symlinks the `rapid-mlx` CLI into `~/.local/bin/`, and prints a serve command sized to your Mac (8–15 GB → `lfm2.5-2.6b-4bit`; 16–17 GB → `qwen3.5-4b-4bit`; 18–23 GB → `qwen3.5-9b-4bit`; 24–31 GB → `bonsai-27b-2bit`; 32 GB+ → `qwen3.8-27b-4bit`).
 
 > **Install security.** `install.sh` is served over HTTPS (HSTS-preload) from `rapidmlx.com` and is a byte-identical mirror of [`install.sh`](install.sh) at the release commit — read it before running if you like. If you want a cryptographically verified installer rather than trusting the website pipe, don't `curl | bash` the URL above: instead download the release's `install.sh` asset, verify it against the cosign-signed `SHA256SUMS.txt` shipped alongside it, and run that verified copy — full recipe in [SECURITY.md](SECURITY.md). PyPI artifacts additionally carry Sigstore attestations (PEP 740). Two more low-trust paths:
 > - **Pin to a commit hash** — `curl -fsSL https://raw.githubusercontent.com/raullenchai/Rapid-MLX/<commit>/install.sh -o install.sh && shasum -a 256 install.sh && bash install.sh`
@@ -240,7 +240,7 @@ The installer and desktop app use the same RAM-tier recommendation catalog. Run 
 This table is the same one the desktop app's picker reads, and the installer
 prints the matching line for your Mac — a CI test parses both files and fails
 if they drift apart. Measured rows use the standard ~8K prompt peak of the
-complete `rapid-mlx serve` process tree on an M2 Pro 32 GB Mac mini.
+complete `rapid-mlx serve` process tree on an M2 Pro 32 GB Mac mini (the 32 GB+ row: M3 Ultra, 2026-08-18 — footprint is config-bound, speed reads lower on smaller chips).
 
 | RAM | Recommended | Peak RSS | One-shot |
 |---|---|---:|---|
@@ -248,13 +248,14 @@ complete `rapid-mlx serve` process tree on an M2 Pro 32 GB Mac mini.
 | **16–17 GB** MacBook Air / Pro | `qwen3.5-4b-4bit` | 5.8 GB | `rapid-mlx serve qwen3.5-4b-4bit` |
 | **18–23 GB** MacBook Pro | `qwen3.5-9b-4bit` | 8.7 GB | `rapid-mlx serve qwen3.5-9b-4bit` |
 | **24–31 GB** Mac Mini / MacBook Pro | `bonsai-27b-2bit` | 13.0 GB | `rapid-mlx serve bonsai-27b-2bit` |
-| **32–63 GB** Mac Studio / high-spec Mini | `gemma-4-26b-4bit` | 20.0 GB | `rapid-mlx serve gemma-4-26b-4bit --no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512` |
-| **64–95 GB** Mac Studio | `qwen3.6-35b-8bit` | 37.7 GB | `rapid-mlx serve qwen3.6-35b-8bit` |
-| **96 GB+** Mac Studio / Pro | `qwen3.5-122b-mxfp4` | — | `rapid-mlx serve qwen3.5-122b-mxfp4` |
+| **32 GB+** Mac Studio / MacBook Pro | `qwen3.8-27b-4bit` | 20.0 GB | `rapid-mlx serve qwen3.8-27b-4bit` |
 
-The 32–63 GB flags are not optional: Gemma 4 26B ships a vision tower that tier
-has no memory for, and an uncapped KV budget claims the headroom the rest of
-your Mac needs.
+Every Mac from 32 GB up gets the same pick, and that is the point: Qwen3.8-27B
+scores 52 on the Artificial Analysis Intelligence Index (2026-08-18) —
+GPT-5.6-class, the highest of any open-weights model we serve, ahead of the
+much larger 122B (33) and 35B (32) it replaces. Multi-token prediction is on by
+default (~40 tok/s decode, 8K prefill at ~324 tok/s, zero swap at every tier
+budget).
 
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
 → [Every alias, quant, and family (166 text + 41 audio + 8 video aliases, 215 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)

--- a/README.md
+++ b/README.md
@@ -253,7 +253,9 @@ complete `rapid-mlx serve` process tree on an M2 Pro 32 GB Mac mini (the 32 GB+ 
 Every Mac from 32 GB up gets the same pick, and that is the point: Qwen3.8-27B
 scores 52 on the Artificial Analysis Intelligence Index (2026-08-18) —
 GPT-5.6-class, the highest of any open-weights model we serve, ahead of the
-much larger 122B (33) and 35B (32) it replaces. Multi-token prediction is on by
+much larger 122B (33) and 35B (32) it replaces (the index scores the
+full-precision release; our 4-bit build's deltas are unmeasured — the
+standing caveat for every quantized pick here). Multi-token prediction is on by
 default (~40 tok/s decode, 8K prefill at ~324 tok/s, zero swap at every tier
 budget).
 

--- a/apps/rapid-mac/Sources/Rapid/Resources/benchmark-scores.json
+++ b/apps/rapid-mac/Sources/Rapid/Resources/benchmark-scores.json
@@ -5,7 +5,7 @@
   "axes": {
     "general_reasoning": {
       "label_en": "General & Reasoning",
-      "label_zh": "\u901a\u8bc6\u548c\u63a8\u7406",
+      "label_zh": "通识和推理",
       "definition": "arithmetic_mean(mmlu_pro, gpqa_diamond) when both present; otherwise the single available bench",
       "thresholds": {
         "good": 50.0,
@@ -259,7 +259,7 @@
     "qwen3-coder-30b-4bit": {
       "general_reasoning": null,
       "code": null,
-      "code_null_reason": "Qwen publishes no LiveCodeBench/HumanEval/SWE-bench pass@1 for the Coder variant; the only available number was Artificial Analysis's Coding *Index* (29.0), a normalized composite on a different scale than the pass@1 family the Code axis renders. Shown beside its bucket-mates it put our dedicated coder below every general-purpose model (#468). Honest gap per the no-fabrication / no-incomparable-substitution policy \u2014 leave null rather than display a cross-scale number.",
+      "code_null_reason": "Qwen publishes no LiveCodeBench/HumanEval/SWE-bench pass@1 for the Coder variant; the only available number was Artificial Analysis's Coding *Index* (29.0), a normalized composite on a different scale than the pass@1 family the Code axis renders. Shown beside its bucket-mates it put our dedicated coder below every general-purpose model (#468). Honest gap per the no-fabrication / no-incomparable-substitution policy — leave null rather than display a cross-scale number.",
       "tool": null,
       "tool_null_reason": "Qwen does not publish BFCL for the Coder variant",
       "ifeval": null,
@@ -278,7 +278,7 @@
       "code": 83.9,
       "code_source": "https://huggingface.co/Qwen/Qwen3.6-27B",
       "tool": null,
-      "tool_null_reason": "Qwen3.6 blog does not publish BFCL \u2014 focuses on SWE-bench + Terminal-Bench",
+      "tool_null_reason": "Qwen3.6 blog does not publish BFCL — focuses on SWE-bench + Terminal-Bench",
       "ifeval": null,
       "ifeval_null_reason": "Qwen3.6 blog does not publish IFEval",
       "speed_tps": 36.5,
@@ -471,6 +471,21 @@
       "speed_tps": 21.14,
       "speed_source": "Rapid-MLX 0.12.7 M2 Pro 32GB ~8K decode",
       "local_release_eval_composite": 84.25
+    },
+    "qwen3.8-27b-4bit": {
+      "general_reasoning": 89.2,
+      "general_reasoning_source": "gpqa_diamond only (Qwen3.8 model card does not publish MMLU-Pro)",
+      "general_reasoning_basis": {
+        "gpqa_diamond": 89.2
+      },
+      "code": 90.3,
+      "code_source": "LiveCodeBench v6, Qwen3.8-27B model card (vendor-reported)",
+      "tool": null,
+      "tool_null_reason": "Qwen3.8 model card publishes Terminal-Bench 2.1 (73.0) and SWE-bench Pro (61.7), not BFCL or tau-bench",
+      "ifeval": null,
+      "ifeval_null_reason": "Qwen3.8 model card publishes IFBench (79.5), not IFEval prompt-strict",
+      "speed_tps": 40.7,
+      "speed_source": "docs/benchmarks/model-recommendation-measurements.json (8K prompt, M3 Ultra, MTP on)"
     }
   },
   "ground_truth_source": "data/benchmark-ground-truth.json"

--- a/apps/rapid-mac/Sources/Rapid/Resources/benchmark-scores.json
+++ b/apps/rapid-mac/Sources/Rapid/Resources/benchmark-scores.json
@@ -485,7 +485,7 @@
       "ifeval": null,
       "ifeval_null_reason": "Qwen3.8 model card publishes IFBench (79.5), not IFEval prompt-strict",
       "speed_tps": 40.7,
-      "speed_source": "docs/benchmarks/model-recommendation-measurements.json (8K prompt, M3 Ultra, MTP on)"
+      "speed_source": "docs/benchmarks/model-recommendation-measurements.json (short-prompt decode, M3 Ultra, MTP on; 8K decode: 37.6)"
     }
   },
   "ground_truth_source": "data/benchmark-ground-truth.json"

--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -34,17 +34,21 @@ private final class RecommendationBundleFinder: NSObject {}
 /// | 16 GB  | qwen3.5-4b-4bit     |  6.0 | 78% | 60.7  | lfm2.5-1b-4bit · basic · 208.4   |
 /// | 18 GB  | qwen3.5-9b-4bit     |  8.7 | 82% | 35.7  | qwen3.5-4b-4bit · 78% · 60.7     |
 /// | 24 GB  | bonsai-27b-2bit     | 13.0 | 86% | 17.5  | qwen3.5-4b-4bit · 78% · 60.7     |
-/// | 32 GB  | gemma-4-26b-4bit    | 17.0 | 87% | 49.5  | qwen3.5-4b-4bit · 78% · 60.7     |
-/// | 48 GB  | gemma-4-26b-4bit    | 17.0 | 87% | 49.5  | qwen3.6-35b-4bit · 87% · 60      |
-/// | 64 GB  | qwen3.6-35b-8bit    | 37.7 | 87% | —     | qwen3.6-35b-4bit · 87% · 60      |
-/// | 96 GB+ | qwen3.5-122b-mxfp4  | 65.0 | 88% | —     | qwen3.6-35b-4bit · 87% · 60      |
+/// | 32 GB  | qwen3.8-27b-4bit    | 20.0 | 92% | 40.7  | qwen3.5-4b-4bit · 78% · 60.7     |
+/// | 48 GB  | qwen3.8-27b-4bit    | 20.0 | 92% | 40.7  | qwen3.6-35b-4bit · 87% · 60      |
+/// | 64 GB  | qwen3.8-27b-4bit    | 20.0 | 92% | 40.7  | qwen3.6-35b-4bit · 87% · 60      |
+/// | 96 GB+ | qwen3.8-27b-4bit    | 20.0 | 92% | 40.7  | qwen3.6-35b-4bit · 87% · 60      |
+///
+/// Every tier from 32 GB up shares one smart pick (AA-Index policy,
+/// 2026-08-18): qwen3.8-27b-4bit is the highest-scoring open-weights model
+/// the engine serves on the Artificial Analysis Intelligence Index (52 —
+/// GPT-5.6-class; the 122B it displaced scores 33), and its measured 8K
+/// peak clears every one of those tiers' budgets.
 ///
 /// The measured rows use the standard ~8K prompt peak of the complete
-/// ``rapid-mlx serve`` process tree on an M2 Pro 32 GB Mac mini, not weight
-/// size or an idle/short-prompt RSS. Recommendations require zero new swap,
-/// peak below 75% of the tier floor, 8K prefill >=100 tok/s, and decode
-/// >=10 tok/s. The 64/96 GB rows predate this run and remain explicitly
-/// unmeasured until matching hardware is available.
+/// ``rapid-mlx serve`` process tree, not weight size or an idle/short-prompt
+/// RSS. Recommendations require zero new swap, peak below 75% of the tier
+/// floor, 8K prefill >=100 tok/s, and decode >=10 tok/s.
 ///
 /// These figures must be measured THROUGH serve: a bare ``mlx_lm`` probe
 /// does not exercise the product's cache configuration or full process

--- a/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/RAMBucketedDefaultTests.swift
@@ -14,10 +14,10 @@ import Testing
 ///   16 GB  → qwen3.5-4b-4bit   (+ fast lfm2.5-1b-4bit)
 ///   18 GB  → qwen3.5-9b-4bit   (+ fast qwen3.5-4b-4bit)
 ///   24 GB  → bonsai-27b-2bit   (+ fast qwen3.5-4b-4bit)
-///   32 GB  → gemma-4-26b-4bit  (+ fast qwen3.5-4b-4bit)
-///   48 GB  → gemma-4-26b-4bit  (+ fast qwen3.6-35b-4bit)
-///   64 GB  → qwen3.6-35b-8bit  (+ fast qwen3.6-35b-4bit)
-///   96 GB+ → qwen3.5-122b-mxfp4 (+ fast qwen3.6-35b-4bit)
+///   32 GB  → qwen3.8-27b-4bit  (+ fast qwen3.5-4b-4bit)
+///   48 GB  → qwen3.8-27b-4bit  (+ fast qwen3.6-35b-4bit)
+///   64 GB  → qwen3.8-27b-4bit  (+ fast qwen3.6-35b-4bit)
+///   96 GB+ → qwen3.8-27b-4bit  (+ fast qwen3.6-35b-4bit)
 ///
 /// Note: the picks trust the maintainer's MEASURED footprints, which are
 /// smaller than ``ModelSizing``'s heuristic estimate for low-bit / MoE
@@ -36,11 +36,11 @@ struct RAMBucketedDefaultTests {
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 17) == "qwen3.5-4b-4bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 18) == "qwen3.5-9b-4bit")
         #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 24) == "bonsai-27b-2bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 32) == "gemma-4-26b-4bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 48) == "gemma-4-26b-4bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 64) == "qwen3.6-35b-8bit")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 96) == "qwen3.5-122b-mxfp4")
-        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 256) == "qwen3.5-122b-mxfp4") // 96 tier
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 32) == "qwen3.8-27b-4bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 48) == "qwen3.8-27b-4bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 64) == "qwen3.8-27b-4bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 96) == "qwen3.8-27b-4bit")
+        #expect(RAMBucketedDefault.alias(forPhysicalRAMGB: 256) == "qwen3.8-27b-4bit") // 96 tier
     }
 
     @Test("A 20 GB Mac rounds DOWN to the 18 GB pick (fits), not up to 24 GB")
@@ -77,9 +77,9 @@ struct RAMBucketedDefaultTests {
         #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 24).map(\.alias)
             == ["bonsai-27b-2bit", "qwen3.5-4b-4bit"])
         #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 32).map(\.alias)
-            == ["gemma-4-26b-4bit", "qwen3.5-4b-4bit"])
+            == ["qwen3.8-27b-4bit", "qwen3.5-4b-4bit"])
         #expect(RAMBucketedDefault.picks(forPhysicalRAMGB: 48).map(\.alias)
-            == ["gemma-4-26b-4bit", "qwen3.6-35b-4bit"])
+            == ["qwen3.8-27b-4bit", "qwen3.6-35b-4bit"])
         // 64/96 GB: fast alt is the lighter 4-bit Qwen3.6-35B (no caveat).
         let tier64 = RAMBucketedDefault.picks(forPhysicalRAMGB: 64)
         #expect(tier64.count == 2)
@@ -95,11 +95,12 @@ struct RAMBucketedDefaultTests {
     @Test("Flags apply only when the alias IS the pick for that Mac's RAM")
     func launchFlagsAreRAMGated() {
         #expect(RAMBucketedDefault.launchFlags(forAlias: "qwen3.5-9b-4bit", physicalRAMGB: 18).isEmpty)
-        #expect(RAMBucketedDefault.launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 32)
-            == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"])
+        // No tier carries launch flags since the gemma pick retired with
+        // the AA-Index roster (qwen3.8-27b-4bit runs bare; MTP is in the
+        // alias). The RAM-gating machinery itself is still exercised: a
+        // non-pick alias and a foreign tier both come back flagless.
+        #expect(RAMBucketedDefault.launchFlags(forAlias: "qwen3.8-27b-4bit", physicalRAMGB: 32).isEmpty)
         #expect(RAMBucketedDefault.launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 48).isEmpty)
-        // Hand-picking gemma-26b on a 64 GB Mac (where it is NOT the pick)
-        // → no forced flags, so it keeps vision.
         #expect(RAMBucketedDefault.launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 64).isEmpty)
         #expect(RAMBucketedDefault.launchFlags(forAlias: "not-a-pick", physicalRAMGB: 32).isEmpty)
     }
@@ -365,11 +366,13 @@ struct CacheAwareDefaultTests {
     @Test("Cached preference walks closest eligible tier downward, smart before fast")
     func curatedPreferenceOrder() {
         let order = RAMBucketedDefault.preferenceOrder(forPhysicalRAMGB: 256)
+        // 96/64/48 dedupe to the shared 27B smart + 35B fast picks, so the
+        // walk reaches the 32-tier fast and the 24-tier smart next.
         #expect(order.prefix(4) == [
-            "qwen3.5-122b-mxfp4",
+            "qwen3.8-27b-4bit",
             "qwen3.6-35b-4bit",
-            "qwen3.6-35b-8bit",
-            "gemma-4-26b-4bit",
+            "qwen3.5-4b-4bit",
+            "bonsai-27b-2bit",
         ])
         #expect(Set(order).count == order.count)
         #expect(RAMBucketedDefault.preferenceOrder(forPhysicalRAMGB: 4).prefix(2) == [

--- a/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
+++ b/apps/rapid-mac/scripts/verify-recommendation-tiers.swift
@@ -102,11 +102,11 @@ check(alias(forPhysicalRAMGB: 18) == "qwen3.5-9b-4bit",     "18GB → qwen3.5-9b
 check(alias(forPhysicalRAMGB: 20) == "qwen3.5-9b-4bit",     "20GB rounds DOWN to 18 (qwen9), not 24")
 check(alias(forPhysicalRAMGB: 24) == "bonsai-27b-2bit",     "24GB → bonsai-27b")
 check(alias(forPhysicalRAMGB: 30) == "bonsai-27b-2bit",     "30GB → 24 tier")
-check(alias(forPhysicalRAMGB: 32) == "gemma-4-26b-4bit",    "32GB → gemma-4-26b")
-check(alias(forPhysicalRAMGB: 48) == "gemma-4-26b-4bit",    "48GB → gemma-4-26b")
-check(alias(forPhysicalRAMGB: 64) == "qwen3.6-35b-8bit",    "64GB → qwen3.6-35b-8bit")
-check(alias(forPhysicalRAMGB: 96) == "qwen3.5-122b-mxfp4",  "96GB → 122b-mxfp4")
-check(alias(forPhysicalRAMGB: 256) == "qwen3.5-122b-mxfp4", "256GB → 96 tier (122b-mxfp4)")
+check(alias(forPhysicalRAMGB: 32) == "qwen3.8-27b-4bit",    "32GB → qwen3.8-27b")
+check(alias(forPhysicalRAMGB: 48) == "qwen3.8-27b-4bit",    "48GB → qwen3.8-27b")
+check(alias(forPhysicalRAMGB: 64) == "qwen3.8-27b-4bit",    "64GB → qwen3.8-27b")
+check(alias(forPhysicalRAMGB: 96) == "qwen3.8-27b-4bit",    "96GB → qwen3.8-27b")
+check(alias(forPhysicalRAMGB: 256) == "qwen3.8-27b-4bit",   "256GB → 96 tier (qwen3.8-27b)")
 
 print("Smart + fast picks per tier:")
 for floor in [8.0, 16.0, 18.0, 24.0, 32.0, 48.0, 64.0, 96.0] {
@@ -115,7 +115,7 @@ for floor in [8.0, 16.0, 18.0, 24.0, 32.0, 48.0, 64.0, 96.0] {
 check(picks(forPhysicalRAMGB: 18).count == 2, "18GB has smart + fast")
 check(picks(forPhysicalRAMGB: 18)[1].alias == "qwen3.5-4b-4bit", "18GB fast is qwen3.5-4b")
 check(picks(forPhysicalRAMGB: 24)[0].alias == "bonsai-27b-2bit", "24GB smart is bonsai")
-check(picks(forPhysicalRAMGB: 32)[0].alias == "gemma-4-26b-4bit", "32GB smart is gemma")
+check(picks(forPhysicalRAMGB: 32)[0].alias == "qwen3.8-27b-4bit", "32GB smart is qwen3.8-27b")
 check(picks(forPhysicalRAMGB: 48)[1].alias == "qwen3.6-35b-4bit", "48GB retains reviewed Qwen3.6 fast pick")
 // 64/96 GB → fast alt is the lighter 4-bit Qwen3.6-35B.
 check(picks(forPhysicalRAMGB: 64).count == 2, "64GB has smart + fast")
@@ -136,7 +136,7 @@ for ram in [8.0, 16.0, 18.0, 24.0, 32.0, 48.0, 64.0, 96.0] {
               "\(Int(ram))GB smart (\(ps[0].capabilityPct)%) not shown below its fast alt (\(ps[1].capabilityPct)%)")
     }
 }
-check(picks(forPhysicalRAMGB: 64)[0].capabilityPct == 87, "64GB 8-bit floored at its 4-bit's 87%")
+check(picks(forPhysicalRAMGB: 64)[0].capabilityPct == 92, "64GB smart (qwen3.8-27b) reads 92%, above its 35b-4bit alt")
 
 print("Smart-pick capability is monotonic non-decreasing by RAM (no 'more RAM, worse pick' dip):")
 let floors = [8.0, 16.0, 18.0, 24.0, 32.0, 48.0, 64.0, 96.0]
@@ -164,15 +164,17 @@ check(pickStatsLine(fast96) == "20.0 GB · 87% capability · ~60 tok/s", "genera
 let smart16 = picks(forPhysicalRAMGB: 16)[0]
 check(pickStatsLine(smart16) == "6.0 GB · 78% capability · ~61 tok/s", "16GB qwen4 renders measured 8K peak")
 let smart96 = picks(forPhysicalRAMGB: 96)[0]
-check(pickStatsLine(smart96) == "65.0 GB · 88% capability", "no-tok/s smart pick omits the speed figure")
+check(pickStatsLine(smart96) == "20.0 GB · 92% capability · ~41 tok/s", "96GB smart renders measured 8K peak + speed")
 
 print("Launch flags travel with the recommendation, gated by RAM:")
 check(launchFlags(forAlias: "lfm2.5-2.6b-4bit", physicalRAMGB: 8).isEmpty, "8GB lfm2.5-2.6b → no flags")
 check(launchFlags(forAlias: "qwen3.5-9b-4bit", physicalRAMGB: 18).isEmpty, "18GB qwen9 → no flags")
-check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 32) == ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"], "32GB gemma-26b → kv trio")
+// No tier carries launch flags since the gemma pick retired with the
+// AA-Index roster — qwen3.8-27b-4bit runs bare (MTP lives in the alias).
+// The gating machinery is still exercised via non-pick and foreign-tier lookups.
+check(launchFlags(forAlias: "qwen3.8-27b-4bit", physicalRAMGB: 32).isEmpty, "32GB qwen3.8-27b → no flags")
 check(launchFlags(forAlias: "qwen3.6-35b-4bit", physicalRAMGB: 48).isEmpty, "48GB reviewed 35b-4bit → no flags")
-// Key: hand-picking gemma-26b on a big Mac (where it is NOT the pick) → no forced flags.
-check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 64).isEmpty, "gemma-26b on 64GB (not its tier) keeps vision")
+check(launchFlags(forAlias: "gemma-4-26b-4bit", physicalRAMGB: 64).isEmpty, "gemma-26b on 64GB (not a pick) keeps vision")
 check(launchFlags(forAlias: "some-random", physicalRAMGB: 32).isEmpty, "unknown alias → no flags")
 
 print("isRecommendedPick is floor-gated (the floor is now 8 GB, not 16):")
@@ -184,9 +186,10 @@ check(isRecommendedPick(alias: "qwen3.5-9b-4bit", physicalRAMGB: 18), "qwen9 rec
 check(!isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 18), "bonsai is not recommended below 24GB")
 check(!isRecommendedPick(alias: "gemma-4-12b-4bit", physicalRAMGB: 18), "gemma-12b NOT recommended anywhere (dropped from picks)")
 check(isRecommendedPick(alias: "bonsai-27b-2bit", physicalRAMGB: 24), "bonsai recommended on 24GB")
-check(isRecommendedPick(alias: "gemma-4-26b-4bit", physicalRAMGB: 32), "gemma-26b recommended on 32GB")
-check(isRecommendedPick(alias: "qwen3.5-122b-mxfp4", physicalRAMGB: 96), "122b-mxfp4 recommended on 96GB")
-check(!isRecommendedPick(alias: "qwen3.5-122b-mxfp4", physicalRAMGB: 64), "122b-mxfp4 NOT recommended on 64GB")
+check(isRecommendedPick(alias: "qwen3.8-27b-4bit", physicalRAMGB: 32), "qwen3.8-27b recommended on 32GB")
+check(isRecommendedPick(alias: "qwen3.8-27b-4bit", physicalRAMGB: 96), "qwen3.8-27b recommended on 96GB")
+check(!isRecommendedPick(alias: "qwen3.5-122b-mxfp4", physicalRAMGB: 96), "122b-mxfp4 no longer a pick anywhere (AA-Index roster)")
+check(!isRecommendedPick(alias: "qwen3.8-27b-4bit", physicalRAMGB: 24), "qwen3.8-27b NOT recommended below 32GB (8K peak 20 GB misses the 24 GB tier budget)")
 // The fast alt is a recommended pick on its tiers too (skips the .tooBig gate).
 check(isRecommendedPick(alias: "qwen3.6-35b-4bit", physicalRAMGB: 64), "qwen3.6-35b-4bit fast alt recommended on 64GB")
 check(isRecommendedPick(alias: "qwen3.6-35b-4bit", physicalRAMGB: 96), "qwen3.6-35b-4bit fast alt recommended on 96GB")

--- a/docs/benchmarks/model-recommendation-measurements.json
+++ b/docs/benchmarks/model-recommendation-measurements.json
@@ -170,6 +170,84 @@
       "decode_short_tps": 59.86,
       "decode_8k_tps": null,
       "swap_delta_mb": 648.4
+    },
+    {
+      "model": "qwen3.8-27b-4bit",
+      "status": "ok",
+      "load_s": 7.08,
+      "idle_footprint_gb": 15.0,
+      "load_peak_gb": 15.0,
+      "short_footprint_gb": 15.0,
+      "short_peak_gb": 16.0,
+      "long_footprint_gb": 17.0,
+      "long_peak_gb": 20.0,
+      "short": {
+        "elapsed_s": 1.539,
+        "prompt_tokens": 24,
+        "completion_tokens": 51,
+        "wall_decode_tps": 33.13,
+        "server_prompt_tps": 125.83,
+        "server_generation_tps": 40.66,
+        "metal": {
+          "active_memory_gb": 15.13,
+          "peak_memory_gb": 15.51,
+          "cache_memory_gb": 0.11
+        }
+      },
+      "long": {
+        "elapsed_s": 26.649,
+        "prompt_tokens": 8112,
+        "completion_tokens": 56,
+        "wall_decode_tps": 2.1,
+        "server_prompt_tps": 324.26,
+        "server_generation_tps": 37.64,
+        "metal": {
+          "active_memory_gb": 15.13,
+          "peak_memory_gb": 19.08,
+          "cache_memory_gb": 1.62
+        }
+      },
+      "swap_delta_mb": 0.0,
+      "environment_note": "Measured 2026-08-18 on Mac15,14 (M3 Ultra, 256 GB), rapid-mlx 0.12.15 — not this file's M2 Pro 32 GB baseline host. Footprint figures are config-bound (weights + KV at the same context) rather than host-bound; the tok/s figures are M3 Ultra and will read lower on smaller chips."
+    },
+    {
+      "model": "qwen3.8-27b-mixed-3.5bpw",
+      "status": "ok",
+      "load_s": 11.12,
+      "idle_footprint_gb": 13.0,
+      "load_peak_gb": 14.0,
+      "short_footprint_gb": 14.0,
+      "short_peak_gb": 14.0,
+      "long_footprint_gb": 16.0,
+      "long_peak_gb": 19.0,
+      "short": {
+        "elapsed_s": 2.541,
+        "prompt_tokens": 24,
+        "completion_tokens": 92,
+        "wall_decode_tps": 36.21,
+        "server_prompt_tps": 123.86,
+        "server_generation_tps": 40.83,
+        "metal": {
+          "active_memory_gb": 13.46,
+          "peak_memory_gb": 13.83,
+          "cache_memory_gb": 0.11
+        }
+      },
+      "long": {
+        "elapsed_s": 25.443,
+        "prompt_tokens": 8112,
+        "completion_tokens": 10,
+        "wall_decode_tps": 0.39,
+        "server_prompt_tps": 323.74,
+        "server_generation_tps": 42.3,
+        "metal": {
+          "active_memory_gb": 13.46,
+          "peak_memory_gb": 17.4,
+          "cache_memory_gb": 1.62
+        }
+      },
+      "swap_delta_mb": 0.0,
+      "environment_note": "Measured 2026-08-18 on Mac15,14 (M3 Ultra, 256 GB), rapid-mlx 0.12.15 — not this file's M2 Pro 32 GB baseline host. Footprint figures are config-bound (weights + KV at the same context) rather than host-bound; the tok/s figures are M3 Ultra and will read lower on smaller chips."
     }
   ]
 }

--- a/docs/benchmarks/model-recommendations.md
+++ b/docs/benchmarks/model-recommendations.md
@@ -72,6 +72,15 @@ regression test in this change.
 
 ## Table 2 — two choices per RAM tier
 
+Since 2026-08-18 the Smarter column follows the Artificial Analysis
+Intelligence Index: each tier recommends the highest-scoring open-weights
+model the engine serves that clears the tier's fit gates (peak < 75 % of the
+floor, zero new swap, 8K prefill ≥ 100 tok/s, decode ≥ 10 tok/s). Qwen3.8-27B
+scores 52 (GPT-5.6-class) — above every larger model we serve — so every tier
+from 32 GB up shares it. Quantization note: the index scores the full-precision
+release; our 4-bit build's vendor-published deltas are unmeasured, which is the
+standing caveat for every quantized pick in this table.
+
 “Smarter” is the primary pick. “Faster” deliberately trades capability for
 latency. Rows above the measured 32 GB host retain the existing reviewed
 large-memory picks and must gain host-specific measurements before their next
@@ -83,10 +92,10 @@ release change.
 | 16–17 GB | `lfm2.5-1b-4bit` | `qwen3.5-4b-4bit` | Instant basic chat vs reliable general use |
 | 18–23 GB | `qwen3.5-4b-4bit` | `qwen3.5-9b-4bit` | Both tool-capable and comfortably above 10 tok/s |
 | 24–31 GB | `qwen3.5-4b-4bit` | `bonsai-27b-2bit` | 13 GB measured peak; Gemma 26B is too large at 24 GB |
-| 32–47 GB | `qwen3.5-4b-4bit` | `gemma-4-26b-4bit` | 17 GB 8K peak with no new swap on the 32 GB floor |
-| 48–63 GB | `qwen3.6-35b-4bit` | `gemma-4-26b-4bit` | Retains the existing reviewed fast pick pending a 48 GB host measurement |
-| 64–95 GB | `qwen3.6-35b-4bit` | `qwen3.6-35b-8bit` | Same family: speed vs quantization fidelity |
-| 96 GB+ | `qwen3.6-35b-4bit` | `qwen3.5-122b-mxfp4` | Workhorse speed vs maximum local capability |
+| 32–47 GB | `qwen3.5-4b-4bit` | `qwen3.8-27b-4bit` | 20 GB 8K peak, zero swap; AA Intelligence Index 52 — the highest of any open-weights model we serve |
+| 48–63 GB | `qwen3.6-35b-4bit` | `qwen3.8-27b-4bit` | Same smart pick — nothing larger we serve scores higher (122B: 33, 35B: 32) |
+| 64–95 GB | `qwen3.6-35b-4bit` | `qwen3.8-27b-4bit` | Same smart pick — parameter count stopped predicting capability at this roster |
+| 96 GB+ | `qwen3.6-35b-4bit` | `qwen3.8-27b-4bit` | Same smart pick; the 122B it displaces scores 33 on the same index |
 
 Recommendation data is hardware-specific. A result from one chip/RAM pair must
 not be silently copied to another; missing rows are estimates and should be

--- a/docs/benchmarks/model-recommendations.md
+++ b/docs/benchmarks/model-recommendations.md
@@ -70,6 +70,18 @@ contamination (#1641) is prevented by the harness. The Gemma 12B base-install
 launch omission found by this sweep is tracked in #1648 and covered by a
 regression test in this change.
 
+### 2026-08-18 addendum — Qwen3.8-27B (M3 Ultra host)
+
+Measured on the real serve path on Mac15,14 (M3 Ultra, 256 GB), Rapid-MLX
+0.12.15 — not the M2 Pro baseline host above; footprint columns are
+config-bound, throughput is chip-bound (reads lower on smaller chips). Raw
+rows live in `model-recommendation-measurements.json` with the same note.
+
+| Model | Load | Idle | 8K peak | Prefill tok/s | Decode tok/s | New swap | Decision |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `qwen3.8-27b-4bit` | 7.1s | 15.0 GB | 20.0 GB | 324 | 40.7 / 37.6 | 0 MB | Smart pick for every tier from 32 GB (fits 24.0 GB budget); misses the 24 GB tier's 18.0 GB budget |
+| `qwen3.8-27b-mixed-3.5bpw` | 11.1s | 13.0 GB | 19.0 GB | 324 | 40.8 / 42.3 | 0 MB | Also clears 32 GB+; still misses the 24 GB budget, so it stays a non-default alias |
+
 ## Table 2 — two choices per RAM tier
 
 Since 2026-08-18 the Smarter column follows the Artificial Analysis
@@ -79,7 +91,12 @@ floor, zero new swap, 8K prefill ≥ 100 tok/s, decode ≥ 10 tok/s). Qwen3.8-27
 scores 52 (GPT-5.6-class) — above every larger model we serve — so every tier
 from 32 GB up shares it. Quantization note: the index scores the full-precision
 release; our 4-bit build's vendor-published deltas are unmeasured, which is the
-standing caveat for every quantized pick in this table.
+standing caveat for every quantized pick in this table. In the SSOT the
+`footprint_gb` column stores the measured **8K-prompt peak** (the gate's
+number), not the steady post-load footprint; and `capability_pct` is the
+same curated 0–100 display scale the existing picks use (ordered by the
+AA index; 92 keeps the 27B above the 88 the retired 122B carried), not a
+benchmark score.
 
 “Smarter” is the primary pick. “Faster” deliberately trades capability for
 latency. Rows above the measured 32 GB host retain the existing reviewed

--- a/install.sh
+++ b/install.sh
@@ -219,10 +219,14 @@ fi
 # Mac a command that does not fit in it.
 RAM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%d", $1/1073741824}')
 RECOMMENDED_FLAGS=""
-if   [ "$RAM_GB" -ge 96 ]; then RECOMMENDED_MODEL="qwen3.5-122b-mxfp4";  RAM_TIER="96+ GB"
-elif [ "$RAM_GB" -ge 64 ]; then RECOMMENDED_MODEL="qwen3.6-35b-8bit";    RAM_TIER="64-95 GB"
-elif [ "$RAM_GB" -ge 32 ]; then RECOMMENDED_MODEL="gemma-4-26b-4bit";    RAM_TIER="32-63 GB"
-                                RECOMMENDED_FLAGS=" --no-mllm --kv-cache-dtype bf16 --cache-memory-mb 512"
+# 32 GB and up all get the same pick (AA-Index policy, 2026-08-18):
+# qwen3.8-27b-4bit is the highest-scoring open-weights model we serve
+# (AA Intelligence Index 52 — GPT-5.6-class), and its measured 8K-prefill
+# peak of 20 GB clears every one of these tiers' 75 % budgets. The
+# branches stay split so the banner names the user's actual tier.
+if   [ "$RAM_GB" -ge 96 ]; then RECOMMENDED_MODEL="qwen3.8-27b-4bit";    RAM_TIER="96+ GB"
+elif [ "$RAM_GB" -ge 64 ]; then RECOMMENDED_MODEL="qwen3.8-27b-4bit";    RAM_TIER="64-95 GB"
+elif [ "$RAM_GB" -ge 32 ]; then RECOMMENDED_MODEL="qwen3.8-27b-4bit";    RAM_TIER="32-63 GB"
 elif [ "$RAM_GB" -ge 24 ]; then RECOMMENDED_MODEL="bonsai-27b-2bit";     RAM_TIER="24-31 GB"
 elif [ "$RAM_GB" -ge 18 ]; then RECOMMENDED_MODEL="qwen3.5-9b-4bit";     RAM_TIER="18-23 GB"
 elif [ "$RAM_GB" -ge 16 ]; then RECOMMENDED_MODEL="qwen3.5-4b-4bit";     RAM_TIER="16-17 GB"

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -31,16 +31,15 @@ def test_recipe_json_is_stable_and_has_two_picks(monkeypatch, capsys) -> None:
     assert payload["tier_floor_gb"] == 32
     assert [pick["role"] for pick in payload["picks"]] == ["smart", "fast"]
     assert [pick["alias"] for pick in payload["picks"]] == [
-        "gemma-4-26b-4bit",
+        "qwen3.8-27b-4bit",
         "qwen3.5-4b-4bit",
     ]
-    assert payload["picks"][0]["launch_flags"] == [
-        "--no-mllm",
-        "--kv-cache-dtype",
-        "bf16",
-        "--cache-memory-mb",
-        "512",
-    ]
+    # qwen3.8-27b-4bit needs no tier flags — MTP is baked into the alias
+    # and the measured 8K peak (20.0 GB) fits the 32 GB tier bare. The
+    # flag-carrying pick moved out of the recommendation table with
+    # gemma-4-26b; flag propagation is still covered by
+    # test_ram_tier_recommendations_agree.py against the SSOT.
+    assert payload["picks"][0]["launch_flags"] == []
 
 
 def test_recipe_text_prints_ready_to_run_commands(monkeypatch, capsys) -> None:

--- a/tests/test_ram_tier_recommendations_agree.py
+++ b/tests/test_ram_tier_recommendations_agree.py
@@ -152,21 +152,20 @@ def _render_banner(ram_gb: int) -> str:
     ).stdout
 
 
-def test_the_banner_actually_prints_the_launch_flags():
-    """gemma-4-26b-4bit at 32 GB needs its vision tower dropped and its KV
-    budget capped. That is not advice — without the flags the command does
-    not fit on the Mac it is being handed to."""
-    printed = _render_banner(32)
-    assert "gemma-4-26b-4bit" in printed, printed
-    for flag in ("--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"):
-        assert flag in printed, (
-            f"{flag!r} missing from the quick-start line:\n{printed}"
-        )
+def test_the_banner_prints_the_27b_bare_from_32_gb_up():
+    """AA-Index policy (2026-08-18): every Mac from 32 GB up is handed
+    qwen3.8-27b-4bit, and it needs no tier flags — MTP is baked into the
+    alias and the measured 8K peak (20.0 GB) fits every one of these
+    tiers bare. The gemma flag bundle left the table with gemma."""
+    for ram in (32, 64, 96):
+        printed = _render_banner(ram)
+        assert "qwen3.8-27b-4bit" in printed, f"{ram} GB banner: {printed}"
 
 
 def test_the_banner_prints_a_bare_command_where_no_flags_are_needed():
-    """Control: the flags must not leak onto tiers that do not want them."""
-    for ram in (8, 16, 24, 64):
+    """Control: launch flags must not leak onto tiers that do not want
+    them — since the gemma pick retired, that is every tier."""
+    for ram in (8, 16, 24, 32, 64, 96):
         printed = _render_banner(ram)
         assert "rapid-mlx serve" in printed
         assert "--no-mllm" not in printed, f"{ram} GB banner: {printed}"

--- a/vllm_mlx/model_recommendations.json
+++ b/vllm_mlx/model_recommendations.json
@@ -33,28 +33,28 @@
     {
       "floor_gb": 32,
       "picks": [
-        {"role": "smart", "alias": "gemma-4-26b-4bit", "footprint_gb": 17.0, "capability_pct": 87, "tokens_per_sec": 49.5, "launch_flags": ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"]},
+        {"role": "smart", "alias": "qwen3.8-27b-4bit", "footprint_gb": 20.0, "capability_pct": 92, "tokens_per_sec": 40.7, "launch_flags": []},
         {"role": "fast", "alias": "qwen3.5-4b-4bit", "footprint_gb": 6.0, "capability_pct": 78, "tokens_per_sec": 60.7, "launch_flags": []}
       ]
     },
     {
       "floor_gb": 48,
       "picks": [
-        {"role": "smart", "alias": "gemma-4-26b-4bit", "footprint_gb": 17.0, "capability_pct": 87, "tokens_per_sec": 49.5, "launch_flags": ["--no-mllm", "--kv-cache-dtype", "bf16", "--cache-memory-mb", "512"]},
+        {"role": "smart", "alias": "qwen3.8-27b-4bit", "footprint_gb": 20.0, "capability_pct": 92, "tokens_per_sec": 40.7, "launch_flags": []},
         {"role": "fast", "alias": "qwen3.6-35b-4bit", "footprint_gb": 20.0, "capability_pct": 87, "tokens_per_sec": 60.0, "launch_flags": []}
       ]
     },
     {
       "floor_gb": 64,
       "picks": [
-        {"role": "smart", "alias": "qwen3.6-35b-8bit", "footprint_gb": 37.7, "capability_pct": 87, "tokens_per_sec": null, "launch_flags": []},
+        {"role": "smart", "alias": "qwen3.8-27b-4bit", "footprint_gb": 20.0, "capability_pct": 92, "tokens_per_sec": 40.7, "launch_flags": []},
         {"role": "fast", "alias": "qwen3.6-35b-4bit", "footprint_gb": 20.0, "capability_pct": 87, "tokens_per_sec": 60.0, "launch_flags": []}
       ]
     },
     {
       "floor_gb": 96,
       "picks": [
-        {"role": "smart", "alias": "qwen3.5-122b-mxfp4", "footprint_gb": 65.0, "capability_pct": 88, "tokens_per_sec": null, "launch_flags": []},
+        {"role": "smart", "alias": "qwen3.8-27b-4bit", "footprint_gb": 20.0, "capability_pct": 92, "tokens_per_sec": 40.7, "launch_flags": []},
         {"role": "fast", "alias": "qwen3.6-35b-4bit", "footprint_gb": 20.0, "capability_pct": 87, "tokens_per_sec": 60.0, "launch_flags": []}
       ]
     }


### PR DESCRIPTION
## Why

The Artificial Analysis Intelligence Index (2026-08-18) shows our top tiers inverted actual capability: Qwen3.8-27B scores **52** (GPT-5.6-class — the first open-weights model at frontier level) while the models our biggest Macs were handed score far lower — `qwen3.5-122b-mxfp4` (96 GB tier): **33**, `qwen3.6-35b-8bit` (64 GB): **32**, `gemma-4-26b-4bit` (32/48 GB): **26**. Users with the most RAM got measurably weaker models than a 32 GB Mac can run. Because the recommendation slot should hold what measurement says is smartest, not what parameter count implies.

Closes #2054.

## What

**Policy** (documented in `docs/benchmarks/model-recommendations.md`): each tier's smart pick = the highest-AA-scoring open-weights model the engine serves that clears the tier's fit gates (measured 8K peak < 75 % of floor, zero new swap, prefill ≥ 100 tok/s, decode ≥ 10 tok/s, live dogfood).

- **32/48/64/96 GB smart → `qwen3.8-27b-4bit`** (one pick, no launch flags — MTP lives in the alias). 122B retires.
- **24 GB keeps `bonsai-27b-2bit`**: the 27B's 8K peak is 19–20 GB even with the cache capped — misses that tier's 18 GB budget honestly.
- **8/16/18 GB unchanged**: incumbents lead or tie their class on the same index (`gemma-4-12b` at 22 vs `qwen3.5-4b` at 20 noted as a 16 GB follow-up candidate, not mixed into this PR).
- **Fast picks unchanged** — that column's job is tok/s and `qwen3.6-35b-4bit` still wins it.

## Measurements (real serve path, this run)

`qwen3.8-27b-4bit`: 8K-prompt peak **20.0 GB**, decode **~41 tok/s**, prefill **324 tok/s**, **zero swap** (M3 Ultra; appended to `model-recommendation-measurements.json` with an explicit host note — footprint is config-bound, speed is chip-bound). `mixed-3.5bpw` also measured (19.0 GB peak) and recorded.

## Dogfood before shipping the slot

Serve ready → multi-turn arithmetic-with-memory coherent → tool-call probe with **byte-exact argument equality 3/3 at temperature 0** (the #1996 probe) → the installer's printed sequence (`serve` + paired `chat --port 8000`) run **verbatim** end-to-end, then port-qualified teardown.

## Blast radius

SSOT (`model_recommendations.json`) + `install.sh` mirror + README prose & table + `RAMBucketedDefaultTests` + `verify-recommendation-tiers.swift` + `benchmark-scores.json` (new sourced qwen3.8 row) + both benchmark docs updated together. Green: cross-surface drift suite 25/25, rapid-mac unit suite (2405), verify executable ALL PASS, ruff clean. GUI model-management cards read the SSOT dynamically — no AX baseline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)