### PR TITLE
fix(mac): transcode Apple audio formats for transcription

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Audio/AudioClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Audio/AudioClient.swift
@@ -336,7 +336,10 @@ struct AudioClient {
 
     private static func safeExtension(_ raw: String) -> String {
         let lower = raw.lowercased()
-        let allowed = Set(["wav", "mp3", "m4a", "aac", "flac", "ogg", "opus", "webm", "mp4"])
+        let allowed = Set([
+            "wav", "mp3", "m4a", "aac", "flac", "ogg", "opus", "webm", "mp4",
+            "aif", "aiff", "aifc", "caf",
+        ])
         return allowed.contains(lower) ? lower : "audio"
     }
 
@@ -366,7 +369,8 @@ enum AudioUploadTranscoder {
     private static let bytesPerFrame = 2
 
     static func requiresWAV(_ fileExtension: String) -> Bool {
-        ["m4a", "mp4", "aac"].contains(fileExtension.lowercased())
+        ["m4a", "mp4", "aac", "aif", "aiff", "aifc", "caf"]
+            .contains(fileExtension.lowercased())
     }
 
     /// Decode Apple-native compressed containers and normalize them to the

--- a/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/AudioView.swift
@@ -307,7 +307,7 @@ struct AudioView: View {
 
     private var fileCaption: String {
         guard let url = viewModel.selectedFileURL else {
-            return "WAV, MP3, M4A, AAC, FLAC, or MP4 - up to 25 MB"
+            return "WAV, MP3, M4A, AAC, FLAC, MP4, AIFF, or CAF - up to 25 MB"
         }
         if let bytes = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize {
             return ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)

--- a/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioCatalogTests.swift
@@ -114,7 +114,7 @@ struct AudioCatalogTests {
         #expect(source.contains("@Environment(DownloadManager.self) private var downloads"))
         #expect(source.contains(".task(id: downloads.cacheGeneration)"),
                 "The Audio view may stay mounted while Settings downloads a model.")
-        #expect(source.contains("WAV, MP3, M4A, AAC, FLAC, or MP4 - up to 25 MB"))
+        #expect(source.contains("WAV, MP3, M4A, AAC, FLAC, MP4, AIFF, or CAF - up to 25 MB"))
         #expect(!source.contains("OGG, Opus, WebM"),
                 "The desktop sidecar does not bundle ffmpeg for these formats.")
     }

--- a/apps/rapid-mac/Tests/RapidTests/AudioClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AudioClientTests.swift
@@ -71,6 +71,39 @@ struct AudioClientTests {
         #expect(body.contains("Content-Type: audio/wav"))
         #expect(bodyData.range(of: Data("RIFF".utf8)) != nil)
         #expect(bodyData.range(of: Data("WAVEfmt ".utf8)) != nil)
+        let format = try wavFormat(in: bodyData)
+        #expect(format.sampleRate == 16_000)
+        #expect(format.channels == 1)
+    }
+
+    @Test("AIFF transcription is normalized to a 16 kHz WAV upload")
+    @MainActor
+    func aiffTranscriptionRequest() async throws {
+        let client = makeClient()
+        AudioStubProtocol.response = (
+            200,
+            ["Content-Type": "application/json"],
+            Data(#"{"text":"local aiff","language":"en","duration":0.1}"#.utf8)
+        )
+        let file = try temporaryAIFF()
+        defer { try? FileManager.default.removeItem(at: file.deletingLastPathComponent()) }
+
+        _ = try await client.transcribe(
+            fileURL: file,
+            model: "whisper-medium",
+            port: 8125,
+            bearer: nil
+        )
+
+        let bodyData = try #require(AudioStubProtocol.bodies.first)
+        let body = String(decoding: bodyData, as: UTF8.self)
+        #expect(body.contains("name=\"file\"; filename=\"input.wav\""))
+        #expect(body.contains("Content-Type: audio/wav"))
+        #expect(bodyData.range(of: Data("RIFF".utf8)) != nil)
+        #expect(bodyData.range(of: Data("WAVEfmt ".utf8)) != nil)
+        let format = try wavFormat(in: bodyData)
+        #expect(format.sampleRate == 16_000)
+        #expect(format.channels == 1)
     }
 
     @Test("Voices sends model query and omits an empty bearer")
@@ -244,6 +277,73 @@ struct AudioClientTests {
         )
         try output.write(from: buffer)
         return file
+    }
+
+    private func temporaryAIFF() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-audio-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("sample.aiff")
+        let sampleRate = 22_050.0
+        let format = try #require(AVAudioFormat(
+            standardFormatWithSampleRate: sampleRate,
+            channels: 1
+        ))
+        let frames: AVAudioFrameCount = 2_205
+        let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames))
+        buffer.frameLength = frames
+        let samples = try #require(buffer.floatChannelData?[0])
+        for index in 0..<Int(frames) {
+            samples[index] = Float(sin(2.0 * .pi * 440.0 * Double(index) / sampleRate) * 0.2)
+        }
+        let output = try AVAudioFile(
+            forWriting: file,
+            settings: [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: sampleRate,
+                AVNumberOfChannelsKey: 1,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: true,
+            ]
+        )
+        try output.write(from: buffer)
+        return file
+    }
+
+    private func wavFormat(in multipartBody: Data) throws -> (sampleRate: UInt32, channels: UInt16) {
+        let riff = try #require(multipartBody.range(of: Data("RIFF".utf8))?.lowerBound)
+        let wave = riff + 8
+        #expect(multipartBody[wave..<(wave + 4)] == Data("WAVE".utf8))
+
+        var chunk = wave + 4
+        while chunk + 8 <= multipartBody.endIndex {
+            let chunkID = multipartBody[chunk..<(chunk + 4)]
+            let chunkSize = Int(littleEndianUInt32(in: multipartBody, at: chunk + 4))
+            let payload = chunk + 8
+            guard payload + chunkSize <= multipartBody.endIndex else { break }
+            if chunkID == Data("fmt ".utf8) {
+                #expect(chunkSize >= 16)
+                return (
+                    littleEndianUInt32(in: multipartBody, at: payload + 4),
+                    littleEndianUInt16(in: multipartBody, at: payload + 2)
+                )
+            }
+            chunk = payload + chunkSize + (chunkSize % 2)
+        }
+        Issue.record("Uploaded WAV is missing its fmt chunk")
+        throw CocoaError(.fileReadCorruptFile)
+    }
+
+    private func littleEndianUInt16(in data: Data, at offset: Int) -> UInt16 {
+        UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+    }
+
+    private func littleEndianUInt32(in data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[offset])
+            | (UInt32(data[offset + 1]) << 8)
+            | (UInt32(data[offset + 2]) << 16)
+            | (UInt32(data[offset + 3]) << 24)
     }
 }
 

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4265,6 +4265,11 @@ flow_audio_readiness() {
     done
     [[ "$transcription_ready" == 1 ]] \
         || die "Transcription did not expose download-only readiness"
+    jq -e '.data.ui_elements[]?
+           | select(.role == "AXStaticText"
+                    and ((.value // "") | contains("AIFF")))' \
+        "$OUT/transcription.json" >/dev/null \
+        || die "Transcription picker copy does not advertise its supported AIFF input"
     baseline audio-readiness.transcription "$OUT/transcription.json"
 
     press "$OUT/transcription.json" Readiness.Action "$OUT/transcription-download.json" \


### PR DESCRIPTION
## Why

The macOS file picker accepts all `UTType.audio` files, but the upload path only normalized M4A/MP4/AAC. A standard AIFF/AIFF-C file selected successfully and then failed at the server with `could not decode audio file`.

## What changed

- normalize AIFF/AIFC/CAF alongside Apple compressed containers to 16 kHz mono WAV before upload
- keep the picker copy truthful about those accepted formats
- add an end-to-end multipart regression using a real generated AIFF fixture
- extend the existing `audio-readiness` GUI Golden Flow to assert the supported-format copy

## Validation

- `swift test --filter AudioClientTests` (8/8)
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- real mini dogfood: AIFF reproduced the pre-fix decode failure; the same recording converted to WAV transcribed as `Hello from RapidMLX Transcription Test.`