### PR TITLE
fix(cache): sliding-window models get bounded trim-free prefix reuse (#2061)

### DIFF
--- a/tests/test_hybrid_prefix_cache_auto_default.py
+++ b/tests/test_hybrid_prefix_cache_auto_default.py
@@ -296,3 +296,206 @@ def _patch_resolve_profile(
     monkeypatch.setattr(
         "vllm_mlx.model_aliases.resolve_profile", lambda _name: mock_profile
     )
+
+
+# ---------------------------------------------------------------------------
+# #2061: sliding-window (RotatingKVCache) families need bounded trim-free reuse
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDeclaresSlidingWindow:
+    """Unit tests for the architecture-driven sliding-window probe (no I/O)."""
+
+    def test_layer_types_sliding_is_detected(self):
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert _config_declares_sliding_window(
+            {"layer_types": ["sliding_attention", "full_attention"]}
+        )
+
+    def test_positive_sliding_window_int_is_detected(self):
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert _config_declares_sliding_window({"sliding_window": 512})
+
+    def test_nested_text_config_is_inspected(self):
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        # Gemma VLM checkpoints nest the language config under ``text_config``.
+        assert _config_declares_sliding_window(
+            {"text_config": {"sliding_window": 1024}}
+        )
+
+    def test_full_attention_only_is_not_detected(self):
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert not _config_declares_sliding_window(
+            {"layer_types": ["full_attention", "full_attention"]}
+        )
+
+    def test_layer_types_wins_over_inert_sliding_window_scalar(self):
+        """An authoritative all-full-attention ``layer_types`` must NOT be
+        overridden by a leftover ``sliding_window`` scalar — that field is inert
+        without a sliding layer to apply it (codex #2064)."""
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert not _config_declares_sliding_window(
+            {"layer_types": ["full_attention"], "sliding_window": 4096}
+        )
+
+    def test_layer_types_sliding_still_detected_with_sliding_window(self):
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert _config_declares_sliding_window(
+            {
+                "layer_types": ["sliding_attention", "full_attention"],
+                "sliding_window": 1024,
+            }
+        )
+
+    def test_nested_language_config_wins_over_top_level_scalar(self):
+        """The language backbone (``text_config``) is authoritative: an all-
+        full-attention LM must not be forced sliding by a top-level
+        ``sliding_window`` scalar (often a vision/default field) — codex #2064."""
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert not _config_declares_sliding_window(
+            {"sliding_window": 4096, "text_config": {"layer_types": ["full_attention"]}}
+        )
+
+    def test_top_level_used_when_nested_lm_config_has_no_signal(self):
+        """If ``text_config`` carries no attention signal at all, root-level
+        fields still count (checkpoints that place them at the root)."""
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert _config_declares_sliding_window(
+            {"sliding_window": 512, "text_config": {"hidden_size": 1}}
+        )
+
+    def test_use_sliding_window_false_disables_scalar(self):
+        """Qwen2 / Mistral carry a ``sliding_window`` scalar gated behind
+        ``use_sliding_window`` — a positive scalar with the flag off is inert and
+        must NOT trigger bounded snapshots (memory regression) — codex #2064."""
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert not _config_declares_sliding_window(
+            {"use_sliding_window": False, "sliding_window": 32768}
+        )
+
+    def test_use_sliding_window_true_keeps_scalar(self):
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert _config_declares_sliding_window(
+            {"use_sliding_window": True, "sliding_window": 4096}
+        )
+
+    def test_empty_or_zero_or_none_is_not_detected(self):
+        from vllm_mlx.cli import _config_declares_sliding_window
+
+        assert not _config_declares_sliding_window({})
+        assert not _config_declares_sliding_window(None)
+        assert not _config_declares_sliding_window({"sliding_window": 0})
+
+
+class TestSlidingWindowNeedsBoundedReuse:
+    """#2061: Gemma-2/3/4 sliding layers run on RotatingKVCache, which is
+    non-trimmable once the ring rotates past its window. They must take the
+    bounded snapshot path or --enable-prefix-cache is a silent no-op and every
+    agentic turn re-prefills the whole context. Detection is config-driven so a
+    bare local path (with no alias) is covered too — exactly how #2061 was
+    served (an lm-studio gemma-4 checkpoint path)."""
+
+    _SLIDING = {"layer_types": ["sliding_attention", "full_attention"]}
+    _FULL = {"layer_types": ["full_attention", "full_attention"]}
+
+    def test_sliding_window_alias_needs_bounded_reuse(self, monkeypatch):
+        # Reference cli through the live module object (not a load-time import)
+        # and patch the probe on that SAME object, so a sibling test that
+        # reload/pops ``vllm_mlx.cli`` cannot desync the two (per the string-
+        # patch-target rule in testing-gotchas).
+        import vllm_mlx.cli as cli
+
+        _patch_resolve_profile(monkeypatch, is_hybrid=False)
+        monkeypatch.setattr(
+            cli, "_resolve_checkpoint_config", lambda _name, _profile: self._SLIDING
+        )
+        assert cli._needs_bounded_trim_free_reuse("gemma-4-26b-4bit") is True
+
+    def test_sliding_window_alias_auto_defaults_entries(self, monkeypatch):
+        import vllm_mlx.cli as cli
+
+        _patch_resolve_profile(monkeypatch, is_hybrid=False)
+        monkeypatch.setattr(
+            cli, "_resolve_checkpoint_config", lambda _name, _profile: self._SLIDING
+        )
+        result = cli._resolve_hybrid_cache_entries(
+            enable_prefix_cache=True,
+            explicit_value=0,
+            user_set_explicit=False,
+            model_name="gemma-4-26b-4bit",
+        )
+        assert result == cli._DEFAULT_HYBRID_CACHE_ENTRIES
+
+    def test_sliding_window_bare_path_no_alias(self, monkeypatch):
+        """#2061 exactly: served by a bare checkpoint path (resolve_profile
+        returns None), so only the config probe can classify it."""
+        import vllm_mlx.cli as cli
+
+        monkeypatch.setattr(
+            "vllm_mlx.model_aliases.resolve_profile", lambda _name: None
+        )
+        monkeypatch.setattr(
+            cli, "_resolve_checkpoint_config", lambda _name, _profile: self._SLIDING
+        )
+        assert (
+            cli._needs_bounded_trim_free_reuse(
+                "/models/lmstudio-community/gemma-4-26B-A4B-it-QAT-MLX-4bit"
+            )
+            is True
+        )
+
+    def test_full_attention_config_stays_trimmable(self, monkeypatch):
+        """A pure full-attention checkpoint must NOT be pushed onto the bounded
+        snapshot path — its KVCache is ordinarily trimmable."""
+        import vllm_mlx.cli as cli
+
+        monkeypatch.setattr(
+            "vllm_mlx.model_aliases.resolve_profile", lambda _name: None
+        )
+        monkeypatch.setattr(
+            cli, "_resolve_checkpoint_config", lambda _name, _profile: self._FULL
+        )
+        assert cli._needs_bounded_trim_free_reuse("/models/llama-3-8b") is False
+
+    @staticmethod
+    def _write_config(dir_path, config: dict) -> str:
+        import json
+
+        (dir_path / "config.json").write_text(json.dumps(config))
+        return str(dir_path)
+
+    def test_bare_path_real_config_discovery_sliding(self, tmp_path):
+        """End-to-end #2061: a bare on-disk checkpoint dir (no alias, nothing
+        mocked) whose config.json declares sliding attention is classified as
+        needing bounded reuse via the real offline config probe."""
+        from vllm_mlx.cli import _needs_bounded_trim_free_reuse
+
+        path = self._write_config(
+            tmp_path,
+            {
+                "model_type": "gemma4",
+                "sliding_window": 512,
+                "layer_types": ["sliding_attention", "full_attention"],
+            },
+        )
+        assert _needs_bounded_trim_free_reuse(path) is True
+
+    def test_bare_path_real_config_discovery_full_attention(self, tmp_path):
+        """The same real path, for a full-attention checkpoint, stays off the
+        bounded path — guards against the probe defaulting to True."""
+        from vllm_mlx.cli import _needs_bounded_trim_free_reuse
+
+        path = self._write_config(
+            tmp_path, {"model_type": "llama", "layer_types": ["full_attention"]}
+        )
+        assert _needs_bounded_trim_free_reuse(path) is False

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2464,6 +2464,89 @@ def _resolve_hybrid_cache_entries(
     return explicit_value
 
 
+def _config_declares_sliding_window(config: dict | None) -> bool:
+    """True if the checkpoint config declares sliding-window (local) attention.
+
+    Gemma-2/3/4 and other local-attention families run their sliding layers on
+    ``RotatingKVCache``, which reports ``is_trimmable() == False`` once the ring
+    has rotated past its window (the front is overwritten, so a trim-then-
+    continue would reconstruct wrong KV — see ``memory_cache`` ``_layer_forbids_
+    trim``). Such a cache is non-trimmable but still REUSABLE at an exact token
+    boundary, so these models need the bounded trim-free snapshot path — exactly
+    like the recurrent-state families — or every agentic turn re-prefills the
+    whole accumulated context (#2061).
+
+    The signal is read straight off the checkpoint config so it is
+    architecture-driven rather than a name list: it covers the whole sliding-
+    window family, future additions, and bare local paths that resolve to no
+    alias.
+
+    The LANGUAGE backbone's attention config is authoritative — VLM checkpoints
+    nest it under ``text_config``, so that is judged first and alone when it
+    carries a signal (a top-level ``sliding_window`` scalar on such a checkpoint
+    is often a vision/default value unrelated to the LM's attention). Within the
+    chosen config, ``layer_types`` (Gemma-3/4's explicit per-layer attention
+    kinds) is authoritative: a config listing only ``full_attention`` is NOT
+    sliding even if it also carries a leftover ``sliding_window`` value (that
+    field is inert without a sliding layer to apply it). A bare positive
+    ``sliding_window`` is consulted only as the fallback for older configs that
+    omit ``layer_types``. Only if the nested language config carries no signal
+    at all does the top level get a look, for checkpoints that place attention
+    fields at the root.
+    """
+    if not isinstance(config, dict):
+        return False
+
+    def _level_signal(cfg: object) -> bool | None:
+        """True/False if ``cfg`` declares sliding-window state, None if it
+        carries no attention signal at all (so the caller may look elsewhere)."""
+        if not isinstance(cfg, dict):
+            return None
+        layer_types = [
+            lt for lt in (cfg.get("layer_types") or []) if isinstance(lt, str)
+        ]
+        if layer_types:
+            return any("sliding" in lt for lt in layer_types)
+        # Qwen2 / Mistral carry a ``sliding_window`` scalar but gate it behind an
+        # explicit ``use_sliding_window`` flag — a positive scalar with the flag
+        # off is inert, so honour the disable before the legacy scalar. Treating
+        # it as active would auto-allocate bounded snapshots and regress memory.
+        if cfg.get("use_sliding_window") is False:
+            return False
+        sliding_window = cfg.get("sliding_window")
+        if isinstance(sliding_window, int):
+            return sliding_window > 0
+        return None
+
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        nested = _level_signal(text_config)
+        if nested is not None:
+            return nested
+    return bool(_level_signal(config))
+
+
+def _resolve_checkpoint_config(model_name: str, profile) -> dict | None:
+    """Read the checkpoint ``config.json`` for ``model_name`` offline.
+
+    Works for a bare local path or HF repo id directly, and for a registered
+    alias by resolving it to its ``hf_path`` (the alias name itself is not a
+    readable checkpoint dir). Never touches the network — mirrors the offline
+    metadata probes ``is_mllm_model`` already relies on.
+    """
+    from .api.utils import read_model_metadata
+
+    metadata = read_model_metadata(model_name)
+    if metadata is not None and metadata.config:
+        return metadata.config
+    hf_path = getattr(profile, "hf_path", None) if profile is not None else None
+    if isinstance(hf_path, str) and hf_path and hf_path != model_name:
+        metadata = read_model_metadata(hf_path)
+        if metadata is not None and metadata.config:
+            return metadata.config
+    return None
+
+
 def _needs_bounded_trim_free_reuse(model_name: str) -> bool:
     """Whether this model's cache can reuse prefixes but not trim exact hits."""
     from .model_aliases import resolve_profile as _resolve_alias
@@ -2492,6 +2575,20 @@ def _needs_bounded_trim_free_reuse(model_name: str) -> bool:
         # so no throttle, no snapshot path, no wedge.
         if profile.is_hybrid_explicit and not profile.is_hybrid:
             return True
+
+    # Sliding-window attention families (Gemma-2/3/4, …) carry RotatingKVCache
+    # local-attention layers that go non-trimmable once the ring rotates past
+    # their window, so — like the recurrent families above — they can only
+    # reuse a prefix through the bounded snapshot path, never the ordinary
+    # trimmable prefix cache. Without this, --enable-prefix-cache is a silent
+    # no-op for them and every agentic turn re-prefills the whole accumulated
+    # context (#2061). Detected from the checkpoint config (architecture-driven,
+    # so it also covers a bare local path that resolves to no alias, which is
+    # exactly how #2061 was served). This does NOT touch routing — is_hybrid is
+    # untouched, so no throttle and no hybrid allocation path / wedge.
+    if _config_declares_sliding_window(_resolve_checkpoint_config(model_name, profile)):
+        return True
+
     return is_deepseek_v4_0731(model_name)
 
 


### PR DESCRIPTION
## Why

Fixes #2061. On a sliding-window model (Gemma-2/3/4, served `--no-mllm --enable-prefix-cache`), a follow-up agentic turn re-prefills the **entire** accumulated context instead of reusing the shared prefix — the reporter saw a ~19K-token prefix thrown away and `tokens_to_prefill=19485`.

**Root cause.** Gemma's sliding layers run on `RotatingKVCache`, whose `is_trimmable()` returns False once the ring has rotated past its window (trimming a rotated ring reconstructs wrong KV — this refusal is *correct*, guarded by `memory_cache._layer_forbids_trim`). So their state can only be reused through the **bounded trim-free snapshot path**, never the ordinary trimmable prefix cache. But `_needs_bounded_trim_free_reuse` gated that path on recurrent-state signals only (`is_hybrid` / `is_hybrid_explicit` / deepseek). Sliding-window models fell through to `False`, so `hybrid_cache_entries` stayed 0 and every non-trimmable gemma entry was dropped at store time (`stored=False`) — `--enable-prefix-cache` was a silent no-op. #2061 served a bare lm-studio path, so `resolve_profile → None` made it `False` regardless of any alias metadata.

## What

Detect sliding-window attention straight off the checkpoint `config.json` — `layer_types` containing `sliding_attention` (Gemma-3/4's explicit per-layer kinds), or a positive `sliding_window` (older configs). Architecture-driven rather than a name list, so it covers the whole family, future additions, and **bare local paths that resolve to no alias** (exactly how #2061 was served). VLM checkpoints nest under `text_config`, so both levels are inspected. `is_hybrid` is untouched → routing / throttle / the hybrid-allocation wedge are unaffected; this only flips the reuse gate.

## Tests

- **Reproduced + validated end-to-end** on `mlx-community/gemma-4-e2b-it-4bit` (`--no-mllm --enable-prefix-cache`, >512-token context so the window rotates): turn-2 `tokens_to_prefill` **1607 → 14** (1593 reused), assistant outputs unchanged (`apple` / `banana`). Before the fix the same turn was a full `MISS` with `entries=0`.
- Hermetic regression tests in `test_hybrid_prefix_cache_auto_default.py`: unit cases for `_config_declares_sliding_window` (layer_types / sliding_window / nested text_config / full-attention-only / empty), and gate cases for an aliased sliding-window model, a **bare path with no alias** (#2061), auto-default to 8, and a full-attention config staying trimmable. **Mutation-verified** (neutralizing the new branch fails the three sliding-window gate tests).
- No regression across the prefix-cache suite: `test_hybrid_prefix_cache_auto_default` / `_growth` / `test_prefix_boundary_path_parity` / `test_prompt_cache_snapshot` / `test_cli_bench_hybrid_cache_flag` / `test_prefix_cache` — **138 passed**. ruff clean.

## Notes

No product behavior changes for non-sliding models (the probe returns False for full-attention configs). Found while triaging incoming issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)