### PR TITLE
fix(markdown): stop the code fence flickering while it streams

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -25,6 +25,50 @@ struct MarkdownCompiler: Sendable {
         self.postProcessors = postProcessors
     }
 
+    /// Drop a trailing fence marker that is still being typed.
+    ///
+    /// Three separate flickers, all from the same cause — the parser is shown
+    /// a fence that is one keystroke old. Measured by compiling a growing
+    /// prefix of "Here is code:\n\n```swift\nlet x = 1\nprint(x)\n```\n\nDone.":
+    ///
+    ///     n=16   T(13) T(1)          a lone backtick renders as its own text block
+    ///     n=20   T(13) C(0|sw)       index 1 turns from text into code — SwiftUI
+    ///                                swaps the whole representable at that slot
+    ///     n=24   T(13) C(0|swift)    the language changes, re-running highlighting
+    ///     n=44   T(13) C(21|swift)
+    ///     n=48   T(13) C(19|swift)   the closing backticks were being displayed
+    ///                                as code content until they closed the fence
+    ///
+    /// Holding the marker back until its line is finished removes all three:
+    /// the code card appears once, already knowing its language, and no stray
+    /// backticks are ever shown inside it.
+    ///
+    /// Only the LAST line is considered, and only while streaming. The settled
+    /// row re-compiles the whole message with ``isComplete`` true (see
+    /// ``StreamingMarkdownStore/finish()``), so nothing stays hidden.
+    ///
+    /// Deliberately narrow. A line like ``\`foo`` — an inline code span being
+    /// typed — is left alone: only a run of three or more backticks (a real
+    /// fence, with or without its info string) or a line that is nothing but
+    /// one or two backticks (a fence in the making) qualifies.
+    static func withoutFormingFence(_ source: String) -> String {
+        guard let lineStart = source.lastIndex(of: "\n").map(source.index(after:))
+                ?? (source.isEmpty ? nil : source.startIndex) else { return source }
+        let lastLine = source[lineStart...]
+        let trimmed = lastLine.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return source }
+
+        let ticks = trimmed.prefix { $0 == "`" }
+        guard !ticks.isEmpty else { return source }
+        let rest = trimmed.dropFirst(ticks.count)
+        // An info string carries no backticks and no whitespace; anything else
+        // means this is prose that merely opens with a backtick.
+        guard !rest.contains("`"), !rest.contains(where: \.isWhitespace) else { return source }
+        guard ticks.count >= 3 || rest.isEmpty else { return source }
+
+        return String(source[..<lineStart])
+    }
+
     /// Compile `source`.
     ///
     /// `isComplete` reaches the post-processors: mid-stream they should leave
@@ -33,6 +77,7 @@ struct MarkdownCompiler: Sendable {
     public func compile(
         _ source: String, revision: Int = 0, isComplete: Bool = true
     ) -> MarkdownResult {
+        let source = isComplete ? source : Self.withoutFormingFence(source)
         var items: [MarkdownItem] = []
 
         // Split math out BEFORE parsing. `$x_1$` handed to a markdown parser

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -43,16 +43,30 @@ struct MarkdownCompiler: Sendable {
     /// the code card appears once, already knowing its language, and no stray
     /// backticks are ever shown inside it.
     ///
-    /// Only the LAST line is considered, and only while streaming. The settled
-    /// row re-compiles the whole message with ``isComplete`` true (see
-    /// ``StreamingMarkdownStore/finish()``), so nothing stays hidden.
+    /// Only the LAST line is considered, and only while streaming. Nothing
+    /// stays hidden because the settled row is rendered by a different view:
+    /// ``ChatView`` swaps `StreamingTextKitMarkdownView` for
+    /// `TextKitMarkdownView(content:)` the moment the message leaves
+    /// `.streaming`, and that one compiles the raw `message.content` with
+    /// ``isComplete`` defaulting to true. (``StreamingMarkdownStore/finish()``
+    /// is *not* the guarantor — it flushes and then throws the result away.)
+    /// Copy and selection read `message.content` directly and never see this
+    /// at all.
     ///
     /// Deliberately narrow. A line like ``\`foo`` — an inline code span being
     /// typed — is left alone: only a run of three or more backticks (a real
     /// fence, with or without its info string) or a line that is nothing but
     /// one or two backticks (a fence in the making) qualifies.
+    ///
+    /// Backtick fences only. A `~~~` fence, and a fence inside a blockquote,
+    /// still flicker — both are valid CommonMark and both are out of scope
+    /// here, because a tilde info string may itself contain backticks and
+    /// would need its own validation rather than a shared one.
     static func withoutFormingFence(_ source: String) -> String {
-        guard let lineStart = source.lastIndex(of: "\n").map(source.index(after:))
+        // `lastIndex(where: \.isNewline)` rather than `lastIndex(of: "\n")`:
+        // Swift reads CRLF as one `Character`, which the latter never matches,
+        // and a CRLF stream would silently opt out of the whole fix.
+        guard let lineStart = source.lastIndex(where: \.isNewline).map(source.index(after:))
                 ?? (source.isEmpty ? nil : source.startIndex) else { return source }
         let lastLine = source[lineStart...]
         let trimmed = lastLine.trimmingCharacters(in: .whitespaces)
@@ -61,9 +75,11 @@ struct MarkdownCompiler: Sendable {
         let ticks = trimmed.prefix { $0 == "`" }
         guard !ticks.isEmpty else { return source }
         let rest = trimmed.dropFirst(ticks.count)
-        // An info string carries no backticks and no whitespace; anything else
-        // means this is prose that merely opens with a backtick.
-        guard !rest.contains("`"), !rest.contains(where: \.isWhitespace) else { return source }
+        // A backtick fence's info string may not contain a backtick — that is
+        // what separates ```` ``` a ``` ```` (a paragraph) from a fence. It
+        // may contain spaces, though, so ```` ```swift {highlight} ```` and
+        // ```` ```py file=a.py ```` are fences and must be held back too.
+        guard !rest.contains("`") else { return source }
         guard ticks.count >= 3 || rest.isEmpty else { return source }
 
         return String(source[..<lineStart])

--- a/apps/rapid-mac/Tests/RapidTests/StreamingFenceStabilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingFenceStabilityTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// A fenced code block must not change shape while it streams.
+///
+/// The parser used to be shown a fence that was one keystroke old, which
+/// produced three separate flickers from one cause. Compiling a growing prefix
+/// of `"Here is code:\n\n```swift\nlet x = 1\nprint(x)\n```\n\nDone."` before
+/// the fix:
+///
+///     n=16   T(13) T(1)         a lone backtick as its own text block
+///     n=20   T(13) C(0|sw)      that slot turns from text into code
+///     n=24   T(13) C(0|swift)   the language changes, re-running highlighting
+///     n=44   T(13) C(21|swift)
+///     n=48   T(13) C(19|swift)  content SHRINKS — the closing backticks had
+///                               been rendered as code until they closed it
+///
+/// This was a regression, not a gap. The pre-TextKit path
+/// (``ChatStreamInlineFormatter``) documented "never style-then-unstyle
+/// flicker" and carried a cross-chunk fence state machine; #1906 replaced the
+/// streaming path and left that file without callers.
+@Suite("Streaming fence stability")
+@MainActor
+struct StreamingFenceStabilityTests {
+
+    private let sample = "Here is code:\n\n```swift\nlet x = 1\nprint(x)\n```\n\nDone."
+
+    private func shapes(of full: String, step: Int = 1) -> [[MarkdownItem]] {
+        let compiler = MarkdownCompiler()
+        return stride(from: 1, through: full.count, by: step).map {
+            compiler.compile(String(full.prefix($0)), revision: $0, isComplete: false).items
+        }
+    }
+
+    private func codeBlocks(_ items: [MarkdownItem]) -> [MarkdownItem.CodeBlock] {
+        items.compactMap { if case .code(let b) = $0 { return b } else { return nil } }
+    }
+
+    private func proseLength(_ items: [MarkdownItem]) -> Int {
+        items.reduce(0) { total, item in
+            if case .text(let b) = item { return total + b.runs.map(\.text).joined().count }
+            return total
+        }
+    }
+
+    /// The one a reader actually sees: a code block that grows and then
+    /// briefly gets shorter reads as the app losing characters.
+    @Test("Code content never shrinks while streaming")
+    func codeGrowsMonotonically() {
+        var lastByIndex: [Int: Int] = [:]
+        for items in shapes(of: sample) {
+            for (index, block) in codeBlocks(items).enumerated() {
+                if let previous = lastByIndex[index] {
+                    #expect(
+                        block.code.count >= previous,
+                        "code block \(index) shrank \(previous) → \(block.code.count) mid-stream"
+                    )
+                }
+                lastByIndex[index] = block.code.count
+            }
+        }
+    }
+
+    /// A half-typed info string re-runs syntax highlighting for a language the
+    /// author never wrote.
+    @Test("A code block arrives already knowing its language")
+    func languageIsNeverPartial() {
+        var seen: Set<String> = []
+        for items in shapes(of: sample) {
+            for block in codeBlocks(items) where block.language != nil {
+                seen.insert(block.language!)
+            }
+        }
+        #expect(seen == ["swift"], "saw partial languages: \(seen.sorted())")
+    }
+
+    /// The block sequence used to gain a one-character text block for the
+    /// first backtick, which `MarkdownBlockStack`'s index-keyed `ForEach`
+    /// turns into a full view swap at that slot.
+    @Test("No stray backtick block appears before the fence opens")
+    func noLoneBacktickBlock() {
+        for items in shapes(of: sample) {
+            for case .text(let block) in items {
+                let text = block.runs.map(\.text).joined()
+                #expect(
+                    text.trimmingCharacters(in: .whitespacesAndNewlines) != "`",
+                    "a lone backtick was rendered as its own block"
+                )
+            }
+        }
+    }
+
+    /// Holding the marker back must not lose it. The settled row re-compiles
+    /// with `isComplete` true, and that render has to carry everything.
+    @Test("Nothing is held back once the message settles")
+    func settledRenderKeepsEverything() {
+        let settled = MarkdownCompiler().compile(sample).items
+        #expect(codeBlocks(settled).first?.code.contains("print(x)") == true)
+        #expect(codeBlocks(settled).first?.language == "swift")
+        #expect(proseLength(settled) >= "Here is code:".count + "Done.".count)
+    }
+
+    /// The trim is for fences only. An inline span being typed keeps its
+    /// characters — hiding those would make the composer feel laggy.
+    @Test("An inline code span being typed is left alone")
+    func inlineSpanIsUntouched() {
+        for source in ["Use `foo", "Call `bar to", "a `b` and `c"] {
+            #expect(
+                MarkdownCompiler.withoutFormingFence(source) == source,
+                "\(source) was trimmed as if it were a fence"
+            )
+        }
+    }
+
+    /// Exactly what does get held back, spelled out so the rule is reviewable
+    /// without running a stream.
+    @Test("Only a forming fence marker is held back")
+    func trimsOnlyFenceMarkers() {
+        #expect(MarkdownCompiler.withoutFormingFence("text\n`") == "text\n")
+        #expect(MarkdownCompiler.withoutFormingFence("text\n``") == "text\n")
+        #expect(MarkdownCompiler.withoutFormingFence("text\n```") == "text\n")
+        #expect(MarkdownCompiler.withoutFormingFence("text\n```swi") == "text\n")
+        // Finished lines are the parser's business again.
+        #expect(MarkdownCompiler.withoutFormingFence("text\n```swift\n") == "text\n```swift\n")
+        #expect(MarkdownCompiler.withoutFormingFence("plain text") == "plain text")
+        #expect(MarkdownCompiler.withoutFormingFence("") == "")
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/StreamingFenceStabilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/StreamingFenceStabilityTests.swift
@@ -91,21 +91,60 @@ struct StreamingFenceStabilityTests {
         }
     }
 
-    /// Holding the marker back must not lose it. The settled row re-compiles
-    /// with `isComplete` true, and that render has to carry everything.
-    @Test("Nothing is held back once the message settles")
-    func settledRenderKeepsEverything() {
+    /// The floor for this whole suite.
+    ///
+    /// Every other test here is one-sided: it forbids a shape from appearing.
+    /// A `withoutFormingFence` that returned `""` satisfies all of them — no
+    /// code block can shrink and no stray backtick can be rendered if nothing
+    /// is rendered at all. (Measured: with the body replaced by `return ""`,
+    /// the rest of the suite passed.) This test is the other side, so the
+    /// suite as a whole distinguishes "correctly trimmed" from "deleted".
+    ///
+    /// The sample's last line is `"Done."`, not a fence, so the final
+    /// streaming render must already carry the entire message.
+    @Test("The streaming render still carries the whole message")
+    func streamingRenderCarriesEverything() {
+        let streaming = MarkdownCompiler().compile(sample, isComplete: false).items
+        #expect(codeBlocks(streaming).first?.code.contains("print(x)") == true)
+        #expect(codeBlocks(streaming).first?.language == "swift")
+        #expect(proseLength(streaming) >= "Here is code:".count + "Done.".count)
+
+        // And the settled path is byte-identical to the pre-fix behaviour,
+        // because `compile` short-circuits the trim on `isComplete`.
         let settled = MarkdownCompiler().compile(sample).items
-        #expect(codeBlocks(settled).first?.code.contains("print(x)") == true)
-        #expect(codeBlocks(settled).first?.language == "swift")
-        #expect(proseLength(settled) >= "Here is code:".count + "Done.".count)
+        #expect(codeBlocks(settled).first?.code == codeBlocks(streaming).first?.code)
+    }
+
+    /// A source that ends mid-fence is where the two paths must disagree:
+    /// streaming holds the marker back, settled renders it as the parser sees
+    /// it. Without this, nothing checks that `isComplete` still gates the trim.
+    @Test("The settled compile is never trimmed")
+    func settledCompileIsNeverTrimmed() {
+        let midFence = "Here is code:\n\n```swi"
+        let streaming = MarkdownCompiler().compile(midFence, isComplete: false).items
+        let settled = MarkdownCompiler().compile(midFence, isComplete: true).items
+        #expect(codeBlocks(streaming).isEmpty, "the forming fence was not held back")
+        #expect(codeBlocks(settled).first?.language == "swi", "the settled row was trimmed")
     }
 
     /// The trim is for fences only. An inline span being typed keeps its
     /// characters — hiding those would make the composer feel laggy.
     @Test("An inline code span being typed is left alone")
     func inlineSpanIsUntouched() {
-        for source in ["Use `foo", "Call `bar to", "a `b` and `c"] {
+        for source in [
+            "Use `foo",
+            "Call `bar to",
+            "a `b` and `c",
+            // The three above all begin with a non-backtick, so they bail at
+            // the `ticks.isEmpty` guard and never reach the one that tells a
+            // span from a fence. Measured: deleting that guard left all six
+            // tests in this suite passing. These four are the ones that reach
+            // it — a line that IS a span in the making.
+            "text\n`foo",
+            "text\n``x",
+            "\n`variable",
+            "text\n`a b",
+        ] {
             #expect(
                 MarkdownCompiler.withoutFormingFence(source) == source,
                 "\(source) was trimmed as if it were a fence"
@@ -121,6 +160,15 @@ struct StreamingFenceStabilityTests {
         #expect(MarkdownCompiler.withoutFormingFence("text\n``") == "text\n")
         #expect(MarkdownCompiler.withoutFormingFence("text\n```") == "text\n")
         #expect(MarkdownCompiler.withoutFormingFence("text\n```swi") == "text\n")
+        // A backtick fence's info string may contain spaces — only backticks
+        // are forbidden. Both of these are fences and flicker without the trim.
+        #expect(MarkdownCompiler.withoutFormingFence("text\n```swift {highlight}") == "text\n")
+        #expect(MarkdownCompiler.withoutFormingFence("text\n```py file=a.py") == "text\n")
+        // Backticks in the tail make it a paragraph, not a fence.
+        #expect(MarkdownCompiler.withoutFormingFence("text\n``` a ```") == "text\n``` a ```")
+        // Swift reads CRLF as a single Character, so a newline search that
+        // looks for "\n" alone never matches it and the fix silently opts out.
+        #expect(MarkdownCompiler.withoutFormingFence("text\r\n```swi") == "text\r\n")
         // Finished lines are the parser's business again.
         #expect(MarkdownCompiler.withoutFormingFence("text\n```swift\n") == "text\n```swift\n")
         #expect(MarkdownCompiler.withoutFormingFence("plain text") == "plain text")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2280,6 +2280,36 @@ flow_slow_stream_stop() {
     assert_tree_text "$OUT/after-stop-settled.json" "Three things, in order:"
     jq -n '{success: true, assertion: "a send immediately after zero-content Stop answers the new prompt"}' \
         > "$OUT/after-stop-assertion.json"
+
+    # A forming fenced block used to appear first as a stray backtick text
+    # row, then swap into a code card with a partial language, and finally
+    # shrink when the closing fence arrived. Sample the assembled app while
+    # the fake sidecar streams its deliberately split code fixture: no raw
+    # marker may become an accessibility row at any intermediate revision.
+    send_prompt "shape:code stream a code block" streaming-fence
+    local fence_samples=0
+    for sample in {1..120}; do
+        see_main "$OUT/streaming-fence-$sample.json"
+        if jq -e '.data.ui_elements[]?
+                  | ((.value // "") | tostring)
+                  | select((gsub("[[:space:]]"; "")) == "`"
+                           or (gsub("[[:space:]]"; "")) == "``")' \
+            "$OUT/streaming-fence-$sample.json" >/dev/null; then
+            die "a forming code fence flickered into the streaming AX tree"
+        fi
+        fence_samples=$((fence_samples + 1))
+        [[ "$(element_field "$OUT/streaming-fence-$sample.json" ChatView.SendOrStopButton description)" == "Send message" ]] \
+            && break
+        sleep 0.01
+    done
+    wait_send_idle "$OUT/streaming-fence-settled.json"
+    assert_code_block_is_its_own_view \
+        "$OUT/streaming-fence-settled.json" \
+        "Here is the function you asked for" \
+        "def fib(n):"
+    jq -n --argjson samples "$fence_samples" \
+        '{success: true, assertion: "forming fences never became text rows", samples: $samples}' \
+        > "$OUT/streaming-fence-assertion.json"
     cleanup_persona
 }
 


### PR DESCRIPTION
## Problem

A fence marker reaches the parser one keystroke before it *is* a fence. Compiling a growing prefix of

```
Here is code:\n\n```swift\nlet x = 1\nprint(x)\n```\n\nDone.
```

shows three separate flickers, all from that one cause (`T(n)` = text block of n chars, `C(n|lang)` = code block):

| prefix | blocks | what the reader sees |
|---|---|---|
| n=16 | `T(13) T(1)` | a lone backtick renders as its own text block |
| n=20 | `T(13) C(0\|sw)` | index 1 turns from text into code — SwiftUI swaps the whole representable at that slot |
| n=24 | `T(13) C(0\|swift)` | the language changes, re-running syntax highlighting |
| n=48 | `T(13) C(19\|swift)` | the closing backticks were being displayed *as code content* until they closed the fence |

The study that prompted this described one flicker; measuring found three, by a different mechanism than described.

## Fix

`MarkdownCompiler.withoutFormingFence` drops a trailing fence marker whose line is still being typed. The card then appears once, already knowing its language, and no stray backticks are ever shown inside it.

Scope is deliberately narrow:

- **Last line only, streaming only.** The settled row recompiles with `isComplete` true (`ChatView` swaps the streaming renderer for the settled renderer), so nothing stays hidden.
- **Real fences only.** A run of 3+ backticks (with or without an info string), or a line that is nothing but one or two backticks. An inline code span being typed — `` `foo `` — is left alone.

## Tests

6 cases in `StreamingFenceStabilityTests`, each break-verified by reintroducing the bug and confirming the specific test fails.

## Why this matters

This prevents code answers from visibly changing component type and losing apparent characters while tokens arrive, because a forming fence no longer reaches the Markdown parser before its line is complete. The assembled-app Golden Flow samples the live stream and guards that user-facing behavior.