### PR TITLE
chore: bump version to 0.12.16

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -13,6 +13,56 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.16] — 2026-08-19
+
+Dictate into any app from a global hotkey, web search works out of the box,
+chat typesets math, and conversations can be filed into folders and
+exported.
+
+### Added
+
+- **Dictate into any app.** Tap right Option, speak, and the words land at
+  your cursor — in any app, even with Rapid's window closed. Transcription
+  runs through your local server, so audio never leaves the Mac.
+- **Math renders as math.** Chat typesets inline and block LaTeX the way
+  models actually write it, so equations show up as equations instead of
+  raw markup.
+- **Web search that just works.** Chat's web search defaults to Keenable's
+  keyless service — real query-relevant snippets with no account and no API
+  key, replacing the DuckDuckGo scrape that rate-limited after a few
+  searches. Want the best measured quality? Paste a free Parallel key in
+  Settings → Tools (it tops the Artificial Analysis Search Index; the free
+  tier covers about 1,000 searches a month). Brave's entry now says plainly
+  that its API requires a card on file and auto-bills overage.
+- **File conversations into folders, and export them.** Create a folder from
+  any conversation's row menu, rename it, and export conversations as
+  Markdown from the same place.
+
+### Changed
+
+- **Model recommendations follow the Artificial Analysis Intelligence
+  Index.** Every Mac from 32 GB up is offered Qwen3.8-27B — GPT-5.6-class
+  intelligence at ~40 tok/s with multi-token prediction on — replacing
+  larger models that score far lower on the same index. Smaller Macs keep
+  their best-in-class picks.
+- Getting a model is now two explicit steps — Download, then Start when
+  you're ready — and the launch memory modal is gone.
+- Setup fills the window instead of floating as a small card over a dimmed
+  chat, so every step is reachable on every display.
+- Opt-in telemetry now includes the chip family and a rounded memory tier —
+  never raw bytes — and the privacy policy spells that out.
+
+### Fixed
+
+- The main window can no longer shrink below a usable size.
+- "Jump to latest" works after an answer finishes.
+- The same file can no longer be attached twice.
+- Code blocks no longer flicker between plain and code styling while an
+  answer streams.
+- Markdown code blocks and tables are visible again in chat.
+- Voice notes in Apple formats (M4A, CAF, …) transcribe directly — the app
+  transcodes them for the server on the fly.
+
 ## [0.12.15] — 2026-08-17
 
 Fixes a bug that could silently truncate files your coding agent writes, adds a

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.15</string>
+	<string>0.12.16</string>
 	<key>CFBundleVersion</key>
-	<string>159</string>
+	<string>160</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.12.16.md
+++ b/docs/release-notes/v0.12.16.md
@@ -1,0 +1,76 @@
+## Highlights
+
+- **Dictate into any app.** Tap right Option, speak, and the words land at
+  your cursor — in any app, even with Rapid's window closed. Transcription
+  runs through your local server, so audio never leaves the Mac. (#2049)
+- **Web search now works out of the box.** Desktop chat's web search defaults
+  to Keenable's keyless service: real query-relevant snippets, no account, no
+  API key, and no more DuckDuckGo rate-limit dead ends a few searches in. Want
+  the best measured quality? Paste a free Parallel key in Settings → Tools —
+  it tops the Artificial Analysis Search Index, and the free tier covers about
+  1,000 searches a month. Brave's entry now says plainly that its API requires
+  a card on file and auto-bills overage, so nobody walks into a surprise
+  charge. (#2040, #2041, #2042, #2043)
+- **Your Mac is offered the smartest model it can actually run.** Model
+  recommendations now follow the Artificial Analysis Intelligence Index:
+  every Mac from 32 GB up gets Qwen3.8-27B — GPT-5.6-class intelligence
+  (index 52) at ~40 tok/s with multi-token prediction on — replacing larger
+  models that score far lower. Smaller Macs keep their best-in-class picks.
+  (#2054)
+- **Math renders as math.** Chat now typesets inline and block LaTeX the way
+  models actually write it (`\(...\)`, `\[...\]`, `$$`), so equations show up
+  as equations instead of raw markup. (#2107)
+- **File conversations into folders, and export them.** Create a folder from
+  any conversation's row menu, rename it, and export conversations as
+  Markdown from the same place.
+- **Downloads no longer auto-start models.** Getting a model is now two
+  explicit steps — Download, then Start when you're ready — and the launch
+  memory modal is gone. (#2053)
+
+## Improvements
+
+- `rapid-mlx chat --port N` now asks the server what it's serving and uses
+  that, instead of assuming your local default model. (#2046)
+- The prefix cache releases its memory after sitting idle (#2038), and chat
+  can opt out of prefix caching for sensitive prompts (#2048).
+- MCP tool rounds stream as they happen instead of appearing all at once.
+- Voice notes in Apple formats (M4A, CAF, …) now transcribe directly — the
+  app transcodes them for the server on the fly. (#2101)
+- Sliding-window models keep reusing the prompt cache across turns instead
+  of re-prefilling the whole conversation. (#2064)
+- `rapid-mlx launch continue` and `continue-dev` are now the same thing, and
+  `rapid-mlx agents` counts what it actually ships: "10 agents +
+  3 frameworks supported". (#2108)
+- `rapid-mlx recipe` checks free disk space before printing a `serve`
+  command, and says so instead of handing you a download that cannot fit.
+  (#2119)
+- Setup fills the window instead of floating as a small card over a dimmed
+  chat, so every step and the full-height rail are actually reachable.
+  (#2063)
+- Opt-in telemetry now includes the chip family and a rounded memory tier —
+  never raw bytes — and the privacy policy spells that out. (#2090)
+
+## Fixes
+
+- Main window can no longer shrink below a usable size. (#2022)
+- "Jump to latest" works after an answer finishes. (#2021)
+- The same file can no longer be attached twice. (#2023)
+- Onboarding recovery states are truthful and reachable.
+- In-app upgrade prefers rapidmlx.com with a github.io fallback. (#2034)
+- The installer's printed quick-start commands run verbatim, in sequence, on
+  a fresh install. (#2030, #2036)
+- Code blocks no longer flicker between plain text and code styling while an
+  answer streams — a forming fence is held back until it is real. (#2106)
+- Markdown code blocks and tables are visible again in chat. (#2056)
+
+## Docs
+
+- **The documentation went through a full audit against the shipped code** —
+  every guide, reference page, and printed command re-checked, ~20 fix PRs.
+  The CLI reference now documents every `serve` flag (94), every operator
+  environment variable, and the complete endpoint surface; six drifted
+  defaults were fixed and are now pinned by tests; PRIVACY and SECURITY
+  describe the shipped architecture in full. (#2088–#2113)
+- The `install.sh` you curl from rapidmlx.com is now published only at
+  release tags, so it is byte-identical to the tagged source — never a
+  moving target. (#2092)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.15"
+version = "0.12.16"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Ship the post-0.12.15 batch: the web-search overhaul (Keenable keyless default, Parallel recommended, honest Brave billing copy — #2044), AA-Intelligence-Index model recommendations (qwen3.8-27b-4bit for every Mac from 32 GB up — #2055), conversation folders + Markdown export, two-step Download/Start (#2053), chat attach-mode model discovery (#2046, closes the 0.12.15 papercut family), prefix-cache idle release (#2038) and privacy opt-out (#2048), plus the window/scroll/attachment fixes. Because the features are merged, dogfooded, and users should get them.

## What

- `pyproject.toml` 0.12.15 → 0.12.16
- `apps/rapid-mac/Resources/Info.plist` CFBundleShortVersionString 0.12.16, CFBundleVersion 160
- `docs/release-notes/unreleased.md` → `docs/release-notes/v0.12.16.md` (user-voice highlights), fresh empty scratch recreated
- `apps/rapid-mac/CHANGELOG.md` gains the 0.12.16 section (user-voice)

## Dogfood (all on merged main, this machine)

- Full GUI golden suite: PASS — all (including the previously-born-red folder/export legs).
- Live end-to-end in an isolated app instance with a real sidecar: chat on qwen3.8-27b-4bit → `web_search` → **Keenable keyless, 6 real results** → model chose to `browse` the top hit → **approval gate fired correctly** → approved → grounded, accurate final answer about the AA Search Index.
- Recommended card renders "Best pick: Qwen 3.8 · 27B · 4-bit · 20.0 GB · 92% capability · ~41 tok/s" on this 256 GB Mac; Settings → Tools shows the five-provider roster with Keenable selected by default.
- Engine-side: 27B serve → multi-turn coherence → tool-call probe with byte-exact argument equality 3/3 at temperature 0 → installer's printed quick-start sequence run verbatim.
- Suites: python drift tests 25/25, rapid-mac 2445 unit tests green (one known local-env text-layout flake, green on CI), verify-recommendation-tiers ALL PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)