### PR TITLE
feat(mac): report chip brand + bucketed memory in desktop telemetry

### DIFF
--- a/apps/rapid-mac/PRIVACY.md
+++ b/apps/rapid-mac/PRIVACY.md
@@ -1,6 +1,6 @@
 # Rapid-MLX Desktop — Privacy Policy
 
-Last updated: 2026-07-28.
+Last updated: 2026-08-18.
 
 Rapid-MLX Desktop ("the App") is a local-first SwiftUI Mac client for the
 `rapid-mlx` inference server. We designed it so that your prompts,
@@ -34,7 +34,9 @@ so one Mac is not counted as two installs. We collect:
     serial, or hardware identifier. It is shared only between the desktop app
     and embedded engine for anonymous de-duplication.
   * `session_id` — random UUID, regenerated on every launch.
-  * App version + macOS version + CPU architecture.
+  * App version, macOS version, CPU architecture, Apple chip family (or the
+    coarse label `Intel` on legacy Macs), and memory tier rounded to the nearest
+    GiB. No serial number, exact Intel CPU SKU, clock speed, or exact byte count.
 * `error` — when the app crashes or hits an unhandled exception.
   Includes:
   * Error type + message (e.g. `EXC_BAD_ACCESS`, `Bundle.module

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryClient.swift
@@ -154,8 +154,59 @@ struct TelemetryClient: @unchecked Sendable {
             app: "rapid-desktop",
             os: "macos",
             os_version: osStr,
-            arch: arch
+            arch: arch,
+            chip: chipBrand(),
+            memory_gb: bucketMemoryGB(totalMemoryBytes())
         )
+    }
+
+    /// Apple Silicon chip brand — e.g. ``"Apple M4 Max"`` — read via
+    /// ``sysctlbyname("machdep.cpu.brand_string", …)``. This is the
+    /// exact same sysctl key the engine's
+    /// ``redact._read_chip_brand()`` shells out to
+    /// (``sysctl -n machdep.cpu.brand_string``), so the two clients
+    /// produce byte-identical brand strings and bucket into the same
+    /// per-chip analytics label. Whitespace-trimmed to match the
+    /// engine's ``.strip()``; returns ``nil`` (field omitted on the
+    /// wire) if the value is unreadable or empty rather than shipping
+    /// a placeholder that would pollute the chip breakdown.
+    static func chipBrand() -> String? {
+        var size = 0
+        // First call sizes the buffer; a failure or zero length means
+        // the key is unavailable (should not happen on macOS, but we
+        // degrade to "field absent" rather than trap).
+        guard sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0) == 0,
+              size > 0 else {
+            return nil
+        }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("machdep.cpu.brand_string", &buffer, &size, nil, 0) == 0 else {
+            return nil
+        }
+        let brand = String(cString: buffer)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return brand.isEmpty ? nil : brand
+    }
+
+    /// Total physical RAM in bytes. ``physicalMemory`` is the same
+    /// quantity the engine reads via ``psutil.virtual_memory().total``.
+    static func totalMemoryBytes() -> UInt64 {
+        ProcessInfo.processInfo.physicalMemory
+    }
+
+    /// Round a byte count to the nearest GB (GiB, 1024³), clamping a
+    /// non-positive input to 0. A faithful port of the engine's
+    /// ``redact.bucket_memory_gb`` — coarse tiers so exact byte counts
+    /// can't fingerprint a machine, and the two telemetry sources land
+    /// on identical integers for the same hardware. Uses
+    /// round-half-to-even (``.toNearestOrEven``) to mirror Python's
+    /// ``round()`` semantics exactly; in practice Mac RAM configs are
+    /// whole GiB multiples so the tie-break never fires, but matching
+    /// it keeps the two implementations provably equivalent.
+    static func bucketMemoryGB(_ bytes: UInt64) -> Int {
+        guard bytes > 0 else { return 0 }
+        let gib = 1024.0 * 1024.0 * 1024.0
+        return Int((Double(bytes) / gib).rounded(.toNearestOrEven))
     }
 
     /// Current bundle short-version. Falls back to ``"0.0.0"`` so a

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryClient.swift
@@ -165,12 +165,20 @@ struct TelemetryClient: @unchecked Sendable {
     /// exact same sysctl key the engine's
     /// ``redact._read_chip_brand()`` shells out to
     /// (``sysctl -n machdep.cpu.brand_string``), so the two clients
-    /// produce byte-identical brand strings and bucket into the same
-    /// per-chip analytics label. Whitespace-trimmed to match the
-    /// engine's ``.strip()``; returns ``nil`` (field omitted on the
+    /// produce byte-identical Apple Silicon brand strings and bucket into the
+    /// same per-chip analytics label. Intel is deliberately reduced to the
+    /// coarse label ``"Intel"`` because its raw brand includes detailed SKU
+    /// and clock information. Whitespace-trimmed to match the engine's
+    /// ``.strip()``; returns ``nil`` (field omitted on the
     /// wire) if the value is unreadable or empty rather than shipping
     /// a placeholder that would pollute the chip breakdown.
     static func chipBrand() -> String? {
+        #if arch(x86_64)
+        // Intel's brand string includes the exact CPU SKU and clock speed,
+        // which is substantially more identifying than an Apple chip family.
+        // Desktop analytics only needs a coarse legacy-Mac bucket.
+        return "Intel"
+        #else
         var size = 0
         // First call sizes the buffer; a failure or zero length means
         // the key is unavailable (should not happen on macOS, but we
@@ -183,9 +191,16 @@ struct TelemetryClient: @unchecked Sendable {
         guard sysctlbyname("machdep.cpu.brand_string", &buffer, &size, nil, 0) == 0 else {
             return nil
         }
-        let brand = String(cString: buffer)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Do not rely on `String(cString:)`: although this sysctl normally
+        // includes a trailing NUL, its contract is the returned byte count.
+        // Decode only the bytes written and reject malformed UTF-8.
+        let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        guard let decoded = String(bytes: bytes, encoding: .utf8) else {
+            return nil
+        }
+        let brand = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
         return brand.isEmpty ? nil : brand
+        #endif
     }
 
     /// Total physical RAM in bytes. ``physicalMemory`` is the same
@@ -194,8 +209,8 @@ struct TelemetryClient: @unchecked Sendable {
         ProcessInfo.processInfo.physicalMemory
     }
 
-    /// Round a byte count to the nearest GB (GiB, 1024³), clamping a
-    /// non-positive input to 0. A faithful port of the engine's
+    /// Round a byte count to the nearest GB (GiB, 1024³), returning 0 for an
+    /// empty reading. A faithful port of the engine's
     /// ``redact.bucket_memory_gb`` — coarse tiers so exact byte counts
     /// can't fingerprint a machine, and the two telemetry sources land
     /// on identical integers for the same hardware. Uses

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryEvent.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryEvent.swift
@@ -43,19 +43,15 @@ struct TelemetryEvent: Codable, Sendable {
         /// engine's ``redact._read_chip_brand()`` so a desktop machine
         /// buckets into the SAME per-chip label the CLI reports, instead
         /// of being invisible behind the generic ``arch`` ("arm64").
+        /// Legacy Intel Macs use the coarse fixed label ``"Intel"``.
         ///
         /// Optional on the wire (``encodeIfPresent`` omits it when nil)
         /// so this is a backward-compatible schema addition: an older
         /// telemetry-worker that doesn't read ``chip`` ignores the extra
         /// key, and a build that can't read the brand simply omits it.
         ///
-        /// ⚠️ Adding a real chip brand here means desktop clients now
-        /// LOOK like CLI clients under the analytics "chip-absence"
-        /// CLI-vs-App heuristic. The authoritative discriminator is
-        /// ``app == "rapid-desktop"`` (always set below); the worker
-        /// rollup + DAU split MUST switch to keying off ``app`` before
-        /// this reaches production. See the PR body's coordinated
-        /// follow-up note.
+        /// Analytics uses ``app == "rapid-desktop"`` as the authoritative
+        /// surface discriminator; chip is hardware metadata, not identity.
         ///
         /// The ``= nil`` default keeps the synthesized memberwise
         /// initializer callable with the original four labels, so every

--- a/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryEvent.swift
+++ b/apps/rapid-mac/Sources/Rapid/Telemetry/TelemetryEvent.swift
@@ -38,6 +38,36 @@ struct TelemetryEvent: Codable, Sendable {
         var os: String
         var os_version: String
         var arch: String
+        /// Apple Silicon chip brand (e.g. ``"Apple M4 Max"``), read via
+        /// ``sysctlbyname("machdep.cpu.brand_string")``. Mirrors the
+        /// engine's ``redact._read_chip_brand()`` so a desktop machine
+        /// buckets into the SAME per-chip label the CLI reports, instead
+        /// of being invisible behind the generic ``arch`` ("arm64").
+        ///
+        /// Optional on the wire (``encodeIfPresent`` omits it when nil)
+        /// so this is a backward-compatible schema addition: an older
+        /// telemetry-worker that doesn't read ``chip`` ignores the extra
+        /// key, and a build that can't read the brand simply omits it.
+        ///
+        /// ⚠️ Adding a real chip brand here means desktop clients now
+        /// LOOK like CLI clients under the analytics "chip-absence"
+        /// CLI-vs-App heuristic. The authoritative discriminator is
+        /// ``app == "rapid-desktop"`` (always set below); the worker
+        /// rollup + DAU split MUST switch to keying off ``app`` before
+        /// this reaches production. See the PR body's coordinated
+        /// follow-up note.
+        ///
+        /// The ``= nil`` default keeps the synthesized memberwise
+        /// initializer callable with the original four labels, so every
+        /// existing ``Platform(app:os:os_version:arch:)`` call site (and
+        /// the decode path) stays source-compatible.
+        var chip: String? = nil
+        /// Total physical RAM rounded to the nearest GB. Mirrors the
+        /// engine's ``redact.bucket_memory_gb`` so desktop + CLI machines
+        /// aggregate uniformly and exact byte counts can't fingerprint a
+        /// machine. Never carries raw bytes. Optional/back-compat like
+        /// ``chip`` above.
+        var memory_gb: Int? = nil
     }
 
     /// Build a session_start (no error fields populated).

--- a/apps/rapid-mac/Tests/RapidTests/TelemetryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TelemetryTests.swift
@@ -362,6 +362,121 @@ final class TelemetryTests {
         #expect(p.arch == "arm64" || p.arch == "x86_64" || p.arch == "unknown")
     }
 
+    // MARK: - Machine identity (chip + bucketed memory)
+
+    @Test("currentPlatform now reports a chip brand so desktop machines appear in the per-chip breakdown")
+    func platformCarriesChip() {
+        let p = TelemetryClient.currentPlatform()
+        // Every CI + dev host this runs on is a real Mac, so the sysctl
+        // key resolves — the whole point of this change is that the
+        // field is populated (was nil/absent before) so desktop
+        // machines stop being invisible next to CLI ones.
+        let chip = try! #require(p.chip)
+        #expect(!chip.isEmpty)
+        // Apple Silicon brand strings start with "Apple" (e.g.
+        // "Apple M4 Max"); on the arm64 CI fleet this pins that the
+        // value is the real brand, not the generic arch fallback.
+        #if arch(arm64)
+        #expect(chip.hasPrefix("Apple"))
+        #endif
+    }
+
+    @Test("currentPlatform chip matches the raw sysctl brand string the engine also reads")
+    func platformChipMatchesSysctl() {
+        // Read the same key the engine shells out to
+        // (`sysctl -n machdep.cpu.brand_string`) and confirm the Swift
+        // reader returns the byte-identical, whitespace-trimmed value —
+        // so desktop + CLI bucket into the same analytics label.
+        var size = 0
+        _ = sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
+        var buffer = [CChar](repeating: 0, count: size)
+        _ = sysctlbyname("machdep.cpu.brand_string", &buffer, &size, nil, 0)
+        let raw = String(cString: buffer)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(TelemetryClient.chipBrand() == raw)
+    }
+
+    @Test("currentPlatform reports bucketed memory matching this host's rounded physical RAM")
+    func platformCarriesBucketedMemory() {
+        let p = TelemetryClient.currentPlatform()
+        let mem = try! #require(p.memory_gb)
+        // Bucket is the rounded physical RAM — strictly positive on any
+        // real machine, and it must equal the bucket of the raw byte
+        // count (no raw bytes ever leave the process).
+        #expect(mem > 0)
+        let expected = TelemetryClient.bucketMemoryGB(
+            ProcessInfo.processInfo.physicalMemory
+        )
+        #expect(mem == expected)
+    }
+
+    @Test("bucketMemoryGB rounds to coarse GB tiers exactly like the engine's bucket_memory_gb")
+    func memoryBucketingMatchesEngineTiers() {
+        let giB: UInt64 = 1024 * 1024 * 1024
+        // Whole-GiB Mac configs map to their integer GB (the common case).
+        #expect(TelemetryClient.bucketMemoryGB(8 * giB) == 8)
+        #expect(TelemetryClient.bucketMemoryGB(16 * giB) == 16)
+        #expect(TelemetryClient.bucketMemoryGB(24 * giB) == 24)
+        #expect(TelemetryClient.bucketMemoryGB(64 * giB) == 64)
+        #expect(TelemetryClient.bucketMemoryGB(128 * giB) == 128)
+        // Non-positive clamps to 0 (mirrors the engine's `<= 0` guard).
+        #expect(TelemetryClient.bucketMemoryGB(0) == 0)
+        // Sub-GB rounds to nearest (0.4 GiB → 0, 0.6 GiB → 1).
+        #expect(TelemetryClient.bucketMemoryGB(UInt64(0.4 * Double(giB))) == 0)
+        #expect(TelemetryClient.bucketMemoryGB(UInt64(0.6 * Double(giB))) == 1)
+        // Round-half-to-even: 1.5 → 2, 2.5 → 2 — mirrors Python round().
+        #expect(TelemetryClient.bucketMemoryGB(UInt64(1.5 * Double(giB))) == 2)
+        #expect(TelemetryClient.bucketMemoryGB(UInt64(2.5 * Double(giB))) == 2)
+    }
+
+    @Test("session_start encodes chip + memory_gb when present (parity with the engine platform shape)")
+    func platformEncodesMachineFields() throws {
+        let event = TelemetryEvent.sessionStart(
+            version: "0.5.12",
+            platform: TelemetryEvent.Platform(
+                app: "rapid-desktop",
+                os: "macos",
+                os_version: "26.0.0",
+                arch: "arm64",
+                chip: "Apple M4 Max",
+                memory_gb: 48
+            )
+        )
+        let data = try JSONEncoder().encode(event)
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let platform = try #require(json["platform"] as? [String: Any])
+        #expect(platform["app"] as? String == "rapid-desktop")
+        #expect(platform["chip"] as? String == "Apple M4 Max")
+        #expect(platform["memory_gb"] as? Int == 48)
+    }
+
+    @Test("chip + memory_gb are omitted on the wire when nil so the addition is backward-compatible")
+    func platformOmitsMachineFieldsWhenNil() throws {
+        // A build that couldn't read the brand (chip == nil) must not
+        // emit a null/placeholder key — the field is simply absent, so
+        // an older worker sees the exact legacy 4-field platform shape.
+        let event = TelemetryEvent.sessionStart(
+            version: "0.5.12",
+            platform: TelemetryEvent.Platform(
+                app: "rapid-desktop",
+                os: "macos",
+                os_version: "26.0.0",
+                arch: "arm64"
+            )
+        )
+        let data = try JSONEncoder().encode(event)
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let platform = try #require(json["platform"] as? [String: Any])
+        #expect(platform["chip"] == nil)
+        #expect(platform["memory_gb"] == nil)
+        // The discriminator the CLI-vs-App split must key off stays set.
+        #expect(platform["app"] as? String == "rapid-desktop")
+    }
+
     // MARK: - Crash marker directory
 
     @Test("crash marker directory is created on demand under Application Support")

--- a/apps/rapid-mac/Tests/RapidTests/TelemetryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TelemetryTests.swift
@@ -383,6 +383,10 @@ final class TelemetryTests {
 
     @Test("currentPlatform chip matches the raw sysctl brand string the engine also reads")
     func platformChipMatchesSysctl() {
+        #if arch(x86_64)
+        // Do not transmit Intel's detailed SKU/frequency-bearing brand string.
+        #expect(TelemetryClient.chipBrand() == "Intel")
+        #else
         // Read the same key the engine shells out to
         // (`sysctl -n machdep.cpu.brand_string`) and confirm the Swift
         // reader returns the byte-identical, whitespace-trimmed value —
@@ -391,9 +395,11 @@ final class TelemetryTests {
         _ = sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
         var buffer = [CChar](repeating: 0, count: size)
         _ = sysctlbyname("machdep.cpu.brand_string", &buffer, &size, nil, 0)
-        let raw = String(cString: buffer)
+        let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        let raw = String(bytes: bytes, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         #expect(TelemetryClient.chipBrand() == raw)
+        #endif
     }
 
     @Test("currentPlatform reports bucketed memory matching this host's rounded physical RAM")


### PR DESCRIPTION
## Why
Desktop opt-in telemetry reported only app/OS/architecture, so desktop machines were absent from the real-chip breakdown and gave us no coarse memory-tier signal for model-fit decisions.

## What changed
- Adds optional `chip` and rounded `memory_gb` fields to the desktop platform payload.
- Reads `machdep.cpu.brand_string` without shelling out and safely decodes only returned bytes.
- Uses `ProcessInfo.physicalMemory`, rounded to nearest GiB with Python-compatible ties-to-even behavior; raw byte counts are never sent.
- Keeps optional fields absent on read failure for wire compatibility.
- Updates the opt-in privacy policy to disclose desktop chip family and memory tier.
- Adds host parity, bucketing, and Codable coverage.

## Coordinated worker rollout
The prerequisite worker fix landed as `rapidmlx.com#95` and was deployed to production before this client change. `platform.app == "rapid-desktop"` is now the classification SSOT, with historical arch-only fallback, so real desktop chip brands cannot be misclassified as CLI.

## Validation
- `swift test --filter TelemetryTests` — 45 passed
- worker prerequisite: 51 tests passed + hosted Docker build green + production `/healthz` green
- full hosted PR validation pending on the rebased head