### PR TITLE
docs(multimodal): fix MLLM cache section to match the real API [skip-version-bump]

### DIFF
--- a/docs/guides/multimodal.md
+++ b/docs/guides/multimodal.md
@@ -245,16 +245,29 @@ When you send an image to the model, the vision encoder processes it into embedd
 
 The cache uses content-based hashing (similar to LMCache) to identify identical images regardless of how they're provided (URL, base64, or file path).
 
-### Enabling the Cache
+### Default Behavior
+
+The cache is engine-internal and enabled by default — there is no serve flag
+to turn it on. When you start a multimodal server, every request automatically
+benefits from it:
 
 ```bash
-# Enable with default settings (512 MB max)
-rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --enable-mllm-cache
+rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
 
-# With custom memory limit
-rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit \
-    --enable-mllm-cache \
-    --mllm-cache-max-mb 1024
+Defaults: up to 50 entries and 2048 MB of cache memory, with LRU eviction.
+
+If you use the Python API directly, you can opt out or resize the cache when
+constructing the model:
+
+```python
+from vllm_mlx.models import MLXMultimodalLM
+
+mllm = MLXMultimodalLM(
+    "mlx-community/Qwen3-VL-4B-Instruct-3bit",
+    enable_cache=True,   # default
+    cache_size=50,       # max cache entries
+)
 ```
 
 ### Python API
@@ -262,8 +275,8 @@ rapid-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit \
 ```python
 from vllm_mlx.mllm_cache import MLLMPrefixCacheManager
 
-# Create cache manager
-cache = MLLMPrefixCacheManager(max_memory_mb=512)
+# Create cache manager (max_memory_mb defaults to 2048)
+cache = MLLMPrefixCacheManager(max_entries=50, max_memory_mb=2048)
 
 # Store embeddings and KV cache after processing
 cache.store(
@@ -271,7 +284,7 @@ cache.store(
     prompt="Describe this image",
     vision_embeddings=embeddings,
     kv_cache=kv_state,
-    num_tokens=128
+    token_ids=token_ids,  # full token sequence, e.g. from the processor
 )
 
 # Fetch from cache on subsequent requests
@@ -284,11 +297,13 @@ if entry:
 
 ### Cache Statistics
 
+`get_stats()` returns a plain dictionary:
+
 ```python
 stats = cache.get_stats()
-print(f"Hit rate: {stats.hit_rate:.1%}")
-print(f"Memory used: {stats.memory_used_mb:.1f} MB")
-print(f"Tokens saved: {stats.tokens_saved}")
+print(f"Hit rate: {stats['hit_rate']:.1%}")
+print(f"Memory used: {stats['memory_used_mb']:.1f} MB")
+print(f"Tokens saved: {stats['tokens_saved']}")
 ```
 
 ### Memory Management


### PR DESCRIPTION
## Summary

From the 2026-08-18 documentation dogfooding audit (issue #2070): the "MLLM Cache" section of `docs/guides/multimodal.md` was fiction in three places, verified against current `main` before editing.

1. **Nonexistent serve flags.** The doc told users to run `rapid-mlx serve ... --enable-mllm-cache [--mllm-cache-max-mb 1024]`. Neither flag exists anywhere in the codebase (the only grep hits were this doc itself); argparse rejects them and the server refuses to start. Ground truth: the cache is engine-internal and **on by default** — `MLXMultimodalLM.__init__` has `enable_cache: bool = True` (`vllm_mlx/models/mllm.py:1058`) and builds the manager at `:1082-1083`; the serving engine constructs `MLXMultimodalLM` with defaults (`vllm_mlx/engine/batched.py:1121`), so there is no server-side knob. The "Enabling the Cache" section is now "Default Behavior": it shows the plain serve command, states the defaults (50 entries / 2048 MB, LRU), and documents the real Python-API knobs (`enable_cache`, `cache_size`).

2. **Python samples crashed.** `cache.store(..., num_tokens=128)` — `store()` has no `num_tokens` parameter and requires `token_ids: list[int]` (`vllm_mlx/mllm_cache.py:347-355`; `num_tokens` belongs to the legacy `store_cache()`). And `stats.hit_rate` / `stats.memory_used_mb` — `get_stats()` returns a plain `dict` (`mllm_cache.py:418-425`), so attribute access raises `AttributeError`. Samples now pass `token_ids=` and use dict indexing.

3. **Wrong default.** "default settings (512 MB max)" corrected to the actual manager default `max_memory_mb=2048` (`mllm_cache.py:212`).

The rest of the guide was cross-checked against the code while verifying and left untouched: `--mllm` / `--vision-max-pixels` / `--vision-min-pixels` exist (`vllm_mlx/cli.py:9368-9377,9680`), `video_fps` / `video_max_frames` are honoured (`vllm_mlx/routes/chat.py:4260-4263`), `describe_image` / `describe_video(fps=)` / `generate(prompt=, images=)` match their signatures (`models/mllm.py:1572,2505,2559`), the `rapid-mlx[chat]` extra exists (`pyproject.toml:220`), and the `qwen3-vl-4b-4bit` alias exists (`vllm_mlx/aliases.json:546`).

## Test plan

- [x] Verified every ground-truth claim by reading the current code in a fresh worktree off `main` (files/lines cited above), not by trusting the issue text.
- [x] Executed the rewritten Python samples verbatim against the real API (`PYTHONPATH=<worktree> python3.12`): `MLLMPrefixCacheManager(max_entries=50, max_memory_mb=2048)` -> `store(token_ids=...)` -> `fetch()` -> `get_stats()['hit_rate'|'memory_used_mb'|'tokens_saved']` round-trip passes (hit rate 100%, tokens saved 4, no exceptions).
- [x] Confirmed at runtime that the default `max_memory_mb` is 2048 and that `inspect.signature(store)` requires `token_ids: list[int]` with no `num_tokens`.
- [x] Confirmed `from vllm_mlx.models import MLXMultimodalLM` imports and its constructor exposes `enable_cache=True, cache_size=50` (no model load, no GPU used).
- [x] CJK scan over the file (regex over the CJK Unified Ideographs, kana, and hangul Unicode ranges): zero hits. No relative links exist in the file, so none could break.
- [x] Grep re-confirmed `--enable-mllm-cache` / `--mllm-cache-max-mb` now appear nowhere in the repo.

Closes #2070.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
