### PR TITLE
test(scheduler): un-break positional-prefix guard + run it in CI [skip-version-bump]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,7 @@ jobs:
             tests/test_forced_alignment_route_hardening.py \
             tests/test_muse_glimmer_model.py \
             tests/test_bailing_hybrid_model.py \
+            tests/test_mtp_spec_decode.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -3402,7 +3402,12 @@ def test_scheduler_config_preserves_the_historical_positional_prefix():
         "model_name",
     ]
     assert names[:50] == historical_prefix
-    assert names[49:] == ["model_name", "vision_min_pixels", "vision_max_pixels"]
+    # ``model_name`` (index 49) and the two vision fields hold their historical
+    # positions; anything the future appends lands at index 52+ rather than
+    # shifting them. A slice equality here (not the whole tail) is what lets a
+    # genuinely-appended field — e.g. ``idle_cache_clear_seconds`` (#2038) —
+    # pass while a field INSERTED into the prefix still fails.
+    assert names[49:52] == ["model_name", "vision_min_pixels", "vision_max_pixels"]
 
 
 def test_fixed_k_observer_leaves_the_ceiling_to_whoever_selects_depth():


### PR DESCRIPTION
## Why

`test_mtp_spec_decode.py::test_scheduler_config_preserves_the_historical_positional_prefix` is **deterministically red on `main`**. #2038 (`8f950553`, idle-cache-clear) appended `idle_cache_clear_seconds` to the end of `SchedulerConfig` — a correct, positional-safe addition — but the test asserted the field list *ends* exactly at `vision_max_pixels`, so it broke.

It broke **silently**: the required `tests` CI job runs an explicit per-file allowlist (`ci.yml`) that never listed `test_mtp_spec_decode.py`, so CI never ran it. Only a full local `pytest tests/` (a dogfood run) surfaced it.

## What

1. **Fix the assertion to match its own docstring** ("New fields append after, rather than shifting, the historical tail"): the rigid tail-equality becomes a positional slice `names[49:52] == [...]`. A genuinely-appended field now passes; a field *inserted into the prefix* still fails. `names[:50] == historical_prefix` is unchanged.
2. **Add `tests/test_mtp_spec_decode.py` to the apple-silicon CI job** (the MLX-dependent one) so this class of contract regression can't merge unrun again.

## Tests

- Fixed test passes; whole file **113 passed in ~4s** under the exact CI flags (`-m "not slow" -k "not Integration"`), hermetic (`HF_HUB_OFFLINE=1`).
- **Mutation-verified**: inserting a bogus field before `vision_max_pixels` still fails the test (guard intact); revert → passes.
- `check_workflow_expressions.py` OK; `ci.yml` valid YAML.

## Notes

No product code changed (test + CI only). Found during a full-surface release-prep dogfood of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)