### PR TITLE
feat(mac): apply Direction D onboarding UI

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -77,61 +77,13 @@ struct ContentView: View {
         // picker lives inline in the compose box (see ChatView) and the
         // model comes up on first send (implicit lifecycle). Search belongs
         // to the sidebar column beside macOS's native collapse control.
-        VStack(spacing: 0) {
-            // #1588: this recovery path existed since the app was introduced
-            // but was never mounted, so a failed Finder replacement was
-            // detected and then silently discarded.
-            FailedReplaceBanner()
-            NavigationSplitView {
-                SidebarView(
-                selection: $section,
-                chat: chat,
-                onNewChat: {
-                    chat.newConversation()
-                    section = .chat
-                },
-                onSearchChats: {
-                    showConversationSearch = true
-                },
-                onSelectConversation: { id in
-                    chat.selectConversation(id)
-                    section = .chat
-                },
-                server: server
-            )
-            // v1.0: the rail paints an explicit warm surface rather than
-            // inheriting the system sidebar material. The material is a
-            // cool translucent grey that fought the warm canvas beside
-            // it — the two planes read as belonging to different apps.
-            .background(RapidTheme.surfaceSidebar)
-            .navigationSplitViewColumnWidth(
-                min: SidebarView.columnMinWidth,
-                ideal: SidebarView.columnIdealWidth,
-                max: SidebarView.columnMaxWidth
-            )
-            } detail: {
-                detailArea
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                // Detail floor dropped 520 → 440 alongside the narrower
-                // rail, back when the window floor was 640 and the old pair
-                // (190 sidebar + 520 detail) over-committed it by 70pt —
-                // which is what forced horizontal clipping instead of
-                // graceful compression. The floor is 720 now, so this has
-                // 80pt of slack; it stays at 440 because it is the detail's
-                // own minimum, not a number derived from the window.
-                .frame(minWidth: 440, minHeight: Self.minWindowHeight)
-                    .background(RapidTheme.surfaceCanvas)
+        Group {
+            if quickstartVisible {
+                // Setup owns the window (Paper 05.1.A). See ``onboardingShell``.
+                onboardingShell
+            } else {
+                productionShell
             }
-            // Background pulls are process-wide, not chat-only.  Keep their
-            // progress visible whichever sidebar destination is selected.
-            DownloadStrip(downloads: downloads)
-            if showLogs {
-                LogDrawer(server: server)
-                    .frame(minHeight: 100, idealHeight: 150, maxHeight: 220)
-                    .accessibilityIdentifier("ContentView.LogDrawer")
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
-            statusFooter
         }
         // `.windowResizability(.contentMinSize)` derives the window's floor
         // from this, so the shell states it once here rather than leaving it
@@ -243,14 +195,6 @@ struct ContentView: View {
         .sheet(isPresented: firstRunSheetPresented) {
             firstRunSheet
         }
-        // Presented from the split view — NOT from `mainArea` — so onboarding
-        // covers the whole window. Rendered inside the detail pane it left the
-        // sidebar exposed and clickable, which reads as "the app is already
-        // running, this panel is just one more surface" rather than "finish
-        // setup first".
-        .sheet(isPresented: quickstartSheetPresented) {
-            quickstartSheet
-        }
         .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
             quickstartDismissedThisSession = false
         }
@@ -288,6 +232,115 @@ struct ContentView: View {
                 await server.refreshResidency()
                 try? await Task.sleep(for: .seconds(5))
             }
+        }
+    }
+
+    /// First-run setup, filling the window (Paper 05.1.A).
+    ///
+    /// ## Why this is not a sheet
+    ///
+    /// It was one, and that was the defect. `.sheet` on macOS is a
+    /// document-modal panel: AppKit sizes it to its content's ideal width,
+    /// insets it, rounds its corners and leaves the parent window visible
+    /// around and behind it. So onboarding rendered as a centred card floating
+    /// over a dimmed chat surface — the exact composition 05.1.A rules out
+    /// ("no dimmed application, no modal card floating over a live app, no
+    /// composer, no production sidebar and no status strip behind it"). Worse,
+    /// the sheet settled at its 620pt minimum, which is below the 820pt
+    /// breakpoint, so the rail collapsed to its compact strip on a 1440pt
+    /// display and the full-height rail was effectively unreachable.
+    ///
+    /// Replacing the shell instead of covering it makes the geometry correct
+    /// by construction: this view IS the window's content, so it fills
+    /// everything below the native title bar, has no corner radius of its own,
+    /// and there is nothing behind it to show through. The title bar and its
+    /// traffic lights are untouched — "full window" here means the app's
+    /// content area, never macOS fullscreen.
+    ///
+    /// Nothing about the state machine moves with it. ``quickstartVisible`` is
+    /// the same predicate that gated the sheet, and every alert, dialog and
+    /// task modifier stays attached to the root above this branch, so consent,
+    /// approvals and the launch auto-start all behave exactly as before.
+    @ViewBuilder
+    private var onboardingShell: some View {
+        quickstartSurface
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(RapidTheme.surfaceCanvas)
+            // The last resort for a dismissal request that did not come from a
+            // visible control. Every Step 2 micro-stage, the hero and both
+            // warning screens carry a `.cancelAction` control, and AppKit
+            // resolves Escape against those first — so this only ever fires on
+            // the screens that have none (downloading, Ready, a failure), where
+            // it reproduces exactly what the sheet's own dismissal used to do.
+            .onExitCommand {
+                if quickstart.retreatWithinStep2() { return }
+                quickstartDismissedThisSession = true
+                quickstart.skipForNow()
+            }
+    }
+
+    /// The ordinary application shell: sidebar, detail pane, download
+    /// strip, log drawer and status footer.
+    ///
+    /// Swapped out wholesale while setup is owed, rather than dimmed
+    /// behind it — see ``onboardingShell``.
+    @ViewBuilder
+    private var productionShell: some View {
+        VStack(spacing: 0) {
+            // #1588: this recovery path existed since the app was introduced
+            // but was never mounted, so a failed Finder replacement was
+            // detected and then silently discarded.
+            FailedReplaceBanner()
+            NavigationSplitView {
+                SidebarView(
+                selection: $section,
+                chat: chat,
+                onNewChat: {
+                    chat.newConversation()
+                    section = .chat
+                },
+                onSearchChats: {
+                    showConversationSearch = true
+                },
+                onSelectConversation: { id in
+                    chat.selectConversation(id)
+                    section = .chat
+                },
+                server: server
+            )
+            // v1.0: the rail paints an explicit warm surface rather than
+            // inheriting the system sidebar material. The material is a
+            // cool translucent grey that fought the warm canvas beside
+            // it — the two planes read as belonging to different apps.
+            .background(RapidTheme.surfaceSidebar)
+            .navigationSplitViewColumnWidth(
+                min: SidebarView.columnMinWidth,
+                ideal: SidebarView.columnIdealWidth,
+                max: SidebarView.columnMaxWidth
+            )
+            } detail: {
+                detailArea
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Detail floor dropped 520 → 440 alongside the narrower
+                // rail, back when the window floor was 640 and the old pair
+                // (190 sidebar + 520 detail) over-committed it by 70pt —
+                // which is what forced horizontal clipping instead of
+                // graceful compression. The floor is 720 now, so this has
+                // 80pt of slack; it stays at 440 because it is the detail's
+                // own minimum, not a number derived from the window.
+                .frame(minWidth: 440, minHeight: Self.minWindowHeight)
+                    .background(RapidTheme.surfaceCanvas)
+            }
+            // Background pulls are process-wide, not chat-only.  Keep their
+            // progress visible whichever sidebar destination is selected.
+            DownloadStrip(downloads: downloads)
+            if showLogs {
+                LogDrawer(server: server)
+                    .frame(minHeight: 100, idealHeight: 150, maxHeight: 220)
+                    .accessibilityIdentifier("ContentView.LogDrawer")
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+            statusFooter
         }
     }
 
@@ -589,45 +642,10 @@ struct ContentView: View {
 
     // MARK: - Quickstart presentation
 
-    private var quickstartSheetPresented: Binding<Bool> {
-        Binding(
-            get: { quickstartVisible },
-            set: { presented in
-                // A swipe-down / Esc means "let me look around first" — the
-                // same intent as the card's own "Skip for now", so route it to
-                // the same session flag rather than dropping it.
-                //
-                // NOT the same intent as "Browse all models", which used to
-                // land here too: that one asks to see the catalogue, and
-                // answering it by closing the wizard discarded the user's
-                // selection and left them on the alphabetical fallback
-                // (#1653). It opens Settings → Models now and leaves the
-                // wizard standing.
-                //
-                // Routed through ``skipForNow`` for the same reason it is the
-                // same intent: a user who escapes the Ready screen has
-                // answered it, and returning them to it on the next launch
-                // would be re-asking. Safe on the completion path too — the
-                // record is already retired and this never touches ``done``.
-                //
-                // Browse all models and Review download are Step 2 sub-stages,
-                // and Paper 05.2.G's invariant is that Escape can only move the
-                // user one level closer to the shortlist from inside them —
-                // never out of setup. The footer's `.cancelAction` Back
-                // normally consumes the key first; asking the coordinator to
-                // retreat before treating this as a skip is what makes that
-                // true even when the sheet sees it anyway.
-                if !presented {
-                    if quickstart.retreatWithinStep2() { return }
-                    quickstartDismissedThisSession = true
-                    quickstart.skipForNow()
-                }
-            }
-        )
-    }
-
+    /// The setup surface itself. Sized by its container now that the
+    /// container is the window rather than a sheet.
     @ViewBuilder
-    private var quickstartSheet: some View {
+    private var quickstartSurface: some View {
         QuickstartView(
             coordinator: quickstart,
             downloads: downloads,
@@ -648,12 +666,6 @@ struct ContentView: View {
             onSeedWelcome: seedQuickstartWelcome,
             onCompleted: finishOnboardingHandoff
         )
-        // QuickstartView was written for the detail column and its comments
-        // cite a ~360pt worst case (the 640pt window floor minus the sidebar).
-        // A sheet has no such parent, so without an explicit size it would
-        // collapse to its content's ideal width. Pin it near the window floor
-        // so the model cards keep the room they were laid out for.
-        .frame(minWidth: 620, minHeight: Self.minWindowHeight)
     }
 
     /// Steps 1 + 2 of the Start chatting transaction: make sure the chat the
@@ -831,97 +843,95 @@ struct ContentView: View {
 
     // MARK: - Missing-sidecar overlay
 
+    /// The missing-engine recovery (Paper 05.1 state 20).
+    ///
+    /// Direction D's outcome composition — tinted glyph, kicker, display
+    /// headline, one amber primary and a bordered Quit — rather than the
+    /// previous centred card. The red tone is deliberate and is the one place
+    /// setup uses it: this is not a recoverable step of setup, it is setup
+    /// being unable to run at all.
+    ///
+    /// **Deliberate Paper deviation.** Paper draws this state inside the
+    /// full-window setup shell with the rail inert. Upstream renders it in the
+    /// detail pane with the live sidebar beside it, and moving it would change
+    /// which surface owns the window — a presentation-ownership change, not a
+    /// visual one, and out of scope for this PR. The composition matches; the
+    /// containing plane does not.
     @ViewBuilder
     private var missingOverlay: some View {
-        VStack {
-            Spacer()
-            VStack(spacing: RapidTheme.Space.lg) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
-                        .fill(RapidTheme.brandPrimaryTint)
-                        .frame(width: 48, height: 48)
-                    Image(systemName: "arrow.down.circle")
-                        .font(.system(size: 22, weight: .regular))
-                        .foregroundStyle(RapidTheme.brandPrimaryDeep)
-                }
-                .accessibilityHidden(true)
-                VStack(spacing: RapidTheme.Space.sm) {
-                    Text("Setup didn't finish")
-                        .font(RapidFont.pageTitle)
-                    Text("Rapid-MLX isn't fully set up yet. Reopen Rapid-MLX to run the one-time setup again.")
-                        .font(RapidFont.secondary)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .lineSpacing(2)
-                }
-                // Same two branches, same actions, same ordering as
-                // before — only the button tiers change. The recovery
-                // action (download the update, or recheck) is the amber
-                // primary; Quit steps down to secondary, since making
-                // "give up" the most prominent control on a recoverable
-                // failure was the wrong emphasis.
-                if let release = updater.availableUpdate,
-                   let downloadURL = ContentView.missingOverlayDownloadURL(for: release) {
-                    VStack(spacing: RapidTheme.Space.sm) {
-                        Button("Download update \(release.version)") {
-                            NSWorkspace.shared.open(downloadURL)
-                        }
-                        .buttonStyle(.rapidPrimaryWide)
-                        .accessibilityIdentifier("MissingRuntime.DownloadUpdate")
-                        HStack(spacing: RapidTheme.Space.sm) {
+        VStack(alignment: .leading, spacing: 0) {
+            Spacer(minLength: 24)
+
+            OnboardingOutcomeBlock(
+                glyph: "exclamationmark.octagon",
+                tone: .error,
+                kicker: "SETUP COULDN'T RUN",
+                title: "Setup didn't finish",
+                message: "Rapid-MLX isn't fully set up yet. "
+                    + "Reopen Rapid-MLX to run the one-time setup again."
+            ) {
+                VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
+                    // Same two branches, same actions, same ordering as
+                    // before — only the button tiers change. The recovery
+                    // action (download the update, or recheck) is the amber
+                    // primary; Quit steps down, since making "give up" the
+                    // most prominent control on a recoverable failure was the
+                    // wrong emphasis.
+                    if let release = updater.availableUpdate,
+                       let downloadURL = ContentView.missingOverlayDownloadURL(for: release) {
+                        OnboardingActionLane {
+                            Button("Download update \(release.version)") {
+                                NSWorkspace.shared.open(downloadURL)
+                            }
+                            .buttonStyle(.onboardingPrimary)
+                            .accessibilityIdentifier("MissingRuntime.DownloadUpdate")
                             Button("Recheck") { recheckEngine() }
-                                .buttonStyle(.rapidSecondary)
+                                .buttonStyle(.onboardingOutline)
                                 .accessibilityIdentifier("MissingRuntime.Recheck")
                             Button("Quit Rapid-MLX") { NSApp.terminate(nil) }
-                                .buttonStyle(.rapidSecondary)
+                                .buttonStyle(.onboardingQuiet)
+                                .accessibilityIdentifier("MissingRuntime.Quit")
+                        }
+                    } else {
+                        OnboardingActionLane {
+                            Button("Recheck") { recheckEngine() }
+                                .buttonStyle(.onboardingPrimary)
+                                .accessibilityIdentifier("MissingRuntime.Recheck")
+                            Button("Quit Rapid-MLX") { NSApp.terminate(nil) }
+                                .buttonStyle(.onboardingOutline)
                                 .accessibilityIdentifier("MissingRuntime.Quit")
                         }
                     }
-                } else {
-                    HStack(spacing: RapidTheme.Space.sm) {
-                        Button("Recheck") { recheckEngine() }
-                            .buttonStyle(.rapidPrimary)
-                            .accessibilityIdentifier("MissingRuntime.Recheck")
-                        Button("Quit Rapid-MLX") { NSApp.terminate(nil) }
-                            .buttonStyle(.rapidSecondary)
-                            .accessibilityIdentifier("MissingRuntime.Quit")
+
+                    // Recheck's result, once there is one. Without this the
+                    // control is genuinely working — a full ``ServerLocator``
+                    // re-resolution — and yet reads as dead, because a still-
+                    // missing engine leaves every visible thing unchanged.
+                    if let status = ServerManager.recheckStatusMessage(for: server.lastBinaryRecheck) {
+                        Text(status)
+                            .scaledSystemFont(13)
+                            .foregroundStyle(RapidTheme.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .accessibilityIdentifier("MissingRuntime.RecheckStatus")
                     }
-                }
-                // Recheck's result, once there is one. Without this the
-                // control is genuinely working — a full ``ServerLocator``
-                // re-resolution — and yet reads as dead, because a still-
-                // missing engine leaves every visible thing unchanged.
-                if let status = ServerManager.recheckStatusMessage(for: server.lastBinaryRecheck) {
-                    Text(status)
-                        .font(RapidFont.secondary)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
+
+                    Text("Rapid-MLX runs AI models on your Mac. Your chats stay on "
+                         + "this computer — no messages are sent to the cloud.")
+                        .scaledSystemFont(13)
+                        .foregroundStyle(RapidTheme.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
-                        .accessibilityIdentifier("MissingRuntime.RecheckStatus")
+                        .frame(maxWidth: 600, alignment: .leading)
                 }
-                Text("Rapid-MLX runs AI models on your Mac. Your chats stay on this computer — no messages are sent to the cloud.")
-                    .font(RapidFont.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(RapidTheme.Space.xl)
-            .frame(maxWidth: 400)
-            .background(
-                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
-                    .fill(RapidTheme.surfaceRaised)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: RapidTheme.Radius.card, style: .continuous)
-                    .strokeBorder(RapidTheme.hairline, lineWidth: 1)
-            )
-            .shadow(color: Color.black.opacity(0.05), radius: 14, x: 0, y: 6)
-            Spacer()
+
+            Spacer(minLength: 24).layoutPriority(-1)
         }
-        .padding(.horizontal, RapidTheme.Space.xl)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(LeopardSpots(opacity: 0.06))
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(.top, OnboardingD.canvasTop)
+        .padding(.bottom, OnboardingD.canvasBottom)
+        .padding(.leading, OnboardingD.canvasLeading)
+        .padding(.trailing, OnboardingD.canvasTrailing)
+        .background(RapidTheme.surfaceCanvas)
     }
 
     /// The missing-engine screen's Recheck.

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
@@ -1,177 +1,20 @@
 import SwiftUI
 
-/// Shared primitives for the first-run onboarding wizard (#1524).
+/// The selectable model rows of first-run setup, in the Direction D visual
+/// language (Paper 05.1.B state 04, 05.2.C, 05.2.D).
 ///
-/// These are the reusable pieces the ``QuickstartView`` steps compose:
-/// a brand mark, a top bar with step progress, a Back/primary footer, an
-/// attribute chip, and the two model-choice cards. The patterns are
-/// borrowed from FluidVoice's onboarding framework (a shared footer
-/// scaffold + progress affordance + selectable cards) but rebuilt on
-/// ``RapidTheme`` tokens — we deliberately did NOT port FluidVoice's
-/// whole theme-as-EnvironmentValue system for one wizard.
+/// ## What changed, and what did not
 ///
-/// Everything here is a thin, host-free ``View`` over ``RapidTheme`` +
-/// the #507 components (``BrandIcon`` / ``ModelMeter``), so the wizard
-/// can be snapshot-rendered offscreen without a running app.
-
-// MARK: - Brand mark
-
-/// The circular Rapid brand mark — an amber-tint disc with the
-/// ``RapidMark`` speed streaks. A pure ``Shape`` (no bundled asset), so
-/// it renders in the test bundle unlike the image-backed logo views.
-struct OnboardingBrandMark: View {
-    var size: CGFloat = 26
-
-    var body: some View {
-        ZStack {
-            Circle()
-                .fill(RapidTheme.brandAmberTint)
-                .frame(width: size, height: size)
-            RapidMark()
-                .fill(RapidTheme.brandAmber)
-                .frame(width: size * 0.58, height: size * 0.38)
-        }
-        .accessibilityHidden(true)
-    }
-}
-
-// MARK: - Step progress
-
-/// Honest wizard progress. The old three capsules looked like a carousel
-/// page control even though onboarding only advances through its explicit
-/// buttons (#1792). A labelled linear meter communicates position without
-/// advertising swipe, drag, or arbitrary-page navigation.
-/// ``current`` is 0-indexed.
+/// The previous versions of these cards carried the wizard's old centred-card
+/// styling: benchmark meters, a `ViewThatFits` two-row fallback, and a shared
+/// footer scaffold. Direction D replaces the composition — a fixed heading
+/// column beside a list of quiet cards, with exactly one amber moment on the
+/// screen — but not the contract. Selection is still a single click that never
+/// navigates, double-click is still a shortcut for the visible primary, and a
+/// row that cannot run on this Mac is still inert rather than merely dimmed.
 ///
-/// ``total`` defaults to ``QuickstartCoordinator.Step.total`` so the public
-/// step count lives in exactly one place. Onboarding V3 (Paper 05.1.G,
-/// "Four public steps, and Ready is confirmed") makes that four — Welcome,
-/// Choose a model, Download, Start — and no "Step N of 3" language survives
-/// anywhere in production.
-struct OnboardingStepProgress: View {
-    let current: Int
-    var total: Int = QuickstartCoordinator.Step.total
-
-    var body: some View {
-        VStack(alignment: .trailing, spacing: 5) {
-            Text("Step \(current + 1) of \(total)")
-                .scaledSystemFont(10, weight: .medium)
-                .foregroundStyle(.secondary)
-            ProgressView(value: Double(current + 1), total: Double(total))
-                .progressViewStyle(.linear)
-                .tint(RapidTheme.brand)
-                .frame(width: 92)
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityIdentifier("Quickstart.Progress")
-        // A custom SwiftUI container is AXUnknown on macOS and drops its
-        // AXValue. Keep the full status in the label so VoiceOver receives it
-        // reliably instead of announcing only "Setup progress".
-        .accessibilityLabel("Setup progress, step \(current + 1) of \(total)")
-    }
-}
-
-// MARK: - Top bar
-
-/// The interior-step header: brand mark + wordmark on the left, step
-/// dots on the right. ``step`` is the public macro step this screen
-/// belongs to — never a raw ordinal, so a screen can't drift out of the
-/// four-step model by miscounting.
-struct OnboardingTopBar: View {
-    let step: QuickstartCoordinator.Step
-
-    var body: some View {
-        HStack(spacing: 10) {
-            OnboardingBrandMark(size: 26)
-            Text("Rapid-MLX").scaledSystemFont(13, weight: .semibold)
-            Spacer()
-            OnboardingStepProgress(current: step.rawValue)
-        }
-    }
-}
-
-// MARK: - Footer
-
-/// The shared wizard footer: an optional Back on the left, a prominent
-/// amber primary pill on the right. Wires Return → primary and (when
-/// Back is present) Escape → back, so every step gets identical keyboard
-/// behaviour for free.
-///
-/// Those two shortcuts are the whole of Step 2's keyboard contract, and they
-/// work because the footer is the only progression mechanism:
-///
-/// * **Return** carries `.defaultAction`, and `.disabled(!primaryEnabled)`
-///   means a disabled primary swallows it. So Return can never reach an
-///   action the user cannot see — the activation truth table's "No-op" rows
-///   are enforced by AppKit rather than re-implemented per screen.
-/// * **Escape** carries `.cancelAction` on Back. Because every Step 2
-///   micro-stage supplies its own Back, Escape resolves to the visible
-///   control at each depth: it clears a search field first (that field
-///   consumes the key itself), then leaves Review, then leaves the
-///   catalogue, and only at the Step 2 root does onboarding's own meaning
-///   resume. Every Escape destination therefore has a control on screen.
-struct OnboardingWizardFooter: View {
-    let primaryTitle: String
-    var primaryEnabled: Bool = true
-    /// Back's label. Named for its destination on the Step 2 micro-stages
-    /// ("← Back to recommended models") so the control says where it goes
-    /// instead of only that it goes back.
-    var backTitle: String = "Back"
-    var onBack: (() -> Void)?
-    let onPrimary: () -> Void
-
-    var body: some View {
-        HStack {
-            if let onBack {
-                Button(action: onBack) {
-                    Text(backTitle)
-                        .scaledSystemFont(13, weight: .medium)
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .keyboardShortcut(.cancelAction)
-                .accessibilityIdentifier("Quickstart.Footer.Back")
-                .accessibilityLabel(backTitle)
-            }
-            Spacer()
-            Button(action: onPrimary) {
-                Text(primaryTitle)
-                    .scaledSystemFont(13, weight: .semibold)
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 9)
-                    .background(Capsule().fill(RapidTheme.amber.opacity(primaryEnabled ? 1 : 0.4)))
-            }
-            .buttonStyle(.plain)
-            .disabled(!primaryEnabled)
-            .keyboardShortcut(.defaultAction)
-            .accessibilityIdentifier("Quickstart.Footer.Primary")
-        }
-    }
-}
-
-// MARK: - Attribute chip
-
-/// A small icon+label pill used on the starter card ("Instant", "Runs
-/// on any Mac") in place of benchmark meters — the starter has no
-/// published benchmark, so a qualitative chip is honest where a meter
-/// would be a dashed blank (decision (b), #1524).
-struct OnboardingAttrChip: View {
-    let symbol: String
-    let text: String
-    let foreground: Color
-    let background: Color
-
-    var body: some View {
-        Label(text, systemImage: symbol)
-            .labelStyle(.titleAndIcon)
-            .scaledSystemFont(10.5, weight: .medium)
-            .foregroundStyle(foreground)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .background(Capsule().fill(background))
-    }
-}
+/// Every card is a pure ``View`` over ``RapidTheme`` and ``OnboardingD``, so a
+/// screen can be composed without a coordinator and rendered without an app.
 
 // MARK: - Row activation
 
@@ -201,117 +44,164 @@ extension View {
     }
 }
 
-// MARK: - Model choice cards
+// MARK: - Model monogram
 
-/// The explicit below-quality-floor escape hatch. It looks distinct from
-/// both the recommended starter and benchmarked trade-ups, and puts the
-/// capability cost on screen so "lower memory" is never read as "same model,
-/// only faster".
-struct QuickstartLowMemoryCard: View {
-    let choice: QuickstartModelChoice
-    let selected: Bool
-    let sizeText: String
-    /// Double-click activation. See ``View/modelRowActivation(_:)``.
-    var onActivate: (() -> Void)? = nil
-    let onTap: () -> Void
+/// The flat identity tile Direction D uses for a model.
+///
+/// Reuses ``ModelBrandStyle/monogram(forAlias:)`` so the letter is the same one
+/// the rest of the app shows for that family, but paints it flat rather than
+/// with ``BrandIcon``'s per-brand gradient. Setup is the one surface where the
+/// rule is a single strong colour moment per screen — eleven saturated brand
+/// gradients down a list would spend that budget before the primary action got
+/// any of it. Settings → Models keeps ``BrandIcon`` and is untouched.
+struct OnboardingModelTile: View {
+    enum Tone {
+        /// The recommended starter — the one identity that gets a colour.
+        case feature
+        /// Everything else.
+        case neutral
+        /// A model this Mac cannot run.
+        case muted
+    }
+
+    let alias: String
+    var size: CGFloat = 32
+    var tone: Tone = .neutral
+
+    private var monogram: String { ModelBrandStyle.monogram(forAlias: alias) }
 
     var body: some View {
-        Button(action: onTap) {
-            HStack(alignment: .top, spacing: 11) {
-                BrandIcon(alias: choice.alias, size: 32)
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 7) {
-                        Text(choice.displayName).scaledSystemFont(13, weight: .semibold)
-                        Text("LOWEST MEMORY")
-                            .scaledSystemFont(8.5, weight: .bold)
-                            .foregroundStyle(RapidTheme.green)
-                            .padding(.horizontal, 6).padding(.vertical, 2)
-                            .background(Capsule().fill(RapidTheme.green.opacity(0.12)))
-                        Spacer()
-                        if !sizeText.isEmpty {
-                            Text(sizeText).scaledSystemFont(11).foregroundStyle(.secondary)
-                        }
-                    }
-                    Text(choice.blurb)
-                        .scaledSystemFont(11)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                selectionGlyph(selected: selected, size: 18)
+        RoundedRectangle(cornerRadius: size * 0.25, style: .continuous)
+            .fill(background)
+            .frame(width: size, height: size)
+            .overlay {
+                Text(monogram)
+                    .scaledSystemFont(size * 0.42, relativeTo: .body, weight: .semibold)
+                    .foregroundStyle(foreground)
+                    .minimumScaleFactor(0.6)
+                    .lineLimit(1)
             }
-            .padding(.horizontal, 14).padding(.vertical, 11)
-            .background(cardFill(selected: selected))
-            .overlay(cardStroke(selected: selected))
-            .contentShape(Rectangle())
+            .accessibilityHidden(true)
+    }
+
+    private var background: Color {
+        switch tone {
+        case .feature: return RapidTheme.brandSecondaryTint
+        case .neutral, .muted: return RapidTheme.surfaceCode
         }
-        .buttonStyle(.pressableCard)
-        .modelRowActivation(onActivate)
-        .accessibilityIdentifier("Quickstart.Choice.\(choice.alias)")
-        .accessibilityAddTraits(selected ? .isSelected : [])
-        .accessibilityLabel("\(choice.displayName). Lowest memory. \(choice.blurb) Download \(sizeText)")
+    }
+
+    private var foreground: Color {
+        switch tone {
+        case .feature: return RapidTheme.brandSecondary
+        case .neutral: return RapidTheme.textSecondary
+        case .muted: return RapidTheme.textTertiary
+        }
     }
 }
 
-/// The recommended starter card: brand icon + name + "START HERE" badge
-/// + a qualitative blurb + attribute chips (NO meters — the starter
-/// card is deliberately qualitative; decision (b)). Selectable; the whole card is the
-/// tap target.
+// MARK: - Card chrome
+
+/// The shared card shell. Selection is a 2pt amber border rather than a fill,
+/// and the horizontal padding drops by the same point so the content does not
+/// shift when a row is picked.
+private struct OnboardingCardChrome: ViewModifier {
+    let selected: Bool
+    var fill: Color = RapidTheme.surfaceRaised
+    var verticalPadding: CGFloat
+    var horizontalPadding: CGFloat = 18
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.vertical, verticalPadding)
+            .padding(.horizontal, selected ? horizontalPadding - 1 : horizontalPadding)
+            .background(
+                RoundedRectangle(cornerRadius: OnboardingD.cardRadius, style: .continuous)
+                    .fill(fill)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: OnboardingD.cardRadius, style: .continuous)
+                    .strokeBorder(
+                        selected ? RapidTheme.brandPrimary : RapidTheme.hairline,
+                        lineWidth: selected ? 2 : 1
+                    )
+            )
+            .contentShape(RoundedRectangle(cornerRadius: OnboardingD.cardRadius, style: .continuous))
+    }
+}
+
+private extension View {
+    func onboardingCard(
+        selected: Bool,
+        fill: Color = RapidTheme.surfaceRaised,
+        verticalPadding: CGFloat,
+        horizontalPadding: CGFloat = 18
+    ) -> some View {
+        modifier(OnboardingCardChrome(
+            selected: selected,
+            fill: fill,
+            verticalPadding: verticalPadding,
+            horizontalPadding: horizontalPadding
+        ))
+    }
+}
+
+// MARK: - Recommended starter
+
+/// The starter card. The only row that carries prose, attribute pills and a
+/// coloured monogram — it is the recommendation, and the composition says so
+/// without a meter or a benchmark claim.
 struct QuickstartRecommendedCard: View {
     let choice: QuickstartModelChoice
     let selected: Bool
     let sizeText: String
-    /// Double-click activation. See ``View/modelRowActivation(_:)``.
     var onActivate: (() -> Void)? = nil
     let onTap: () -> Void
 
     var body: some View {
         Button(action: onTap) {
-            HStack(alignment: .top, spacing: 13) {
-                BrandIcon(alias: choice.alias, size: 38)
+            HStack(alignment: .top, spacing: 14) {
+                OnboardingModelTile(alias: choice.alias, size: 38, tone: .feature)
                 VStack(alignment: .leading, spacing: 7) {
-                    HStack(spacing: 8) {
-                        Text(choice.displayName).scaledSystemFont(15, weight: .semibold)
+                    HStack(spacing: 9) {
+                        Text(choice.displayName)
+                            .scaledSystemFont(15, weight: .semibold)
+                            .foregroundStyle(RapidTheme.textPrimary)
                         if choice.isStarter {
-                            Text("START HERE")
-                                .scaledSystemFont(9, weight: .bold)
-                                .foregroundStyle(RapidTheme.brand)
-                                .padding(.horizontal, 6).padding(.vertical, 2)
-                                .background(Capsule().fill(RapidTheme.brand.opacity(0.14)))
+                            OnboardingBadge(text: "START HERE", tone: .ink)
                         }
-                        Spacer()
+                        Spacer(minLength: 8)
                         if !sizeText.isEmpty {
-                            Text(sizeText).scaledSystemFont(12).foregroundStyle(.secondary)
+                            Text(sizeText)
+                                .scaledSystemFont(12, design: .monospaced)
+                                .foregroundStyle(RapidTheme.textSecondary)
+                                .fixedSize()
                         }
                     }
                     Text(choice.blurb)
-                        .scaledSystemFont(12)
-                        .foregroundStyle(.secondary)
+                        .scaledSystemFont(13)
+                        .foregroundStyle(RapidTheme.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                     HStack(spacing: 7) {
-                        OnboardingAttrChip(symbol: "bolt.fill", text: "Instant",
-                                           foreground: RapidTheme.amberDeep, background: RapidTheme.amberTint)
-                        OnboardingAttrChip(symbol: "checkmark.seal.fill", text: "Runs on any Mac",
-                                           foreground: RapidTheme.green, background: RapidTheme.green.opacity(0.12))
+                        OnboardingAttributePill(text: "Instant")
+                        OnboardingAttributePill(text: "Runs on any Mac")
                     }
-                    .padding(.top, 1)
+                    .padding(.top, 2)
                 }
-                selectionGlyph(selected: selected, size: 20)
+                OnboardingSelectionGlyph(isSelected: selected)
             }
-            .padding(14)
-            .background(cardFill(selected: selected))
-            .overlay(cardStroke(selected: selected))
-            .contentShape(Rectangle())
+            .onboardingCard(selected: selected, verticalPadding: 18)
         }
-        .buttonStyle(.pressableCard)
+        .buttonStyle(.plain)
         .modelRowActivation(onActivate)
         .accessibilityIdentifier("Quickstart.Choice.\(choice.alias)")
         .accessibilityAddTraits(selected ? .isSelected : [])
         .accessibilityLabel(accessibilityText)
     }
 
-    /// Fold the "recommended starter" framing, size, and the attribute
-    /// chips into the spoken label — the button overrides its children,
-    /// so VoiceOver users otherwise hear only the name + blurb.
+    /// Fold the framing, size and attribute pills into the spoken label — the
+    /// button overrides its children, so VoiceOver otherwise hears the name
+    /// and blurb only.
     private var accessibilityText: String {
         var parts = [choice.displayName]
         if choice.isStarter { parts.append("recommended starter") }
@@ -322,95 +212,110 @@ struct QuickstartRecommendedCard: View {
     }
 }
 
-/// A compact bigger-option row: brand icon + name + blurb, inline
-/// Accuracy·Speed numbers (real benchmark values via ``ModelMeter``),
-/// size, and a selection glyph. Selectable.
+// MARK: - Low-memory fallback
+
+/// The explicit below-quality-floor escape hatch. It names the capability cost
+/// so "lowest memory" is never read as "same model, only faster".
+struct QuickstartLowMemoryCard: View {
+    let choice: QuickstartModelChoice
+    let selected: Bool
+    let sizeText: String
+    var onActivate: (() -> Void)? = nil
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(alignment: .top, spacing: 14) {
+                OnboardingModelTile(alias: choice.alias, size: 32)
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 9) {
+                        Text(choice.displayName)
+                            .scaledSystemFont(14, weight: .semibold)
+                            .foregroundStyle(RapidTheme.textPrimary)
+                        OnboardingBadge(text: "LOWEST MEMORY", tone: .ready)
+                        Spacer(minLength: 8)
+                        if !sizeText.isEmpty {
+                            Text(sizeText)
+                                .scaledSystemFont(12, design: .monospaced)
+                                .foregroundStyle(RapidTheme.textSecondary)
+                                .fixedSize()
+                        }
+                    }
+                    Text(choice.blurb)
+                        .scaledSystemFont(12)
+                        .foregroundStyle(RapidTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                OnboardingSelectionGlyph(isSelected: selected)
+            }
+            .onboardingCard(selected: selected, verticalPadding: 15)
+        }
+        .buttonStyle(.plain)
+        .modelRowActivation(onActivate)
+        .accessibilityIdentifier("Quickstart.Choice.\(choice.alias)")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+        .accessibilityLabel(
+            "\(choice.displayName). Lowest memory. \(choice.blurb)"
+                + (sizeText.isEmpty ? "" : " Download \(sizeText)")
+        )
+    }
+}
+
+// MARK: - Compact trade-up / cached row
+
+/// A one-line choice: name, one-line blurb, size, selection. Used for the
+/// bigger trade-ups and for models already on this Mac.
 struct QuickstartCompactCard: View {
     let choice: QuickstartModelChoice
     let selected: Bool
     let sizeText: String
     var isCached: Bool = false
-    /// Double-click activation. See ``View/modelRowActivation(_:)``.
     var onActivate: (() -> Void)? = nil
     let onTap: () -> Void
 
-    private var accValue: String { ModelMeter.qualityMeter(for: choice.alias).formattedValue }
-    private var spdValue: String { ModelMeter.speedMeter(for: choice.alias).formattedValue }
-
     var body: some View {
-        // Prefer the elegant single row; when the detail pane is too narrow
-        // for the full name beside the fixed meter/size columns (~380pt at
-        // the 640pt window floor), fall back to a two-row layout so the
-        // model name — the key identifier (4B vs 9B) — is NEVER truncated
-        // (memory #459/#464). ViewThatFits picks the wide row only while its
-        // full-name ideal width fits.
         Button(action: onTap) {
-            ViewThatFits(in: .horizontal) {
-                wideRow
-                narrowRow
+            HStack(spacing: 14) {
+                OnboardingModelTile(alias: choice.alias, size: 28)
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 9) {
+                        Text(choice.displayName)
+                            .scaledSystemFont(14, weight: .semibold)
+                            .foregroundStyle(RapidTheme.textPrimary)
+                            .lineLimit(1)
+                        if isCached {
+                            OnboardingBadge(text: "ON THIS MAC", tone: .ready)
+                        }
+                    }
+                    if !choice.blurb.isEmpty {
+                        Text(choice.blurb)
+                            .scaledSystemFont(12)
+                            .foregroundStyle(RapidTheme.textSecondary)
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 8)
+                if !sizeText.isEmpty {
+                    Text(sizeText)
+                        .scaledSystemFont(12, design: .monospaced)
+                        .foregroundStyle(RapidTheme.textSecondary)
+                        .fixedSize()
+                }
+                OnboardingSelectionGlyph(isSelected: selected)
             }
-            .padding(.horizontal, 14).padding(.vertical, 11)
-            .background(cardFill(selected: selected))
-            .overlay(cardStroke(selected: selected))
-            .contentShape(Rectangle())
+            .onboardingCard(selected: selected, verticalPadding: 13)
         }
-        .buttonStyle(.pressableCard)
+        .buttonStyle(.plain)
         .modelRowActivation(onActivate)
         .accessibilityIdentifier("Quickstart.Choice.\(choice.alias)")
         .accessibilityAddTraits(selected ? .isSelected : [])
         .accessibilityLabel(accessibilityText)
     }
 
-    /// Wide layout: icon + name, then Accuracy·Speed meters, size, glyph —
-    /// all on one row. Measurement is driven by the name's full ideal
-    /// width (the trade-up cards carry no blurb — it's the recommended
-    /// starter card that gets prose), so ViewThatFits drops to
-    /// ``narrowRow`` exactly when the name would otherwise be squeezed.
-    private var wideRow: some View {
-        HStack(spacing: 10) {
-            BrandIcon(alias: choice.alias, size: 30)
-            Text(choice.displayName).scaledSystemFont(13, weight: .medium).lineLimit(1)
-            Spacer(minLength: 8)
-            metric("Accuracy", accValue)
-            metric("Speed", spdValue)
-            sizeLabel
-            selectionGlyph(selected: selected, size: 18)
-        }
-    }
-
-    /// Narrow fallback: name (never truncated) + size on the first line,
-    /// the meters on a second line — so the 4B/9B identifier always reads.
-    private var narrowRow: some View {
-        HStack(spacing: 10) {
-            BrandIcon(alias: choice.alias, size: 30)
-            VStack(alignment: .leading, spacing: 5) {
-                HStack(spacing: 6) {
-                    Text(choice.displayName).scaledSystemFont(13, weight: .medium).lineLimit(1).fixedSize()
-                    Spacer(minLength: 6)
-                    sizeLabel
-                }
-                HStack(spacing: 14) {
-                    inlineMetric("Accuracy", accValue)
-                    inlineMetric("Speed", spdValue)
-                    Spacer(minLength: 0)
-                }
-            }
-            selectionGlyph(selected: selected, size: 18)
-        }
-    }
-
-    @ViewBuilder private var sizeLabel: some View {
-        if !sizeText.isEmpty {
-            Text(sizeText).scaledSystemFont(12).foregroundStyle(.secondary).fixedSize()
-        }
-    }
-
-    /// Fold the accuracy / speed / size read-outs into the spoken label —
-    /// the button's own label overrides the child ``Text``s, so without
-    /// this VoiceOver users lose the exact numbers sighted users compare.
     private var accessibilityText: String {
-        var parts = ["\(choice.displayName). \(choice.blurb)"]
-        parts.append("Accuracy \(accValue), speed \(spdValue)")
+        var parts = [choice.displayName]
+        if !choice.blurb.isEmpty { parts.append(choice.blurb) }
         if isCached {
             parts.append(sizeText.isEmpty ? "on disk" : "on disk \(sizeText)")
         } else if !sizeText.isEmpty {
@@ -418,46 +323,94 @@ struct QuickstartCompactCard: View {
         }
         return parts.joined(separator: ". ")
     }
+}
 
-    // #546: the metric VALUE keeps its Font-level `.monospacedDigit()`
-    // (so the Accuracy/Speed numbers stay column-aligned), which
-    // `.scaledSystemFont` can't carry — so it scales via a local
-    // `@ScaledMetric` instead. 12/11pt at the default size, unchanged.
-    @ScaledMetric(relativeTo: .body) private var metricValueSize: CGFloat = 12
-    @ScaledMetric(relativeTo: .body) private var inlineMetricValueSize: CGFloat = 11
+// MARK: - Catalogue row
 
-    private func metric(_ label: String, _ value: String) -> some View {
-        VStack(spacing: 1) {
-            Text(value).font(.system(size: metricValueSize, weight: .semibold).monospacedDigit())
-            Text(label).scaledSystemFont(9).foregroundStyle(.tertiary)
-        }
-        .fixedSize()
+/// One row of in-window Browse all models (Paper 05.2.C).
+///
+/// Fixed slots, not gaps: the badge lane and the size lane are pinned widths so
+/// they form vertical columns down a list of 175 rows whose names vary wildly
+/// in length. Without them the sizes wander and the list stops being scannable.
+struct OnboardingCatalogRow: View {
+    let alias: String
+    /// Hugging Face repo, shown under the alias. Falls back to the memory
+    /// explanation when the row cannot run here.
+    let subtitle: String
+    let sizeText: String
+    let selected: Bool
+    /// False when ``ModelSizing`` says this will not run on this Mac.
+    let isAvailable: Bool
+    let badges: [OnboardingCatalogRow.Badge]
+    var onActivate: (() -> Void)? = nil
+    let onTap: () -> Void
+
+    struct Badge: Identifiable {
+        let id = UUID()
+        let text: String
+        let tone: OnboardingBadge.Tone
     }
 
-    private func inlineMetric(_ label: String, _ value: String) -> some View {
-        HStack(spacing: 3) {
-            Text(label).scaledSystemFont(9).foregroundStyle(.tertiary)
-            Text(value).font(.system(size: inlineMetricValueSize, weight: .semibold).monospacedDigit())
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 14) {
+                OnboardingModelTile(
+                    alias: alias,
+                    size: 32,
+                    tone: isAvailable ? .neutral : .muted
+                )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(alias)
+                        .scaledSystemFont(14, weight: .semibold)
+                        .foregroundStyle(isAvailable ? RapidTheme.textPrimary : RapidTheme.textTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(subtitle)
+                        .scaledSystemFont(11, design: .monospaced)
+                        .foregroundStyle(RapidTheme.textTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer(minLength: 8)
+                HStack(spacing: 6) {
+                    Spacer(minLength: 0)
+                    ForEach(badges) { badge in
+                        OnboardingBadge(text: badge.text, tone: badge.tone)
+                    }
+                }
+                .frame(width: OnboardingD.rowBadgeSlot, alignment: .trailing)
+                Text(sizeText)
+                    .scaledSystemFont(12, design: .monospaced)
+                    .foregroundStyle(isAvailable ? RapidTheme.textSecondary : RapidTheme.textTertiary)
+                    .frame(width: OnboardingD.rowSizeSlot, alignment: .trailing)
+                OnboardingSelectionGlyph(isSelected: selected, isEnabled: isAvailable)
+            }
+            .padding(.horizontal, selected ? 17 : 18)
+            .frame(height: OnboardingD.rowHeight)
+            .background(
+                RoundedRectangle(cornerRadius: OnboardingD.cardRadius, style: .continuous)
+                    .fill(isAvailable ? RapidTheme.surfaceRaised : RapidTheme.surfaceCanvas)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: OnboardingD.cardRadius, style: .continuous)
+                    .strokeBorder(
+                        selected ? RapidTheme.brandPrimary : RapidTheme.hairline,
+                        lineWidth: selected ? 2 : 1
+                    )
+            )
+            .contentShape(RoundedRectangle(cornerRadius: OnboardingD.cardRadius, style: .continuous))
         }
-        .fixedSize()
+        .buttonStyle(.plain)
+        .modelRowActivation(onActivate)
+        .accessibilityIdentifier("Quickstart.CatalogRow.\(alias)")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+        .accessibilityLabel(accessibilityText)
     }
-}
 
-// MARK: - Shared card chrome
-
-private func selectionGlyph(selected: Bool, size: CGFloat) -> some View {
-    Image(systemName: selected ? "checkmark.circle.fill" : "circle")
-        .font(.system(size: size))
-        .foregroundStyle(selected ? RapidTheme.brand : Color.secondary.opacity(0.4))
-}
-
-private func cardFill(selected: Bool) -> some View {
-    RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-        .fill(selected ? RapidTheme.brandTint : RapidTheme.card)
-}
-
-private func cardStroke(selected: Bool) -> some View {
-    RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-        .stroke(selected ? RapidTheme.brand.opacity(0.5) : RapidTheme.hairline,
-                lineWidth: selected ? 1.5 : 1)
+    private var accessibilityText: String {
+        var parts = [alias, subtitle]
+        parts.append(contentsOf: badges.map(\.text.localizedLowercase))
+        if !sizeText.isEmpty { parts.append(sizeText) }
+        return parts.joined(separator: ". ")
+    }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingDirectionD.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingDirectionD.swift
@@ -1,0 +1,1483 @@
+import SwiftUI
+
+/// The Direction D visual system for first-run setup (Paper 05.1 / 05.2).
+///
+/// ## What this file is
+///
+/// Paper 05.1.A defines setup as a *full-window application experience*
+/// composed of two planes, and every one of the twenty registered states is a
+/// variation on that pair:
+///
+/// * **The rail owns where you are, and what this Mac is.** SET UP, the four
+///   steps with current / completed states, and the machine facts that bear on
+///   the decision. During the blocking lifecycle states it owns the lifecycle
+///   name, the model identity, real progress and a measured ETA instead.
+/// * **The canvas owns the decision, and what the action will do.** The active
+///   choice, its explanation, warnings, whether leaving is safe, and the
+///   recovery actions. Never a second copy of what the rail already says.
+///
+/// D1 asks; D2 waits. D1 is the mineral rail — Welcome, detection, the
+/// chooser, warnings and recoverable failures. D2 is the full-height graphite
+/// subject rail — Download, Preparing, Starting: the states where the user
+/// cannot act and the honest thing to show is the work itself.
+///
+/// ## Why a separate file
+///
+/// ``QuickstartView`` is the behaviour: a coordinator, a download observer, a
+/// serve observer, a pre-flight, a diagnosis table and a completion
+/// transaction. Mixing a full visual language into it would make both harder
+/// to review, and the visual layer has to be replaceable without anyone
+/// re-reading the state machine. Everything here is a host-free ``View`` over
+/// ``RapidTheme``, so a screen can be composed — and snapshot-rendered —
+/// without a running app.
+///
+/// ## Tokens
+///
+/// Nothing here invents a colour. ``RapidTheme`` already carries the whole
+/// Direction D palette at the exact values Paper names, with Light and Dark
+/// resolved per token, so this file maps roles onto existing names and adds
+/// only the geometry Paper specifies.
+enum OnboardingD {
+
+    // MARK: - Geometry
+
+    /// D1 rail width at full size (Paper 05.1.B, 1440).
+    static let railWidth: CGFloat = 300
+    /// D1 rail width once the window can no longer afford 300 (Paper 05.1.D,
+    /// 1000×700). The rail keeps every element; it just gives width back.
+    static let railNarrowWidth: CGFloat = 240
+
+    /// At or above this window width the Step 2 heading sits BESIDE the list
+    /// (Paper 05.1.B). Below it, Paper stacks them — see 05.1.D, where the
+    /// 1000pt chooser runs kicker, title, subtitle and list down one column.
+    ///
+    /// The number is derived, not guessed. Side-by-side costs the rail (300),
+    /// the canvas gutters (96 + 56), the heading column (360) and the column
+    /// gap (56) — 868pt before a single model row is drawn. Below
+    /// 1290 the rows fall under ``rowMinWidth`` and the alias, repo, badge and
+    /// size lanes start colliding, so the heading stacks above the list
+    /// instead (Paper 05.1.D draws exactly that at 1000).
+    static let columnsMinWidth: CGFloat = 1290
+
+    /// The narrowest a catalogue row can be and still hold its four lanes.
+    static let rowMinWidth: CGFloat = 420
+    /// D2 subject rail width (Paper: 340). Wider because it carries a 64pt
+    /// percentage and a byte line that must not wrap.
+    static let subjectRailWidth: CGFloat = 340
+
+    /// Top inset before rail content begins.
+    ///
+    /// Paper's frames mock a whole window, so they draw a 52pt titlebar with
+    /// traffic lights inside the rail. Setup is the window's CONTENT view, and
+    /// macOS has already drawn the real title bar above it — so the 52pt is
+    /// spoken for and painting a second set of dots would be decoration that
+    /// cannot be clicked. What is left is the breathing room Paper puts
+    /// between the titlebar and the brand mark.
+    static let railTopInset: CGFloat = 24
+
+    /// Canvas top inset, measured the same way: Paper's 56 runs from the top
+    /// of a mocked window, and roughly 28 of that is the title bar the system
+    /// now provides.
+    static let canvasTop: CGFloat = 32
+
+    /// Canvas insets. Asymmetric by design: Direction D leads from a deep left
+    /// margin and lets content run out to a tighter right edge.
+    static let canvasBottom: CGFloat = 44
+    static let canvasLeading: CGFloat = 96
+    static let canvasTrailing: CGFloat = 56
+
+    /// Content width caps Paper uses per composition.
+    static let decisionWidth: CGFloat = 660
+    static let proseWidth: CGFloat = 640
+    /// The chooser's fixed heading column.
+    static let headingColumnWidth: CGFloat = 360
+    /// Gap between the heading column and the choice list.
+    static let columnGap: CGFloat = 56
+
+    /// Below this window width the vertical rail would leave the canvas around
+    /// 400pt — unusable for the model cards — so it rotates into a horizontal
+    /// strip and the canvas takes the full width (Paper 05.1.E).
+    static let railCollapseWidth: CGFloat = 820
+
+    /// The collapsed rail's height, and the D2 band's.
+    static let compactRailHeight: CGFloat = 46
+    static let compactBandHeight: CGFloat = 56
+    /// The canvas gutter once the rail is horizontal.
+    static let compactGutter: CGFloat = 28
+
+    /// Standard control height for the action lane.
+    static let actionHeight: CGFloat = 44
+    static let actionRadius: CGFloat = 10
+    static let cardRadius: CGFloat = 12
+
+    /// Catalogue row geometry — fixed slots so badges and sizes form vertical
+    /// lanes across rows rather than drifting with name length.
+    static let rowHeight: CGFloat = 56
+    static let rowBadgeSlot: CGFloat = 172
+    static let rowSizeSlot: CGFloat = 76
+    static let selectionGlyph: CGFloat = 18
+
+    // MARK: - Type
+
+    /// Tracking values Paper specifies in em, converted to points at the size
+    /// they are used. SwiftUI's `.tracking` is absolute, so these cannot be
+    /// shared across sizes.
+    enum Tracking {
+        /// 0.14em label tracking on an 11pt kicker.
+        static let kicker: CGFloat = 1.54
+        /// 0.12em on a 10pt group label.
+        static let groupLabel: CGFloat = 1.2
+        /// 0.08em on a 9pt badge.
+        static let badge: CGFloat = 0.72
+        /// 0.16em on the D2 lifecycle name.
+        static let lifecycle: CGFloat = 1.76
+        /// Display tracking, applied per display size below.
+        static func display(_ size: CGFloat) -> CGFloat { size * -0.026 }
+    }
+}
+
+// MARK: - Step titles
+
+extension QuickstartCoordinator.Step {
+    /// The rail's name for this step (Paper 05.1.A — "SET UP · Welcome ·
+    /// Choose a model · Download · Start").
+    ///
+    /// Presentation only, and deliberately an extension rather than a stored
+    /// property on the coordinator: the four-step MODEL is behaviour and is
+    /// owned there; what the rail calls each step is this file's business.
+    var railTitle: String {
+        switch self {
+        case .welcome:     return "Welcome"
+        case .chooseModel: return "Choose a model"
+        case .download:    return "Download"
+        case .start:       return "Start"
+        }
+    }
+}
+
+// MARK: - Rail
+
+/// One step in the setup rail, and how it is drawn.
+enum OnboardingStepState: Equatable {
+    case complete
+    case current
+    case upcoming
+}
+
+/// The D1 setup rail (Paper 05.1.A, and every D1 frame in 05.1.B).
+///
+/// Replaces the production sidebar for the duration of setup. It never shows
+/// chat, a composer or a status strip: setup owns the window until it ends.
+struct OnboardingSetupRail: View {
+    @Environment(\.onboardingLayout) private var layout
+    /// The macro step the user is on. Steps before it read complete, steps
+    /// after it read upcoming.
+    let step: QuickstartCoordinator.Step
+    /// This Mac, for the footer facts. `nil` omits the footer entirely rather
+    /// than printing placeholders for numbers we do not have.
+    var hardware: MacHardware?
+    /// Free space on the volume that holds the model cache, once measured.
+    ///
+    /// Paper adds this row from Step 2 onward (05.1 frames 03 and 04): once
+    /// the user is choosing what to download, how much room there is becomes
+    /// one of the machine facts the decision rests on. `nil` omits the row.
+    var freeSpace: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Color.clear.frame(height: OnboardingD.railTopInset)
+
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 9) {
+                    OnboardingRailMark()
+                    Text("Rapid-MLX")
+                        .scaledSystemFont(13, weight: .semibold)
+                        .foregroundStyle(RapidTheme.textPrimary)
+                }
+                Text("SET UP")
+                    .scaledSystemFont(11, relativeTo: .caption, weight: .semibold, design: .monospaced)
+                    .tracking(OnboardingD.Tracking.kicker)
+                    .foregroundStyle(RapidTheme.textTertiary)
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 12)
+            .padding(.bottom, 22)
+
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(QuickstartCoordinator.Step.allCases, id: \.rawValue) { entry in
+                    OnboardingRailStepRow(step: entry, state: state(for: entry))
+                }
+            }
+            .padding(.horizontal, 16)
+            // The rail is a progress report, not a control: reading it as one
+            // element keeps VoiceOver from offering four inert rows.
+            .accessibilityElement(children: .ignore)
+            .accessibilityIdentifier("Quickstart.Progress")
+            .accessibilityLabel(Self.progressAccessibilityLabel(current: step))
+            .accessibilityValue(Self.progressAccessibilityValue(current: step))
+
+            Spacer(minLength: 0)
+
+            if let hardware {
+                OnboardingRailFacts(
+                    hardware: hardware,
+                    freeSpace: freeSpace,
+                    isNarrow: layout != .wide
+                )
+            }
+        }
+        .frame(width: layout.railWidth)
+        .frame(maxHeight: .infinity)
+        .background(RapidTheme.surfaceSidebar)
+        .overlay(alignment: .trailing) {
+            Rectangle().fill(RapidTheme.hairline).frame(width: 1)
+        }
+    }
+
+    private func state(for entry: QuickstartCoordinator.Step) -> OnboardingStepState {
+        if entry.rawValue < step.rawValue { return .complete }
+        if entry == step { return .current }
+        return .upcoming
+    }
+
+    /// Spoken name of the rail.
+    ///
+    /// Kept EXACTLY at `Setup progress, step N of M`. This string is a
+    /// contract, not styling: `gui-golden-flows.sh` matches it verbatim on
+    /// three screens to prove the rail reports honest progress, and PR #1917
+    /// put it there. Anything richer belongs in the value below, where it can
+    /// grow without breaking the pin.
+    static func progressAccessibilityLabel(current: QuickstartCoordinator.Step) -> String {
+        "Setup progress, step \(current.displayNumber) of \(QuickstartCoordinator.Step.total)"
+    }
+
+    /// What the rail says beyond its position: the step's name, and which
+    /// steps are already behind the user. VoiceOver reads a value after a
+    /// label, so this arrives in the right order without disturbing the pin.
+    static func progressAccessibilityValue(current: QuickstartCoordinator.Step) -> String {
+        let done = QuickstartCoordinator.Step.allCases
+            .prefix(current.rawValue)
+            .map(\.railTitle)
+        var value = current.railTitle
+        if !done.isEmpty {
+            value += ". Completed: \(done.joined(separator: ", "))"
+        }
+        return value
+    }
+}
+
+/// The brand mark in the rail head: an ink tile with an amber R.
+private struct OnboardingRailMark: View {
+    var body: some View {
+        RoundedRectangle(cornerRadius: 5, style: .continuous)
+            .fill(RapidTheme.textPrimary)
+            .frame(width: 22, height: 22)
+            .overlay {
+                Text("R")
+                    .scaledSystemFont(13, relativeTo: .caption, weight: .bold)
+                    .foregroundStyle(RapidTheme.brandPrimary)
+            }
+            .accessibilityHidden(true)
+    }
+}
+
+private struct OnboardingRailStepRow: View {
+    let step: QuickstartCoordinator.Step
+    let state: OnboardingStepState
+
+    var body: some View {
+        HStack(spacing: 12) {
+            marker.frame(width: 16)
+            Text(step.railTitle)
+                .scaledSystemFont(13, weight: state == .current ? .semibold : .regular)
+                .foregroundStyle(state == .current ? RapidTheme.textPrimary : RapidTheme.textTertiary)
+            Spacer(minLength: 0)
+        }
+        .padding(.leading, state == .current ? 9 : 12)
+        .frame(height: 34)
+        .background(alignment: .leading) {
+            if state == .current {
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: 0,
+                    bottomTrailingRadius: 6,
+                    topTrailingRadius: 6,
+                    style: .continuous
+                )
+                .fill(RapidTheme.textPrimary.opacity(0.043))
+                .overlay(alignment: .leading) {
+                    Rectangle().fill(RapidTheme.textPrimary).frame(width: 3)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var marker: some View {
+        switch state {
+        case .complete:
+            Text("✓")
+                .scaledSystemFont(11, relativeTo: .caption, weight: .semibold, design: .monospaced)
+                .foregroundStyle(RapidTheme.statusReady)
+        case .current:
+            Text("\(step.displayNumber)")
+                .scaledSystemFont(11, relativeTo: .caption, weight: .semibold, design: .monospaced)
+                .foregroundStyle(RapidTheme.textPrimary)
+        case .upcoming:
+            Text("\(step.displayNumber)")
+                .scaledSystemFont(11, relativeTo: .caption, weight: .medium, design: .monospaced)
+                .foregroundStyle(RapidTheme.textTertiary)
+        }
+    }
+}
+
+/// THIS MAC — the machine facts that bear on the model decision.
+private struct OnboardingRailFacts: View {
+    let hardware: MacHardware
+    var freeSpace: String?
+    /// At 240pt the two-column `label … value` rows start truncating the chip
+    /// name, so Paper collapses them to a single line (05.1.D).
+    var isNarrow: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("THIS MAC")
+                .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+                .tracking(OnboardingD.Tracking.groupLabel)
+                .foregroundStyle(RapidTheme.textTertiary)
+            if isNarrow {
+                // Paper 05.1.D: at 240pt the rail states the machine as one
+                // full-width line and drops the free-space row. A label/value
+                // pair at this width truncates the chip name, which is the one
+                // thing the line exists to say.
+                Text("\(Self.memoryText(hardware)) · \(hardware.brandString)")
+                    .scaledSystemFont(12, design: .monospaced)
+                    .foregroundStyle(RapidTheme.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if let freeSpace {
+                // From Step 2 onward the decision rests on room as well as
+                // memory, so the chip joins the memory line to make space for
+                // it (Paper 05.1 frame 04).
+                row("Memory", "\(Self.memoryText(hardware)) · \(hardware.brandString)")
+                row("Free space", freeSpace)
+            } else {
+                row("Chip", hardware.brandString)
+                row("Memory", Self.memoryText(hardware))
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 18)
+        .padding(.bottom, 22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .overlay(alignment: .top) {
+            Rectangle().fill(RapidTheme.hairline).frame(height: 1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("Quickstart.Rail.ThisMac")
+        .accessibilityLabel(Self.spokenFacts(hardware: hardware, freeSpace: freeSpace))
+    }
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .scaledSystemFont(12)
+                .foregroundStyle(RapidTheme.textSecondary)
+            Spacer(minLength: 8)
+            Text(value)
+                .scaledSystemFont(12, design: .monospaced)
+                .foregroundStyle(RapidTheme.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+    }
+
+    /// Whole gibibytes, matching how macOS About reports memory. Pure so the
+    /// rounding is pinned rather than re-derived at the call site.
+    static func memoryText(_ hardware: MacHardware) -> String {
+        "\(Int(hardware.physicalRAMGB.rounded())) GB"
+    }
+
+    /// The footer read aloud as one sentence, so VoiceOver gets the machine
+    /// facts in one stop rather than three unlabelled fragments.
+    static func spokenFacts(hardware: MacHardware, freeSpace: String?) -> String {
+        var text = "This Mac. Chip \(hardware.brandString). Memory \(memoryText(hardware))."
+        if let freeSpace { text += " Free space \(freeSpace)." }
+        return text
+    }
+}
+
+// MARK: - D2 subject rail
+
+/// The graphite lifecycle rail (Paper 05.1.A "D2 waits", state 09/14/15).
+///
+/// Everything on it is measured. The percentage, the byte line and the rate
+/// are rendered only when the caller has real values to pass; a `nil` becomes
+/// an absent row, never a zero or a guess.
+struct OnboardingSubjectRail: View {
+    /// The lifecycle name — DOWNLOADING, PREPARING, STARTING.
+    let lifecycle: String
+    /// Model identity, as an alias rather than a display name: this rail is
+    /// the technical plane.
+    let identity: String
+    /// Measured fraction 0...1, or `nil` for an indeterminate stage.
+    var fraction: Double?
+    /// "271 MB / 633 MB", or `nil` before bytes are observed.
+    var bytesLine: String?
+    /// "4.4 MB/s · 1 min left", or `nil` until the rate stabilises.
+    var rateLine: String?
+    /// Footer left — "STEP 3 OF 4".
+    let stepLabel: String
+    /// Footer right — the macro step name.
+    let stepName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Color.clear.frame(height: OnboardingD.railTopInset)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(lifecycle)
+                    .scaledSystemFont(11, relativeTo: .caption, weight: .semibold, design: .monospaced)
+                    .tracking(OnboardingD.Tracking.lifecycle)
+                    .foregroundStyle(RapidTheme.bandInkSecondary)
+                    .padding(.bottom, 20)
+
+                Text(identity)
+                    .scaledSystemFont(19, relativeTo: .title3, weight: .medium, design: .monospaced)
+                    .foregroundStyle(RapidTheme.bandInk)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let fraction {
+                    Text(Self.percentText(fraction))
+                        .scaledSystemFont(64, relativeTo: .largeTitle, weight: .semibold)
+                        .monospacedDigit()
+                        .foregroundStyle(RapidTheme.brandPrimary)
+                        .padding(.top, 26)
+                        .accessibilityIdentifier("Quickstart.Subject.Percent")
+
+                    OnboardingSubjectTrack(fraction: fraction)
+                        .padding(.top, 16)
+                } else {
+                    OnboardingIndeterminateTrack()
+                        .padding(.top, 26)
+                }
+
+                if let bytesLine {
+                    Text(bytesLine)
+                        .scaledSystemFont(13, design: .monospaced)
+                        .foregroundStyle(RapidTheme.bandInk)
+                        .padding(.top, 16)
+                        .accessibilityIdentifier("Quickstart.Subject.Bytes")
+                }
+                if let rateLine {
+                    Text(rateLine)
+                        .scaledSystemFont(12, design: .monospaced)
+                        .foregroundStyle(RapidTheme.bandInkSecondary)
+                        .padding(.top, 7)
+                        .accessibilityIdentifier("Quickstart.Subject.Rate")
+                }
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 28)
+            .padding(.top, 22)
+
+            HStack {
+                Text(stepLabel)
+                    .foregroundStyle(RapidTheme.bandInkSecondary)
+                Spacer(minLength: 8)
+                Text(stepName)
+                    .foregroundStyle(RapidTheme.bandInk)
+            }
+            .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+            .tracking(OnboardingD.Tracking.groupLabel)
+            .padding(.horizontal, 28)
+            .padding(.top, 20)
+            .padding(.bottom, 24)
+            .overlay(alignment: .top) {
+                Rectangle().fill(Color.white.opacity(0.09)).frame(height: 1)
+            }
+        }
+        .frame(width: OnboardingD.subjectRailWidth)
+        .frame(maxHeight: .infinity)
+        .background(RapidTheme.surfaceBand)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("Quickstart.Subject.Rail")
+    }
+
+    /// Whole percent, floored, so the rail never rounds 99.6% up to a "100%"
+    /// that sits there while files are still being written.
+    static func percentText(_ fraction: Double) -> String {
+        let clamped = min(max(fraction, 0), 1)
+        return "\(Int(clamped * 100))%"
+    }
+}
+
+private struct OnboardingSubjectTrack: View {
+    let fraction: Double
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule().fill(RapidTheme.bandTrack)
+                Capsule()
+                    .fill(RapidTheme.brandPrimary)
+                    .frame(width: max(0, min(1, fraction)) * proxy.size.width)
+            }
+        }
+        .frame(height: 5)
+        .accessibilityHidden(true)
+    }
+}
+
+/// Indeterminate stages get a travelling segment, never a static partial bar
+/// and never 0% (Paper state 14: "No number at all"). Reduced Motion pulses
+/// the track instead of moving anything.
+private struct OnboardingIndeterminateTrack: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var phase: CGFloat = -0.4
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule().fill(RapidTheme.bandTrack)
+                if reduceMotion {
+                    Capsule()
+                        .fill(RapidTheme.brandPrimary.opacity(0.55))
+                } else {
+                    Capsule()
+                        .fill(RapidTheme.brandPrimary)
+                        .frame(width: proxy.size.width * 0.4)
+                        .offset(x: phase * proxy.size.width)
+                }
+            }
+        }
+        .frame(height: 5)
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: false)) {
+                phase = 1.0
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Compact rail
+
+/// The rail, rotated (Paper 05.1.E).
+///
+/// Below ``OnboardingD/railCollapseWidth`` the vertical rail would squeeze the
+/// canvas to roughly 400pt, which the model cards cannot use. It becomes a
+/// 46pt strip instead: the same three facts — that this is setup, which step,
+/// and how far along — in a horizontal reading order. Nothing is dropped; the
+/// machine facts move into the screens that actually need them.
+struct OnboardingCompactRail: View {
+    let step: QuickstartCoordinator.Step
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text("SET UP")
+                .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+                .tracking(OnboardingD.Tracking.kicker)
+                .foregroundStyle(RapidTheme.textTertiary)
+            Text(step.railTitle)
+                .scaledSystemFont(13, weight: .semibold)
+                .foregroundStyle(RapidTheme.textPrimary)
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            Text("STEP \(step.displayNumber) OF \(QuickstartCoordinator.Step.total)")
+                .scaledSystemFont(10, relativeTo: .caption2, design: .monospaced)
+                .foregroundStyle(RapidTheme.textTertiary)
+                .fixedSize()
+            HStack(spacing: 4) {
+                ForEach(QuickstartCoordinator.Step.allCases, id: \.rawValue) { entry in
+                    Capsule()
+                        .fill(entry.rawValue <= step.rawValue
+                              ? RapidTheme.textPrimary
+                              : RapidTheme.hairlineStrong)
+                        .frame(width: 26, height: 4)
+                }
+            }
+            .fixedSize()
+        }
+        .padding(.horizontal, 20)
+        .frame(height: OnboardingD.compactRailHeight)
+        .frame(maxWidth: .infinity)
+        .background(RapidTheme.surfaceSidebar)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(RapidTheme.hairline).frame(height: 1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("Quickstart.Progress")
+        .accessibilityLabel(OnboardingSetupRail.progressAccessibilityLabel(current: step))
+        .accessibilityValue(OnboardingSetupRail.progressAccessibilityValue(current: step))
+    }
+}
+
+/// The D2 rail, rotated: a 56pt graphite band in the same slot.
+struct OnboardingCompactSubjectBand: View {
+    let lifecycle: String
+    let identity: String
+    var fraction: Double?
+    var bytesLine: String?
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Text(lifecycle)
+                .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+                .tracking(OnboardingD.Tracking.groupLabel)
+                .foregroundStyle(RapidTheme.bandInkSecondary)
+                .fixedSize()
+            Text(identity)
+                .scaledSystemFont(13, design: .monospaced)
+                .foregroundStyle(RapidTheme.bandInk)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 8)
+            if let bytesLine {
+                Text(bytesLine)
+                    .scaledSystemFont(11, design: .monospaced)
+                    .foregroundStyle(RapidTheme.bandInkSecondary)
+                    .fixedSize()
+            }
+            if let fraction {
+                Text(OnboardingSubjectRail.percentText(fraction))
+                    .scaledSystemFont(15, weight: .semibold)
+                    .monospacedDigit()
+                    .foregroundStyle(RapidTheme.brandPrimary)
+                    .fixedSize()
+                    .accessibilityIdentifier("Quickstart.Subject.Percent")
+            }
+        }
+        .padding(.horizontal, 20)
+        .frame(height: OnboardingD.compactBandHeight)
+        .frame(maxWidth: .infinity)
+        .background(RapidTheme.surfaceBand)
+        .overlay(alignment: .bottom) {
+            if let fraction {
+                GeometryReader { proxy in
+                    Rectangle()
+                        .fill(RapidTheme.brandPrimary)
+                        .frame(width: max(0, min(1, fraction)) * proxy.size.width)
+                }
+                .frame(height: 3)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("Quickstart.Subject.Rail")
+    }
+}
+
+// MARK: - Canvas scaffold
+
+/// How much room setup has, in the three shapes Paper draws it at.
+///
+/// Decided once by the shell from the real window width, then read from the
+/// environment, so no screen re-measures and none can disagree with another
+/// about which side of a breakpoint it is on.
+enum OnboardingLayout: Equatable {
+    /// 1440-class. Full 300pt rail; Step 2's heading sits beside the list.
+    case wide
+    /// 1000-class. Rail narrows to 240 and the canvas stacks (Paper 05.1.D).
+    case medium
+    /// Below 820. The rail rotates into a strip (Paper 05.1.E).
+    case compact
+
+    static func resolve(width: CGFloat) -> OnboardingLayout {
+        if width < OnboardingD.railCollapseWidth { return .compact }
+        if width < OnboardingD.columnsMinWidth { return .medium }
+        return .wide
+    }
+
+    /// True once the rail is horizontal.
+    var isCompact: Bool { self == .compact }
+
+    /// Only the widest tier can afford the side-by-side heading.
+    var usesColumns: Bool { self == .wide }
+
+    var railWidth: CGFloat {
+        self == .wide ? OnboardingD.railWidth : OnboardingD.railNarrowWidth
+    }
+}
+
+private struct OnboardingLayoutKey: EnvironmentKey {
+    static let defaultValue = OnboardingLayout.wide
+}
+
+extension EnvironmentValues {
+    var onboardingLayout: OnboardingLayout {
+        get { self[OnboardingLayoutKey.self] }
+        set { self[OnboardingLayoutKey.self] = newValue }
+    }
+}
+
+/// The right-hand plane. Applies Paper's asymmetric insets once so no screen
+/// re-states them, and lets a screen override the trailing inset when its
+/// content runs wider (the catalogue does). Once the rail has rotated, both
+/// insets collapse to the compact gutter and the asymmetry goes with them —
+/// there is no rail to lead away from any more.
+struct OnboardingCanvas<Content: View>: View {
+    @Environment(\.onboardingLayout) private var layout
+    var trailing: CGFloat = OnboardingD.canvasTrailing
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        content()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .padding(.top, layout.isCompact ? OnboardingD.compactGutter : OnboardingD.canvasTop)
+            .padding(.bottom, layout.isCompact ? OnboardingD.compactGutter : OnboardingD.canvasBottom)
+            .padding(.leading, layout.isCompact ? OnboardingD.compactGutter : OnboardingD.canvasLeading)
+            .padding(.trailing, layout.isCompact ? OnboardingD.compactGutter : trailing)
+            .background(RapidTheme.surfaceCanvas)
+    }
+}
+
+/// The canvas's vertical composition, in one place (Paper 05.1.B).
+///
+/// Every Paper canvas is the same two-part shape: a **principal group** that
+/// takes the remaining height and centres its content in it, and an optional
+/// **action lane** anchored beneath. In the frames this is `flexGrow: 1` with
+/// `alignItems: center` on the content, then the footer with a `marginTop`.
+///
+/// It lives here rather than in each screen because the alternative — a
+/// per-state top padding — is what produced the defect it replaces: the states
+/// drifted apart, Welcome sat near centre and Step 2 sat pinned to the top,
+/// and there was no single number to correct because each screen had its own.
+struct OnboardingCanvasLayout<Principal: View, Footer: View>: View {
+    @ViewBuilder var principal: () -> Principal
+    @ViewBuilder var footer: () -> Footer
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                Spacer(minLength: 24)
+                principal()
+                Spacer(minLength: 24)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+
+            footer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+extension OnboardingCanvasLayout where Footer == EmptyView {
+    init(@ViewBuilder principal: @escaping () -> Principal) {
+        self.init(principal: principal, footer: { EmptyView() })
+    }
+}
+
+/// A canvas whose content is vertically centred with no action lane — the
+/// hero and every outcome screen.
+struct OnboardingCenteredCanvas<Content: View>: View {
+    var trailing: CGFloat = OnboardingD.canvasTrailing
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        OnboardingCanvas(trailing: trailing) {
+            OnboardingCanvasLayout(principal: content)
+        }
+    }
+}
+
+// MARK: - Text roles
+
+/// `STEP 2 OF 4 · CHOOSE A MODEL` — the one element that names the branch.
+struct OnboardingKicker: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .scaledSystemFont(11, relativeTo: .caption, weight: .semibold, design: .monospaced)
+            .tracking(OnboardingD.Tracking.kicker)
+            .foregroundStyle(RapidTheme.textTertiary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+/// The one display line on a setup screen.
+///
+/// One size on the desktop, one step at the floor — never a curve.
+///
+/// The headline holds its full size through BOTH the wide and the medium
+/// layouts and changes exactly once, at the compact breakpoint where the rail
+/// rotates. An earlier version scaled it proportionally off the layout tier,
+/// which made the title read as shrinking continuously as the window narrowed
+/// and left it small long before the window was actually small.
+///
+/// **Deliberate Paper deviation.** Paper 05.1.D redraws this at 28/34 in its
+/// 1000×700 frame, i.e. it steps at medium as well. The approved instruction
+/// for this pass is to preserve the desktop size through wide and medium and
+/// change only at compact, so that is what ships; the medium step is the one
+/// Paper value not carried over.
+struct OnboardingDisplayTitle: View {
+    @Environment(\.onboardingLayout) private var layout
+    let text: String
+    var size: CGFloat = 38
+    /// The single compact step. Defaults to Paper's floor relationship.
+    var compactSize: CGFloat?
+
+    private var resolvedSize: CGFloat {
+        guard layout.isCompact else { return size }
+        return compactSize ?? max(24, (size * 0.68).rounded())
+    }
+
+    var body: some View {
+        // The hard line break is authored for the desktop measure. It is only
+        // dropped where the column is genuinely too narrow to honour it.
+        Text(layout.isCompact ? text.replacingOccurrences(of: "\n", with: " ") : text)
+            .scaledSystemFont(resolvedSize, relativeTo: .largeTitle, weight: .semibold)
+            .tracking(OnboardingD.Tracking.display(resolvedSize))
+            .foregroundStyle(RapidTheme.textPrimary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+/// Paper's Step 2 body: a fixed heading column beside the live list, which
+/// stacks once the rail has rotated.
+///
+/// The asymmetry is load-bearing at full width. The heading column is where
+/// the branch names itself and — on Review download — where the cost is
+/// stated, while the list stays in exactly the same place across all three
+/// micro-stages so switching between them never moves the rows under the
+/// pointer.
+///
+/// A struct rather than a `@ViewBuilder` method on the screen, because it has
+/// to READ ``EnvironmentValues/onboardingLayout``, and a value set inside a
+/// view's own body is not visible to that same body.
+struct OnboardingStepColumns<Aside: View, Content: View>: View {
+    @Environment(\.onboardingLayout) private var layout
+    let kicker: String
+    let title: String
+    var subtitle: String?
+    @ViewBuilder var aside: () -> Aside
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        if layout.usesColumns {
+            // Paper's `alignItems: center` on the Columns row: the heading and
+            // the list are centred against each other, and the row as a whole
+            // is centred in the canvas by ``OnboardingCanvasLayout``.
+            HStack(alignment: .center, spacing: OnboardingD.columnGap) {
+                heading.frame(width: OnboardingD.headingColumnWidth, alignment: .leading)
+                content().frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 20) {
+                heading
+                content().frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var heading: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Micro progress. The step number is repeated deliberately: this is
+            // the only element that names the branch, and it must not be
+            // mistaken for a step of its own. Never sub-numbered.
+            OnboardingKicker(text: kicker)
+                .accessibilityIdentifier("Quickstart.Step2.Kicker")
+                .padding(.bottom, 16)
+
+            OnboardingDisplayTitle(text: title)
+
+            if let subtitle {
+                Text(subtitle)
+                    .scaledSystemFont(15, relativeTo: .callout)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 14)
+            }
+
+            aside()
+        }
+    }
+}
+
+/// A small caps group label above a run of rows.
+struct OnboardingGroupLabel: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+            .tracking(OnboardingD.Tracking.groupLabel)
+            .foregroundStyle(RapidTheme.textTertiary)
+    }
+}
+
+// MARK: - Intrinsic column
+
+/// A column that keeps its natural height while it fits, and only becomes a
+/// scroller when it genuinely cannot.
+///
+/// ## The defect this exists to prevent
+///
+/// Paper frame 04 centres the Step 2 heading and the model list against each
+/// other, and centres the pair in the canvas. Wrapping the list in a bare
+/// `ScrollView` breaks that silently: a `ScrollView` is vertically GREEDY, so
+/// it takes the whole offered height. The enclosing `HStack(alignment:
+/// .center)` then dutifully centres a child that is already full-height, and
+/// the rows inside it stack from ITS top — so the heading reads centred while
+/// the list reads pinned to the top of the canvas, which is exactly the
+/// mismatch it looks like.
+///
+/// `ViewThatFits` is the fix rather than a tweak: it offers the content the
+/// available height first and takes the intrinsic layout when that fits, so
+/// the column has a real height for the centring to act on. Only when the
+/// list is genuinely taller than the canvas does the scrolling variant win,
+/// and at that point filling the height is the correct behaviour anyway.
+///
+/// The content closure is evaluated in both branches; it must therefore stay a
+/// pure function of state, which every Step 2 list already is.
+struct OnboardingIntrinsicColumn<Content: View>: View {
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        ViewThatFits(in: .vertical) {
+            // Preferred: natural height, so the parent can centre it.
+            content()
+            // Fallback: taller than the canvas, so scrolling is the honest
+            // shape and filling the height is what it should do.
+            ScrollView {
+                content()
+            }
+            .scrollBounceBehavior(.basedOnSize)
+        }
+    }
+}
+
+// MARK: - Selection-driven heading content
+
+/// The trade-up comparison Paper draws when a bigger model is picked
+/// (05.1 state 05 — "Bigger, and what it costs").
+///
+/// Two columns of the same three facts, with the picked one in full ink and
+/// the alternative stepped back. Every value is read from ``ModelSizing``
+/// against ``MacHardware`` — the same estimate the footer primary is already
+/// gated on — so this table compares; it does not appraise.
+struct OnboardingComparisonTable: View {
+    struct Column: Identifiable {
+        let id = UUID()
+        /// Short header, e.g. "9B".
+        let title: String
+        let isPicked: Bool
+        let download: String
+        let memory: String
+        let fit: String
+        /// True when the fit reads as a caution rather than a reassurance.
+        let fitIsWarning: Bool
+    }
+
+    let columns: [Column]
+    /// Row label for the fit line, e.g. "Fit on 32 GB".
+    let fitLabel: String
+
+    private let labelWidth: CGFloat = 158
+    private let valueWidth: CGFloat = 100
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .bottom, spacing: 0) {
+                Color.clear.frame(width: labelWidth, height: 1)
+                ForEach(columns) { column in
+                    Text(column.isPicked ? "\(column.title) · PICKED" : column.title)
+                        .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+                        .tracking(OnboardingD.Tracking.groupLabel)
+                        .foregroundStyle(column.isPicked ? RapidTheme.textPrimary : RapidTheme.textTertiary)
+                        .frame(width: valueWidth, alignment: .trailing)
+                }
+            }
+            .frame(height: 32, alignment: .bottom)
+            .overlay(alignment: .bottom) {
+                Rectangle().fill(RapidTheme.hairlineStrong).frame(height: 1)
+            }
+
+            row("Download") { $0.download }
+            row("Memory when loaded") { $0.memory }
+            row(fitLabel, isFit: true) { $0.fit }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("Quickstart.Compare")
+    }
+
+    @ViewBuilder
+    private func row(
+        _ label: String,
+        isFit: Bool = false,
+        value: @escaping (Column) -> String
+    ) -> some View {
+        HStack(spacing: 0) {
+            Text(label)
+                .scaledSystemFont(13)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .frame(width: labelWidth, alignment: .leading)
+            ForEach(columns) { column in
+                Text(value(column))
+                    .scaledSystemFont(13, design: isFit ? .default : .monospaced)
+                    .foregroundStyle(tint(for: column, isFit: isFit))
+                    .frame(width: valueWidth, alignment: .trailing)
+            }
+        }
+        .frame(height: 44)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(RapidTheme.hairline).frame(height: 1)
+        }
+    }
+
+    private func tint(for column: Column, isFit: Bool) -> Color {
+        if isFit {
+            return column.fitIsWarning ? RapidTheme.statusWarning : RapidTheme.statusReady
+        }
+        return column.isPicked ? RapidTheme.textPrimary : RapidTheme.textSecondary
+    }
+}
+
+/// The "what the primary will do" summary Paper puts under the heading when
+/// nothing is on this Mac yet (05.1 state 07).
+struct OnboardingSelectionSummary: View {
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+                .tracking(OnboardingD.Tracking.groupLabel)
+                .foregroundStyle(RapidTheme.textTertiary)
+            Text(detail)
+                .scaledSystemFont(13)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("Quickstart.SelectionSummary")
+        .accessibilityLabel("\(title). \(detail)")
+    }
+}
+
+/// A placeholder for a value that is genuinely still being read.
+///
+/// Deliberately static. Paper 05.1 state 02 is explicit that the hardware read
+/// "must never be dressed as a scanning animation with fake duration" — this is
+/// a shape standing in for a number that has not arrived, and nothing more.
+struct OnboardingSkeleton: View {
+    var width: CGFloat?
+    var height: CGFloat = 12
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: height / 3, style: .continuous)
+            .fill(RapidTheme.hairline)
+            .frame(width: width, height: height)
+            .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Glyph tile
+
+/// The 52pt tinted tile above a recovery or completion headline. Its tint is
+/// the state's meaning: amber for something recoverable, red for something
+/// that stopped setup, green for done.
+struct OnboardingGlyphTile: View {
+    enum Tone {
+        case amber
+        case error
+        case ready
+
+        var tint: Color {
+            switch self {
+            case .amber: return RapidTheme.brandPrimaryTint
+            case .error: return RapidTheme.statusErrorTint
+            case .ready: return RapidTheme.statusReadyTint
+            }
+        }
+
+        var ink: Color {
+            switch self {
+            case .amber: return RapidTheme.brandPrimaryDeep
+            case .error: return RapidTheme.statusError
+            case .ready: return RapidTheme.statusReady
+            }
+        }
+    }
+
+    let systemName: String
+    let tone: Tone
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 13, style: .continuous)
+            .fill(tone.tint)
+            .frame(width: 52, height: 52)
+            .overlay {
+                Image(systemName: systemName)
+                    .font(.system(size: 24, weight: .regular))
+                    .foregroundStyle(tone.ink)
+            }
+            .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Badges
+
+/// A row badge. Fixed vocabulary so a row cannot invent a claim: each case
+/// maps to a fact the catalogue or ``ModelSizing`` already reports.
+struct OnboardingBadge: View {
+    enum Tone {
+        case ink
+        case ready
+        case amber
+        case error
+        case neutral
+    }
+
+    let text: String
+    let tone: Tone
+
+    var body: some View {
+        Text(text)
+            .scaledSystemFont(9, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+            .tracking(OnboardingD.Tracking.badge)
+            .foregroundStyle(foreground)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(RoundedRectangle(cornerRadius: 4, style: .continuous).fill(background))
+            .fixedSize()
+    }
+
+    private var foreground: Color {
+        switch tone {
+        case .ink: return RapidTheme.surfaceCanvas
+        case .ready: return RapidTheme.statusReady
+        case .amber: return RapidTheme.brandPrimaryDeep
+        case .error: return RapidTheme.statusError
+        case .neutral: return RapidTheme.textSecondary
+        }
+    }
+
+    private var background: Color {
+        switch tone {
+        case .ink: return RapidTheme.textPrimary
+        case .ready: return RapidTheme.statusReadyTint
+        case .amber: return RapidTheme.brandPrimaryTint
+        case .error: return RapidTheme.statusErrorTint
+        case .neutral: return RapidTheme.surfaceCode
+        }
+    }
+}
+
+/// The qualitative pill under the starter card ("Instant", "Runs on any Mac").
+struct OnboardingAttributePill: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .scaledSystemFont(11, relativeTo: .caption, weight: .medium)
+            .foregroundStyle(RapidTheme.textSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(RapidTheme.surfaceCode))
+    }
+}
+
+// MARK: - Selection glyph
+
+/// The 18pt selection dot. Filled amber when picked, a hairline ring when not,
+/// and a dimmer ring when the row cannot be chosen at all.
+struct OnboardingSelectionGlyph: View {
+    let isSelected: Bool
+    var isEnabled: Bool = true
+
+    var body: some View {
+        Group {
+            if isSelected {
+                Circle()
+                    .fill(RapidTheme.brandPrimary)
+                    .overlay {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(RapidTheme.brandOnAccent)
+                    }
+            } else {
+                Circle()
+                    .strokeBorder(
+                        isEnabled ? RapidTheme.hairlineStrong : RapidTheme.hairline,
+                        lineWidth: 1
+                    )
+            }
+        }
+        .frame(width: OnboardingD.selectionGlyph, height: OnboardingD.selectionGlyph)
+        .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Buttons
+
+/// The one strong amber moment on a screen.
+struct OnboardingPrimaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaledSystemFont(15, weight: .semibold)
+            .foregroundStyle(RapidTheme.brandOnAccent)
+            .padding(.horizontal, 30)
+            .frame(height: OnboardingD.actionHeight)
+            .background(
+                RoundedRectangle(cornerRadius: OnboardingD.actionRadius, style: .continuous)
+                    .fill(RapidTheme.brandPrimary)
+            )
+            .opacity(isEnabled ? (configuration.isPressed ? 0.86 : 1) : 0.4)
+            .contentShape(RoundedRectangle(cornerRadius: OnboardingD.actionRadius, style: .continuous))
+    }
+}
+
+/// A bordered secondary — used where the alternative is a real, weighty action
+/// (Quit) rather than a quiet way back.
+struct OnboardingOutlineButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaledSystemFont(14, weight: .medium)
+            .foregroundStyle(RapidTheme.textPrimary)
+            .padding(.horizontal, 20)
+            .frame(height: OnboardingD.actionHeight)
+            .background(
+                RoundedRectangle(cornerRadius: OnboardingD.actionRadius, style: .continuous)
+                    .fill(RapidTheme.surfaceRaised)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: OnboardingD.actionRadius, style: .continuous)
+                    .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
+            )
+            .opacity(isEnabled ? (configuration.isPressed ? 0.86 : 1) : 0.4)
+            .contentShape(RoundedRectangle(cornerRadius: OnboardingD.actionRadius, style: .continuous))
+    }
+}
+
+/// A quiet text action in the footer lane — Back, Skip, Cancel.
+struct OnboardingQuietButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+    var tone: Color = RapidTheme.textSecondary
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaledSystemFont(13, weight: .medium)
+            .foregroundStyle(tone)
+            .frame(height: OnboardingD.actionHeight)
+            .opacity(isEnabled ? (configuration.isPressed ? 0.6 : 1) : 0.4)
+            .contentShape(Rectangle())
+    }
+}
+
+extension ButtonStyle where Self == OnboardingPrimaryButtonStyle {
+    static var onboardingPrimary: OnboardingPrimaryButtonStyle { .init() }
+}
+
+extension ButtonStyle where Self == OnboardingOutlineButtonStyle {
+    static var onboardingOutline: OnboardingOutlineButtonStyle { .init() }
+}
+
+extension ButtonStyle where Self == OnboardingQuietButtonStyle {
+    /// Neutral quiet action.
+    static var onboardingQuiet: OnboardingQuietButtonStyle { .init() }
+    /// Quiet action that navigates somewhere — steel, the link colour.
+    static var onboardingLink: OnboardingQuietButtonStyle {
+        .init(tone: RapidTheme.brandSecondary)
+    }
+}
+
+// MARK: - Fact table
+
+/// One `label · value` line in a Review-style fact table.
+struct OnboardingFactRow: Identifiable {
+    let id = UUID()
+    let label: String
+    let value: String
+    /// Soft values (a path, "Not downloaded yet") sit back a step so the
+    /// numbers that drive the decision stay the strongest thing in the column.
+    var isStrong: Bool = true
+    var identifier: String?
+
+    init(_ label: String, _ value: String, isStrong: Bool = true, identifier: String? = nil) {
+        self.label = label
+        self.value = value
+        self.isStrong = isStrong
+        self.identifier = identifier
+    }
+}
+
+/// Hairline-separated facts. No card, no fill: Paper puts information directly
+/// on the surface and reserves boxes for choices.
+struct OnboardingFactTable: View {
+    let rows: [OnboardingFactRow]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                if index > 0 {
+                    Rectangle().fill(RapidTheme.hairline).frame(height: 1)
+                }
+                HStack(alignment: .firstTextBaseline, spacing: 12) {
+                    Text(row.label)
+                        .scaledSystemFont(13)
+                        .foregroundStyle(RapidTheme.textSecondary)
+                    Spacer(minLength: 12)
+                    Text(row.value)
+                        .scaledSystemFont(13, design: .monospaced)
+                        .foregroundStyle(row.isStrong ? RapidTheme.textPrimary : RapidTheme.textSecondary)
+                        .multilineTextAlignment(.trailing)
+                        .textSelection(.enabled)
+                }
+                .padding(.top, index == 0 ? 0 : 11)
+                .padding(.bottom, index == rows.count - 1 ? 0 : 11)
+                .accessibilityElement(children: .combine)
+                .accessibilityIdentifier(row.identifier ?? "")
+                .accessibilityLabel("\(row.label): \(row.value)")
+            }
+        }
+    }
+}
+
+// MARK: - Recovery / completion composition
+
+/// The shared template behind every state that reports an outcome: the
+/// recoverable failures, the disk warning, the memory guard, missing engine
+/// and Ready (Paper 05.1 states 10–13, 16, 19, 20).
+///
+/// One shape, four slots. What changes between them is the tone of the glyph,
+/// the words, and which actions are offered — never the composition, so a user
+/// who has seen one recognises the next.
+struct OnboardingOutcomeBlock<Actions: View, Detail: View>: View {
+    let glyph: String
+    let tone: OnboardingGlyphTile.Tone
+    let kicker: String
+    let title: String
+    let message: String
+    @ViewBuilder var detail: () -> Detail
+    @ViewBuilder var actions: () -> Actions
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            OnboardingGlyphTile(systemName: glyph, tone: tone)
+                .padding(.bottom, 26)
+
+            OnboardingKicker(text: kicker)
+                .padding(.bottom, 16)
+
+            OnboardingDisplayTitle(text: title)
+
+            Text(message)
+                .scaledSystemFont(16, relativeTo: .title3)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 16)
+
+            detail()
+
+            actions()
+                .padding(.top, 34)
+        }
+        .frame(maxWidth: OnboardingD.decisionWidth, alignment: .leading)
+    }
+}
+
+extension OnboardingOutcomeBlock where Detail == EmptyView {
+    init(
+        glyph: String,
+        tone: OnboardingGlyphTile.Tone,
+        kicker: String,
+        title: String,
+        message: String,
+        @ViewBuilder actions: @escaping () -> Actions
+    ) {
+        self.init(
+            glyph: glyph,
+            tone: tone,
+            kicker: kicker,
+            title: title,
+            message: message,
+            detail: { EmptyView() },
+            actions: actions
+        )
+    }
+}
+
+/// The horizontal action lane under an outcome: one amber primary, then quiet
+/// alternatives. 22pt apart so the secondary reads as a different weight of
+/// choice rather than a second button.
+struct OnboardingActionLane<Content: View>: View {
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        HStack(spacing: 22) {
+            content()
+        }
+    }
+}
+
+/// The one footer lane a Step 2 micro-stage may hold: at most one Back on the
+/// left, exactly one primary on the right.
+///
+/// Replaces `OnboardingWizardFooter`. The keyboard contract is carried over
+/// verbatim, because it is behaviour and PR #1931 pinned it: Return is the
+/// primary's `.defaultAction`, so a disabled primary swallows it and no input
+/// can reach an action the user cannot see; Escape is Back's `.cancelAction`,
+/// so it resolves to the visible control at each depth.
+struct OnboardingStepFooter: View {
+    let primaryTitle: String
+    var primaryEnabled: Bool = true
+    /// Back's label, named for its destination ("← Back to all models") so the
+    /// control says where it goes rather than only that it goes back.
+    var backTitle: String = "Back"
+    /// Spoken form of ``backTitle``, without the arrow glyph.
+    var backAccessibilityLabel: String?
+    var onBack: (() -> Void)?
+    let onPrimary: () -> Void
+
+    var body: some View {
+        HStack(spacing: 22) {
+            if let onBack {
+                Button(action: onBack) {
+                    Text(backTitle)
+                }
+                .buttonStyle(.onboardingLink)
+                .keyboardShortcut(.cancelAction)
+                .accessibilityIdentifier("Quickstart.Footer.Back")
+                .accessibilityLabel(backAccessibilityLabel ?? backTitle)
+            }
+            Spacer(minLength: 12)
+            Button(action: onPrimary) {
+                Text(primaryTitle)
+            }
+            .buttonStyle(.onboardingPrimary)
+            .disabled(!primaryEnabled)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("Quickstart.Footer.Primary")
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+/// A statistic pair under a warning — "FREE NOW 1.4 GB".
+struct OnboardingStat: View {
+    let label: String
+    let value: String
+    var tone: Color = RapidTheme.textPrimary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(label)
+                .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+                .tracking(OnboardingD.Tracking.groupLabel)
+                .foregroundStyle(RapidTheme.textTertiary)
+            Text(value)
+                .scaledSystemFont(22, relativeTo: .title2, design: .monospaced)
+                .foregroundStyle(tone)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1424,13 +1424,149 @@ struct QuickstartView: View {
             }
     }
 
-    /// Top-level router. While ``phase`` is ``.idle`` the wizard shows
-    /// the ``stage``-driven welcome / choose-model steps (full pane);
-    /// once a download is in flight the download-lifecycle cards take
-    /// the frame (centered). The lifecycle machine itself is unchanged —
-    /// only its idle branch now fans out to two wizard screens.
-    @ViewBuilder
+    /// The Direction D two-plane shell (Paper 05.1.A).
+    ///
+    /// Every state is a rail beside a canvas. The rail says where you are and
+    /// what this Mac is; the canvas says what is being decided and what the
+    /// action will do. Which rail depends on whether the user can act: D1 —
+    /// the mineral setup rail — asks, and D2 — the graphite subject rail —
+    /// waits. Nothing here decides *what* the state is; that is still
+    /// ``coordinator.phase`` and ``coordinator.stage``, unchanged.
     private var content: some View {
+        GeometryReader { proxy in
+            let layout = OnboardingLayout.resolve(width: proxy.size.width)
+            Group {
+                if layout.isCompact {
+                    // Paper 05.1.E. The rail rotates rather than shrinking:
+                    // a 300pt column beside a 720pt window leaves the canvas
+                    // around 400pt, which the model cards cannot use.
+                    VStack(spacing: 0) {
+                        compactRailPlane
+                        canvasPlane
+                    }
+                } else {
+                    HStack(spacing: 0) {
+                        railPlane
+                        canvasPlane
+                    }
+                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
+            .environment(\.onboardingLayout, layout)
+        }
+        // The surface fills whatever the window gives it. There is no maximum:
+        // setup IS the window now, not a panel inside one.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// The rotated rail, D2 band included.
+    @ViewBuilder
+    private var compactRailPlane: some View {
+        if let lifecycle = subjectLifecycle {
+            let job = downloads.job(for: coordinator.selection.alias)
+            OnboardingCompactSubjectBand(
+                lifecycle: lifecycle,
+                identity: coordinator.selection.alias,
+                fraction: coordinator.phase == .downloading ? job?.progress.progressFraction : nil,
+                bytesLine: Self.subjectBytesLine(job: job)
+            )
+        } else {
+            OnboardingCompactRail(step: coordinator.step)
+        }
+    }
+
+    /// D2 for the blocking lifecycle states, D1 for everything else.
+    ///
+    /// A memory warning parked on top of ``Phase/starting`` is a DECISION, not
+    /// a wait, so it keeps the D1 rail — the user has something to answer and
+    /// the rail must keep showing them the step and the machine facts that
+    /// answer it with.
+    @ViewBuilder
+    private var railPlane: some View {
+        if let lifecycle = subjectLifecycle {
+            let job = downloads.job(for: coordinator.selection.alias)
+            OnboardingSubjectRail(
+                lifecycle: lifecycle,
+                identity: coordinator.selection.alias,
+                fraction: coordinator.phase == .downloading ? job?.progress.progressFraction : nil,
+                bytesLine: Self.subjectBytesLine(job: job),
+                rateLine: Self.subjectRateLine(job: job),
+                stepLabel: "STEP \(coordinator.step.displayNumber) OF \(QuickstartCoordinator.Step.total)",
+                stepName: coordinator.step.railTitle.localizedUppercase
+            )
+        } else {
+            OnboardingSetupRail(
+                step: coordinator.step,
+                hardware: hardware,
+                // Free space joins the rail from Step 2 onward, where it
+                // starts bearing on the decision (Paper 05.1 frames 03/04).
+                freeSpace: coordinator.step == .welcome
+                    ? nil
+                    : freeBytesProbe().map { Self.wholeGB(Double($0) / Double(1 << 30)) }
+            )
+        }
+    }
+
+    /// The lifecycle name for the D2 rail, or `nil` when this state is a D1
+    /// decision. Derived from the real download phase so "PREPARING" is only
+    /// claimed while the pull genuinely has nothing to report yet.
+    private var subjectLifecycle: String? {
+        switch coordinator.phase {
+        case .downloading:
+            let job = downloads.job(for: coordinator.selection.alias)
+            return Self.downloadLifecycleName(phase: job?.progress.phase)
+        case .starting:
+            guard QuickstartView.memoryWarningToPresent(
+                phase: coordinator.phase,
+                pending: server.pendingMemoryWarning,
+                selectionAlias: coordinator.selection.alias
+            ) == nil else { return nil }
+            return "STARTING"
+        case .idle, .lowDiskWarning, .ready, .dismissed, .failed:
+            return nil
+        }
+    }
+
+    /// Which of Paper's two download lifecycles a job is in.
+    ///
+    /// Pure so "a pull with nothing observed yet must not be called
+    /// DOWNLOADING" can be pinned. Paper draws these as separate states (09
+    /// and 14) and the difference is real: one has bytes to report, the other
+    /// has a request that landed and no transfer yet.
+    static func downloadLifecycleName(phase: DownloadProgress.Phase?) -> String {
+        switch phase {
+        case .downloading, .fetching:
+            return "DOWNLOADING"
+        case .idle, .preparing, .warmingUp, nil:
+            return "PREPARING"
+        }
+    }
+
+    /// "271 MB / 633 MB" — only once the byte monitor has observed real disk
+    /// growth against a known total. Never a synthesised denominator.
+    static func subjectBytesLine(job: DownloadManager.Job?) -> String? {
+        guard let progress = job?.progress,
+              progress.hasDiskObservation,
+              let bytes = progress.bytesDownloaded,
+              let total = progress.totalBytes, total > 0
+        else { return nil }
+        return "\(DownloadProgress.formatBytes(bytes)) / \(DownloadProgress.formatBytes(total))"
+    }
+
+    /// "4.4 MB/s · 2 min left" — rate first, and the ETA appended only when
+    /// ``DownloadProgress`` has measured one. Paper 05.1.A forbids an ETA
+    /// before bytes move, so there is deliberately no pre-download branch.
+    static func subjectRateLine(job: DownloadManager.Job?) -> String? {
+        guard let progress = job?.progress, let speed = progress.bytesPerSecond, speed > 0
+        else { return nil }
+        var parts = [DownloadProgress.formatSpeed(bytesPerSecond: speed)]
+        if let eta = progress.etaText { parts.append(eta) }
+        return parts.joined(separator: " · ")
+    }
+
+    /// The right-hand plane: one composition per state.
+    @ViewBuilder
+    private var canvasPlane: some View {
         switch coordinator.phase {
         case .idle:
             switch coordinator.stage {
@@ -1438,15 +1574,15 @@ struct QuickstartView: View {
             case .chooseModel: chooseModelStep
             }
         case .lowDiskWarning(let freeBytes, let requiredBytes):
-            centeredCard(progressStep: nil) {
+            OnboardingCenteredCanvas {
                 lowDiskCard(freeBytes: freeBytes, requiredBytes: requiredBytes)
             }
         case .downloading:
-            centeredCard(progressStep: .download) { downloadingCard }
+            OnboardingCenteredCanvas(trailing: 72) { downloadingCard }
         case .ready:
             // Onboarding V3: readiness is a destination, not a hand-off.
             // The surface stays here until the user confirms.
-            centeredCard(progressStep: .start) { readyCard }
+            OnboardingCenteredCanvas { readyCard }
         case .dismissed:
             // Terminal — the parent's visibility predicate has already
             // dropped this surface. A one-frame race can still render here,
@@ -1470,58 +1606,16 @@ struct QuickstartView: View {
                 pending: server.pendingMemoryWarning,
                 selectionAlias: coordinator.selection.alias
             ) {
-                centeredCard(progressStep: nil) { memoryWarningCard(warning) }
+                OnboardingCenteredCanvas { memoryWarningCard(warning) }
             } else {
                 // .ready is transitional — the parent swaps to ChatView, but
                 // a one-frame race can land here; the starting copy is a calm
                 // fallback so the user never sees a blank pane.
-                centeredCard(progressStep: .start) { startingCard }
+                OnboardingCenteredCanvas(trailing: 72) { startingCard }
             }
         case .failed(let message, _):
-            centeredCard(progressStep: nil) { failedCard(message: message) }
+            OnboardingCenteredCanvas { failedCard(message: message) }
         }
-    }
-
-    /// The centered card chrome shared by the download-lifecycle states.
-    /// ``progressStep`` shows the top progress bar on the happy path
-    /// (download / starting / ready); ``nil`` omits it for the low-disk /
-    /// failed interstitials, where a "progress" bar would misread.
-    ///
-    /// The card caps at 460pt but SHRINKS on a narrow detail pane rather
-    /// than overflowing — ``QuickstartView`` lives in the split view's
-    /// detail column, so at the 640pt window floor with the sidebar
-    /// visible the pane is only ~360pt (memory #459/#464: NavigationSplit
-    /// detail clips instead of scrolling on macOS 14/15). ``maxWidth`` +
-    /// the outer horizontal inset keeps the chrome inside the column.
-    @ViewBuilder
-    private func centeredCard<Content: View>(
-        progressStep: QuickstartCoordinator.Step?,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(spacing: 0) {
-            if let progressStep {
-                OnboardingTopBar(step: progressStep)
-                    .padding(.top, 22)
-            }
-            Spacer()
-            VStack(spacing: 20) { content() }
-                .padding(28)
-                .frame(maxWidth: 460)
-                .background(
-                    RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                        .fill(RapidTheme.card)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
-                        .stroke(RapidTheme.hairline, lineWidth: 1)
-                )
-                .shadow(color: Color.black.opacity(0.06), radius: 18, x: 0, y: 8)
-                .accessibilityElement(children: .contain)
-                .accessibilityLabel("Quickstart")
-            Spacer()
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 24)
     }
 
     /// Stable key for ``.task(id:)`` so SwiftUI re-fires the handler on
@@ -1545,99 +1639,87 @@ struct QuickstartView: View {
     /// Step 1 — the centered brand hero. "Get started" advances to the
     /// model chooser (it no longer kicks off a download directly; the
     /// download starts from the chooser once a model is picked).
+    /// Step 1 — the privacy claim, at display scale (Paper 05.1 state 01).
+    ///
+    /// The headline is the product's one substantive promise rather than a
+    /// marketing line, and the mascot carries the brand so the type does not
+    /// have to. Left-aligned against the canvas's deep leading margin: the
+    /// asymmetry is the composition, and a centred hero would read as a
+    /// landing page rather than a setup screen.
     @ViewBuilder
     private var welcomeStep: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            OnboardingBrandMark(size: 78).padding(.bottom, 22)
+        OnboardingCenteredCanvas {
+            VStack(alignment: .leading, spacing: 0) {
+                CheetahLogo(size: 156)
+                    .padding(.bottom, 30)
 
-            Text("WELCOME TO RAPID-MLX")
-                .scaledSystemFont(11, weight: .semibold)
-                .tracking(2.2)
-                .foregroundStyle(.secondary)
-                .padding(.bottom, 14)
+                OnboardingDisplayTitle(text: "Nothing you type\nleaves this Mac.", size: 52)
 
-            (Text("Fast, free AI\n")
-             + Text("that runs on your Mac.").italic().foregroundColor(RapidTheme.brand))
-                .scaledSystemFont(38, relativeTo: .largeTitle, weight: .bold)
-                .multilineTextAlignment(.center)
-                .lineSpacing(3)
+                VStack(alignment: .leading, spacing: 9) {
+                    Text("Models run locally on Apple Silicon. You download one model "
+                         + "once — after that it works with no network at all.")
+                    Text("No account, no subscription.")
+                }
+                .scaledSystemFont(17, relativeTo: .title3)
+                .foregroundStyle(RapidTheme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
-                .padding(.bottom, 16)
+                .frame(maxWidth: OnboardingD.proseWidth, alignment: .leading)
+                .padding(.top, 26)
 
-            VStack(spacing: 5) {
-                Text("Local models on Apple Silicon — no account, no subscription.")
-                Text("Download one model and start chatting in minutes.")
+                // Setup was entered on an earlier launch and never finished.
+                // Say so, and say what is and is not carried over — nothing
+                // is, and a screen that stayed silent about it while offering
+                // to "continue" would let the user assume a download picked up
+                // where it left off. Paper 05.1 state 18: "The copy promises a
+                // fresh download, never a resume."
+                if coordinator.isResumingIncompleteSetup {
+                    Text("Setup didn't finish last time. Nothing was carried over — "
+                         + "choose a model and it downloads from here.")
+                        .scaledSystemFont(13)
+                        .foregroundStyle(RapidTheme.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: OnboardingD.proseWidth, alignment: .leading)
+                        .padding(.top, 18)
+                        .accessibilityIdentifier("Quickstart.ResumeNotice")
+                }
+
+                OnboardingActionLane {
+                    Button {
+                        coordinator.advanceToChooseModel()
+                    } label: {
+                        Text(Self.welcomePrimaryTitle(resuming: coordinator.isResumingIncompleteSetup))
+                    }
+                    .buttonStyle(.onboardingPrimary)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("Quickstart.GetStarted")
+                    .accessibilityLabel(
+                        coordinator.isResumingIncompleteSetup
+                            ? "Continue setup — choose your first model"
+                            : "Get started — choose your first model"
+                    )
+
+                    // #549 (§16 wayfinding): the hero must answer "how do I
+                    // get out?" — before this the only exit was the "Browse
+                    // all models" link on step 2, trapping a first-run user
+                    // sitting on step 1. A low-emphasis Skip drops straight
+                    // into the app, and `.cancelAction` makes Esc leave
+                    // onboarding.
+                    //
+                    // This is the app's one genuine "dismiss onboarding"
+                    // control. "Browse all models" on step 2 shared it until
+                    // #1653; it does not any more, because a user asking to
+                    // see the catalogue has not asked to leave setup.
+                    Button("Skip for now") {
+                        onSkip()
+                    }
+                    .buttonStyle(.onboardingQuiet)
+                    .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("Quickstart.Skip")
+                    .accessibilityLabel("Skip onboarding and go to the app")
+                }
+                .padding(.top, 44)
             }
-            .scaledSystemFont(14)
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-
-            // Setup was entered on an earlier launch and never finished. Say
-            // so, and say what is and is not carried over — nothing is, and a
-            // screen that stayed silent about it while offering to "continue"
-            // would let the user assume a download picked up where it left
-            // off. Paper 05.1 state 18: "The copy promises a fresh download,
-            // never a resume."
-            if coordinator.isResumingIncompleteSetup {
-                Text("Setup didn't finish last time. Nothing was carried over — "
-                     + "choose a model and it downloads from here.")
-                    .scaledSystemFont(12)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.top, 12)
-                    .accessibilityIdentifier("Quickstart.ResumeNotice")
-            }
-
-            Spacer()
-
-            Button {
-                coordinator.advanceToChooseModel()
-            } label: {
-                Text(Self.welcomePrimaryTitle(resuming: coordinator.isResumingIncompleteSetup))
-                    .scaledSystemFont(15, weight: .semibold)
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 34).padding(.vertical, 12)
-                    .background(Capsule().fill(RapidTheme.amber))
-            }
-            .buttonStyle(.plain)
-            .keyboardShortcut(.defaultAction)
-            .accessibilityIdentifier("Quickstart.GetStarted")
-            .accessibilityLabel(
-                coordinator.isResumingIncompleteSetup
-                    ? "Continue setup — choose your first model"
-                    : "Get started — choose your first model"
-            )
-            .padding(.bottom, 10)
-
-            // #549 (§16 wayfinding): the hero must answer "how do I get
-            // out?" — before this the only exit was the "Browse all
-            // models" link on step 2, trapping a first-run user sitting
-            // on step 1. A low-emphasis Skip drops straight into the app,
-            // and `.cancelAction` makes Esc leave onboarding — mirroring
-            // the Skip control OnboardingTour already ships.
-            //
-            // This is the app's one genuine "dismiss onboarding" control.
-            // "Browse all models" on step 2 shared it until #1653; it does
-            // not any more, because a user asking to see the catalogue has
-            // not asked to leave setup.
-            Button("Skip for now") {
-                onSkip()
-            }
-            .buttonStyle(.plain)
-            .scaledSystemFont(12, weight: .medium)
-            .foregroundStyle(.secondary)
-            .keyboardShortcut(.cancelAction)
-            .accessibilityIdentifier("Quickstart.Skip")
-            .accessibilityLabel("Skip onboarding and go to the app")
-            .padding(.bottom, 18)
-
-            OnboardingStepProgress(current: QuickstartCoordinator.Step.welcome.rawValue)
-                .padding(.bottom, 34)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, 44)
     }
 
     /// The welcome primary's verb.
@@ -1657,26 +1739,18 @@ struct QuickstartView: View {
 
     /// Step 2's router over its five micro-stages (Paper 05.2.B).
     ///
-    /// Every branch renders ``OnboardingTopBar(step: .chooseModel)`` through
-    /// the one shared scaffold, so the rail cannot drift off `Step 2 of 4` by
-    /// a screen forgetting which step it belongs to — the mistake the old
-    /// three-step model made twice.
+    /// Every branch renders through the one shared ``step2Scaffold``, so the
+    /// rail cannot drift off `Step 2 of 4` by a screen forgetting which step it
+    /// belongs to — the mistake the old three-step model made twice. The rail
+    /// itself is drawn once, by ``railPlane``, from ``coordinator.step``.
     @ViewBuilder
     private var chooseModelStep: some View {
         Group {
             switch coordinator.step2Stage {
             case .checkingHardware:
-                recommendationLoadingStep(
-                    kicker: "CHECKING THIS MAC",
-                    title: "Reading this Mac…",
-                    identifier: "Quickstart.Step2.CheckingHardware"
-                )
+                checkingHardwareStep
             case .findingFit:
-                recommendationLoadingStep(
-                    kicker: "FINDING THE BEST FIT",
-                    title: "Matching models to this Mac…",
-                    identifier: "Quickstart.Step2.FindingFit"
-                )
+                findingFitStep
             case .choosing:
                 recommendedShortlistStep
             case .browsing:
@@ -1692,54 +1766,48 @@ struct QuickstartView: View {
         }
     }
 
-    /// The chrome every Step 2 micro-stage shares.
+    /// The canvas + footer lane every Step 2 micro-stage shares.
     ///
-    /// One rail (macro progress, always Step 2 of 4), one kicker (micro
-    /// progress, names the branch), one title, the content, and exactly one
-    /// footer lane holding at most one Back and one primary. No breadcrumb: a
-    /// trail would imply a depth this flow does not have.
+    /// One canvas, and exactly one footer lane holding at most one Back and one
+    /// primary. No breadcrumb: a trail would imply a depth this flow does not
+    /// have. The kicker and title live in the body, because Direction D places
+    /// them differently for the column layouts (beside the content) and for the
+    /// catalogue (above it).
     @ViewBuilder
-    private func step2Scaffold<Content: View, Footer: View>(
+    private func step2Scaffold<Body: View, Footer: View>(
+        trailing: CGFloat = OnboardingD.canvasTrailing,
+        @ViewBuilder body: @escaping () -> Body,
+        @ViewBuilder footer: @escaping () -> Footer
+    ) -> some View {
+        OnboardingCanvas(trailing: trailing) {
+            // One geometry for every state: the principal group fills the
+            // canvas and centres in it, the action lane is anchored beneath.
+            OnboardingCanvasLayout(principal: body) {
+                footer().padding(.top, 28)
+            }
+        }
+    }
+
+    /// Paper's Step 2 body: a fixed heading column beside the live list.
+    ///
+    /// The asymmetry is load-bearing. The heading column is where the branch
+    /// names itself and — on Review download — where the cost is stated, while
+    /// the list stays in exactly the same place across all three micro-stages
+    /// so switching between them never moves the rows under the pointer.
+    private func step2Columns<Aside: View, Content: View>(
         kicker: String,
         title: String,
         subtitle: String?,
-        @ViewBuilder content: () -> Content,
-        @ViewBuilder footer: () -> Footer
+        @ViewBuilder aside: @escaping () -> Aside,
+        @ViewBuilder content: @escaping () -> Content
     ) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            OnboardingTopBar(step: .chooseModel).padding(.top, 22)
-
-            // Micro progress. The step number is repeated deliberately: this
-            // is the only element that names the branch, and it must not be
-            // mistaken for a step of its own. Never sub-numbered.
-            Text(Self.microStageKicker(kicker))
-                .scaledSystemFont(10, weight: .semibold).tracking(1)
-                .foregroundStyle(.tertiary)
-                .padding(.top, 18)
-                .accessibilityIdentifier("Quickstart.Step2.Kicker")
-
-            Text(title)
-                .scaledSystemFont(24, relativeTo: .title, weight: .bold)
-                .padding(.top, 6)
-            if let subtitle {
-                Text(subtitle)
-                    .scaledSystemFont(13).foregroundStyle(.secondary)
-                    .padding(.top, 4)
-            }
-
-            content()
-                .padding(.top, 16)
-
-            footer()
-                .padding(.top, 12)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // Tighter than the welcome hero's 44pt inset: Step 2 holds rigid-column
-        // cards, and it lives in the split-view detail pane (~360pt at the
-        // 640pt window floor with the sidebar shown). 24pt keeps model names
-        // readable instead of squeezed to a sliver (memory #459/#464).
-        .padding(.horizontal, 24)
-        .padding(.bottom, 26)
+        OnboardingStepColumns(
+            kicker: Self.microStageKicker(kicker),
+            title: title,
+            subtitle: subtitle,
+            aside: aside,
+            content: content
+        )
     }
 
     /// `STEP 2 OF 4 · <MICRO-STAGE>`. Pure so a test can pin the format —
@@ -1752,31 +1820,118 @@ struct QuickstartView: View {
 
     // MARK: - 2a / 2b — hardware detection and recommendation loading
 
-    /// The pre-shortlist wait. Indeterminate on purpose: neither catalogue
-    /// subprocess reports progress, so a determinate bar would be a number we
-    /// made up. The footer is present but disabled — the user can still go
-    /// Back, and there is nothing yet to progress to.
+    /// 2a — reading this Mac (Paper 05.1 state 02).
+    ///
+    /// The chip and the unified memory are synchronous sysctl reads and are
+    /// therefore already known when this draws; the free-space probe is the
+    /// one value that genuinely arrives later, so it is the only one shown as
+    /// a placeholder. Nothing here is a scanning animation with an invented
+    /// duration — Paper forbids that explicitly, and the honest rendering of a
+    /// read that has already happened is the answer.
     @ViewBuilder
-    private func recommendationLoadingStep(
+    private var checkingHardwareStep: some View {
+        transientStep(
+            kicker: "CHECKING THIS MAC",
+            title: "Reading this Mac…",
+            subtitle: "Rapid-MLX checks the chip, the unified memory and the free "
+                + "space on the volume that holds your Hugging Face cache. "
+                + "Nothing is uploaded — the read is local.",
+            identifier: "Quickstart.Step2.CheckingHardware"
+        ) {
+            VStack(spacing: 0) {
+                transientFact("Chip") {
+                    Text(hardware.brandString)
+                        .scaledSystemFont(13, design: .monospaced)
+                        .foregroundStyle(RapidTheme.textPrimary)
+                }
+                transientFact("Unified memory") {
+                    Text(Self.wholeGB(hardware.physicalRAMGB))
+                        .scaledSystemFont(13, design: .monospaced)
+                        .foregroundStyle(RapidTheme.textPrimary)
+                }
+                transientFact("Free on cache volume") {
+                    if let free = freeBytesProbe() {
+                        Text(Self.formatBytesForBanner(free))
+                            .scaledSystemFont(13, design: .monospaced)
+                            .foregroundStyle(RapidTheme.textPrimary)
+                    } else {
+                        OnboardingSkeleton(width: 84)
+                    }
+                }
+            }
+            .frame(maxWidth: 460, alignment: .leading)
+        }
+    }
+
+    /// 2b — matching models to this Mac (Paper 05.1 state 03).
+    ///
+    /// The genuinely asynchronous one: the shortlist cannot say which models
+    /// are already on disk until ``ModelCatalog/load`` answers. Only the
+    /// "already on this Mac" group is unknown, so only it is drawn as
+    /// placeholder rows — the ladder below it is a fixed list and is never
+    /// pretended to be computed.
+    @ViewBuilder
+    private var findingFitStep: some View {
+        transientStep(
+            kicker: "FINDING THE BEST FIT",
+            title: "Matching models to \(Self.wholeGB(hardware.physicalRAMGB))…",
+            subtitle: "Rapid-MLX is reading the model catalogue to see which models "
+                + "are already on this Mac and how much each one would download. "
+                + "The short list below is fixed; only the “already downloaded” "
+                + "part depends on this read.",
+            identifier: "Quickstart.Step2.FindingFit"
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                OnboardingGroupLabel(text: "ALREADY ON THIS MAC")
+                ForEach(0..<2, id: \.self) { _ in
+                    HStack(spacing: 14) {
+                        OnboardingSkeleton(width: 32, height: 32)
+                        VStack(alignment: .leading, spacing: 6) {
+                            OnboardingSkeleton(width: 168, height: 10)
+                            OnboardingSkeleton(width: 116, height: 9)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, 18)
+                    .frame(height: OnboardingD.rowHeight)
+                    .background(
+                        RoundedRectangle(cornerRadius: OnboardingD.cardRadius, style: .continuous)
+                            .fill(RapidTheme.surfaceRaised)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: OnboardingD.cardRadius, style: .continuous)
+                            .strokeBorder(RapidTheme.hairline, lineWidth: 1)
+                    )
+                }
+            }
+        }
+    }
+
+    /// The chrome the two pre-shortlist micro-stages share. The footer is
+    /// present but disabled — the user can still go Back, and there is nothing
+    /// yet to progress to.
+    @ViewBuilder
+    private func transientStep<Content: View>(
         kicker: String,
         title: String,
-        identifier: String
+        subtitle: String,
+        identifier: String,
+        @ViewBuilder content: @escaping () -> Content
     ) -> some View {
-        step2Scaffold(
-            kicker: kicker,
-            title: title,
-            subtitle: "Nothing is downloaded yet."
-        ) {
-            HStack(spacing: 9) {
-                ProgressView().controlSize(.small)
-                Text("Reading the model catalogue…")
-                    .scaledSystemFont(12)
-                    .foregroundStyle(.secondary)
+        step2Scaffold {
+            step2Columns(
+                kicker: kicker,
+                title: title,
+                subtitle: subtitle
+            ) {
+                EmptyView()
+            } content: {
+                content()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityIdentifier(identifier)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .accessibilityIdentifier(identifier)
         } footer: {
-            OnboardingWizardFooter(
+            OnboardingStepFooter(
                 primaryTitle: OnboardingModelSelection.disabledPrimary.title,
                 primaryEnabled: false,
                 onBack: { coordinator.backToWelcome() },
@@ -1785,7 +1940,141 @@ struct QuickstartView: View {
         }
     }
 
+    @ViewBuilder
+    private func transientFact<Value: View>(
+        _ label: String,
+        @ViewBuilder value: () -> Value
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(label)
+                .scaledSystemFont(13)
+                .foregroundStyle(RapidTheme.textSecondary)
+            Spacer(minLength: 12)
+            value()
+        }
+        .padding(.vertical, 11)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(RapidTheme.hairline).frame(height: 1)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
     // MARK: - 2c — the recommended shortlist
+
+    /// What the Step 2 heading column says about the current selection.
+    ///
+    /// Paper draws the chooser three ways, and which one shows is a pure
+    /// function of the pick (05.1 states 04, 05, 06). The list on the right is
+    /// identical in all three — only the narrative beside it changes, because
+    /// what the user needs explained differs completely between "here is the
+    /// recommendation", "you have chosen something bigger, here is the cost"
+    /// and "this one is already downloaded".
+    enum SelectionNarrative: Equatable {
+        /// State 04 — the default. The starter, the low-memory fallback, or
+        /// anything the other two cases do not claim.
+        case chooseFirst
+        /// State 05 — a bigger model is picked, so the cost is compared.
+        case biggerAndCost
+        /// State 06 — the pick is already in the shared cache.
+        case alreadyHere
+
+        var title: String {
+            switch self {
+            case .chooseFirst:   return "Choose your\nfirst model"
+            case .biggerAndCost: return "Bigger, and\nwhat it costs"
+            case .alreadyHere:   return "One is already\nhere."
+            }
+        }
+    }
+
+    /// Resolve the narrative from the selection alone.
+    ///
+    /// Pure, and ordered: cached-ness wins over size, because "you already
+    /// have this" is the more useful thing to say about a 9B that happens to
+    /// be on disk than "here is what it costs to download". A trade-up only
+    /// takes the comparison branch when there is something to compare it
+    /// WITH — a lone trade-up would produce a one-column table, which is a
+    /// statement dressed as a comparison.
+    static func selectionNarrative(
+        alias: String,
+        cachedModels: [ModelEntry],
+        comparableTradeUps: [QuickstartModelChoice]
+    ) -> SelectionNarrative {
+        if canStartWithoutDownload(alias: alias, cachedModels: cachedModels) {
+            return .alreadyHere
+        }
+        let isTradeUp = comparableTradeUps.contains { $0.alias == alias }
+        if isTradeUp, comparableTradeUps.count >= 2 {
+            return .biggerAndCost
+        }
+        return .chooseFirst
+    }
+
+    /// The subtitle under the narrative title.
+    static func selectionSubtitle(
+        _ narrative: SelectionNarrative,
+        hardware: MacHardware
+    ) -> String {
+        switch narrative {
+        case .chooseFirst:
+            return "Start small — you can download bigger models anytime in Settings."
+        case .biggerAndCost:
+            return "The difference is download size and how much memory the model "
+                + "holds while it runs, against this Mac's \(wholeGB(hardware.physicalRAMGB))."
+        case .alreadyHere:
+            return "Another MLX app already downloaded this model into the shared "
+                + "Hugging Face cache. Picking it skips the download entirely."
+        }
+    }
+
+    /// The comparison columns for ``SelectionNarrative/biggerAndCost``.
+    ///
+    /// Every figure is an existing reading: ``sizeText`` for the download,
+    /// ``ModelSizing/estimate(alias:)`` for the memory, and
+    /// ``ModelSizing/classify(_:on:)`` — the same classification the primary is
+    /// gated on — for the fit. No benchmark, no quality claim.
+    static func comparisonColumns(
+        selection: String,
+        tradeUps: [QuickstartModelChoice],
+        hardware: MacHardware
+    ) -> [OnboardingComparisonTable.Column] {
+        tradeUps.map { choice in
+            let footprint = ModelSizing.estimate(alias: choice.alias)
+            let fit = ModelSizing.classify(footprint, on: hardware)
+            return OnboardingComparisonTable.Column(
+                title: comparisonColumnTitle(for: choice),
+                isPicked: choice.alias == selection,
+                download: sizeText(for: choice),
+                memory: footprint.totalGB > 0 ? "≈ \(preciseGB(footprint.totalGB))" : "Unknown",
+                fit: fitText(fit),
+                fitIsWarning: fit != .recommended
+            )
+        }
+    }
+
+    /// The short column header — the parameter count, which is the axis the
+    /// user is actually comparing. Falls back to the display name when the
+    /// alias carries no size token.
+    static func comparisonColumnTitle(for choice: QuickstartModelChoice) -> String {
+        if let params = ModelSizing.estimate(alias: choice.alias).paramsBillions {
+            let whole = params.rounded()
+            let text = abs(params - whole) < 0.05
+                ? String(Int(whole))
+                : String(format: "%.1f", params)
+            return "\(text)B"
+        }
+        return choice.displayName
+    }
+
+    /// Plain words for a ``ModelSizing/Fit``. Read from the classification, so
+    /// the table and the disabled primary can never disagree.
+    static func fitText(_ fit: ModelSizing.Fit) -> String {
+        switch fit {
+        case .recommended: return "Comfortable"
+        case .borderline:  return "Tight"
+        case .tooBig:      return "Won't fit"
+        }
+    }
 
     /// The recommended shortlist: models already on this Mac, the starter, an
     /// honest low-memory fallback, bigger trade-ups, a catalogue pick carried
@@ -1794,29 +2083,48 @@ struct QuickstartView: View {
     private var recommendedShortlistStep: some View {
         let list = shortlist
         let primary = primary(for: .shortlist)
-        step2Scaffold(
-            kicker: "CHOOSE A MODEL",
-            title: "Choose your first model",
-            subtitle: "Start small — you can download bigger models anytime in Settings."
-        ) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
+        let narrative = Self.selectionNarrative(
+            alias: coordinator.selection.alias,
+            cachedModels: cachedModels,
+            comparableTradeUps: list.tradeUps
+        )
+        step2Scaffold {
+            step2Columns(
+                kicker: "CHOOSE A MODEL",
+                title: narrative.title,
+                subtitle: Self.selectionSubtitle(narrative, hardware: hardware)
+            ) {
+                // Paper 05.1 state 05: the comparison is part of the heading
+                // column, not a second panel — it is the explanation of the
+                // pick, and it sits where every other explanation sits.
+                if narrative == .biggerAndCost {
+                    OnboardingComparisonTable(
+                        columns: Self.comparisonColumns(
+                            selection: coordinator.selection.alias,
+                            tradeUps: list.tradeUps,
+                            hardware: hardware
+                        ),
+                        fitLabel: "Fit on \(Self.wholeGB(hardware.physicalRAMGB))"
+                    )
+                    .padding(.top, 26)
+                }
+            } content: {
+            OnboardingIntrinsicColumn {
+                VStack(alignment: .leading, spacing: 10) {
                     if !list.cached.isEmpty {
-                        shortlistHeading("ALREADY ON THIS MAC")
-                        VStack(spacing: 9) {
-                            ForEach(list.cached) { entry in
-                                let choice = Self.choice(forCachedModel: entry)
-                                QuickstartCompactCard(
-                                    choice: choice,
-                                    selected: coordinator.selection.alias == entry.alias,
-                                    sizeText: entry.sizeOnDisk ?? "",
-                                    isCached: true,
-                                    onActivate: { activatePrimary(in: .shortlist) }
-                                ) { coordinator.select(choice) }
-                                .accessibilityIdentifier("Quickstart.CachedModel.\(entry.alias)")
-                            }
+                        OnboardingGroupLabel(text: "ALREADY ON THIS MAC")
+                            .padding(.top, 14)
+                        ForEach(list.cached) { entry in
+                            let choice = Self.choice(forCachedModel: entry)
+                            QuickstartCompactCard(
+                                choice: choice,
+                                selected: coordinator.selection.alias == entry.alias,
+                                sizeText: entry.sizeOnDisk ?? "",
+                                isCached: true,
+                                onActivate: { activatePrimary(in: .shortlist) }
+                            ) { coordinator.select(choice) }
+                            .accessibilityIdentifier("Quickstart.CachedModel.\(entry.alias)")
                         }
-                        .padding(.bottom, 16)
                     }
 
                     ForEach(list.starters) { choice in
@@ -1826,11 +2134,11 @@ struct QuickstartView: View {
                             sizeText: Self.sizeText(for: choice),
                             onActivate: { activatePrimary(in: .shortlist) }
                         ) { coordinator.select(choice) }
-                        .padding(.bottom, 16)
                     }
 
                     if !list.lowMemory.isEmpty {
-                        shortlistHeading("NEED THE LIGHTEST OPTION?")
+                        OnboardingGroupLabel(text: "NEED THE LIGHTEST OPTION?")
+                            .padding(.top, 14)
                         ForEach(list.lowMemory) { choice in
                             QuickstartLowMemoryCard(
                                 choice: choice,
@@ -1838,26 +2146,24 @@ struct QuickstartView: View {
                                 sizeText: Self.sizeText(for: choice),
                                 onActivate: { activatePrimary(in: .shortlist) }
                             ) { coordinator.select(choice) }
-                            .padding(.bottom, 16)
                         }
                     }
 
                     if !list.tradeUps.isEmpty {
-                        shortlistHeading("OR PICK A BIGGER ONE")
-                        VStack(spacing: 9) {
-                            ForEach(list.tradeUps) { choice in
-                                let cached = Self.cachedModel(
-                                    alias: choice.alias,
-                                    cachedModels: cachedModels
-                                )
-                                QuickstartCompactCard(
-                                    choice: choice,
-                                    selected: coordinator.selection.alias == choice.alias,
-                                    sizeText: cached?.sizeOnDisk ?? Self.sizeText(for: choice),
-                                    isCached: cached != nil,
-                                    onActivate: { activatePrimary(in: .shortlist) }
-                                ) { coordinator.select(choice) }
-                            }
+                        OnboardingGroupLabel(text: "OR PICK A BIGGER ONE")
+                            .padding(.top, 14)
+                        ForEach(list.tradeUps) { choice in
+                            let cached = Self.cachedModel(
+                                alias: choice.alias,
+                                cachedModels: cachedModels
+                            )
+                            QuickstartCompactCard(
+                                choice: choice,
+                                selected: coordinator.selection.alias == choice.alias,
+                                sizeText: cached?.sizeOnDisk ?? Self.sizeText(for: choice),
+                                isCached: cached != nil,
+                                onActivate: { activatePrimary(in: .shortlist) }
+                            ) { coordinator.select(choice) }
                         }
                     }
 
@@ -1867,7 +2173,8 @@ struct QuickstartView: View {
                     // a list that visibly disagrees with the footer, which
                     // reads as "my choice was ignored".
                     if let pick = list.yourPick {
-                        shortlistHeading("YOUR PICK").padding(.top, 16)
+                        OnboardingGroupLabel(text: "YOUR PICK")
+                            .padding(.top, 14)
                         let choice = Self.choice(forCatalogEntry: pick)
                         QuickstartCompactCard(
                             choice: choice,
@@ -1879,35 +2186,25 @@ struct QuickstartView: View {
                         .accessibilityIdentifier("Quickstart.YourPick.\(pick.alias)")
                     }
 
-                    Button {
+                    Button("Browse all models →") {
                         browseAllModels()
-                    } label: {
-                        Text("Browse all models →")
-                            .scaledSystemFont(12, weight: .medium)
-                            .foregroundStyle(RapidTheme.brand)
                     }
-                    .buttonStyle(.plain)
-                    .padding(.top, 14)
+                    .buttonStyle(.onboardingLink)
+                    .padding(.top, 2)
                     .accessibilityIdentifier("Quickstart.BrowseAll")
                     .accessibilityLabel("Browse all models")
                 }
+                .padding(.trailing, 2)
+            }
             }
         } footer: {
-            OnboardingWizardFooter(
+            OnboardingStepFooter(
                 primaryTitle: primary.title,
                 primaryEnabled: primary.isEnabled,
                 onBack: { coordinator.backToWelcome() },
                 onPrimary: { activatePrimary(in: .shortlist) }
             )
         }
-    }
-
-    @ViewBuilder
-    private func shortlistHeading(_ text: String) -> some View {
-        Text(text)
-            .scaledSystemFont(10, weight: .semibold).tracking(1)
-            .foregroundStyle(.tertiary)
-            .padding(.bottom, 9)
     }
 
     // MARK: - 2d — Browse all models, in window
@@ -1927,20 +2224,40 @@ struct QuickstartView: View {
             totalCount: Self.onboardingCatalogModels(cachedModels).count
         )
         let primary = primary(for: .catalogue)
-        step2Scaffold(
-            kicker: "BROWSE ALL MODELS",
-            title: "All models",
-            subtitle: nil
-        ) {
-            VStack(alignment: .leading, spacing: 10) {
+        // The catalogue is the one Step 2 stage that does NOT use the fixed
+        // heading column: 175 rows carrying an alias, a repo, badges and a size
+        // need the full canvas width, so the heading becomes a band across the
+        // top instead (Paper 05.2.C).
+        step2Scaffold(trailing: OnboardingD.canvasTrailing) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .bottom, spacing: OnboardingD.columnGap) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        OnboardingKicker(text: Self.microStageKicker("BROWSE ALL MODELS"))
+                            .accessibilityIdentifier("Quickstart.Step2.Kicker")
+                            .padding(.bottom, 16)
+                        OnboardingDisplayTitle(text: "All models")
+                    }
+                    Spacer(minLength: 24)
+                    Text("Everything rapid-mlx can serve on this Mac. "
+                         + "Your shortlist pick stays selected.")
+                        .scaledSystemFont(15, relativeTo: .callout)
+                        .foregroundStyle(RapidTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: 330, alignment: .leading)
+                }
+
                 catalogToolbar(heading: heading)
+                    .padding(.top, 26)
+
                 catalogBody(entries: entries)
+                    .padding(.top, 20)
             }
         } footer: {
-            OnboardingWizardFooter(
+            OnboardingStepFooter(
                 primaryTitle: primary.title,
                 primaryEnabled: primary.isEnabled,
                 backTitle: "← Back to recommended models",
+                backAccessibilityLabel: "Back to recommended models",
                 onBack: { returnToRecommendedModels() },
                 onPrimary: { activatePrimary(in: .catalogue) }
             )
@@ -1951,17 +2268,19 @@ struct QuickstartView: View {
     /// they survive Review download and a SwiftUI re-mount.
     @ViewBuilder
     private func catalogToolbar(heading: ModelCacheActions.ListHeading) -> some View {
-        VStack(spacing: 8) {
-            HStack(spacing: 8) {
-                HStack(spacing: 6) {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                HStack(spacing: 9) {
                     Image(systemName: "magnifyingglass")
-                        .foregroundStyle(.secondary)
+                        .font(.system(size: 13))
+                        .foregroundStyle(RapidTheme.textSecondary)
                         .accessibilityHidden(true)
                     TextField(
                         "Search models or Hugging Face repo",
                         text: $coordinator.catalogQuery
                     )
                     .textFieldStyle(.plain)
+                    .scaledSystemFont(13)
                     // Escape priority 1. A search field holding text owns the
                     // key and clears itself; empty, it declines so the event
                     // reaches the footer's Back at priority 3. Without this,
@@ -1975,16 +2294,26 @@ struct QuickstartView: View {
                     .accessibilityIdentifier("Quickstart.BrowseAll.Search")
                     .accessibilityLabel("Search models")
                 }
-                .padding(.horizontal, 9)
-                .frame(height: 28)
+                .padding(.horizontal, 13)
+                .frame(height: 36)
                 .background(
-                    RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
-                        .fill(RapidTheme.card)
+                    RoundedRectangle(cornerRadius: OnboardingD.actionRadius, style: .continuous)
+                        .fill(RapidTheme.surfaceRaised)
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: RapidTheme.Radius.input, style: .continuous)
+                    RoundedRectangle(cornerRadius: OnboardingD.actionRadius, style: .continuous)
                         .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
                 )
+
+                RapidSegmentedControl(
+                    selection: $coordinator.catalogFilter,
+                    options: ModelCacheActions.FilterMode.allCases.map {
+                        .init(value: $0, title: $0.displayLabel)
+                    },
+                    accessibilityLabel: "Filter"
+                )
+                .fixedSize()
+                .accessibilityIdentifier("Quickstart.BrowseAll.Filter")
 
                 Menu {
                     ForEach(ModelCacheActions.SortOrder.allCases) { order in
@@ -2003,37 +2332,51 @@ struct QuickstartView: View {
                         .accessibilityIdentifier("Quickstart.BrowseAll.Sort.\(order.rawValue)")
                     }
                 } label: {
-                    Label("Sort", systemImage: "arrow.up.arrow.down")
+                    Text(coordinator.catalogSort.displayLabel)
                         .scaledSystemFont(12)
                 }
                 .menuStyle(.borderlessButton)
                 .fixedSize()
+                .padding(.horizontal, 13)
+                .frame(height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: OnboardingD.actionRadius, style: .continuous)
+                        .fill(RapidTheme.surfaceRaised)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: OnboardingD.actionRadius, style: .continuous)
+                        .strokeBorder(RapidTheme.hairlineStrong, lineWidth: 1)
+                )
                 // The scene tints app-wide amber and a borderless Menu's label
                 // reads the TINT, not the foreground style — without this the
                 // utility control renders as the page's primary action.
                 .tint(nil)
-                .foregroundStyle(RapidTheme.utilityActionLabel)
+                .foregroundStyle(RapidTheme.textPrimary)
                 .accessibilityIdentifier("Quickstart.BrowseAll.SortMenu")
+                .accessibilityLabel("Sort")
             }
 
-            HStack(spacing: 10) {
-                RapidSegmentedControl(
-                    selection: $coordinator.catalogFilter,
-                    options: ModelCacheActions.FilterMode.allCases.map {
-                        .init(value: $0, title: $0.displayLabel)
-                    },
-                    accessibilityLabel: "Filter"
-                )
-                .accessibilityIdentifier("Quickstart.BrowseAll.Filter")
-                Spacer(minLength: 6)
-                Text(heading.countText)
-                    .scaledSystemFont(10, weight: .medium)
+            // The list's own header lane. Column captions live here rather
+            // than on every row, and the trailing spacer reserves the
+            // selection glyph's width so SIZE lands over the size column.
+            HStack(spacing: 14) {
+                Text(heading.countText.localizedUppercase)
+                    .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+                    .tracking(OnboardingD.Tracking.groupLabel)
                     .monospacedDigit()
-                    .foregroundStyle(.tertiary)
-                    .fixedSize()
+                    .foregroundStyle(RapidTheme.textTertiary)
                     .accessibilityIdentifier("Quickstart.BrowseAll.Count")
                     .accessibilityLabel(heading.accessibilityLabel)
+                Spacer(minLength: 8)
+                Text("SIZE")
+                    .scaledSystemFont(10, relativeTo: .caption2, design: .monospaced)
+                    .tracking(OnboardingD.Tracking.badge)
+                    .foregroundStyle(RapidTheme.textTertiary)
+                    .frame(width: OnboardingD.rowSizeSlot, alignment: .trailing)
+                    .accessibilityHidden(true)
+                Color.clear.frame(width: OnboardingD.selectionGlyph, height: 1)
             }
+            .padding(.horizontal, 18)
         }
     }
 
@@ -2090,23 +2433,27 @@ struct QuickstartView: View {
         body: String,
         identifier: String
     ) -> some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 10) {
             if let symbol {
                 Image(systemName: symbol)
-                    .font(.system(size: 22, weight: .regular))
-                    .foregroundStyle(.tertiary)
+                    .font(.system(size: 24, weight: .regular))
+                    .foregroundStyle(RapidTheme.textTertiary)
                     .accessibilityHidden(true)
             } else {
                 ProgressView().controlSize(.small)
             }
-            Text(title).scaledSystemFont(13, weight: .semibold)
+            Text(title)
+                .scaledSystemFont(15, relativeTo: .callout, weight: .semibold)
+                .foregroundStyle(RapidTheme.textPrimary)
             Text(body)
-                .scaledSystemFont(12)
-                .foregroundStyle(.secondary)
+                .scaledSystemFont(13)
+                .foregroundStyle(RapidTheme.textSecondary)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 420)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 48)
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier(identifier)
         .accessibilityLabel("\(title). \(body)")
@@ -2148,11 +2495,17 @@ struct QuickstartView: View {
     private func catalogRow(_ entry: ModelEntry) -> some View {
         let choice = Self.choice(forCatalogEntry: entry)
         let available = OnboardingModelSelection.isAvailable(alias: entry.alias, hardware: hardware)
-        QuickstartCompactCard(
-            choice: choice,
-            selected: coordinator.selection.alias == entry.alias,
+        OnboardingCatalogRow(
+            alias: entry.alias,
+            subtitle: Self.catalogRowSubtitle(
+                entry: entry,
+                available: available,
+                hardware: hardware
+            ),
             sizeText: Self.rowSizeText(for: entry),
-            isCached: entry.cached,
+            selected: coordinator.selection.alias == entry.alias,
+            isAvailable: available,
+            badges: Self.catalogRowBadges(entry: entry, available: available),
             onActivate: { activatePrimary(in: .catalogue) }
         ) {
             coordinator.select(choice)
@@ -2161,8 +2514,72 @@ struct QuickstartView: View {
         // Truthfully won't run here. A disabled Button takes no click, which is
         // the "No-op" row of the activation truth table, enforced rather than
         // merely drawn.
+        //
+        // Deliberately still disabled, NOT merely styled: opening a WON'T FIT
+        // row's read-only detail is a separate, deferred behaviour PR. The
+        // badge below tells the user WHY the row is inert, which is a visual
+        // fix; making it openable would be a new user action.
         .disabled(!available)
-        .opacity(available ? 1 : 0.5)
+    }
+
+    /// The second line of a catalogue row.
+    ///
+    /// Normally the Hugging Face repo — the fact that disambiguates two aliases
+    /// of the same family. For a row this Mac cannot run, the repo is replaced
+    /// by the reason, because at that point the reason is the more useful fact
+    /// and the row is not a candidate anyway. Both come from data the catalogue
+    /// and ``ModelSizing`` already hold; nothing here is a new claim.
+    static func catalogRowSubtitle(
+        entry: ModelEntry,
+        available: Bool,
+        hardware: MacHardware
+    ) -> String {
+        guard available else {
+            let needed = ModelSizing.estimate(alias: entry.alias).totalGB
+            guard needed > 0 else { return "Needs more memory than this Mac has" }
+            return "Needs ≈ \(Self.wholeGB(needed)) · this Mac has \(Self.wholeGB(hardware.physicalRAMGB))"
+        }
+        let repo = entry.hfRepo ?? ""
+        return repo.isEmpty ? entry.alias : repo
+    }
+
+    /// The badges a catalogue row carries.
+    ///
+    /// A fixed, closed set drawn from facts already on screen elsewhere:
+    /// cached-ness from the catalogue snapshot, and runnability from the same
+    /// ``ModelSizing`` classification the primary is already gated on. No new
+    /// capability, benchmark or compatibility claim is introduced.
+    static func catalogRowBadges(
+        entry: ModelEntry,
+        available: Bool
+    ) -> [OnboardingCatalogRow.Badge] {
+        var badges: [OnboardingCatalogRow.Badge] = []
+        if entry.alias == QuickstartCoordinator.defaultChoice.alias {
+            badges.append(.init(text: "RECOMMENDED", tone: .amber))
+        }
+        if !available {
+            badges.append(.init(text: "WON'T FIT", tone: .error))
+        } else if entry.cached {
+            badges.append(.init(text: "ON THIS MAC", tone: .ready))
+        }
+        return badges
+    }
+
+    /// Whole gibibytes — for a MACHINE figure: this Mac's memory, free space,
+    /// the fit threshold. One place so the catalogue row, the rail and the
+    /// Review table cannot round the same number differently.
+    static func wholeGB(_ value: Double) -> String {
+        "\(Int(value.rounded())) GB"
+    }
+
+    /// One decimal — for a MODEL figure: an estimated footprint.
+    ///
+    /// The split is deliberate and matches Paper. A machine has 32 GB, flatly;
+    /// an estimate of 8.7 GB rounded to "9 GB" loses the precision that makes
+    /// two trade-ups distinguishable, and 5.9 vs 6 is exactly the comparison
+    /// the user is being shown.
+    static func preciseGB(_ value: Double) -> String {
+        String(format: "%.1f GB", value)
     }
 
     /// Leave the catalogue, remembering where the user was.
@@ -2175,76 +2592,216 @@ struct QuickstartView: View {
     /// Name the cost before spending it (Paper 05.2.D).
     ///
     /// Shows only what the product can truthfully state: identity, the size
-    /// estimate the rest of the app quotes, whether it is already on disk, and
-    /// the free space the pre-flight probe actually measured. No ETA, no
-    /// benchmark claim, no invented compatibility verdict.
+    /// estimate the rest of the app quotes, whether it is already on disk, the
+    /// memory it will occupy against this Mac's, the free space the pre-flight
+    /// probe actually measured, and where the files land. No ETA, no benchmark
+    /// claim, no invented compatibility verdict.
+    ///
+    /// The shortlist stays live on the right: picking a different row
+    /// re-renders this detail in place, so the user can compare without
+    /// leaving Step 2.
     @ViewBuilder
     private var reviewDownloadStep: some View {
         let alias = coordinator.selection.alias
         let cached = Self.cachedModel(alias: alias, cachedModels: cachedModels)
         let primary = primary(for: .review)
-        step2Scaffold(
-            kicker: "REVIEW DOWNLOAD",
-            title: coordinator.selection.displayName,
-            subtitle: cached == nil
-                ? "This downloads once and then runs entirely on your Mac."
-                : "Already on this Mac — nothing will be downloaded."
-        ) {
-            ScrollView {
+        step2Scaffold {
+            step2Columns(
+                kicker: "REVIEW DOWNLOAD",
+                title: coordinator.selection.displayName,
+                subtitle: cached == nil
+                    ? "This downloads once and then runs entirely on your Mac."
+                    : "Already on this Mac — nothing will be downloaded."
+            ) {
                 VStack(alignment: .leading, spacing: 0) {
-                    reviewFact("Model", alias, identifier: "Quickstart.Review.Alias")
-                    if let repo = Self.reviewRepo(alias: alias, cached: cached, cachedModels: cachedModels) {
-                        reviewFact("Hugging Face", repo, identifier: "Quickstart.Review.Repo")
-                    }
-                    reviewFact(
-                        cached == nil ? "Download size" : "Size on disk",
-                        Self.reviewSizeText(alias: alias, cached: cached),
-                        identifier: "Quickstart.Review.Size"
-                    )
-                    reviewFact(
-                        "On this Mac",
-                        cached == nil ? "Not downloaded yet" : "Already downloaded",
-                        identifier: "Quickstart.Review.CachedStatus"
-                    )
-                    if let free = Self.reviewFreeSpaceText(probe: freeBytesProbe) {
-                        reviewFact("Free space", free, identifier: "Quickstart.Review.FreeSpace")
+                    OnboardingFactTable(rows: Self.reviewFacts(
+                        alias: alias,
+                        cached: cached,
+                        cachedModels: cachedModels,
+                        hardware: hardware,
+                        freeBytes: freeBytesProbe()
+                    ))
+                    .padding(.top, 26)
+
+                    if let footnote = Self.reviewFootnote(alias: alias, cached: cached) {
+                        Text(footnote)
+                            .scaledSystemFont(12)
+                            .foregroundStyle(RapidTheme.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.top, 18)
+                            .accessibilityIdentifier("Quickstart.Review.Footnote")
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+            } content: {
+                reviewCompanionList
             }
         } footer: {
-            OnboardingWizardFooter(
+            OnboardingStepFooter(
                 primaryTitle: primary.title,
                 primaryEnabled: primary.isEnabled,
                 backTitle: coordinator.reviewOrigin == .catalogue
                     ? "← Back to all models"
                     : "← Back to recommended models",
+                backAccessibilityLabel: coordinator.reviewOrigin == .catalogue
+                    ? "Back to all models"
+                    : "Back to recommended models",
                 onBack: { coordinator.backFromReviewDownload() },
                 onPrimary: { activatePrimary(in: .review) }
             )
         }
     }
 
+    /// The shortlist, rendered beside Review download so a comparison never
+    /// costs a navigation. Selecting here re-renders the fact table in place —
+    /// the same ``coordinator.select`` every other list calls, so the
+    /// micro-stage does not change and Back still returns to the origin.
     @ViewBuilder
-    private func reviewFact(_ label: String, _ value: String, identifier: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
-            Text(label)
-                .scaledSystemFont(11, weight: .medium)
-                .foregroundStyle(.tertiary)
-                .frame(width: 108, alignment: .leading)
-            Text(value)
-                .scaledSystemFont(12.5)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
+    private var reviewCompanionList: some View {
+        let list = shortlist
+        OnboardingIntrinsicColumn {
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(list.starters) { choice in
+                    QuickstartRecommendedCard(
+                        choice: choice,
+                        selected: coordinator.selection.alias == choice.alias,
+                        sizeText: Self.sizeText(for: choice),
+                        onActivate: { activatePrimary(in: .review) }
+                    ) { coordinator.select(choice) }
+                }
+                if !list.lowMemory.isEmpty {
+                    OnboardingGroupLabel(text: "NEED THE LIGHTEST OPTION?")
+                        .padding(.top, 14)
+                    ForEach(list.lowMemory) { choice in
+                        QuickstartLowMemoryCard(
+                            choice: choice,
+                            selected: coordinator.selection.alias == choice.alias,
+                            sizeText: Self.sizeText(for: choice),
+                            onActivate: { activatePrimary(in: .review) }
+                        ) { coordinator.select(choice) }
+                    }
+                }
+                if !list.tradeUps.isEmpty {
+                    OnboardingGroupLabel(text: "OR PICK A BIGGER ONE")
+                        .padding(.top, 14)
+                    ForEach(list.tradeUps) { choice in
+                        let cached = Self.cachedModel(alias: choice.alias, cachedModels: cachedModels)
+                        QuickstartCompactCard(
+                            choice: choice,
+                            selected: coordinator.selection.alias == choice.alias,
+                            sizeText: cached?.sizeOnDisk ?? Self.sizeText(for: choice),
+                            isCached: cached != nil,
+                            onActivate: { activatePrimary(in: .review) }
+                        ) { coordinator.select(choice) }
+                    }
+                }
+                if let pick = list.yourPick {
+                    OnboardingGroupLabel(text: "YOUR PICK")
+                        .padding(.top, 14)
+                    let choice = Self.choice(forCatalogEntry: pick)
+                    QuickstartCompactCard(
+                        choice: choice,
+                        selected: coordinator.selection.alias == pick.alias,
+                        sizeText: Self.rowSizeText(for: pick),
+                        isCached: pick.cached,
+                        onActivate: { activatePrimary(in: .review) }
+                    ) { coordinator.select(choice) }
+                    .accessibilityIdentifier("Quickstart.YourPick.\(pick.alias)")
+                }
+            }
+            .padding(.trailing, 2)
         }
-        .padding(.vertical, 8)
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(RapidTheme.hairline).frame(height: 1)
+    }
+
+    /// Review's fact rows, in Paper's order (05.2.D).
+    ///
+    /// Pure, and every value comes from a source the app already reads —
+    /// ``sizeText`` for the download, ``ModelEntry/cached`` for presence,
+    /// ``ModelSizing`` against ``MacHardware`` for memory, the pre-flight probe
+    /// for free space. A row whose source has nothing to say is omitted rather
+    /// than printed with a placeholder.
+    static func reviewFacts(
+        alias: String,
+        cached: ModelEntry?,
+        cachedModels: [ModelEntry],
+        hardware: MacHardware,
+        freeBytes: Int64?
+    ) -> [OnboardingFactRow] {
+        var rows: [OnboardingFactRow] = [
+            // The alias, first. Paper's fact list starts at the download size,
+            // but the identity row predates it and the golden-flow harness
+            // addresses it by identifier — and naming the exact alias about to
+            // be pulled is the least this screen can do.
+            OnboardingFactRow(
+                "Model",
+                alias,
+                identifier: "Quickstart.Review.Alias"
+            ),
+            OnboardingFactRow(
+                cached == nil ? "Download" : "Size on disk",
+                reviewDownloadText(alias: alias, cached: cached),
+                identifier: "Quickstart.Review.Size"
+            ),
+            OnboardingFactRow(
+                "On this Mac",
+                cached == nil ? "Not downloaded yet" : "Already downloaded",
+                isStrong: cached != nil,
+                identifier: "Quickstart.Review.CachedStatus"
+            ),
+        ]
+
+        let footprint = ModelSizing.estimate(alias: alias).totalGB
+        if footprint > 0, hardware.physicalRAMGB > 0 {
+            rows.append(OnboardingFactRow(
+                "Memory when loaded",
+                "≈ \(preciseGB(footprint)) of \(wholeGB(hardware.physicalRAMGB))",
+                identifier: "Quickstart.Review.Memory"
+            ))
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityIdentifier(identifier)
-        .accessibilityLabel("\(label): \(value)")
+
+        if let freeBytes {
+            rows.append(OnboardingFactRow(
+                "Free space",
+                "\(wholeGB(Double(freeBytes) / Double(1 << 30))) available",
+                identifier: "Quickstart.Review.FreeSpace"
+            ))
+        }
+
+        if let repo = reviewRepo(alias: alias, cached: cached, cachedModels: cachedModels) {
+            rows.append(OnboardingFactRow(
+                "Hugging Face",
+                repo,
+                isStrong: false,
+                identifier: "Quickstart.Review.Repo"
+            ))
+        }
+        return rows
+    }
+
+    /// The download size Review quotes.
+    ///
+    /// Prefers the choice's PINNED byte count when the alias is one of the
+    /// onboarding ladder — the same number its card shows. Without this the
+    /// starter read "~633 MB" on the card and "~563 MB" two clicks later,
+    /// because the card uses the pinned figure and the generic path falls back
+    /// to the parameter-derived estimate. One model, one number.
+    static func reviewDownloadText(alias: String, cached: ModelEntry?) -> String {
+        if cached == nil,
+           let choice = QuickstartCoordinator.onboardingChoices.first(where: { $0.alias == alias }),
+           choice.downloadBytes != nil {
+            return sizeText(for: choice)
+        }
+        return reviewSizeText(alias: alias, cached: cached)
+    }
+
+    /// The line under the fact table. Only offered for a download that has not
+    /// happened yet — for a cached model there is no cost to frame.
+    static func reviewFootnote(alias: String, cached: ModelEntry?) -> String? {
+        guard cached == nil else { return nil }
+        let size = reviewDownloadText(alias: alias, cached: nil)
+        guard size != "Unknown" else {
+            return "One download, once. After that this model starts in seconds and needs no network."
+        }
+        return "One \(size) pull, once. After that this model starts in seconds and needs no network."
     }
 
     // MARK: - Step 2 derivation (pure seams)
@@ -2523,65 +3080,78 @@ struct QuickstartView: View {
 
     // MARK: - Subviews
 
+    /// Step 3's canvas (Paper 05.1 state 09).
+    ///
+    /// The rail owns the numbers — percentage, bytes, rate, ETA — so the canvas
+    /// deliberately repeats none of them. What it owns is meaning: what the
+    /// transfer IS, and what leaving, quitting or stopping will do. Everything
+    /// here is a plain statement of consequence; nothing is a progress read-out
+    /// wearing prose.
     @ViewBuilder
     private var downloadingCard: some View {
         let job = downloads.job(for: coordinator.selection.alias)
-        let fraction = job?.progress.progressFraction
-        let subtitle = QuickstartView.progressSubtitle(
-            job: job,
-            displayName: coordinator.selection.displayName
-        )
-        let eta = QuickstartView.etaCaption(job: job)
 
-        if let fraction {
-            ProgressView(value: fraction, total: 1.0)
-                .progressViewStyle(.linear)
-                .frame(maxWidth: 360)
-        } else {
-            ProgressView()
-                .controlSize(.large)
-        }
-        Text("Downloading \(coordinator.selection.displayName)")
-            .font(.title3.weight(.semibold))
-        Text(subtitle)
-            .font(.callout.monospacedDigit())
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-        if let eta {
-            Text(eta)
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.tertiary)
-        }
-        Text("You can keep this window open — we'll start chat as soon as the download finishes.")
-            .font(.caption)
-            .foregroundStyle(.tertiary)
-            .multilineTextAlignment(.center)
-            .padding(.top, 4)
+        VStack(alignment: .leading, spacing: 0) {
+            OnboardingDisplayTitle(text: "One download,\nthen it's yours.")
 
-        // The way out of Step 3.
-        //
-        // Onboarding is a full-window sheet, so ``DownloadStrip`` — the app's
-        // ordinary cancel affordance — is behind it and unreachable for the
-        // entire pull. Without this control the only exits from a download the
-        // user no longer wants are quitting the app or waiting it out, and a
-        // multi-gigabyte trade-up makes "wait it out" a very long time to be
-        // stuck. The cancellation RECOVERY path already existed and was
-        // reachable (an app quit reaches it); what did not exist was any way
-        // to ask for it from the screen that is actually on top.
-        if let cancelAlias = Self.downloadCancelTarget(
-            jobStatus: job?.status,
-            selectionAlias: coordinator.selection.alias,
-            alreadyRequested: cancelRequestedAlias == coordinator.selection.alias
-        ) {
-            Button {
-                cancelRequestedAlias = cancelAlias
-                downloads.cancelDownload(alias: cancelAlias)
-            } label: {
-                Text("Cancel download")
-                    .frame(maxWidth: .infinity)
+            Text("The model files are being written into your Hugging Face cache. "
+                 + "This is a plain file transfer from the model mirror — nothing "
+                 + "about you is sent with it.")
+                .scaledSystemFont(16, relativeTo: .title3)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: OnboardingD.proseWidth, alignment: .leading)
+                .padding(.top, 18)
+
+            VStack(spacing: 0) {
+                downloadFact(
+                    "LEAVING",
+                    "Keep this window open. Setup finishes on its own and opens chat "
+                        + "as soon as the files land.",
+                    isFirst: true
+                )
+                downloadFact(
+                    "QUITTING",
+                    "Quitting Rapid-MLX stops the transfer. Setup is not marked "
+                        + "finished, so it runs again on the next launch."
+                )
+                // Paper's third row said "NO CANCEL — cancelling a download
+                // lives in Settings → Models, which is behind this window until
+                // setup ends". That is superseded: the merged recovery PR added
+                // a Cancel to this screen precisely because that arrangement
+                // left a part-finished download with no exit but quitting. The
+                // row now describes the control that exists.
+                downloadFact(
+                    "STOPPING",
+                    "Cancel download stops the transfer. The model is not installed, "
+                        + "and you can retry it or choose a different one.",
+                    isLast: true
+                )
             }
-            .buttonStyle(.bordered)
-            .controlSize(.large)
+            .frame(maxWidth: OnboardingD.proseWidth, alignment: .leading)
+            .padding(.top, 34)
+
+            // The way out of Step 3.
+            //
+            // Onboarding is a full-window sheet, so ``DownloadStrip`` — the
+            // app's ordinary cancel affordance — is behind it and unreachable
+            // for the entire pull. Without this control the only exits from a
+            // download the user no longer wants are quitting the app or waiting
+            // it out, and a multi-gigabyte trade-up makes "wait it out" a very
+            // long time to be stuck. The cancellation RECOVERY path already
+            // existed and was reachable (an app quit reaches it); what did not
+            // exist was any way to ask for it from the screen that is on top.
+            if let cancelAlias = Self.downloadCancelTarget(
+                jobStatus: job?.status,
+                selectionAlias: coordinator.selection.alias,
+                alreadyRequested: cancelRequestedAlias == coordinator.selection.alias
+            ) {
+                Button("Cancel download") {
+                    cancelRequestedAlias = cancelAlias
+                    downloads.cancelDownload(alias: cancelAlias)
+                }
+                .buttonStyle(.onboardingQuiet)
+                .padding(.top, 26)
             // Deliberately NO keyboard shortcut.
             //
             // `.defaultAction` would put a destructive action on Return, on a
@@ -2598,7 +3168,43 @@ struct QuickstartView: View {
             // Says what is lost, without claiming anything about bytes
             // already on disk — see ``FailureDiagnosis/Kind/downloadCancelled``.
             .accessibilityHint("Stops the download. The model will not be installed.")
+            }
         }
+        .frame(maxWidth: OnboardingD.proseWidth, alignment: .leading)
+    }
+
+    /// One `LABEL · consequence` row on the Step 3 canvas. Hairline-separated
+    /// facts rather than a card: the canvas states consequences, and boxing
+    /// each one would make three equal-weight cards out of three sentences.
+    @ViewBuilder
+    private func downloadFact(
+        _ label: String,
+        _ body: String,
+        isFirst: Bool = false,
+        isLast: Bool = false
+    ) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            Text(label)
+                .scaledSystemFont(10, relativeTo: .caption2, weight: .semibold, design: .monospaced)
+                .tracking(OnboardingD.Tracking.groupLabel)
+                .foregroundStyle(RapidTheme.textTertiary)
+                .frame(width: 92, alignment: .leading)
+                .padding(.top, 3)
+            Text(body)
+                .scaledSystemFont(14)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 16)
+        .overlay(alignment: .top) {
+            Rectangle().fill(RapidTheme.hairline).frame(height: 1)
+        }
+        .overlay(alignment: .bottom) {
+            if isLast { Rectangle().fill(RapidTheme.hairline).frame(height: 1) }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label). \(body)")
     }
 
     /// Which alias, if any, the Step 3 card should offer to cancel.
@@ -2633,60 +3239,57 @@ struct QuickstartView: View {
         return selectionAlias
     }
 
+    /// Step 4's canvas while the serve comes up (Paper 05.1 state 15).
+    ///
+    /// The rail carries STARTING, the identity and the indeterminate track, so
+    /// the canvas states only what loading means and roughly how long it takes.
+    /// No spinner here: a second progress indicator beside the rail's would be
+    /// two things reporting one wait.
     @ViewBuilder
     private var startingCard: some View {
-        ProgressView()
-            .controlSize(.large)
-        Text("Starting \(coordinator.selection.displayName)…")
-            .font(.title3.weight(.semibold))
-        Text("Loading the model into Metal. Usually 5–15 seconds.")
-            .font(.callout)
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
+        VStack(alignment: .leading, spacing: 0) {
+            OnboardingDisplayTitle(text: "Loading into memory.")
+
+            Text("The weights are on disk. They are being loaded into Metal and the "
+                 + "model is warming up — usually 5 to 15 seconds, longer the first "
+                 + "time a model runs.")
+                .scaledSystemFont(16, relativeTo: .title3)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 18)
+        }
+        .frame(maxWidth: OnboardingD.proseWidth, alignment: .leading)
     }
 
     /// The Ready confirmation screen — the end of Step 4 and the only
     /// thing that ends onboarding.
     ///
-    /// Deliberately minimal: this PR carries the BEHAVIOUR change (Ready is
-    /// persistent, completion is confirmed) and reuses the surrounding
-    /// wizard's existing components and styling so the contract can be
-    /// exercised and tested. The Direction D treatment of this screen —
-    /// the ready indicator, the amber primary sitting in the content
-    /// column, the type scale — belongs to the Onboarding visual PR, which
-    /// consumes this state rather than redefining it.
-    ///
     /// No spinner, no progress, no countdown: the model IS ready, and
     /// dressing the wait for a click as work would be a lie about what the
-    /// app is doing.
+    /// app is doing. The green tile is the one place setup uses the ready
+    /// colour, and the amber primary is this screen's single strong moment.
     @ViewBuilder
     private var readyCard: some View {
-        VStack(spacing: 16) {
-            Text("SETUP COMPLETE")
-                .scaledSystemFont(10, weight: .semibold)
-                .tracking(1.4)
-                .foregroundStyle(.tertiary)
-
-            Text("\(coordinator.selection.displayName) is ready.")
-                .font(.title3.weight(.semibold))
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Button {
-                completeOnboarding()
-            } label: {
-                Text("Start chatting")
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 2)
+        OnboardingOutcomeBlock(
+            glyph: "checkmark",
+            tone: .ready,
+            kicker: "SETUP COMPLETE",
+            title: "\(coordinator.selection.displayName) is ready.",
+            message: "It is loaded on this Mac and answering locally. "
+                + "Nothing you type from here leaves the machine."
+        ) {
+            OnboardingActionLane {
+                Button("Start chatting") {
+                    completeOnboarding()
+                }
+                .buttonStyle(.onboardingPrimary)
+                // The native default action, not custom key handling: Return
+                // activates it and Space activates it while focused, both via
+                // AppKit's ordinary button semantics.
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("Quickstart.Ready.StartChatting")
+                .accessibilityLabel("Start chatting with \(coordinator.selection.displayName)")
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            // The native default action, not custom key handling: Return
-            // activates it and Space activates it while focused, both via
-            // AppKit's ordinary button semantics.
-            .keyboardShortcut(.defaultAction)
-            .accessibilityIdentifier("Quickstart.Ready.StartChatting")
-            .accessibilityLabel("Start chatting with \(coordinator.selection.displayName)")
         }
     }
 
@@ -2714,74 +3317,71 @@ struct QuickstartView: View {
     @ViewBuilder
     private func memoryWarningCard(_ warning: ModelSizing.MemoryWarning) -> some View {
         let fallback = Self.lowMemoryRecoveryChoice(for: warning)
-        ZStack {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(RapidTheme.amberTint)
-                .frame(width: 60, height: 60)
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 28, weight: .regular))
-                .foregroundStyle(RapidTheme.amberDeep)
-        }
-        .accessibilityHidden(true)
-
-        VStack(spacing: 8) {
-            Text(warning.title)
-                .font(.title3.weight(.semibold))
-                .multilineTextAlignment(.center)
-            Text(warning.message)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(warning.title). \(warning.message)")
-
-        if let fallback {
-            Button {
-                server.cancelPendingMemoryLoad(warning)
-                coordinator.returnToChooser()
-                coordinator.select(fallback)
-                startQuickstart()
-            } label: {
-                Text("Switch to \(fallback.displayName)")
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 2)
+        OnboardingOutcomeBlock(
+            glyph: "exclamationmark.triangle",
+            tone: .amber,
+            kicker: "STEP \(QuickstartCoordinator.Step.start.displayNumber) "
+                + "OF \(QuickstartCoordinator.Step.total) · BEFORE LOADING",
+            title: warning.title,
+            message: warning.message
+        ) {
+            // The two measured numbers behind the guard's decision, stated as
+            // figures rather than buried in the sentence above.
+            HStack(alignment: .top, spacing: 44) {
+                OnboardingStat(
+                    label: "NEEDS",
+                    value: Self.wholeGB(warning.footprintGB),
+                    tone: RapidTheme.statusError
+                )
+                OnboardingStat(
+                    label: "FREE NOW",
+                    value: Self.wholeGB(warning.freeGB)
+                )
+                if warning.totalGB > 0 {
+                    OnboardingStat(
+                        label: "THIS MAC",
+                        value: Self.wholeGB(warning.totalGB)
+                    )
+                }
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .keyboardShortcut(.defaultAction)
-            .accessibilityIdentifier("Quickstart.Memory.SwitchToLowMemory")
-            .accessibilityLabel("Switch to \(fallback.displayName), the lowest-memory option")
-        }
+            .padding(.top, 30)
+        } actions: {
+            OnboardingActionLane {
+                if let fallback {
+                    Button("Switch to \(fallback.displayName)") {
+                        server.cancelPendingMemoryLoad(warning)
+                        coordinator.returnToChooser()
+                        coordinator.select(fallback)
+                        startQuickstart()
+                    }
+                    .buttonStyle(.onboardingPrimary)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("Quickstart.Memory.SwitchToLowMemory")
+                    .accessibilityLabel("Switch to \(fallback.displayName), the lowest-memory option")
+                }
 
-        Button {
-            // Re-enters ``start`` with the guard bypassed. We stay in
-            // ``.starting``; ``handleServerStateChange`` seeds the welcome
-            // and dismisses the sheet once the child reaches ``.ready``.
-            server.confirmPendingMemoryLoad(warning)
-        } label: {
-            Text(warning.confirmTitle)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 2)
-        }
-        .buttonStyle(.bordered)
-        .controlSize(.large)
-        .accessibilityIdentifier("Quickstart.Memory.LoadAnyway")
+                Button(warning.confirmTitle) {
+                    // Re-enters ``start`` with the guard bypassed. We stay in
+                    // ``.starting``; ``handleServerStateChange`` seeds the
+                    // welcome and dismisses the sheet once the child reaches
+                    // ``.ready``.
+                    server.confirmPendingMemoryLoad(warning)
+                }
+                .buttonStyle(.onboardingOutline)
+                .accessibilityIdentifier("Quickstart.Memory.LoadAnyway")
 
-        Button {
-            // Drop the parked load and leave ``.starting`` for the chooser
-            // so the sheet stops waiting on a serve that will never come.
-            server.cancelPendingMemoryLoad(warning)
-            coordinator.returnToChooser()
-        } label: {
-            Text("Cancel")
-                .frame(maxWidth: .infinity)
+                Button("Cancel") {
+                    // Drop the parked load and leave ``.starting`` for the
+                    // chooser so the sheet stops waiting on a serve that will
+                    // never come.
+                    server.cancelPendingMemoryLoad(warning)
+                    coordinator.returnToChooser()
+                }
+                .buttonStyle(.onboardingQuiet)
+                .keyboardShortcut(.cancelAction)
+                .accessibilityIdentifier("Quickstart.Memory.Cancel")
+            }
         }
-        .buttonStyle(.bordered)
-        .controlSize(.large)
-        .keyboardShortcut(.cancelAction)
-        .accessibilityIdentifier("Quickstart.Memory.Cancel")
     }
 
     /// Return the curated low-memory fallback only when the same snapshot
@@ -2832,60 +3432,58 @@ struct QuickstartView: View {
     /// not an error.
     @ViewBuilder
     private func lowDiskCard(freeBytes: Int64, requiredBytes: Int64) -> some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(RapidTheme.amberTint)
-                .frame(width: 60, height: 60)
-            Image(systemName: "externaldrive.badge.exclamationmark")
-                .font(.system(size: 28, weight: .regular))
-                .foregroundStyle(RapidTheme.amberDeep)
-        }
-        .accessibilityHidden(true)
-
-        VStack(spacing: 8) {
-            Text("Low disk space")
-                .font(.title3.weight(.semibold))
-            Text(QuickstartView.lowDiskBannerBody(
+        OnboardingOutcomeBlock(
+            glyph: "externaldrive.badge.exclamationmark",
+            tone: .amber,
+            kicker: "STEP \(QuickstartCoordinator.Step.download.displayNumber) "
+                + "OF \(QuickstartCoordinator.Step.total) · BEFORE THE DOWNLOAD",
+            title: "Low disk space",
+            message: QuickstartView.lowDiskBannerBody(
                 freeBytes: freeBytes,
                 requiredBytes: requiredBytes,
                 displayName: coordinator.selection.displayName
-            ))
-            .font(.callout)
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-            .fixedSize(horizontal: false, vertical: true)
+            )
+        ) {
+            HStack(alignment: .top, spacing: 44) {
+                OnboardingStat(
+                    label: "FREE NOW",
+                    value: Self.formatBytesForBanner(freeBytes),
+                    tone: RapidTheme.statusError
+                )
+                OnboardingStat(
+                    label: "NEEDED",
+                    value: Self.formatBytesForBanner(requiredBytes)
+                )
+            }
+            .padding(.top, 30)
+            // The prose above already carries both numbers for VoiceOver, so
+            // the figures repeat them visually only.
+            .accessibilityHidden(true)
+        } actions: {
+            OnboardingActionLane {
+                Button("Continue anyway") {
+                    kickoffDownload()
+                }
+                .buttonStyle(.onboardingPrimary)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("Quickstart.LowDisk.Continue")
+                .accessibilityLabel("Continue download despite low disk space")
+
+                Button("Cancel") {
+                    coordinator.cancelLowDiskWarning()
+                }
+                .buttonStyle(.onboardingQuiet)
+                .keyboardShortcut(.cancelAction)
+                .accessibilityIdentifier("Quickstart.LowDisk.Cancel")
+                .accessibilityLabel("Cancel — go back to choosing a model without downloading")
+            }
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(QuickstartView.lowDiskAccessibilityLabel(
             freeBytes: freeBytes,
             requiredBytes: requiredBytes,
             displayName: coordinator.selection.displayName
         ))
-
-        Button {
-            kickoffDownload()
-        } label: {
-            Text("Continue anyway")
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 2)
-        }
-        .buttonStyle(.borderedProminent)
-        .controlSize(.large)
-        .keyboardShortcut(.defaultAction)
-        .accessibilityIdentifier("Quickstart.LowDisk.Continue")
-        .accessibilityLabel("Continue download despite low disk space")
-
-        Button {
-            coordinator.cancelLowDiskWarning()
-        } label: {
-            Text("Cancel")
-                .frame(maxWidth: .infinity)
-        }
-        .buttonStyle(.bordered)
-        .controlSize(.large)
-        .keyboardShortcut(.cancelAction)
-        .accessibilityIdentifier("Quickstart.LowDisk.Cancel")
-        .accessibilityLabel("Cancel — go back to choosing a model without downloading")
     }
 
     @ViewBuilder
@@ -2900,30 +3498,70 @@ struct QuickstartView: View {
         )
         let diagnosis = FailureDiagnoser.diagnosis(for: kind)
 
-        Text(Self.failureTitle(for: kind))
-            .font(.title3.weight(.semibold))
+        OnboardingOutcomeBlock(
+            glyph: Self.failureGlyph(for: kind),
+            tone: kind.severity == .notice ? .amber : .error,
+            kicker: Self.failureKicker(for: kind, origin: coordinator.step),
+            title: Self.failureTitle(for: kind),
+            message: diagnosis.message
+        ) {
+            OnboardingActionLane {
+                if let action = diagnosis.action {
+                    Button(action.title) {
+                        handleQuickstartFailureAction(action)
+                    }
+                    .buttonStyle(.onboardingPrimary)
+                    .disabled(server.isOperating)
+                    .accessibilityIdentifier(quickstartActionIdentifier(for: action) ?? "")
+                }
 
-        FailureDiagnosisView(
-            diagnosis: diagnosis,
-            onAction: handleQuickstartFailureAction,
-            isActionDisabled: server.isOperating,
-            actionAccessibilityIdentifier: quickstartActionIdentifier(for: diagnosis.action)
-        )
-
-        // The way back to choosing. Every failure and every cancellation is
-        // one model's problem, so the user must be able to go pick a
-        // different one — and land where they actually were, not on a
-        // catalogue they may never have opened. Stays inside onboarding: it
-        // does not dismiss setup and it does not open Settings.
-        Button {
-            returnToModelSelection()
-        } label: {
-            Text(Self.failureBackTitle(for: coordinator.step2Stage))
-                .font(.callout)
+                // The way back to choosing. Every failure and every
+                // cancellation is one model's problem, so the user must be
+                // able to go pick a different one — and land where they
+                // actually were, not on a catalogue they may never have
+                // opened. Stays inside onboarding: it does not dismiss setup
+                // and it does not open Settings.
+                Button(Self.failureBackTitle(for: coordinator.step2Stage)) {
+                    returnToModelSelection()
+                }
+                .buttonStyle(.onboardingLink)
+                .accessibilityIdentifier("Quickstart.Failure.BackToModelSelection")
+                .accessibilityLabel(Self.failureBackAccessibilityLabel(for: coordinator.step2Stage))
+            }
         }
-        .buttonStyle(.borderless)
-        .accessibilityIdentifier("Quickstart.Failure.BackToModelSelection")
-        .accessibilityLabel(Self.failureBackAccessibilityLabel(for: coordinator.step2Stage))
+    }
+
+    /// The glyph over a failure headline.
+    ///
+    /// A cancellation is the user's own stop, so it gets a stop mark on the
+    /// amber (caution) lane rather than a red fault symbol — the same
+    /// distinction ``FailureDiagnosis/Kind/downloadCancelled``'s `.notice`
+    /// severity makes in the diagnosis itself.
+    static func failureGlyph(for kind: FailureDiagnosis.Kind) -> String {
+        switch kind {
+        case .downloadCancelled: return "stop.circle"
+        case .downloadSourceUnavailable: return "wifi.exclamationmark"
+        case .modelOutOfMemory: return "memorychip"
+        default: return "exclamationmark.triangle"
+        }
+    }
+
+    /// `STEP 3 OF 4 · DOWNLOAD STOPPED`. The kicker names the macro step the
+    /// failure belongs to — which is the step the user was actually in, never
+    /// a step of the failure's own — and then what happened.
+    static func failureKicker(
+        for kind: FailureDiagnosis.Kind,
+        origin: QuickstartCoordinator.Step
+    ) -> String {
+        let what: String
+        switch kind {
+        case .downloadCancelled:         what = "DOWNLOAD STOPPED"
+        case .downloadSourceUnavailable: what = "SOURCE UNAVAILABLE"
+        case .modelOutOfMemory:          what = "NOT ENOUGH MEMORY"
+        case .modelLoadFailed:           what = "COULDN'T LOAD"
+        default:                         what = "DIDN'T FINISH"
+        }
+        return "STEP \(origin.displayNumber) OF \(QuickstartCoordinator.Step.total) · \(what)"
     }
 
     /// Classify a Quickstart failure. Pure so the one inference that matters —

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1464,10 +1464,13 @@ struct QuickstartView: View {
     private var compactRailPlane: some View {
         if let lifecycle = subjectLifecycle {
             let job = downloads.job(for: coordinator.selection.alias)
+            @Bindable var progress = job?.progress ?? DownloadProgress()
             OnboardingCompactSubjectBand(
-                lifecycle: lifecycle,
+                lifecycle: coordinator.phase == .downloading
+                    ? Self.downloadLifecycleName(progress: progress)
+                    : lifecycle,
                 identity: coordinator.selection.alias,
-                fraction: coordinator.phase == .downloading ? job?.progress.progressFraction : nil,
+                fraction: coordinator.phase == .downloading ? progress.progressFraction : nil,
                 bytesLine: Self.subjectBytesLine(job: job)
             )
         } else {
@@ -1485,10 +1488,13 @@ struct QuickstartView: View {
     private var railPlane: some View {
         if let lifecycle = subjectLifecycle {
             let job = downloads.job(for: coordinator.selection.alias)
+            @Bindable var progress = job?.progress ?? DownloadProgress()
             OnboardingSubjectRail(
-                lifecycle: lifecycle,
+                lifecycle: coordinator.phase == .downloading
+                    ? Self.downloadLifecycleName(progress: progress)
+                    : lifecycle,
                 identity: coordinator.selection.alias,
-                fraction: coordinator.phase == .downloading ? job?.progress.progressFraction : nil,
+                fraction: coordinator.phase == .downloading ? progress.progressFraction : nil,
                 bytesLine: Self.subjectBytesLine(job: job),
                 rateLine: Self.subjectRateLine(job: job),
                 stepLabel: "STEP \(coordinator.step.displayNumber) OF \(QuickstartCoordinator.Step.total)",
@@ -1542,15 +1548,28 @@ struct QuickstartView: View {
         }
     }
 
+    /// The mirror's aggregate byte heartbeat is a stronger signal than its
+    /// coarse phase. It deliberately does not mutate ``phase`` (the next file
+    /// event owns that state), so a rail that looked only at the enum could
+    /// claim PREPARING while measured bytes were already moving.
+    static func downloadLifecycleName(progress: DownloadProgress) -> String {
+        progress.hasDiskObservation ? "DOWNLOADING" : downloadLifecycleName(phase: progress.phase)
+    }
+
     /// "271 MB / 633 MB" — only once the byte monitor has observed real disk
     /// growth against a known total. Never a synthesised denominator.
     static func subjectBytesLine(job: DownloadManager.Job?) -> String? {
         guard let progress = job?.progress,
               progress.hasDiskObservation,
-              let bytes = progress.bytesDownloaded,
-              let total = progress.totalBytes, total > 0
+              let bytes = progress.bytesDownloaded
         else { return nil }
-        return "\(DownloadProgress.formatBytes(bytes)) / \(DownloadProgress.formatBytes(total))"
+        if let total = progress.totalBytes, total > 0 {
+            return "\(DownloadProgress.formatBytes(bytes)) / \(DownloadProgress.formatBytes(total))"
+        }
+        // A measured total is discarded when the mirror proves it wrong
+        // (done > total). Keep the truthful numerator visible rather than
+        // regressing to an indeterminate track while bytes are flowing.
+        return "\(DownloadProgress.formatBytes(bytes)) downloaded"
     }
 
     /// "4.4 MB/s · 2 min left" — rate first, and the ETA appended only when

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact-chooser.txt
@@ -1,0 +1,31 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXUnknown id="Quickstart.Progress" desc="Setup progress, step 2 of 4" enabled=true
+      AXStaticText id="Quickstart.Step2.Kicker" value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXScrollArea
+        AXStaticText value=text enabled=true
+        AXButton id="Quickstart.CachedModel.<model>" desc="<model>. Already downloaded and ready to start.. on disk <size>" enabled=true
+        AXButton id="Quickstart.CachedModel.fake-external-alias" desc="fake-external-alias. Already downloaded by another MLX app.. on disk <size>" enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="LFM2.5 · 1.2B. recommended starter. Small download (~<size>), runs on any Mac. Answers instantly and follows instructions well. Upgrade anytime for more depth.. download ~<size>. instant, runs on any Mac" enabled=true
+        AXStaticText value=text enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="Qwen 3 · 0.6B. Lowest memory. Lowest memory and fastest startup. Good for basic chat, but less accurate and not recommended for tools. Download ~<size>" enabled=true
+        AXStaticText value=text enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="Qwen <version> · 4B. Better everyday quality. Still light on disk.. download <size>" enabled=true
+        AXButton id="Quickstart.Choice.<model>" desc="Qwen <version> · 9B. Strong all-rounder if you have the RAM to spare.. download <size>" enabled=true
+        AXButton id="Quickstart.BrowseAll" desc="Browse all models" enabled=true
+        AXScrollBar value=number enabled=true
+          AXValueIndicator value=number
+          AXButton subrole=AXIncrementArrow
+          AXButton subrole=AXDecrementArrow
+          AXButton subrole=AXIncrementPage
+          AXButton subrole=AXDecrementPage
+      AXButton id="Quickstart.Footer.Back" desc="Back" enabled=true
+      AXButton id="Quickstart.Footer.Primary" desc="Review download" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.compact.txt
@@ -1,0 +1,14 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXUnknown id="Quickstart.Progress" desc="Setup progress, step 1 of 4" enabled=true
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXButton id="Quickstart.GetStarted" desc="Get started — choose your first model" enabled=true
+      AXButton id="Quickstart.Skip" desc="Skip onboarding and go to the app" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.medium.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.medium.txt
@@ -1,0 +1,17 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXUnknown id="Quickstart.Progress" desc="Setup progress, step 1 of 4" enabled=true
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXButton id="Quickstart.GetStarted" desc="Get started — choose your first model" enabled=true
+      AXButton id="Quickstart.Skip" desc="Skip onboarding and go to the app" enabled=true
+      AXStaticText id="Quickstart.Rail.ThisMac" value=text enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.wide.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/onboarding-direction-d.wide.txt
@@ -1,0 +1,17 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXUnknown id="Quickstart.Progress" desc="Setup progress, step 1 of 4" enabled=true
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXStaticText value=text enabled=true
+      AXButton id="Quickstart.GetStarted" desc="Get started — choose your first model" enabled=true
+      AXButton id="Quickstart.Skip" desc="Skip onboarding and go to the app" enabled=true
+      AXStaticText id="Quickstart.Rail.ThisMac" value=text enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -467,14 +467,27 @@ struct AccessibilityIdentifierInventoryTests {
             in: "Sources/Rapid/UI/QuickstartView.swift",
             surface: "Onboarding"
         )
+        // The rail and the footer lane moved into the Direction D design
+        // system when the wizard's centred-card chrome was replaced. The
+        // identifiers did NOT move: golden flows address all three, and
+        // `Quickstart.Progress` in particular is matched with its exact
+        // spoken label on three screens.
         try assertDeclared(
             [
                 #""Quickstart.Progress""#,
                 #""Quickstart.Footer.Back""#,
                 #""Quickstart.Footer.Primary""#,
             ],
+            in: "Sources/Rapid/UI/OnboardingDirectionD.swift",
+            surface: "Onboarding shell"
+        )
+        try assertDeclared(
+            [
+                #""Quickstart.Choice.\(choice.alias)""#,
+                #""Quickstart.CatalogRow.\(alias)""#,
+            ],
             in: "Sources/Rapid/UI/OnboardingComponents.swift",
-            surface: "Onboarding components"
+            surface: "Onboarding model rows"
         )
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
@@ -466,13 +466,18 @@ struct OnboardingCompletionBehaviorTests {
                 "the completion action must be addressable by the golden-flow harness")
         #expect(!body.contains(#".accessibilityIdentifier("Quickstart.Ready")"#),
                 "a container identifier would overwrite the child button's AX identifier")
-        #expect(body.contains(#"Text("Startchatting")"#),
+        #expect(body.contains(#"Button("Startchatting"){completeOnboarding()}"#),
                 "the Ready screen must offer the Start chatting action")
         // The confirmation must run the coordinator transaction, not a
         // local shortcut that bypasses seeding / persistence.
         #expect(body.contains("coordinator.confirmStartChatting(seedWelcome:onSeedWelcome)"))
-        // No fake work between the click and the app.
-        #expect(!body.contains("case.ready:centeredCard(progressStep:.start){ProgressView"),
+        // No fake work between the click and the app. Direction D renders
+        // Ready through the shared outcome block, which has no progress slot
+        // at all; pin the absence directly rather than through the retired
+        // centred-card call shape.
+        #expect(!body.contains("case.ready:OnboardingCenteredCanvas{ProgressView"),
+                "Ready must not render a spinner — the model is already up")
+        #expect(!body.contains("privatevarreadyCard:someView{ProgressView"),
                 "Ready must not render a spinner — the model is already up")
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -1,0 +1,823 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import Rapid
+
+/// Contract for the view logic the Direction D onboarding implementation
+/// introduces (Paper 05.1 / 05.2).
+///
+/// This is a VISUAL slice, so most of it is composition and has no logic to
+/// pin. What does have logic is every place the new surfaces had to *derive*
+/// something in order to draw it — a lifecycle name, a badge, a byte line, a
+/// fact table — and each of those is a place a redesign can quietly start
+/// claiming something the app does not know.
+///
+/// The rule these all serve: the rail and the canvas may only state facts that
+/// already exist. No synthesised percentage, no ETA before a measured rate, no
+/// capability or compatibility claim beyond the ``ModelSizing`` classification
+/// the primary is already gated on.
+@MainActor
+@Suite("Onboarding Direction D — derived display values")
+struct OnboardingDirectionDTests {
+
+    // MARK: - Full-window presentation
+
+    private static func strippedSource(_ relativePath: String) throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(relativePath)
+        return CapabilityChipRenderGateSourceGuardTests
+            .stripCommentsAndWhitespace(try String(contentsOf: url, encoding: .utf8))
+    }
+
+    /// Setup owns the window; it is not a panel inside one.
+    ///
+    /// Manual verification caught this the hard way. Onboarding was presented
+    /// with `.sheet`, which on macOS is a document-modal panel: AppKit sizes it
+    /// to its content's ideal width, insets it, rounds its corners and leaves
+    /// the parent visible around it — so Direction D rendered as a centred card
+    /// over a dimmed chat surface, which is the one composition Paper 05.1.A
+    /// rules out. It also settled at its 620pt minimum, below the 820pt
+    /// breakpoint, so the full-height rail was unreachable on any display.
+    @Test("Onboarding replaces the shell rather than floating over it")
+    func onboardingIsNotPresentedAsASheet() throws {
+        let content = try Self.strippedSource("Sources/Rapid/UI/ContentView.swift")
+
+        #expect(
+            !content.contains(".sheet(isPresented:quickstartSheetPresented)"),
+            """
+            Onboarding is being presented as a sheet again. A macOS sheet is \
+            inset, rounded and leaves the parent window visible behind it — \
+            Paper 05.1.A forbids exactly that ("no dimmed application, no modal \
+            card floating over a live app").
+            """
+        )
+        // The root branches between the two shells, so there is nothing behind
+        // setup to show through.
+        #expect(content.contains("ifquickstartVisible{onboardingShell}else{productionShell}"),
+                "the root must swap the whole shell, not overlay one on the other")
+        #expect(content.contains("privatevaronboardingShell:someView{"))
+        #expect(content.contains("privatevarproductionShell:someView{"))
+        // And the surface itself must not re-impose a panel-sized frame.
+        #expect(!content.contains("quickstartSurface.frame(minWidth:620"),
+                "the setup surface must take the window's size, not a panel's")
+    }
+
+    @Test("The setup surface fills whatever the window gives it")
+    func setupSurfaceFillsTheWindow() throws {
+        let view = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
+        #expect(view.contains(".frame(maxWidth:.infinity,maxHeight:.infinity)"),
+                "the shell must expand to its container in both axes")
+        // No maximum width anywhere in the shell: a cap would recreate the
+        // centred-card look inside a full-width window.
+        #expect(!view.contains(".frame(maxWidth:460)"),
+                "the retired centred-card cap must not come back")
+    }
+
+    // MARK: - Two-column vertical centring
+
+    /// Collects the laid-out frame of instrumented subviews.
+    private struct FrameKey: PreferenceKey {
+        static let defaultValue: [String: CGRect] = [:]
+        static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+            value.merge(nextValue()) { _, new in new }
+        }
+    }
+
+    private struct Probe: ViewModifier {
+        let id: String
+        func body(content: Content) -> some View {
+            content.background(
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: FrameKey.self,
+                        value: [id: proxy.frame(in: .named("canvas"))]
+                    )
+                }
+            )
+        }
+    }
+
+    /// Render a Step 2 column layout and report where its right stack landed.
+    ///
+    /// The probe sits on the INNER stack, not on whatever wrapper the column
+    /// uses. That distinction is the whole point: a greedy wrapper still
+    /// reports a centred frame while the rows inside it stack from its top,
+    /// which is exactly how the defect hid.
+    @MainActor
+    private static func measureRightStack<Wrapper: View>(
+        canvasHeight: CGFloat = 824,
+        footerHeight: CGFloat = 44,
+        rows: [CGFloat] = [150, 70, 70, 70],
+        @ViewBuilder wrap: @escaping (AnyView) -> Wrapper
+    ) -> (stack: CGRect, usableMid: CGFloat) {
+        var captured: [String: CGRect] = [:]
+        let inner = AnyView(
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, height in
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color.gray.opacity(0.2))
+                        .frame(height: height)
+                }
+            }
+            .modifier(Probe(id: "stack"))
+        )
+        let columns = OnboardingStepColumns(
+            kicker: "STEP 2 OF 4 · CHOOSE A MODEL",
+            title: "Choose your\nfirst model",
+            subtitle: "Start small — you can download bigger models anytime in Settings.",
+            aside: { EmptyView() },
+            content: { wrap(inner) }
+        )
+        let root = OnboardingCanvasLayout(principal: { columns }) {
+            Color.clear.frame(height: footerHeight)
+        }
+        .coordinateSpace(name: "canvas")
+        .onPreferenceChange(FrameKey.self) { captured = $0 }
+        .environment(\.onboardingLayout, .wide)
+        .frame(width: 1240, height: canvasHeight)
+
+        let host = NSHostingView(rootView: root)
+        host.frame = CGRect(x: 0, y: 0, width: 1240, height: canvasHeight)
+        host.layoutSubtreeIfNeeded()
+        _ = host.bitmapImageRepForCachingDisplay(in: host.bounds)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.35))
+        host.layoutSubtreeIfNeeded()
+
+        return (captured["stack"] ?? .zero, (canvasHeight - footerHeight) / 2)
+    }
+
+    @Test("The right model stack is centred, not pinned to the top")
+    func rightColumnIsVerticallyCentred() {
+        // Paper frame 04 · D1: the heading and the model list are one
+        // principal group, centred together in the canvas above the footer.
+        let measured = Self.measureRightStack { content in
+            OnboardingIntrinsicColumn { content }
+        }
+        #expect(measured.stack.height > 0, "the stack did not lay out")
+        #expect(
+            abs(measured.stack.midY - measured.usableMid) <= 2,
+            "the model stack midpoint must equal the usable canvas midpoint"
+        )
+        // And it kept its natural height rather than filling the canvas.
+        #expect(measured.stack.height < measured.usableMid * 2 - 20,
+                "the stack expanded to fill the canvas instead of staying intrinsic")
+    }
+
+    @Test("A greedy wrapper would top-pin the stack — the case this guards")
+    func aGreedyWrapperTopPinsTheStack() {
+        // The negative control. A bare ScrollView is vertically greedy, so the
+        // enclosing centred HStack centres a child that is ALREADY full height
+        // and the rows inside it start at its top. If this ever stops
+        // differing from the intrinsic column above, the guard has gone blind.
+        let greedy = Self.measureRightStack { content in
+            ScrollView { content }
+        }
+        let intrinsic = Self.measureRightStack { content in
+            OnboardingIntrinsicColumn { content }
+        }
+        #expect(greedy.stack.height > 0, "the greedy stack did not lay out")
+        #expect(
+            greedy.stack.midY < intrinsic.stack.midY - 20,
+            "a bare ScrollView must pin the stack higher than an intrinsic column"
+        )
+    }
+
+    @Test("A stack taller than the canvas still scrolls")
+    func anOverflowingStackStillScrolls() {
+        // The fallback must survive: when the list genuinely cannot fit,
+        // filling the height and scrolling is the correct shape.
+        let tall = Self.measureRightStack(
+            rows: Array(repeating: 120, count: 12)
+        ) { content in
+            OnboardingIntrinsicColumn { content }
+        }
+        #expect(tall.stack.height > tall.usableMid * 2,
+                "an overflowing stack must keep its full content height inside a scroller")
+    }
+
+    @Test("Both two-column stacks use the intrinsic column, not a bare scroller")
+    func twoColumnStacksUseTheIntrinsicColumn() throws {
+        let view = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
+        // The shortlist and the Review companion list are the two right-hand
+        // columns; both must be intrinsic so the parent can centre them.
+        let intrinsic = view.components(separatedBy: "OnboardingIntrinsicColumn{").count - 1
+        #expect(intrinsic == 2,
+                "expected the shortlist and Review columns to be intrinsic, found \(intrinsic)")
+        // Browse all models is full-width and SHOULD fill, so exactly one bare
+        // ScrollView remains — the catalogue list.
+        let scrollers = view.components(separatedBy: "ScrollView{").count - 1
+        #expect(scrollers == 1,
+                "only the full-width catalogue may be a bare ScrollView, found \(scrollers)")
+    }
+
+    // MARK: - Responsive tiers
+
+    @Test("The three layout tiers resolve at Paper's breakpoints")
+    func layoutTiersResolveAtTheBreakpoints() {
+        // 1440-class: full rail, heading beside the list.
+        #expect(OnboardingLayout.resolve(width: 1440) == .wide)
+        #expect(OnboardingLayout.resolve(width: OnboardingD.columnsMinWidth) == .wide)
+        // 1000-class: rail narrows, canvas stacks (Paper 05.1.D).
+        #expect(OnboardingLayout.resolve(width: OnboardingD.columnsMinWidth - 1) == .medium)
+        #expect(OnboardingLayout.resolve(width: 1200) == .medium)
+        #expect(OnboardingLayout.resolve(width: 1000) == .medium)
+        #expect(OnboardingLayout.resolve(width: 820) == .medium)
+        // Floor: the rail rotates (Paper 05.1.E).
+        #expect(OnboardingLayout.resolve(width: 819) == .compact)
+        #expect(OnboardingLayout.resolve(width: 720) == .compact)
+    }
+
+    @Test("Every width from the floor up leaves the model rows usable")
+    func everyTierLeavesUsableCanvas() {
+        // Swept rather than sampled. Three fixed widths passed while 1200pt —
+        // wide enough for the old breakpoint, too narrow for the columns —
+        // squeezed the list to 332pt. A sweep finds that; three samples did
+        // not.
+        for width in stride(from: 720.0, through: 2000.0, by: 10.0) {
+            let layout = OnboardingLayout.resolve(width: width)
+            let railWidth = layout.isCompact ? 0 : layout.railWidth
+            let gutters = layout.isCompact
+                ? OnboardingD.compactGutter * 2
+                : OnboardingD.canvasLeading + OnboardingD.canvasTrailing
+            let content = width - railWidth - gutters
+            #expect(content >= OnboardingD.rowMinWidth,
+                    "at \(Int(width))pt the canvas leaves only \(Int(content))pt of content")
+            if layout.usesColumns {
+                let list = content - OnboardingD.headingColumnWidth - OnboardingD.columnGap
+                #expect(list >= OnboardingD.rowMinWidth,
+                        "at \(Int(width))pt the two-column list is only \(Int(list))pt wide")
+            }
+        }
+    }
+
+    @Test("The rail narrows before it rotates")
+    func railNarrowsBeforeItRotates() {
+        #expect(OnboardingLayout.wide.railWidth == OnboardingD.railWidth)
+        #expect(OnboardingLayout.medium.railWidth == OnboardingD.railNarrowWidth)
+        #expect(OnboardingD.railNarrowWidth < OnboardingD.railWidth)
+        #expect(OnboardingLayout.wide.usesColumns)
+        #expect(!OnboardingLayout.medium.usesColumns, "1000pt stacks, per Paper 05.1.D")
+        #expect(!OnboardingLayout.compact.usesColumns)
+        #expect(OnboardingLayout.compact.isCompact)
+        #expect(!OnboardingLayout.medium.isCompact)
+    }
+
+    // MARK: - Selection narrative (Paper 05.1 states 04 / 05 / 06)
+
+    private static let tradeUps = QuickstartCoordinator.onboardingChoices
+        .filter { $0.tier == .tradeUp }
+
+    private static func cachedEntry(_ alias: String) -> ModelEntry {
+        ModelEntry(alias: alias, hfRepo: "r", sizeOnDisk: "1.0 GB", cached: true)
+    }
+
+    @Test("The starter selection tells the user to choose a first model")
+    func starterSelectionUsesTheDefaultNarrative() {
+        let narrative = QuickstartView.selectionNarrative(
+            alias: QuickstartCoordinator.defaultChoice.alias,
+            cachedModels: [],
+            comparableTradeUps: Self.tradeUps
+        )
+        #expect(narrative == .chooseFirst)
+        #expect(narrative.title == "Choose your\nfirst model")
+    }
+
+    @Test("The low-memory fallback keeps the default narrative")
+    func lowMemorySelectionKeepsTheDefaultNarrative() {
+        // Paper draws no separate frame for it, and inventing one would be a
+        // claim about a choice the design deliberately leaves plain.
+        let narrative = QuickstartView.selectionNarrative(
+            alias: QuickstartCoordinator.lowMemoryChoice.alias,
+            cachedModels: [],
+            comparableTradeUps: Self.tradeUps
+        )
+        #expect(narrative == .chooseFirst)
+    }
+
+    @Test("A trade-up selection switches to the cost comparison")
+    func tradeUpSelectionComparesCost() {
+        for choice in Self.tradeUps {
+            let narrative = QuickstartView.selectionNarrative(
+                alias: choice.alias,
+                cachedModels: [],
+                comparableTradeUps: Self.tradeUps
+            )
+            #expect(narrative == .biggerAndCost, "\(choice.alias) should compare")
+            #expect(narrative.title == "Bigger, and\nwhat it costs")
+        }
+    }
+
+    @Test("A lone trade-up does not pretend to be a comparison")
+    func loneTradeUpFallsBack() {
+        // One column is a statement, not a comparison. If the shortlist ever
+        // ships a single trade-up the heading must not claim otherwise.
+        let single = [Self.tradeUps[0]]
+        #expect(QuickstartView.selectionNarrative(
+            alias: single[0].alias,
+            cachedModels: [],
+            comparableTradeUps: single
+        ) == .chooseFirst)
+    }
+
+    @Test("A cached selection says it is already here, whatever its size")
+    func cachedSelectionOutranksSize() {
+        // Cached-ness wins over size: "you already have this" is the more
+        // useful fact about a 9B on disk than what it would cost to fetch.
+        let bigCached = Self.tradeUps.last!
+        let narrative = QuickstartView.selectionNarrative(
+            alias: bigCached.alias,
+            cachedModels: [Self.cachedEntry(bigCached.alias)],
+            comparableTradeUps: Self.tradeUps
+        )
+        #expect(narrative == .alreadyHere)
+        #expect(narrative.title == "One is already\nhere.")
+    }
+
+    @Test("Every narrative carries its own subtitle")
+    func everyNarrativeHasItsOwnSubtitle() {
+        let hardware = Self.hardware32
+        let subtitles = Set([
+            QuickstartView.SelectionNarrative.chooseFirst,
+            .biggerAndCost,
+            .alreadyHere,
+        ].map { QuickstartView.selectionSubtitle($0, hardware: hardware) })
+        #expect(subtitles.count == 3, "each narrative must explain its own case")
+        #expect(QuickstartView.selectionSubtitle(.alreadyHere, hardware: hardware)
+            .contains("skips the download"))
+        #expect(QuickstartView.selectionSubtitle(.biggerAndCost, hardware: hardware)
+            .contains("32 GB"), "the comparison names this Mac's memory")
+    }
+
+    @Test("The comparison marks the pick and states only sourced figures")
+    func comparisonColumnsAreSourced() {
+        let picked = Self.tradeUps.last!
+        let columns = QuickstartView.comparisonColumns(
+            selection: picked.alias,
+            tradeUps: Self.tradeUps,
+            hardware: Self.hardware32
+        )
+        #expect(columns.count == Self.tradeUps.count)
+        #expect(columns.filter(\.isPicked).count == 1, "exactly one column is the pick")
+        #expect(columns.last?.isPicked == true)
+        for column in columns {
+            #expect(!column.download.isEmpty)
+            #expect(column.memory.hasPrefix("≈") || column.memory == "Unknown")
+            // Model estimates keep a decimal: 5.9 vs 6 is the comparison.
+            #expect(column.memory == "Unknown" || column.memory.contains("."),
+                    "a footprint estimate must not be rounded to a whole GB")
+            #expect(["Comfortable", "Tight", "Won't fit"].contains(column.fit))
+        }
+    }
+
+    @Test("Fit wording comes from the classification the primary is gated on")
+    func fitWordingFollowsClassification() {
+        #expect(QuickstartView.fitText(.recommended) == "Comfortable")
+        #expect(QuickstartView.fitText(.borderline) == "Tight")
+        #expect(QuickstartView.fitText(.tooBig) == "Won't fit")
+    }
+
+    @Test("Comparison headers name the parameter count being compared")
+    func comparisonHeadersNameParameters() {
+        for choice in Self.tradeUps {
+            let title = QuickstartView.comparisonColumnTitle(for: choice)
+            #expect(title.hasSuffix("B"), "\(choice.alias) header was \(title)")
+        }
+        #expect(Set(Self.tradeUps.map(QuickstartView.comparisonColumnTitle(for:))).count
+                == Self.tradeUps.count, "columns must be distinguishable")
+    }
+
+    // MARK: - The click contract (unchanged by this visual pass)
+
+    @Test("A single click selects and never navigates")
+    func singleClickOnlySelects() {
+        let coord = QuickstartCoordinator()
+        coord._testingReset()
+        defer { coord._testingReset() }
+        coord.advanceToChooseModel()
+        coord.resolveRecommendationLoading(catalogLoaded: true)
+        #expect(coord.step2Stage == .choosing)
+
+        for choice in QuickstartCoordinator.onboardingChoices {
+            coord.select(choice)
+            #expect(coord.selection.alias == choice.alias)
+            #expect(coord.step2Stage == .choosing, "selecting must not navigate")
+            #expect(coord.phase == .idle, "selecting must not start anything")
+        }
+    }
+
+    @Test("Selecting re-resolves the narrative, so the heading follows the click")
+    func selectionDrivesTheNarrative() {
+        // The presentation mapping is a pure function of the selection, so a
+        // click changes the heading by construction rather than by a separate
+        // update path that could drift out of step.
+        let starter = QuickstartCoordinator.defaultChoice.alias
+        let tradeUp = Self.tradeUps.last!.alias
+        #expect(QuickstartView.selectionNarrative(
+            alias: starter, cachedModels: [], comparableTradeUps: Self.tradeUps
+        ) != QuickstartView.selectionNarrative(
+            alias: tradeUp, cachedModels: [], comparableTradeUps: Self.tradeUps
+        ))
+    }
+
+    @Test("Double click activates the visible primary, and nothing else")
+    func doubleClickMirrorsThePrimary() {
+        // Paper 05.2.G "One action, three inputs" / approved default D3. The
+        // row's double-click is a shortcut for whatever the footer currently
+        // says — Review download on an uncached pick, Start existing model on
+        // a cached one — never a separate route with its own rules.
+        let rows = [
+            OnboardingModelSelection.Row(alias: "uncached", isCached: false),
+            OnboardingModelSelection.Row(alias: "cached", isCached: true),
+        ]
+        let uncached = OnboardingModelSelection.primary(
+            selection: "uncached", visibleRows: rows, catalogState: .ready, context: .shortlist
+        )
+        #expect(uncached.action == .reviewDownload)
+        #expect(uncached.title == OnboardingModelSelection.Verb.reviewDownload)
+
+        let cached = OnboardingModelSelection.primary(
+            selection: "cached", visibleRows: rows, catalogState: .ready, context: .shortlist
+        )
+        #expect(cached.action == .startExisting)
+
+        // And a disabled primary makes the shortcut inert.
+        let blocked = OnboardingModelSelection.primary(
+            selection: "missing", visibleRows: rows, catalogState: .ready, context: .shortlist
+        )
+        #expect(!blocked.isEnabled)
+    }
+
+    @Test("Model details stay on the Review destination")
+    func modelDetailsBelongToReview() {
+        // "Model details" is the Review micro-stage, reached by the primary —
+        // it must never replace the shortlist narrative in place.
+        let coord = QuickstartCoordinator()
+        coord._testingReset()
+        defer { coord._testingReset() }
+        coord.advanceToChooseModel()
+        coord.resolveRecommendationLoading(catalogLoaded: true)
+        coord.beginReviewDownload(origin: .shortlist)
+        #expect(coord.step2Stage == .reviewing)
+        #expect(coord.step == .chooseModel, "review is still Step 2")
+        coord.backFromReviewDownload()
+        #expect(coord.step2Stage == .choosing, "Back returns to the shortlist")
+    }
+
+    // MARK: - Transient states (Paper 05.1 states 02 / 03)
+
+    @Test("Both pre-shortlist micro-stages are reachable and distinct")
+    func transientStagesAreReachable() {
+        let coord = QuickstartCoordinator()
+        coord._testingReset()
+        defer { coord._testingReset() }
+
+        // Entering Step 2 lands on the hardware read, never straight on the
+        // shortlist — the list cannot say what is cached yet.
+        coord.advanceToChooseModel()
+        #expect(coord.step2Stage == .checkingHardware)
+
+        // An unresolved catalogue moves to the fit stage and stays there.
+        coord.resolveRecommendationLoading(catalogLoaded: false)
+        #expect(coord.step2Stage == .findingFit)
+        coord.resolveRecommendationLoading(catalogLoaded: false)
+        #expect(coord.step2Stage == .findingFit)
+
+        // Only a landed snapshot opens the shortlist.
+        coord.resolveRecommendationLoading(catalogLoaded: true)
+        #expect(coord.step2Stage == .choosing)
+    }
+
+    @Test("A catalogue invalidated after the fact reports honestly")
+    func staleCatalogueReturnsToFindingFit() {
+        // A download completing bumps the cache generation. Reporting a stale
+        // cached column would be worse than saying it is being re-read.
+        let coord = QuickstartCoordinator()
+        coord._testingReset()
+        defer { coord._testingReset() }
+        coord.advanceToChooseModel()
+        coord.resolveRecommendationLoading(catalogLoaded: true)
+        #expect(coord.step2Stage == .choosing)
+        coord.resolveRecommendationLoading(catalogLoaded: false)
+        #expect(coord.step2Stage == .findingFit)
+    }
+
+    @Test("Navigational micro-stages are never yanked by a catalogue reload")
+    func reloadDoesNotDisturbNavigation() {
+        let coord = QuickstartCoordinator()
+        coord._testingReset()
+        defer { coord._testingReset() }
+        coord.advanceToChooseModel()
+        coord.beginBrowsingCatalog()
+        coord.resolveRecommendationLoading(catalogLoaded: false)
+        #expect(coord.step2Stage == .browsing, "a reload must not eject the user")
+        coord.beginReviewDownload(origin: .catalogue)
+        coord.resolveRecommendationLoading(catalogLoaded: false)
+        #expect(coord.step2Stage == .reviewing)
+    }
+
+    @Test("Both transient screens are wired, with no invented duration")
+    func transientScreensAreWiredWithoutFakeDelay() throws {
+        let view = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")
+        #expect(view.contains("case.checkingHardware:checkingHardwareStep"))
+        #expect(view.contains("case.findingFit:findingFitStep"))
+        // Both screens name themselves through the shared transient scaffold,
+        // which applies the identifier it is handed — so the literals appear
+        // at the call sites and the modifier appears once.
+        #expect(view.contains(#"identifier:"Quickstart.Step2.CheckingHardware""#))
+        #expect(view.contains(#"identifier:"Quickstart.Step2.FindingFit""#))
+        #expect(view.contains(".accessibilityIdentifier(identifier)"),
+                "the transient scaffold must apply the identifier it is given")
+        // Paper is explicit that neither may be dressed as a timed scan.
+        for forbidden in ["Task.sleep", "DispatchQueue.main.asyncAfter", "repeatForever"] {
+            #expect(!view.contains(forbidden.replacingOccurrences(of: " ", with: "")),
+                    "the transient stages must not introduce an artificial delay (\(forbidden))")
+        }
+    }
+
+    // MARK: - The rail
+
+    @Test("The rail names all four steps, and only those")
+    func railNamesTheFourSteps() {
+        #expect(QuickstartCoordinator.Step.welcome.railTitle == "Welcome")
+        #expect(QuickstartCoordinator.Step.chooseModel.railTitle == "Choose a model")
+        #expect(QuickstartCoordinator.Step.download.railTitle == "Download")
+        #expect(QuickstartCoordinator.Step.start.railTitle == "Start")
+        #expect(QuickstartCoordinator.Step.allCases.count == 4)
+    }
+
+    @Test("The rail's spoken label keeps the exact golden-flow contract")
+    func railLabelIsTheContractString() {
+        // gui-golden-flows.sh matches this verbatim on Welcome, the chooser
+        // and Ready. It is a contract, not styling — PR #1917 put it there to
+        // prove the rail reports honest progress.
+        for step in QuickstartCoordinator.Step.allCases {
+            let label = OnboardingSetupRail.progressAccessibilityLabel(current: step)
+            #expect(label == "Setup progress, step \(step.displayNumber) of 4")
+        }
+    }
+
+    @Test("The rail's value carries the detail the label cannot")
+    func railValueCarriesTheDetail() {
+        let welcome = OnboardingSetupRail.progressAccessibilityValue(current: .welcome)
+        #expect(welcome == "Welcome", "nothing is completed on step 1")
+
+        let download = OnboardingSetupRail.progressAccessibilityValue(current: .download)
+        #expect(download.hasPrefix("Download"))
+        #expect(download.contains("Completed: Welcome, Choose a model"))
+        #expect(!download.contains("Start"), "a step ahead of the user is not completed")
+    }
+
+    // MARK: - The D2 subject rail
+
+    @Test("A pull with nothing observed yet is PREPARING, not DOWNLOADING")
+    func lifecycleNameFollowsTheRealPhase() {
+        // Paper draws these as separate states (09 and 14) and the difference
+        // is real: one has bytes to report, the other has a request that
+        // landed and no transfer yet.
+        #expect(QuickstartView.downloadLifecycleName(phase: nil) == "PREPARING")
+        #expect(QuickstartView.downloadLifecycleName(phase: .idle) == "PREPARING")
+        #expect(QuickstartView.downloadLifecycleName(phase: .preparing) == "PREPARING")
+        #expect(QuickstartView.downloadLifecycleName(phase: .warmingUp) == "PREPARING")
+        #expect(QuickstartView.downloadLifecycleName(
+            phase: .fetching(done: 0, total: 9, percent: 0)
+        ) == "DOWNLOADING")
+        #expect(QuickstartView.downloadLifecycleName(
+            phase: .downloading(file: "f", done: "1", total: "2", percent: 50, speed: nil, eta: nil)
+        ) == "DOWNLOADING")
+    }
+
+    @Test("The percentage floors, so it never reads 100% while files are landing")
+    func percentFloors() {
+        #expect(OnboardingSubjectRail.percentText(0) == "0%")
+        #expect(OnboardingSubjectRail.percentText(0.436) == "43%")
+        #expect(OnboardingSubjectRail.percentText(0.996) == "99%")
+        #expect(OnboardingSubjectRail.percentText(1) == "100%")
+        // Defensive clamping — a bad fraction must not print a nonsense figure.
+        #expect(OnboardingSubjectRail.percentText(1.4) == "100%")
+        #expect(OnboardingSubjectRail.percentText(-0.2) == "0%")
+    }
+
+    @Test("The byte line appears only once real disk growth is observed")
+    func byteLineRequiresObservation() {
+        let downloads = DownloadManager()
+        let job = downloads._testingSeedJob(alias: "lfm2.5-1b-4bit", totalBytes: 633_000_000)
+        // A seeded job has a total but no observation yet: a denominator alone
+        // is not progress, and rendering "0 MB / 633 MB" would imply a
+        // transfer that has not started.
+        #expect(QuickstartView.subjectBytesLine(job: job) == nil)
+        #expect(QuickstartView.subjectBytesLine(job: nil) == nil)
+    }
+
+    @Test("The rate line appears only once a rate has been measured")
+    func rateLineRequiresAMeasuredRate() {
+        // Paper 05.1.A forbids an ETA before bytes move, so there is
+        // deliberately no pre-download branch to test — only its absence.
+        let downloads = DownloadManager()
+        let job = downloads._testingSeedJob(alias: "lfm2.5-1b-4bit")
+        #expect(QuickstartView.subjectRateLine(job: job) == nil)
+        #expect(QuickstartView.subjectRateLine(job: nil) == nil)
+    }
+
+    // MARK: - Catalogue rows
+
+    @Test("A runnable row shows its repo; an unrunnable one shows the reason")
+    func catalogSubtitleSwapsForUnavailableRows() {
+        let hardware = MacHardware(
+            brandString: "Apple M2 Max",
+            family: .m2,
+            tier: .max,
+            physicalRAMBytes: 32 * 1024 * 1024 * 1024,
+            memoryBandwidthGBs: 400
+        )
+        let entry = ModelEntry(
+            alias: "llama3.1-70b-4bit",
+            hfRepo: "mlx-community/Llama-3.1-70B-Instruct-4bit",
+            sizeOnDisk: nil,
+            cached: false
+        )
+
+        let available = QuickstartView.catalogRowSubtitle(
+            entry: entry, available: true, hardware: hardware
+        )
+        #expect(available == "mlx-community/Llama-3.1-70B-Instruct-4bit")
+
+        let blocked = QuickstartView.catalogRowSubtitle(
+            entry: entry, available: false, hardware: hardware
+        )
+        #expect(blocked.contains("Needs"))
+        #expect(blocked.contains("32 GB"), "the reason must name what this Mac actually has")
+        #expect(!blocked.contains("mlx-community"), "the reason replaces the repo, not joins it")
+    }
+
+    @Test("Row badges only ever restate facts the app already holds")
+    func catalogBadgesAreClosedVocabulary() {
+        let starter = ModelEntry(
+            alias: QuickstartCoordinator.defaultChoice.alias,
+            hfRepo: "r",
+            sizeOnDisk: nil,
+            cached: true
+        )
+        let starterBadges = QuickstartView.catalogRowBadges(entry: starter, available: true)
+        #expect(starterBadges.map { $0.text } == ["RECOMMENDED", "ON THIS MAC"])
+
+        let plain = ModelEntry(alias: "qwen3.5-4b-4bit", hfRepo: "r", sizeOnDisk: nil, cached: false)
+        #expect(QuickstartView.catalogRowBadges(entry: plain, available: true).isEmpty,
+                "an ordinary uncached row makes no claim at all")
+
+        let cached = ModelEntry(alias: "qwen3.5-4b-4bit", hfRepo: "r", sizeOnDisk: nil, cached: true)
+        #expect(QuickstartView.catalogRowBadges(entry: cached, available: true)
+            .map { $0.text } == ["ON THIS MAC"])
+
+        // WON'T FIT replaces the cached badge rather than stacking with it:
+        // whether it is on disk stops being the useful fact once it cannot run.
+        let tooBig = ModelEntry(alias: "llama3.1-70b-4bit", hfRepo: "r", sizeOnDisk: nil, cached: true)
+        #expect(QuickstartView.catalogRowBadges(entry: tooBig, available: false)
+            .map { $0.text } == ["WON'T FIT"])
+    }
+
+    // MARK: - Review download facts
+
+    private var hardware32: MacHardware { Self.hardware32 }
+
+    fileprivate static let hardware32 = MacHardware(
+        brandString: "Apple M2 Max",
+        family: .m2,
+        tier: .max,
+        physicalRAMBytes: 32 * 1024 * 1024 * 1024,
+        memoryBandwidthGBs: 400
+    )
+
+    @Test("Review states the cost, and omits any row it cannot source")
+    func reviewFactsAreSourcedOrAbsent() {
+        let rows = QuickstartView.reviewFacts(
+            alias: QuickstartCoordinator.defaultChoice.alias,
+            cached: nil,
+            cachedModels: [],
+            hardware: hardware32,
+            freeBytes: 400 * 1024 * 1024 * 1024
+        )
+        let labels = rows.map(\.label)
+        #expect(labels.first == "Model", "the alias about to be pulled is named first")
+        #expect(labels.contains("Download"))
+        #expect(labels.contains("On this Mac"))
+        #expect(labels.contains("Memory when loaded"))
+        #expect(labels.contains("Free space"))
+        // The golden-flow harness addresses this row by identifier.
+        #expect(rows.contains { $0.identifier == "Quickstart.Review.Alias" })
+        // One model, one number: Review must quote the same download figure
+        // the card does, which for a pinned choice is its byte count and not
+        // the parameter-derived estimate.
+        let starter = QuickstartCoordinator.defaultChoice
+        #expect(QuickstartView.reviewDownloadText(alias: starter.alias, cached: nil)
+                == QuickstartView.sizeText(for: starter))
+        #expect(rows.first { $0.label == "Download" }?.value
+                == QuickstartView.sizeText(for: starter))
+    }
+
+    @Test("A probe with no signal removes the free-space row rather than guessing")
+    func reviewOmitsFreeSpaceWithoutAProbe() {
+        let rows = QuickstartView.reviewFacts(
+            alias: QuickstartCoordinator.defaultChoice.alias,
+            cached: nil,
+            cachedModels: [],
+            hardware: hardware32,
+            freeBytes: nil
+        )
+        #expect(!rows.map(\.label).contains("Free space"))
+    }
+
+    @Test("A cached model reports what it occupies, not what it would cost")
+    func reviewSwitchesToSizeOnDiskWhenCached() {
+        let cached = ModelEntry(
+            alias: "qwen3.5-4b-4bit",
+            hfRepo: "r",
+            sizeOnDisk: "2.2 GB",
+            cached: true
+        )
+        let rows = QuickstartView.reviewFacts(
+            alias: "qwen3.5-4b-4bit",
+            cached: cached,
+            cachedModels: [cached],
+            hardware: hardware32,
+            freeBytes: nil
+        )
+        #expect(rows.map(\.label).contains("Size on disk"))
+        #expect(!rows.map(\.label).contains("Download"))
+        #expect(rows.first { $0.label == "On this Mac" }?.value == "Already downloaded")
+    }
+
+    @Test("The Review footnote frames a cost only when there is one")
+    func reviewFootnoteOnlyForUncached() {
+        let uncached = QuickstartView.reviewFootnote(
+            alias: QuickstartCoordinator.defaultChoice.alias,
+            cached: nil
+        )
+        #expect(uncached != nil)
+        #expect(uncached!.contains("once"))
+        #expect(uncached!.lowercased().contains("no network"))
+
+        let cached = ModelEntry(alias: "a", hfRepo: "r", sizeOnDisk: "1 GB", cached: true)
+        #expect(QuickstartView.reviewFootnote(alias: "a", cached: cached) == nil,
+                "nothing is being spent, so there is no cost to frame")
+    }
+
+    @Test("Memory figures round in exactly one place")
+    func memoryFiguresShareOneFormatter() {
+        // The catalogue row and the Review table both quote this Mac's memory.
+        // If they rounded separately they could disagree by a gibibyte on the
+        // same screen.
+        #expect(QuickstartView.wholeGB(32.0) == "32 GB")
+        #expect(QuickstartView.wholeGB(8.7) == "9 GB")
+        // …and a model estimate does not.
+        #expect(QuickstartView.preciseGB(8.7) == "8.7 GB")
+        #expect(QuickstartView.preciseGB(5.94) == "5.9 GB")
+        #expect(QuickstartView.wholeGB(0.4) == "0 GB")
+    }
+
+    // MARK: - Failure presentation
+
+    @Test("A cancellation is drawn as a stop, not a fault")
+    func cancellationGetsItsOwnGlyph() {
+        #expect(QuickstartView.failureGlyph(for: .downloadCancelled) == "stop.circle")
+        #expect(QuickstartView.failureGlyph(for: .downloadFailed) == "exclamationmark.triangle")
+        #expect(QuickstartView.failureGlyph(for: .downloadSourceUnavailable) == "wifi.exclamationmark")
+        #expect(QuickstartView.failureGlyph(for: .modelOutOfMemory) == "memorychip")
+    }
+
+    @Test("The failure kicker keeps the step the user was actually in")
+    func failureKickerKeepsItsOriginStep() {
+        // A failure never becomes a step of its own — a broken pull is still
+        // Step 3, a load failure still Step 4.
+        let download = QuickstartView.failureKicker(for: .downloadCancelled, origin: .download)
+        #expect(download == "STEP 3 OF 4 · DOWNLOAD STOPPED")
+
+        let start = QuickstartView.failureKicker(for: .modelLoadFailed, origin: .start)
+        #expect(start == "STEP 4 OF 4 · COULDN'T LOAD")
+
+        for kind in FailureDiagnosis.Kind.allCases {
+            let kicker = QuickstartView.failureKicker(for: kind, origin: .download)
+            #expect(kicker.hasPrefix("STEP 3 OF 4 · "))
+            #expect(!kicker.contains("OF 5"), "a failure must never add a step")
+        }
+    }
+
+    @Test("Cancellation and failure remain visibly different screens")
+    func cancellationAndFailureLookDifferent() {
+        // The same distinction the merged recovery slice made in the copy,
+        // carried into the composition: a different glyph, a different tone,
+        // a different kicker and a different heading.
+        #expect(QuickstartView.failureGlyph(for: .downloadCancelled)
+                != QuickstartView.failureGlyph(for: .downloadFailed))
+        #expect(QuickstartView.failureKicker(for: .downloadCancelled, origin: .download)
+                != QuickstartView.failureKicker(for: .downloadFailed, origin: .download))
+        #expect(QuickstartView.failureTitle(for: .downloadCancelled)
+                != QuickstartView.failureTitle(for: .downloadFailed))
+        // Tone is chosen from severity, so the notice lane cannot go red.
+        #expect(FailureDiagnosis.Kind.downloadCancelled.severity == .notice)
+        #expect(FailureDiagnosis.Kind.downloadFailed.severity == .error)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -612,6 +612,18 @@ struct OnboardingDirectionDTests {
         #expect(QuickstartView.subjectBytesLine(job: nil) == nil)
     }
 
+    @Test("Measured bytes stay visible when an incorrect total is discarded")
+    func byteLineKeepsTruthfulNumeratorAfterOverrun() {
+        let downloads = DownloadManager()
+        let job = downloads._testingSeedJob(alias: "lfm2.5-1b-4bit", totalBytes: 563 * 1024 * 1024)
+        job.progress.seedDiskBaseline(bytes: 0)
+        job.progress.applyDiskObservation(bytes: 633 * 1024 * 1024)
+
+        #expect(job.progress.totalBytes == nil)
+        #expect(QuickstartView.subjectBytesLine(job: job) == "633 MB downloaded")
+        #expect(QuickstartView.downloadLifecycleName(progress: job.progress) == "DOWNLOADING")
+    }
+
     @Test("The rate line appears only once a rate has been measured")
     func rateLineRequiresAMeasuredRate() {
         // Paper 05.1.A forbids an ETA before bytes move, so there is

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartBrowseAllDestinationTests.swift
@@ -43,6 +43,14 @@ struct QuickstartBrowseAllDestinationTests {
         }
     }
 
+    /// Comment- and whitespace-stripped source, shared with the other
+    /// source-guard suites. Comments must go, not just whitespace: otherwise a
+    /// doc comment that *describes* a call counts as the call, and a wiring
+    /// test passes on prose.
+    private static func stripped(_ source: String) -> String {
+        CapabilityChipRenderGateSourceGuardTests.stripCommentsAndWhitespace(source)
+    }
+
     private static func coordinator() -> QuickstartCoordinator {
         let coord = QuickstartCoordinator()
         coord._testingReset()
@@ -53,16 +61,12 @@ struct QuickstartBrowseAllDestinationTests {
 
     @Test("The link's action calls browseAllModels(), not a dismiss flag")
     func browseAllIsWiredToTheCatalogue() throws {
-        let source = try Self.quickstartSource
+        // Matched on comment- and whitespace-stripped source rather than raw
+        // text: the invariant is which function the control calls, and pinning
+        // the indentation as well made a pure re-layout fail a wiring test.
+        let source = Self.stripped(try Self.quickstartSource)
         #expect(
-            source.contains(
-                """
-                                    Button {
-                                        browseAllModels()
-                                    } label: {
-                                        Text("Browse all models →")
-                """
-            ),
+            source.contains(#"Button("Browseallmodels→"){browseAllModels()}"#),
             """
             The "Browse all models →" button no longer calls browseAllModels(). \
             If it is back to a dismiss closure, that is #1653 returning: the \
@@ -82,20 +86,17 @@ struct QuickstartBrowseAllDestinationTests {
     /// failure card with no way out, or one whose way out leaves setup.
     @Test("The failure card offers a wired route back to model selection")
     func failureCardLinkIsWiredToo() throws {
-        let source = try Self.quickstartSource
+        let source = Self.stripped(try Self.quickstartSource)
         #expect(
             source.contains(
-                """
-                        Button {
-                            returnToModelSelection()
-                        } label: {
-                            Text(Self.failureBackTitle(for: coordinator.step2Stage))
-                """
+                "Button(Self.failureBackTitle(for:coordinator.step2Stage))"
+                + "{returnToModelSelection()}"
             ),
             """
-            The failure card's Back control must call returnToModelSelection(). \
-            It is offered precisely when the user's chosen model failed, which \
-            is the moment they most need to pick a different one.
+            The failure card's Back control must call returnToModelSelection() \
+            and label itself from the origin micro-stage. It is offered \
+            precisely when the user's chosen model failed, which is the moment \
+            they most need to pick a different one.
             """
         )
     }
@@ -248,13 +249,7 @@ struct QuickstartBrowseAllDestinationTests {
             """
         )
         #expect(
-            source.contains(
-                """
-                            Button("Skip for now") {
-                                onSkip()
-                            }
-                """
-            ),
+            Self.stripped(source).contains(#"Button("Skipfornow"){onSkip()}"#),
             "The one onSkip() call must be Skip for now."
         )
     }

--- a/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
@@ -72,6 +72,17 @@ struct Step2ModelSelectionBehaviorTests {
         return try String(contentsOf: url, encoding: .utf8)
     }
 
+    /// The Direction D design system, which owns the shared footer lane and
+    /// therefore the Escape contract that used to live in the components file.
+    private static func directionDSource() throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Rapid/UI/OnboardingDirectionD.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
     /// Comment- and whitespace-stripped source, using the same helper the rest
     /// of the source-guard suites share. Comments must go, not just whitespace:
     /// otherwise a doc comment that *describes* a call counts as the call, and
@@ -122,19 +133,38 @@ struct Step2ModelSelectionBehaviorTests {
         #expect(!kicker.contains("OF 5"), "the catalogue must not add a step")
     }
 
-    @Test("Every micro-stage renders the rail through the shared Step 2 scaffold")
+    @Test("Every micro-stage renders the rail through one shared shell")
     func railIsRenderedOnce() throws {
         let body = Self.stripped(try Self.quickstartSource)
-        // One rail call inside Step 2, in the scaffold every branch goes
-        // through — not one per screen, which is how the old three-step model
-        // ended up with two screens both claiming step 3. Matched with its
-        // trailing modifier so the prose in the doc comment above it does not
-        // count as a second call site.
-        let railCalls = body
-            .components(separatedBy: "OnboardingTopBar(step:.chooseModel).padding(.top,22)")
-            .count - 1
-        #expect(railCalls == 1, "Step 2's rail must be rendered by the scaffold alone")
-        #expect(body.contains("privatefuncstep2Scaffold<Content:View,Footer:View>"))
+        // Direction D draws the rail once for the WHOLE surface, from
+        // `coordinator.step`, rather than once per screen — which is how the
+        // old three-step model ended up with two screens both claiming step 3.
+        // The invariant is unchanged and is now enforced more strongly: no
+        // Step 2 branch can render a rail at all, because none of them has one.
+        let fullRail = body.components(separatedBy: "OnboardingSetupRail(").count - 1
+        let compactRail = body.components(separatedBy: "OnboardingCompactRail(").count - 1
+        #expect(fullRail == 1, "exactly one full-width rail call site, found \(fullRail)")
+        #expect(compactRail == 1, "exactly one rotated-rail call site, found \(compactRail)")
+        // Both live in the shell's rail planes, never inside a micro-stage.
+        #expect(body.contains("privatevarrailPlane:someView{"))
+        #expect(body.contains("privatevarcompactRailPlane:someView{"))
+        // And every micro-stage still routes through the one scaffold.
+        #expect(body.contains("privatefuncstep2Scaffold<Body:View,Footer:View>"))
+    }
+
+    @Test("The rail reports the macro step, and never a micro-stage")
+    func railReportsTheMacroStepOnly() {
+        // The rail reads `coordinator.step`, which is derived from (phase,
+        // stage) and deliberately does not consult `step2Stage`. Browsing and
+        // reviewing must therefore both still report Step 2.
+        let coord = Self.coordinator()
+        coord.advanceToChooseModel()
+        #expect(coord.step == .chooseModel)
+        coord.beginBrowsingCatalog()
+        #expect(coord.step == .chooseModel, "the catalogue is not a step of its own")
+        coord.beginReviewDownload(origin: .catalogue)
+        #expect(coord.step == .chooseModel, "review is not a step of its own")
+        #expect(QuickstartCoordinator.Step.total == 4)
     }
 
     // MARK: - 2. CTA derivation (Paper 05.2.G — canonical)
@@ -519,7 +549,10 @@ struct Step2ModelSelectionBehaviorTests {
     /// see" structural rather than re-implemented per screen.
     @Test("Return is the footer primary, and a disabled primary swallows it")
     func returnIsTheVisiblePrimary() throws {
-        let footer = Self.stripped(try Self.componentsSource())
+        // Direction D moved the shared action lane out of the components file
+        // and into the design system; the contract is unchanged, and it is
+        // still one control rather than one per screen.
+        let footer = Self.stripped(try Self.directionDSource())
         #expect(footer.contains(".disabled(!primaryEnabled).keyboardShortcut(.defaultAction)"),
                 "the default action must sit on the control the derivation disables")
         #expect(footer.contains(#".accessibilityIdentifier("Quickstart.Footer.Primary")"#))
@@ -796,14 +829,14 @@ struct Step2ModelSelectionBehaviorTests {
     @Test("Every Escape destination also has a visible control")
     func escapeMirrorsAVisibleControl() throws {
         let body = Self.stripped(try Self.quickstartSource)
-        let components = Self.stripped(try Self.componentsSource())
         // Escape is `.cancelAction` on Back, and every Step 2 micro-stage
         // supplies a Back — so the key can only ever do what a visible control
         // already does.
-        #expect(components.contains(".keyboardShortcut(.cancelAction).accessibilityIdentifier(\"Quickstart.Footer.Back\")"))
+        let directionD = Self.stripped(try Self.directionDSource())
+        #expect(directionD.contains(".keyboardShortcut(.cancelAction).accessibilityIdentifier(\"Quickstart.Footer.Back\")"))
         #expect(body.contains(#"backTitle:"←Backtorecommendedmodels""#))
         #expect(body.contains(#""←Backtoallmodels""#))
-        let footers = body.components(separatedBy: "OnboardingWizardFooter(").count - 1
+        let footers = body.components(separatedBy: "OnboardingStepFooter(").count - 1
         #expect(footers >= 4, "each Step 2 micro-stage must carry its own footer, found \(footers)")
     }
 

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1172,7 +1172,34 @@ flow_fresh_install() {
         "$OUT/fake-events.jsonl" >/dev/null; then
         die "#1560: first launch probed the model catalog before user interaction"
     fi
-    dismiss_first_run
+    press "$OUT/consent-visible.json" TelemetryConsent.DontShare "$OUT/consent-dismiss.json"
+    wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
+
+    # Direction D owns the window rather than mounting production controls
+    # behind a sheet. Pin all three responsive tiers before continuing the
+    # pre-existing fresh-install journey into the production shell.
+    for hidden in Sidebar.NewChat Sidebar.Launch rapid.chat.compose; do
+        if jq -e --arg id "$hidden" '.data.ui_elements[]? | select(.identifier == $id)' \
+            "$OUT/welcome.json" >/dev/null; then
+            die "Direction D mounted production control $hidden behind onboarding"
+        fi
+    done
+    "$AX_DRIVER" set-window-size "$APP_PID" Rapid-MLX 1400x850 > "$OUT/wide-size.json"
+    see_main "$OUT/wide.json"
+    baseline onboarding-direction-d.wide "$OUT/wide.json"
+    "$AX_DRIVER" set-window-size "$APP_PID" Rapid-MLX 1000x760 > "$OUT/medium-size.json"
+    see_main "$OUT/medium.json"
+    baseline onboarding-direction-d.medium "$OUT/medium.json"
+    "$AX_DRIVER" set-window-size "$APP_PID" Rapid-MLX 720x700 > "$OUT/compact-size.json"
+    see_main "$OUT/compact.json"
+    baseline onboarding-direction-d.compact "$OUT/compact.json"
+    press "$OUT/compact.json" Quickstart.GetStarted "$OUT/get-started.json"
+    wait_tree_text "~633 MB" "$OUT/chooser-settled.json"
+    baseline onboarding-direction-d.compact-chooser "$OUT/chooser-settled.json"
+    press "$OUT/chooser-settled.json" Quickstart.Footer.Back "$OUT/chooser-back.json"
+    wait_identifier Quickstart.Skip "$OUT/welcome-returned.json"
+    press "$OUT/welcome-returned.json" Quickstart.Skip "$OUT/quickstart-skip.json"
+    wait_identifier rapid.chat.compose "$OUT/steady.json"
     selected_model="$(element_field "$OUT/steady.json" ModelPickerBar.ModelMenu value)"
     [[ "$selected_model" == *"lfm2.5-1b-4bit"* ]] \
         || die "#1564: skipping Quickstart selected '$selected_model' instead of the small starter"


### PR DESCRIPTION
## What this is

The approved Paper **Direction D** visual design, applied to the existing four-step onboarding flow. The behaviour and recovery state machine merged in #1946 is the source of truth here — this PR consumes it and does not redefine it. Every recovery route, keyboard contract, accessibility identifier and VoiceOver announcement from that PR still behaves exactly as it did.

The load-bearing change is presentation. Onboarding was a `.sheet`, which on macOS is a *document-modal panel*: AppKit sizes it to its content's ideal width, insets it, rounds its corners and leaves the parent visible around it. So it drew as a centred card floating over a dimmed chat surface — the one composition Paper 05.1.A rules out — and it settled at its 620pt minimum, below the 820pt breakpoint, which made the full-height rail unreachable on any display. The root now branches between the production shell and the setup shell, so setup **is** the window content: it fills everything below the native title bar, has no corner radius of its own, and has nothing behind it to show through.

The native title bar and its traffic lights are untouched. "Full window" here means the app's content area — never macOS fullscreen.

## Direction D screens implemented

| Paper state | Screen |
|---|---|
| 05.1.A | Welcome / step 1, with the setup rail and the hardware subject rail |
| 05.1 · 04 | Model selection — starter recommendation |
| 05.1 · 05 | Model selection — trade-up, with the download / memory / fit comparison |
| 05.1 · 06 | Model selection — a pick already on this Mac |
| 05.2 | Browse all models — catalogue rows, badges, search, filter, sort |
| 05.2.J | Review download — facts table, footnote, primary |
| 05.1 · 08 | Download in progress — subject band, bytes and rate lines |
| 05.1 · 09–12 | Recovery — download stopped, download failed, offline, source unavailable |
| 05.1 · 13 | Missing engine, including repeated Recheck |
| 05.1 · 14 | Low disk — warn-only |
| 05.1 · 15 | Ready / `Start chatting` |

## Visual and layout architecture

**One canvas geometry serves every state.** A principal group fills the canvas and centres in it, with the action lane anchored beneath. This is a shared scaffold rather than a per-screen padding on purpose: the alternative is what it replaced, where each state carried its own top-padding number and they drifted apart.

**Three responsive tiers**, taken from Paper's own frames rather than invented:

| Tier | Width | Rail | Canvas |
|---|---|---|---|
| Wide | ≥ 1290 | 300pt vertical rail | Step 2 heading beside the list (two columns) |
| Medium | 820 – 1289 | 240pt vertical rail | Stacked canvas (05.1.D) |
| Compact | < 820 | 46pt horizontal strip, or a 56pt graphite band during a download | Full-width canvas (05.1.E) |

The columns breakpoint is **derived, not guessed**: rail + gutters + heading column + gap is 868pt before a single row is drawn, so below 1290 the rows fall under the width their four lanes need. A regression test sweeps 720 → 2000 in 10pt steps and asserts the row width never drops below its minimum.

**The right-hand model column is an intrinsic column (`ViewThatFits`), not a `ScrollView`.** A `ScrollView` is vertically greedy: it takes the whole offered height, the enclosing centred `HStack` then centres a child that is already full height, and the cards inside stack from *its* top. The result was a heading that read centred beside a list that read pinned, and no alignment on the parent could have fixed it. There is a measurement test for this — it renders the two-column layout offscreen and asserts the right stack's midpoint matches the canvas midpoint, plus a negative control that fails if the column becomes top-pinned while the left stays centred.

**The Step 2 heading is a pure function of the selection** (Paper 05.1 states 04 / 05 / 06). The starter gets *"Choose your first model"*; a trade-up gets *"Bigger, and what it costs"* with a comparison of download size, memory when loaded, and fit; a pick already on disk gets *"One is already here."* Cached-ness outranks size, because "you already have this" is the more useful thing to say about a 9B that happens to be on disk. Every figure in that table is an existing reading — `sizeText`, `ModelSizing.estimate`, and the same `classify` the footer primary is already gated on — so the screen compares without appraising.

## Behaviour and accessibility contracts preserved from #1946

- Four-step structure; the catalogue and Review are **not** steps of their own
- `Continue setup` on relaunch with an incomplete setup, returning to the correct Step 2 micro-stage
- Cancellation and the truthful `Download stopped` recovery — a user-initiated stop is never dressed as a fault
- Retry, and the exact Back destinations for every failure origin
- Search, filter, sort, scroll and selection restoration when returning to the catalogue
- Genuine download failure, offline, and source-unavailable diagnoses
- Missing engine, including repeated Recheck
- Low disk stays **warn-only**; incompatible memory stays blocking
- Pending Ready and `Start chatting`
- Single click selects and never navigates; double-click mirrors the visible primary through the shared `modelRowActivation` path (Review download on an uncached pick, Start existing model on a cached one, nothing on a disabled one)
- Return is `.defaultAction` on the very control the derivation disables; Escape is `.cancelAction` on Back, with the search field taking priority when it holds text
- Every accessibility identifier and VoiceOver announcement. `Quickstart.Progress` in particular keeps its exact spoken label, which the golden flows match verbatim

## Verification

**Automated**, on this branch rebased onto `upstream/main` @ `fb9475c1`:

- Debug build — clean
- Release build — clean
- Direction D focused suite — **43 / 43 passed**
- Onboarding recovery suite — **60 / 60 passed**
- Accessibility identifier inventory gate — **16 / 16 passed**
- `verify-recommendation-tiers.swift` — ALL PASS
- `verify-conversation-ordering.sh` — ok
- `verify-chat-timeout.swift` — OK
- Full suite — **2489 tests in 216 suites, 1 failure** (see below)

**Live manual pass**, on an isolated dogfood build with its own bundle identifier, preferences, `HOME`, Application Support and model cache:

1. Full-window presentation — no modal card, no dimmed chat behind, native title bar and traffic lights intact
2. All three responsive tiers, resized live across both breakpoints
3. Welcome → model selection → Browse All → Review → download → Ready, end to end
4. All three Step 2 selection narratives (starter, trade-up, already-on-disk)
5. Cancel download, and the `Download stopped` recovery copy and routes
6. Download failure and retry, returning to the correct origin
7. Catalogue state restoration (search, filter, sort, scroll, selection) on Back
8. Missing engine and repeated Recheck
9. Low-disk warning — warn-only, primary still enabled
10. Relaunch with an incomplete setup → `Continue setup` → correct micro-stage

VoiceOver was not manually exercised; its contracts are covered by the deterministic accessibility regression tests added in #1946 and preserved here.

## Known unrelated test failure

`MarkdownLinkPerformanceTests` → *"Adjacent links keep their own hit targets"* fails. **This reproduces on clean `upstream/main` @ `fb9475c1`** in a fresh worktree with none of this branch's changes applied, so it is pre-existing and unrelated to onboarding.

## Deliberate deviations from Paper

Each of these is stated in the code, next to the thing that deviates.

1. **Medium-tier headline sizing.** Paper 05.1.D steps the headline down at medium as well as compact. Here it holds its desktop size through wide *and* medium and steps once, at compact. Continuously scaling the headline with window width made the same screen read as a different screen during a resize.
2. **True centring.** Paper's frames sit roughly 5% above true centre — an optical lift. This centres truly. The lift is not reproducible across three tiers without becoming a magic number per tier, which is the failure mode the shared canvas exists to prevent.
3. **State 07 is not implemented.** Its trigger overlaps state 04 in every real first run, so it would be unreachable.
4. **Missing engine keeps its current presentation ownership.** Moving it into the setup shell would change which surface owns the window, not how it looks — a behaviour change, out of scope here.

## Deferred

**`WON'T FIT` informational Review is not implemented.** Oversized catalogue rows remain dimmed and unselectable. They gained the Paper badge and the memory reason, which is visual, but opening their read-only Review would enable a new user action and belongs in its own behaviour PR.

## Scope

No Paper edits — the document was read only. No Settings, Chat, Images, Audio, Launch, About, Update, menu-bar, Dock, notification or global-shortcut surfaces touched. The diff is 9 files, all under `apps/rapid-mac`: 4 sources and 5 test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
