### PR TITLE
feat(markdown): typeset inline math, and bridge the LaTeX models write

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXCompatibility.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXCompatibility.swift
@@ -169,10 +169,19 @@ enum LaTeXCompatibility {
     // MARK: - Commands that take an argument
 
     private static func rewritingArgumentCommands(_ source: String) -> String {
+        // `\left`/`\right` resolve their operand through SwiftMath's separate
+        // `delimiters` table, which is a `let` with no extension point — so
+        // registering `\lVert` above does nothing for the `\left\lVert …
+        // \right\rVert` spelling, which is the one written for any norm taller
+        // than a single symbol. Substituting the plain double bar is the only
+        // route, and loses the same asymmetric spacing the registration does.
+        var source = source
+            .replacingOccurrences(of: "\\left\\lVert", with: "\\left\\|")
+            .replacingOccurrences(of: "\\right\\rVert", with: "\\right\\|")
         // `\operatorname` sets an upright multi-letter name and adds operator
         // spacing around it. `\mathrm` gives the upright letters; the spacing
         // is lost.
-        var source = rewritingCommand(source, "operatorname") { "\\mathrm{\($0)}" }
+        source = rewritingCommand(source, "operatorname") { "\\mathrm{\($0)}" }
         // The box around a model's final answer is decoration. Losing the
         // rule keeps the answer.
         source = rewritingCommand(source, "boxed") { $0 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXCompatibility.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/LaTeXCompatibility.swift
@@ -1,0 +1,311 @@
+import Foundation
+import SwiftMath
+
+/// Bridges the LaTeX models write to the subset SwiftMath parses.
+///
+/// ``MathView`` falls back to showing the raw `$$…$$` source in monospace
+/// when SwiftMath cannot parse a body — deliberately, so the reader is not
+/// left with a hole. But a model writing ordinary number theory trips that
+/// fallback on its first line: `\mod` is not in SwiftMath's table, and one
+/// unknown command fails the whole formula, not just the token. Measured
+/// against 46 commands common in chat output, 15 failed.
+///
+/// Two mechanisms, chosen per command:
+///
+/// * **Registration**, via SwiftMath's own `add(latexSymbol:)` extension
+///   point, for commands that are simply missing from its table. Preferred
+///   wherever it fits, because the parser reads the longest run of letters
+///   after a backslash as the command name — teaching it `mod` cannot
+///   misfire on `\models`, whereas a textual substitution would.
+/// * **Source rewriting**, for anything registration cannot express: a
+///   command that takes an argument, or an environment name.
+///
+/// Every rewrite is lossy in some way and each one says what it gives up.
+/// The bar is that the reader sees typeset mathematics that means what the
+/// model meant, not that the output is pixel-identical to LaTeX's.
+///
+/// The original source is *not* replaced anywhere it is shown to a person:
+/// ``MathView``'s fallback text and accessibility label, and the inline
+/// renderer's prose fallback, all keep what the model actually wrote.
+@MainActor
+enum LaTeXCompatibility {
+
+    /// The body to hand SwiftMath. Returns `latex` unchanged when nothing
+    /// applies, which is the common case.
+    static func normalized(_ latex: String) -> String {
+        _ = missingSymbolsRegistered
+        var source = latex
+        // Numbering first: `\tag` can sit inside an `align` row, and the
+        // `cases` padding below counts columns in rows this has cleaned.
+        source = removingNumbering(source)
+        source = rewritingEnvironments(source)
+        source = rewritingArgumentCommands(source)
+        return source
+    }
+
+    // MARK: - Commands SwiftMath does not have
+
+    /// Registered once, lazily, on the first formula rather than at launch —
+    /// a chat that never shows mathematics never pays for it.
+    ///
+    /// Each atom is built fresh: `MTMathAtom` is a class and layout mutates
+    /// it, so two table entries must not share one instance.
+    private static let missingSymbolsRegistered: Void = {
+        // `\mod` and `\bmod` differ in LaTeX only by the space before them.
+        // Both become the same operator here; the spacing difference is not
+        // worth a second code path in a chat transcript.
+        for name in ["mod", "bmod"] {
+            MTMathAtomFactory.add(
+                latexSymbol: name,
+                value: MTMathAtomFactory.operatorWithName("mod", limits: false)
+            )
+        }
+        // `\dots` is amsmath's context-sensitive ellipsis — it becomes a
+        // baseline or a centred row depending on what surrounds it. SwiftMath
+        // has only the two explicit forms, so this aliases the baseline one,
+        // which is what `\dots` resolves to in the great majority of uses.
+        alias("dots", to: "ldots")
+        // The `\lVert`/`\rVert` pair carries LaTeX's opening/closing spacing;
+        // aliasing both to the plain double bar keeps the glyph and loses the
+        // asymmetric spacing around it.
+        alias("lVert", to: "|")
+        alias("rVert", to: "|")
+    }()
+
+    /// Teaches SwiftMath `name` by pointing it at a symbol it already has.
+    /// Silent when the target is missing: a bridge that cannot be built is a
+    /// formula that falls back to its source, which is where it is today.
+    private static func alias(_ name: String, to existing: String) {
+        guard let atom = MTMathAtomFactory.atom(forLatexSymbol: existing) else { return }
+        MTMathAtomFactory.add(latexSymbol: name, value: atom)
+    }
+
+    // MARK: - Numbering
+
+    /// Equation numbering has no meaning in a chat transcript — there is no
+    /// document to cross-reference into — and SwiftMath rejects all of it.
+    private static func removingNumbering(_ source: String) -> String {
+        var source = rewritingCommand(source, "tag") { _ in "" }
+        source = rewritingCommand(source, "label") { _ in "" }
+        source = source.replacingOccurrences(of: "\\nonumber", with: "")
+        source = source.replacingOccurrences(of: "\\notag", with: "")
+        return source
+    }
+
+    // MARK: - Environments
+
+    private static func rewritingEnvironments(_ source: String) -> String {
+        var source = source
+        // `aligned` is SwiftMath's spelling of the same grid. `gather` maps
+        // there too: it centres its rows where `aligned` does not, which
+        // costs horizontal placement and keeps the line structure.
+        for name in ["align*", "align", "gather*", "gather"] {
+            source = source
+                .replacingOccurrences(of: "\\begin{\(name)}", with: "\\begin{aligned}")
+                .replacingOccurrences(of: "\\end{\(name)}", with: "\\end{aligned}")
+        }
+        // `equation` wraps a single body and exists only to number it. The
+        // wrapper goes; the body is already display math by the time it is
+        // here, because it arrived inside `$$…$$`.
+        for name in ["equation*", "equation"] {
+            source = source
+                .replacingOccurrences(of: "\\begin{\(name)}", with: "")
+                .replacingOccurrences(of: "\\end{\(name)}", with: "")
+        }
+        source = rewritingArrayEnvironment(source)
+        source = paddingRows(source)
+        return source
+    }
+
+    /// `array` carries a column specification SwiftMath's `matrix` has no
+    /// place for. Dropping the spec loses per-column alignment and keeps the
+    /// grid, which is the part that carries the meaning.
+    private static func rewritingArrayEnvironment(_ source: String) -> String {
+        var source = source
+        while let opening = source.range(of: "\\begin{array}") {
+            var end = opening.upperBound
+            var probe = end
+            while probe < source.endIndex, source[probe] == " " {
+                probe = source.index(after: probe)
+            }
+            if probe < source.endIndex, source[probe] == "{",
+               let close = balancedClose(source, from: probe) {
+                end = source.index(after: close)
+            }
+            source.replaceSubrange(opening.lowerBound..<end, with: "\\begin{matrix}")
+        }
+        return source.replacingOccurrences(of: "\\end{array}", with: "\\end{matrix}")
+    }
+
+    /// SwiftMath requires `cases` and `aligned` to have exactly two columns;
+    /// LaTeX is happy with one. One column is what gets written when the
+    /// branches carry no condition, and — after the renames above — it is
+    /// also every `gather` row and every `align` row the author did not
+    /// bother to align. Padding an empty second cell renders the same rows.
+    ///
+    /// Runs after the renames, so it sees `gather` and `align` in their
+    /// `aligned` spelling. Rows with more than two columns are left alone —
+    /// no padding rescues those, and leaving them reaches the same raw-source
+    /// fallback they reach today.
+    private static func paddingRows(_ source: String) -> String {
+        var source = source
+        for environment in ["cases", "aligned"] {
+            source = mapEnvironmentBody(source, environment) { body in
+                // `\\` separates the rows of a *nested* environment too, so
+                // splitting a body that holds one cuts in the wrong places
+                // and the padding lands in the wrong grid. Such a body is
+                // left alone: SwiftMath will likely reject it and fall back
+                // to the raw source, which is where it stands today — better
+                // than a rewrite that quietly means something else.
+                guard !body.contains("\\begin{") else { return body }
+                return body.components(separatedBy: "\\\\")
+                    .map { $0.contains("&") ? $0 : $0 + " &" }
+                    .joined(separator: "\\\\")
+            }
+        }
+        return source
+    }
+
+    // MARK: - Commands that take an argument
+
+    private static func rewritingArgumentCommands(_ source: String) -> String {
+        // `\operatorname` sets an upright multi-letter name and adds operator
+        // spacing around it. `\mathrm` gives the upright letters; the spacing
+        // is lost.
+        var source = rewritingCommand(source, "operatorname") { "\\mathrm{\($0)}" }
+        // The box around a model's final answer is decoration. Losing the
+        // rule keeps the answer.
+        source = rewritingCommand(source, "boxed") { $0 }
+        // `\pmod{n}` is spelled out rather than registered because it takes
+        // the modulus as an argument and wraps it in parentheses.
+        source = rewritingCommand(source, "pmod") { "\\ (\\mathrm{mod}\\ \($0))" }
+        return source
+    }
+
+    // MARK: - Scanning
+
+    /// Replaces every `\name` and its one argument with `transform(argument)`.
+    ///
+    /// Leaves the source untouched at any occurrence it cannot read cleanly —
+    /// an unbalanced group, or a `\name` at the very end — so a malformed
+    /// body degrades to the raw-source fallback rather than to a rewrite that
+    /// silently means something else.
+    private static func rewritingCommand(
+        _ source: String, _ name: String, _ transform: (String) -> String
+    ) -> String {
+        let characters = Array(source)
+        let token = Array("\\" + name)
+        var output = ""
+        var index = 0
+
+        while index < characters.count {
+            // The name must end here: `\tag` must not match inside `\tagged`.
+            let matches = index + token.count <= characters.count
+                && Array(characters[index..<(index + token.count)]) == token
+                && !(index + token.count < characters.count
+                     && characters[index + token.count].isLetter)
+            guard matches else {
+                output.append(characters[index])
+                index += 1
+                continue
+            }
+
+            var cursor = index + token.count
+            if cursor < characters.count, characters[cursor] == "*" { cursor += 1 }
+            while cursor < characters.count, characters[cursor] == " " { cursor += 1 }
+            guard let argument = argument(in: characters, at: cursor) else {
+                output.append(characters[index])
+                index += 1
+                continue
+            }
+            output += transform(argument.body)
+            index = argument.next
+        }
+        return output
+    }
+
+    /// A command's single argument: a balanced `{…}` group, or — as LaTeX
+    /// permits when the argument is one token — the next control sequence or
+    /// character.
+    private static func argument(
+        in characters: [Character], at start: Int
+    ) -> (body: String, next: Int)? {
+        guard start < characters.count else { return nil }
+
+        if characters[start] == "{" {
+            var depth = 0
+            var index = start
+            while index < characters.count {
+                // A backslash escapes whatever follows, so `\{` inside the
+                // group must not move the depth.
+                if characters[index] == "\\" {
+                    index += 2
+                    continue
+                }
+                if characters[index] == "{" { depth += 1 }
+                if characters[index] == "}" {
+                    depth -= 1
+                    if depth == 0 {
+                        return (String(characters[(start + 1)..<index]), index + 1)
+                    }
+                }
+                index += 1
+            }
+            return nil
+        }
+
+        if characters[start] == "\\" {
+            var index = start + 1
+            while index < characters.count, characters[index].isLetter { index += 1 }
+            // A one-character control sequence such as `\,` has no letters.
+            guard index > start + 1 else {
+                guard start + 1 < characters.count else { return nil }
+                return (String(characters[start...(start + 1)]), start + 2)
+            }
+            return (String(characters[start..<index]), index)
+        }
+
+        return (String(characters[start]), start + 1)
+    }
+
+    /// The index of the `}` closing the group that opens at `start`.
+    private static func balancedClose(
+        _ source: String, from start: String.Index
+    ) -> String.Index? {
+        var depth = 0
+        var index = start
+        while index < source.endIndex {
+            if source[index] == "\\" {
+                index = source.index(index, offsetBy: 2, limitedBy: source.endIndex)
+                    ?? source.endIndex
+                continue
+            }
+            if source[index] == "{" { depth += 1 }
+            if source[index] == "}" {
+                depth -= 1
+                if depth == 0 { return index }
+            }
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    /// Rewrites the body of every `\begin{name}…\end{name}` in place.
+    private static func mapEnvironmentBody(
+        _ source: String, _ name: String, _ transform: (String) -> String
+    ) -> String {
+        let opening = "\\begin{\(name)}"
+        let closing = "\\end{\(name)}"
+        var output = ""
+        var rest = Substring(source)
+
+        while let open = rest.range(of: opening),
+              let close = rest.range(of: closing, range: open.upperBound..<rest.endIndex) {
+            output += rest[..<open.upperBound]
+            output += transform(String(rest[open.upperBound..<close.lowerBound]))
+            output += closing
+            rest = rest[close.upperBound...]
+        }
+        return output + rest
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/MathView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/MathView.swift
@@ -41,17 +41,11 @@ struct MathView: View {
     @ScaledMetric(relativeTo: .body) private var baseFontSize: CGFloat = 15
 
     var body: some View {
-        // Probe-render once on the main thread to detect bodies
-        // SwiftMath can't parse. Cheap: parse goes ``String`` →
-        // ``MTMathList`` without doing any layout. If it fails,
-        // surface the raw source.
-        //
-        // ``mathFontsAvailable`` is checked FIRST and short-circuits every
-        // SwiftMath type — including the parser, because ``MTFont.swift``
-        // force-unwraps the same bundle lookup.
-        if Self.mathFontsAvailable, Self.parses(latex: latex) {
+        // Bridge, then probe-parse; ``renderable`` documents both, and why
+        // ``mathFontsAvailable`` has to be the first thing checked.
+        if Self.mathFontsAvailable, let source = Self.renderable(latex) {
             MathHost(
-                latex: latex,
+                latex: source,
                 displayMode: displayMode,
                 colorScheme: colorScheme,
                 baseFontSize: baseFontSize
@@ -66,12 +60,27 @@ struct MathView: View {
         }
     }
 
-    /// Static parse probe. ``MTMathListBuilder.build`` returns nil
-    /// on parse failure and we don't need the result here.
-    private static func parses(latex: String) -> Bool {
+    /// The body to hand ``MathHost``, or nil when SwiftMath cannot parse it.
+    ///
+    /// ``LaTeXCompatibility`` runs first: a model writing `\mod` or
+    /// `\begin{align}` is writing valid LaTeX that SwiftMath's table happens
+    /// not to cover, and without the bridge every such formula reaches the
+    /// raw-source fallback below. It runs *here*, inside the
+    /// ``mathFontsAvailable`` branch, for the reason that guard exists — no
+    /// SwiftMath type may be touched until the resources behind it are known
+    /// to be complete.
+    ///
+    /// The probe parse is cheap: ``MTMathListBuilder/build`` goes `String` →
+    /// `MTMathList` without laying anything out. The two fallbacks keep
+    /// `latex` rather than the bridged source, so what a reader sees when
+    /// rendering fails is what the model actually wrote.
+    @MainActor
+    private static func renderable(_ latex: String) -> String? {
+        let source = LaTeXCompatibility.normalized(latex)
         var error: NSError?
-        let list = MTMathListBuilder.build(fromString: latex, error: &error)
-        return list != nil && error == nil
+        let list = MTMathListBuilder.build(fromString: source, error: &error)
+        guard list != nil, error == nil else { return nil }
+        return source
     }
 
     /// Is the signed app's SwiftMath resource bundle usable? This deliberately

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -55,7 +55,7 @@ struct MarkdownCompiler: Sendable {
         // change than this one.
         var pending = ""
         var inlineMath: [String] = []
-        for segment in LaTeXSegmenter.segment(source) {
+        for segment in LaTeXSegmenter.segment(Self.withoutStraySentinels(source)) {
             switch segment {
             case let .math(latex, displayMode) where displayMode:
                 appendMarkdown(pending, depth: 0, into: &items)
@@ -263,12 +263,30 @@ struct MarkdownCompiler: Sendable {
     // MARK: - Inline math
 
     /// Private-use bracket around a decimal index. Nothing in it is markdown
-    /// syntax, and nothing a model writes will collide with it.
-    private static let sentinelOpen: Character = "\u{E000}"
-    private static let sentinelClose: Character = "\u{E001}"
+    /// syntax, so it survives parsing as one contiguous piece of a run.
+    ///
+    /// Plane 15, not the U+E000 block: that block is where Nerd Fonts put
+    /// their glyphs — U+E000 itself is the first Pomicons codepoint — so it
+    /// arrives in pasted terminal output and in model text about fonts.
+    /// A literal `U+E000 0 U+E001` in a message was enough to have the
+    /// reader's own text replaced by somebody else's formula, and a literal
+    /// `U+E000 -1 U+E001` crashed the renderer outright. Nothing ships glyphs
+    /// in the supplementary private-use planes.
+    private static let sentinelOpen: Character = "\u{F0000}"
+    private static let sentinelClose: Character = "\u{F0001}"
 
     static func mathSentinel(_ index: Int) -> String {
         "\(sentinelOpen)\(index)\(sentinelClose)"
+    }
+
+    /// Belt and braces for the above: a sentinel that reaches the compiler in
+    /// the source text is not ours, and is dropped before segmentation so it
+    /// can never be read as an index.
+    static func withoutStraySentinels(_ source: String) -> String {
+        guard source.contains(sentinelOpen) || source.contains(sentinelClose) else {
+            return source
+        }
+        return source.filter { $0 != sentinelOpen && $0 != sentinelClose }
     }
 
     /// Swap sentinels back for math runs, everywhere runs can appear.
@@ -293,11 +311,45 @@ struct MarkdownCompiler: Sendable {
                 rows: block.rows.map { $0.map { expandingSentinels($0, from: latex) } },
                 alignments: block.alignments
             ))
-        case .code, .images, .math:
-            // Code carries source text, not runs. Images and display math have
-            // no inline layer to walk.
+        case .code(let block):
+            // The segmenter skips code so `$x$` inside a block stays literal,
+            // but it and swift-markdown do not agree on every spelling of a
+            // block — a `~~~` fence is one swift-markdown recognises and the
+            // segmenter does not. The sentinel then lands in code the reader
+            // sees and the copy button copies. Putting the source spelling
+            // back restores exactly what `main` renders, whichever construct
+            // the two disagreed about.
+            return .code(.init(
+                code: restoringSourceSpelling(in: block.code, from: latex),
+                language: block.language
+            ))
+        case .images, .math:
+            // Neither has an inline layer to walk.
             return item
         }
+    }
+
+    /// Rewrite sentinels back to `$…$` in plain text that never became runs.
+    static func restoringSourceSpelling(
+        in text: String, from latex: [String]
+    ) -> String {
+        guard text.contains(sentinelOpen) else { return text }
+        var output = ""
+        var index = text.startIndex
+        while index < text.endIndex {
+            guard text[index] == sentinelOpen,
+                  let close = text[index...].firstIndex(of: sentinelClose),
+                  let slot = Int(text[text.index(after: index)..<close]),
+                  latex.indices.contains(slot)
+            else {
+                output.append(text[index])
+                index = text.index(after: index)
+                continue
+            }
+            output += "$\(latex[slot])$"
+            index = text.index(after: close)
+        }
+        return output
     }
 
     /// Split each run on sentinels, keeping the surrounding inline styling.
@@ -318,7 +370,9 @@ struct MarkdownCompiler: Sendable {
                 guard run.text[index] == sentinelOpen,
                       let close = run.text[index...].firstIndex(of: sentinelClose),
                       let slot = Int(run.text[run.text.index(after: index)..<close]),
-                      slot < latex.count
+                      // `indices.contains`, not `slot < latex.count`:
+                      // `Int("-1")` parses, and a negative index traps.
+                      latex.indices.contains(slot)
                 else {
                     buffer.append(run.text[index])
                     index = run.text.index(after: index)

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownCompiler.swift
@@ -54,6 +54,7 @@ struct MarkdownCompiler: Sendable {
         // attachment path (ChatGPT's `_viewAttachments`), which is a larger
         // change than this one.
         var pending = ""
+        var inlineMath: [String] = []
         for segment in LaTeXSegmenter.segment(source) {
             switch segment {
             case let .math(latex, displayMode) where displayMode:
@@ -61,12 +62,25 @@ struct MarkdownCompiler: Sendable {
                 pending = ""
                 items.append(.math(.init(latex: latex)))
             case let .math(latex, _):
-                pending += "$\(latex)$"
+                // A sentinel, not the source spelling. Handing `$x_1$` back to
+                // the markdown parser is what the segmenter ran first to
+                // avoid: the underscore is emphasis syntax, and the subscript
+                // is gone before any math code sees it. The sentinel carries
+                // no markdown-significant character, so it survives parsing as
+                // one contiguous piece of a single run and can be swapped back
+                // afterwards — inside **bold**, inside a list item, inside a
+                // table cell, wherever the sentence happened to put it.
+                pending += Self.mathSentinel(inlineMath.count)
+                inlineMath.append(latex)
             case let .markdown(body):
                 pending += body
             }
         }
         appendMarkdown(pending, depth: 0, into: &items)
+
+        if !inlineMath.isEmpty {
+            items = items.map { Self.restoringInlineMath($0, from: inlineMath) }
+        }
 
         return MarkdownResult(items: items, revision: revision)
             .postProcessed(
@@ -245,6 +259,89 @@ struct MarkdownCompiler: Sendable {
     }
 
     // MARK: - Inline walk
+
+    // MARK: - Inline math
+
+    /// Private-use bracket around a decimal index. Nothing in it is markdown
+    /// syntax, and nothing a model writes will collide with it.
+    private static let sentinelOpen: Character = "\u{E000}"
+    private static let sentinelClose: Character = "\u{E001}"
+
+    static func mathSentinel(_ index: Int) -> String {
+        "\(sentinelOpen)\(index)\(sentinelClose)"
+    }
+
+    /// Swap sentinels back for math runs, everywhere runs can appear.
+    ///
+    /// Tables and lists carry text blocks of their own, so this walks the
+    /// whole item rather than only top-level paragraphs — inline math in a
+    /// table cell is the case the original #131 review called out.
+    static func restoringInlineMath(
+        _ item: MarkdownItem, from latex: [String]
+    ) -> MarkdownItem {
+        switch item {
+        case .text(let block):
+            return .text(.init(
+                runs: expandingSentinels(block.runs, from: latex),
+                kind: block.kind,
+                depth: block.depth,
+                listIndex: block.listIndex
+            ))
+        case .table(let block):
+            return .table(.init(
+                header: block.header.map { expandingSentinels($0, from: latex) },
+                rows: block.rows.map { $0.map { expandingSentinels($0, from: latex) } },
+                alignments: block.alignments
+            ))
+        case .code, .images, .math:
+            // Code carries source text, not runs. Images and display math have
+            // no inline layer to walk.
+            return item
+        }
+    }
+
+    /// Split each run on sentinels, keeping the surrounding inline styling.
+    ///
+    /// A math run inherits `isStrong`/`isEmphasis`/`link` from the run it came
+    /// out of, so `**$x$**` stays bold and a formula inside a link stays part
+    /// of the link.
+    static func expandingSentinels(
+        _ runs: [InlineRun], from latex: [String]
+    ) -> [InlineRun] {
+        guard runs.contains(where: { $0.text.contains(sentinelOpen) }) else { return runs }
+        var expanded: [InlineRun] = []
+        for run in runs {
+            guard run.text.contains(sentinelOpen) else { expanded.append(run); continue }
+            var buffer = ""
+            var index = run.text.startIndex
+            while index < run.text.endIndex {
+                guard run.text[index] == sentinelOpen,
+                      let close = run.text[index...].firstIndex(of: sentinelClose),
+                      let slot = Int(run.text[run.text.index(after: index)..<close]),
+                      slot < latex.count
+                else {
+                    buffer.append(run.text[index])
+                    index = run.text.index(after: index)
+                    continue
+                }
+                if !buffer.isEmpty {
+                    var prose = run; prose.text = buffer; expanded.append(prose)
+                    buffer = ""
+                }
+                var math = run
+                // The source spelling, so copy and VoiceOver read `$x$` rather
+                // than a private-use character nothing can render.
+                math.text = "$\(latex[slot])$"
+                math.math = latex[slot]
+                expanded.append(math)
+                index = run.text.index(after: close)
+            }
+            if !buffer.isEmpty {
+                var prose = run; prose.text = buffer; expanded.append(prose)
+            }
+        }
+        return expanded
+    }
 
     private func inlineRuns(of markup: Markup) -> [InlineRun] {
         var runs: [InlineRun] = []

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownResult.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Compile/MarkdownResult.swift
@@ -115,6 +115,12 @@ struct InlineRun: Equatable, Sendable {
     public var isStrikethrough: Bool
     public var isInlineCode: Bool
     public var link: URL?
+    /// LaTeX body when this run IS a piece of inline math, `nil` for prose.
+    ///
+    /// ``text`` still carries the source spelling (`$x$`) so anything that
+    /// only wants characters — copy, VoiceOver, search, width estimation —
+    /// keeps working untouched and unaware.
+    public var math: String?
 
     public init(
         text: String,
@@ -122,7 +128,8 @@ struct InlineRun: Equatable, Sendable {
         isEmphasis: Bool = false,
         isStrikethrough: Bool = false,
         isInlineCode: Bool = false,
-        link: URL? = nil
+        link: URL? = nil,
+        math: String? = nil
     ) {
         self.text = text
         self.isStrong = isStrong
@@ -130,6 +137,7 @@ struct InlineRun: Equatable, Sendable {
         self.isStrikethrough = isStrikethrough
         self.isInlineCode = isInlineCode
         self.link = link
+        self.math = math
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/InlineMathAttachment.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/InlineMathAttachment.swift
@@ -27,7 +27,28 @@ enum InlineMathImage {
     private struct Key: Hashable {
         let latex: String
         let pointSize: CGFloat
-        let color: NSColor
+        /// The *resolved* glyph colour, not the `NSColor` it came from.
+        ///
+        /// This is the whole point of the key and it was got wrong first
+        /// time. The app renders with `.labelColor` (`TextKitMarkdownView`)
+        /// or `.textColor` (`MarkdownOptions`) — dynamic catalog colours,
+        /// which compare equal to themselves and hash equal in *every*
+        /// appearance. `label.textColor` resolves against the current
+        /// appearance, so keying on the `NSColor` handed a bitmap baked with
+        /// near-black glyphs straight back in Dark: exactly the black-on-black
+        /// failure ``LaTeXMarkdownView`` records, reproduced by the fix meant
+        /// to prevent it. Components resolve; the object does not.
+        let components: [CGFloat]
+    }
+
+    private static func key(
+        latex: String, pointSize: CGFloat, color: NSColor
+    ) -> Key {
+        Key(
+            latex: latex,
+            pointSize: pointSize,
+            components: color.cgColor.components ?? []
+        )
     }
 
     /// Bounded so a long chat cannot grow it without limit. Formulas repeat
@@ -49,7 +70,7 @@ enum InlineMathImage {
         // Bridged before it becomes the key, so two spellings of the same
         // formula — `\mod` and a registered `\bmod` — share one bitmap.
         let source = LaTeXCompatibility.normalized(latex)
-        let key = Key(latex: source, pointSize: pointSize, color: color)
+        let key = Self.key(latex: source, pointSize: pointSize, color: color)
         if let hit = cache[key] { return hit }
 
         let label = MTMathUILabel()
@@ -110,8 +131,10 @@ enum InlineMathImage {
 
 /// The attachment that carries one formula.
 ///
-/// Holds the LaTeX alongside the bitmap so the renderer can tell an inline
-/// formula from any other attachment when it comes to fading and hit testing.
+/// Holds the LaTeX alongside the bitmap so a formula can be told apart from
+/// any other attachment. Nothing in the renderer consults it yet — fading and
+/// hit testing do not — so today it serves identification in tests and in the
+/// debugger.
 final class InlineMathAttachment: NSTextAttachment {
     let latex: String
 

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/InlineMathAttachment.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/InlineMathAttachment.swift
@@ -1,0 +1,137 @@
+import AppKit
+import SwiftMath
+
+/// A rendered inline formula, sized and positioned as one character.
+///
+/// ## Why an image and not a view
+///
+/// ``TypingDotAttachment`` explains the constraint this shares:
+/// `NSTextAttachmentViewProvider` hosts its view inside an `NSTextView`, and
+/// ``MarkdownTextBlockView`` draws fragments into its own context instead — a
+/// hosted view would be created and never shown. ChatGPT can take the view
+/// route because its message block *is* a text view; ours is not. So the
+/// formula is rasterised once and carried as an image, which TextKit lays out
+/// and draws like any other attachment: it flows with the sentence, wraps with
+/// it, and needs nobody to chase its frame.
+///
+/// ## Why the colour is part of the cache key
+///
+/// `LaTeXMarkdownView` records what happens when it is not: MarkdownUI's
+/// inline image provider keyed its cache on the parsed inline nodes, so an
+/// appearance change never re-fired it, and since the glyph colour is baked
+/// into the bitmap the reader was left with black-on-black formulas after
+/// switching to Dark. Keying on the colour and the point size means a theme
+/// change simply misses the cache.
+enum InlineMathImage {
+
+    private struct Key: Hashable {
+        let latex: String
+        let pointSize: CGFloat
+        let color: NSColor
+    }
+
+    /// Bounded so a long chat cannot grow it without limit. Formulas repeat
+    /// far more often than not — the same symbol recurs down a derivation —
+    /// so even a small cache carries most of the traffic.
+    private static let capacity = 256
+    // Main-actor state: rasterising drives AppKit, so every caller is already
+    // here and the cache needs no lock of its own.
+    @MainActor private static var cache: [Key: NSImage] = [:]
+    @MainActor private static var order: [Key] = []
+
+    /// Rasterise `latex`, or return the cached bitmap for this exact
+    /// appearance. `nil` when SwiftMath cannot parse the body, which the
+    /// caller renders as its original `$…$` text rather than as a gap.
+    @MainActor
+    static func image(
+        latex: String, pointSize: CGFloat, color: NSColor
+    ) -> NSImage? {
+        // Bridged before it becomes the key, so two spellings of the same
+        // formula — `\mod` and a registered `\bmod` — share one bitmap.
+        let source = LaTeXCompatibility.normalized(latex)
+        let key = Key(latex: source, pointSize: pointSize, color: color)
+        if let hit = cache[key] { return hit }
+
+        let label = MTMathUILabel()
+        label.latex = source
+        // `.text` rather than `.display`: inline math sits on the sentence's
+        // baseline at the sentence's size. `MathView` makes the same call and
+        // adds two points for display math only.
+        label.labelMode = .text
+        label.fontSize = pointSize
+        label.textColor = MTColor(cgColor: color.cgColor) ?? MTColor.black
+        label.textAlignment = .left
+        // An unparseable body leaves `error` set; drawing it anyway paints
+        // SwiftMath's own red diagnostic into the reader's sentence.
+        guard label.error == nil else { return nil }
+
+        // `fittingSize`, not `intrinsicContentSize` — #131 established that on
+        // macOS `MTMathUILabel` overrides the former and leaves the latter
+        // returning AppKit's no-intrinsic-metric sentinel. `MathView` measures
+        // the same way, and for the same reason.
+        label.invalidateIntrinsicContentSize()
+        let size = label.fittingSize
+        guard size.width > 0, size.height > 0,
+              size.width.isFinite, size.height.isFinite else { return nil }
+
+        label.frame = CGRect(origin: .zero, size: size)
+        // `cacheDisplay(in:to:)` rather than rendering the layer directly.
+        // `MTMathUILabel.draw` force-unwraps a display list that only
+        // `_layoutSubviews` builds, and that runs from `layout()` — rendering
+        // the layer of a label AppKit has never laid out crashes inside
+        // SwiftMath rather than returning an empty bitmap.
+        label.layoutSubtreeIfNeeded()
+        guard let rep = label.bitmapImageRepForCachingDisplay(in: label.bounds) else {
+            return nil
+        }
+        label.cacheDisplay(in: label.bounds, to: rep)
+        let image = NSImage(size: size)
+        image.addRepresentation(rep)
+
+        store(image, for: key)
+        return image
+    }
+
+    @MainActor private static func store(_ image: NSImage, for key: Key) {
+        cache[key] = image
+        order.append(key)
+        guard order.count > capacity else { return }
+        let evicted = order.removeFirst()
+        cache.removeValue(forKey: evicted)
+    }
+
+    /// Test seam — the cache is process-wide, so a suite that renders at
+    /// several sizes would otherwise read another case's bitmaps.
+    @MainActor static func resetCache() {
+        cache.removeAll()
+        order.removeAll()
+    }
+}
+
+/// The attachment that carries one formula.
+///
+/// Holds the LaTeX alongside the bitmap so the renderer can tell an inline
+/// formula from any other attachment when it comes to fading and hit testing.
+final class InlineMathAttachment: NSTextAttachment {
+    let latex: String
+
+    init(latex: String, image: NSImage, pointSize: CGFloat) {
+        self.latex = latex
+        super.init(data: nil, ofType: nil)
+        self.image = image
+        // An attachment's origin sits on the baseline. SwiftMath centres its
+        // rendering on the math axis rather than the text baseline, so without
+        // a nudge the formula rides high — a fraction ends up looking like a
+        // superscript. Dropping it by the descender puts the axis back on the
+        // line the words are standing on.
+        let descender = NSFont.systemFont(ofSize: pointSize).descender
+        bounds = CGRect(
+            x: 0,
+            y: descender.rounded(),
+            width: image.size.width,
+            height: image.size.height
+        )
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
@@ -66,9 +66,24 @@ final class MarkdownTextRenderer {
     /// streaming typing dot. Custom-drawn text views publish this through AX.
     var accessibleText: String {
         guard let storage = textContentStorage.textStorage else { return "" }
-        return (storage.string as NSString).substring(
-            with: NSRange(location: 0, length: min(proseLength, storage.length))
-        )
+        let range = NSRange(location: 0, length: min(proseLength, storage.length))
+        let source = NSMutableString(string: (storage.string as NSString).substring(with: range))
+
+        // NSTextAttachment occupies one U+FFFC character in the backing
+        // string. That is correct for layout, but this custom-drawn view uses
+        // this value as its entire accessibility surface: leaving the object
+        // replacement character here makes VoiceOver announce a hole where
+        // the formula is. Replace math attachments from the tail so earlier
+        // ranges stay valid while the string grows.
+        var replacements: [(NSRange, String)] = []
+        storage.enumerateAttribute(.attachment, in: range) { value, attachmentRange, _ in
+            guard let math = value as? InlineMathAttachment else { return }
+            replacements.append((attachmentRange, "$\(math.latex)$"))
+        }
+        for (attachmentRange, latex) in replacements.reversed() {
+            source.replaceCharacters(in: attachmentRange, with: latex)
+        }
+        return source as String
     }
 
     private func typingDotString(trailing prose: NSAttributedString) -> NSAttributedString {

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
@@ -298,6 +298,33 @@ final class MarkdownTextRenderer {
             .foregroundColor: options.textColor,
         ]
 
+        // Inline math becomes one attachment character. Falling through to the
+        // prose path when rasterising fails is deliberate: an unparseable body
+        // renders as the `$…$` the author typed, which is worse than a formula
+        // and much better than a blank.
+        if let latex = run.math,
+           let image = InlineMathImage.image(
+               latex: latex,
+               pointSize: options.textPointSize,
+               color: options.textColor
+           ) {
+            let attachment = InlineMathAttachment(
+                latex: latex, image: image, pointSize: options.textPointSize
+            )
+            let string = NSMutableAttributedString(attachment: attachment)
+            string.addAttributes(
+                [.paragraphStyle: paragraphStyle],
+                range: NSRange(location: 0, length: string.length)
+            )
+            if let link = run.link {
+                string.addAttribute(
+                    .link, value: link,
+                    range: NSRange(location: 0, length: string.length)
+                )
+            }
+            return string
+        }
+
         if run.isInlineCode {
             attributes[.font] = NSFont.monospacedSystemFont(
                 ofSize: options.textPointSize - 1, weight: .regular

--- a/apps/rapid-mac/Tests/RapidTests/InlineMathCompileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InlineMathCompileTests.swift
@@ -114,3 +114,89 @@ struct InlineMathCompileTests {
         }
     }
 }
+
+/// What happens when a message contains the sentinel itself.
+///
+/// All three of these were live defects found in review of #2107, and the
+/// first killed the process.
+@Suite("Inline math — hostile input") @MainActor
+struct InlineMathHostileInputTests {
+
+    private func runs(_ source: String) -> [String] {
+        MarkdownCompiler().compile(source).items.flatMap { item -> [String] in
+            if case .text(let block) = item { return block.runs.map(\.text) }
+            return []
+        }
+    }
+
+    /// `Int("-1")` parses and `-1 < latex.count` is true, so the old bounds
+    /// check let a negative index through to `latex[slot]` and trapped.
+    /// U+E000 was not hypothetical — it is the first Nerd Font Pomicons
+    /// codepoint, so it arrives in pasted terminal output.
+    @Test("A negative index in a literal sentinel does not crash")
+    func negativeIndexDoesNotCrash() {
+        for payload in ["-1", "-99999", "999999", "", "x", "1.5"] {
+            let source = "Value $x$ and \u{E000}\(payload)\u{E001} tail"
+            _ = MarkdownCompiler().compile(source)
+            let plane15 = "Value $x$ and \u{F0000}\(payload)\u{F0001} tail"
+            _ = MarkdownCompiler().compile(plane15)
+        }
+    }
+
+    /// The bounds check, tested at its own boundary.
+    ///
+    /// `withoutStraySentinels` means a hostile index cannot reach here
+    /// through `compile`, so this drives `expandingSentinels` directly —
+    /// otherwise the guard would be code no test can fail. `Int("-1")`
+    /// parses and `-1 < latex.count` is true, so the original
+    /// `slot < latex.count` let it through to `latex[-1]` and trapped.
+    @Test("A malformed sentinel index is left as text, not indexed")
+    func malformedSentinelIndexIsLeftAlone() {
+        for payload in ["-1", "-99999", "999999"] {
+            let text = "a \u{F0000}\(payload)\u{F0001} b"
+            let expanded = MarkdownCompiler.expandingSentinels(
+                [InlineRun(text: text)], from: ["x"]
+            )
+            #expect(expanded.map(\.text).joined() == text)
+            #expect(expanded.allSatisfy { $0.math == nil })
+            #expect(MarkdownCompiler.restoringSourceSpelling(in: text, from: ["x"]) == text)
+        }
+    }
+
+    /// A well-formed literal sentinel used to be read as ours and replaced
+    /// with whichever formula happened to sit at that index.
+    @Test("A literal sentinel is never read as a formula")
+    func literalSentinelIsNotSubstituted() {
+        let text = runs("Value $x$ and \u{F0000}0\u{F0001} tail").joined()
+        #expect(text.contains("tail"))
+        // One `$x$` in, one `$x$` out — not two.
+        #expect(text.components(separatedBy: "$x$").count - 1 == 1)
+    }
+}
+
+/// Inline math must not leak its scaffolding into code.
+@Suite("Inline math — code blocks") @MainActor
+struct InlineMathCodeBlockTests {
+
+    private func code(_ source: String) -> [String] {
+        MarkdownCompiler().compile(source).items.compactMap {
+            if case .code(let block) = $0 { return block.code } else { return nil }
+        }
+    }
+
+    /// `LaTeXSegmenter` skips backtick fences, but swift-markdown also
+    /// recognises `~~~`, which the segmenter does not — so the sentinel
+    /// landed in code the reader sees and the copy button copies.
+    @Test("A tilde-fenced block keeps its literal dollars")
+    func tildeFenceKeepsDollars() {
+        let block = code("~~~\nlet a = $x$\n~~~").first
+        #expect(block?.contains("$x$") == true, "got: \(block ?? "nil")")
+        #expect(block?.contains("\u{F0000}") == false)
+    }
+
+    @Test("A backtick-fenced block is unaffected")
+    func backtickFenceKeepsDollars() {
+        let block = code("```\nlet a = $x$\n```").first
+        #expect(block?.contains("$x$") == true, "got: \(block ?? "nil")")
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/InlineMathCompileTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InlineMathCompileTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// Inline math survives markdown parsing and comes out as its own run.
+///
+/// `LaTeXSegmenter` has always recognised `$…$` and `\(…\)`; the compiler then
+/// threw the result away, re-wrapping each formula back into the prose it
+/// handed the parser (`pending += "$\(latex)$"`). That was the safe choice at
+/// the time — `MarkdownCompiler`'s own comment calls it "correct-but-unstyled,
+/// rather than a shattered sentence" — but it left inline math rendering as
+/// literal dollar signs.
+///
+/// Re-wrapping cannot simply stop: `$x_1$` handed back to the parser becomes
+/// `x`, emphasis, `1` — the underscore is markdown syntax and the subscript is
+/// gone. A sentinel carries the formula through parsing instead, and is
+/// swapped back afterwards.
+@Suite("Inline math compilation")
+@MainActor
+struct InlineMathCompileTests {
+
+    private func runs(_ source: String) -> [InlineRun] {
+        MarkdownCompiler().compile(source).items.flatMap { item -> [InlineRun] in
+            if case .text(let block) = item { return block.runs }
+            return []
+        }
+    }
+
+    private func maths(_ source: String) -> [String] {
+        runs(source).compactMap(\.math)
+    }
+
+    /// The case that forced the sentinel: an underscore inside a formula is
+    /// emphasis syntax to the markdown parser.
+    @Test("A subscript survives the markdown parser")
+    func subscriptSurvives() {
+        #expect(maths("The value $x_1$ matters.") == ["x_1"])
+        #expect(maths("Sum $a_i + b_j$ here.") == ["a_i + b_j"])
+    }
+
+    /// Both spellings the segmenter accepts. The bracket form is not optional:
+    /// some models emit only `\(…\)`.
+    @Test("Both delimiter spellings produce math")
+    func bothSpellings() {
+        #expect(maths("Inline $y$ form.") == ["y"])
+        #expect(maths("Inline \\(y_2\\) form.") == ["y_2"])
+    }
+
+    /// A formula inherits the styling of the run it came from, so emphasis and
+    /// links do not stop at the formula's edge.
+    @Test("Surrounding inline style is inherited")
+    func stylingIsInherited() {
+        let bold = runs("Bold **$e^{i\\pi}$** here.").first { $0.math != nil }
+        #expect(bold?.math == "e^{i\\pi}")
+        #expect(bold?.isStrong == true)
+    }
+
+    /// The formula keeps its source spelling in `text`, so copy, VoiceOver and
+    /// search see `$x$` rather than the private-use sentinel.
+    @Test("The run still carries readable text")
+    func textIsStillReadable() {
+        let math = runs("Value $x$ here.").first { $0.math != nil }
+        #expect(math?.text == "$x$")
+    }
+
+    /// Math reaches every place runs live, not just top-level paragraphs.
+    /// A formula in a table cell is the case the original #131 review named.
+    @Test("Math is restored inside tables and list items")
+    func mathInsideNestedBlocks() {
+        let table = MarkdownCompiler()
+            .compile("| a | b |\n|---|---|\n| $x^2$ | 2 |").items
+        var cellMath: [String] = []
+        for case .table(let block) in table {
+            for row in block.rows { for cell in row { cellMath += cell.compactMap(\.math) } }
+        }
+        #expect(cellMath == ["x^2"])
+        #expect(maths("- item with $\\frac{1}{2}$") == ["\\frac{1}{2}"])
+    }
+
+    /// The segmenter's guards must still hold end to end — these are the
+    /// false positives that would turn ordinary prose into formulas.
+    @Test("Prose that merely contains dollars stays prose")
+    func noFalsePositives() {
+        #expect(maths("Cost is $20 to $30 today.").isEmpty)
+        #expect(maths("Code `$x$` stays literal.").isEmpty)
+        #expect(maths("```\n$x$\n```").isEmpty)
+    }
+
+    /// Display math keeps its own block — this change is about inline only.
+    @Test("Display math is untouched")
+    func displayMathUnchanged() {
+        let items = MarkdownCompiler().compile("Before\n\n$$x^2$$\n\nAfter").items
+        let display = items.compactMap { item -> String? in
+            if case .math(let block) = item { return block.latex }
+            return nil
+        }
+        #expect(display == ["x^2"])
+    }
+
+    /// No sentinel may reach a reader. If expansion ever fails, this is the
+    /// symptom: a private-use character rendered as a missing glyph.
+    @Test("No sentinel leaks into rendered text")
+    func noSentinelLeaks() {
+        for source in [
+            "The value $x_1$ matters.",
+            "Bold **$e^{i\\pi}$** here.",
+            "| a | $x^2$ |\n|---|---|\n| 1 | 2 |",
+            "- item with $\\frac{1}{2}$",
+        ] {
+            for run in runs(source) {
+                #expect(!run.text.contains("\u{E000}"), "sentinel leaked in: \(source)")
+                #expect(!run.text.contains("\u{E001}"), "sentinel leaked in: \(source)")
+            }
+        }
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/InlineMathRenderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InlineMathRenderTests.swift
@@ -73,8 +73,42 @@ struct InlineMathRenderTests {
         #expect(black === InlineMathImage.image(latex: "x", pointSize: 14, color: .black))
     }
 
+    /// The case the app actually ships, and the one the first version of the
+    /// key missed entirely.
+    ///
+    /// `appearanceMissesTheCache` above uses `.black` and `.white` — two
+    /// static colours that genuinely differ, so it passes whether the key
+    /// holds the `NSColor` or its resolved components. But the renderer is
+    /// handed `.labelColor` (`TextKitMarkdownView`) or `.textColor`
+    /// (`MarkdownOptions`), and a dynamic catalog colour compares equal to
+    /// itself and hashes equal in *every* appearance. Keying on the object
+    /// therefore served the Light bitmap back in Dark — the black-on-black
+    /// failure `LaTeXMarkdownView` documents, reproduced by the key added to
+    /// prevent it.
+    @Test("A dynamic colour still misses the cache across appearances")
+    func dynamicColourMissesAcrossAppearances() {
+        InlineMathImage.resetCache()
+        var light: NSImage?
+        var dark: NSImage?
+        NSAppearance(named: .aqua)?.performAsCurrentDrawingAppearance {
+            light = InlineMathImage.image(latex: "x", pointSize: 14, color: .labelColor)
+        }
+        NSAppearance(named: .darkAqua)?.performAsCurrentDrawingAppearance {
+            dark = InlineMathImage.image(latex: "x", pointSize: 14, color: .labelColor)
+        }
+        #expect(light != nil)
+        #expect(dark != nil)
+        #expect(light !== dark, "the Light bitmap was served back in Dark")
+    }
+
     /// An unparseable body renders as the `$…$` the author typed. Returning a
     /// broken bitmap would paint SwiftMath's red diagnostic into the sentence.
+    ///
+    /// This asserts the contract, not the `label.error` guard specifically:
+    /// review showed that deleting that guard leaves this passing, because a
+    /// failed parse also leaves `fittingSize` at zero and the size guard
+    /// declines first. The explicit error check stays as the readable reason,
+    /// with the size check behind it.
     @Test("An unparseable formula declines rather than drawing an error")
     func unparseableDeclines() {
         InlineMathImage.resetCache()

--- a/apps/rapid-mac/Tests/RapidTests/InlineMathRenderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InlineMathRenderTests.swift
@@ -1,0 +1,108 @@
+import AppKit
+import Testing
+@testable import Rapid
+
+/// Inline math has to actually reach pixels.
+///
+/// Rasterisation fails quietly in several ways — a zero-size label, a body
+/// SwiftMath cannot parse, a measurement taken from the wrong property — and
+/// every one of them ends as a formula-shaped hole in a sentence rather than
+/// an error. #131 already lost a release to the last of those: on macOS
+/// `MTMathUILabel` overrides `fittingSize` and leaves `intrinsicContentSize`
+/// returning AppKit's no-intrinsic-metric sentinel, so measuring the obvious
+/// way laid every formula out at zero size.
+@Suite("Inline math rendering")
+@MainActor
+struct InlineMathRenderTests {
+
+    private func inkCount(_ image: NSImage) -> Int {
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff) else { return 0 }
+        var ink = 0
+        for y in 0..<rep.pixelsHigh {
+            for x in 0..<rep.pixelsWide {
+                if let colour = rep.colorAt(x: x, y: y), colour.alphaComponent > 0.1 { ink += 1 }
+            }
+        }
+        return ink
+    }
+
+    @Test("A formula rasterises to a non-empty bitmap")
+    func formulaHasPixels() {
+        InlineMathImage.resetCache()
+        for latex in ["x_1", "\\frac{1}{2}", "e^{i\\pi}"] {
+            guard let image = InlineMathImage.image(
+                latex: latex, pointSize: 14, color: .black
+            ) else {
+                Issue.record("\(latex) produced no image at all")
+                continue
+            }
+            #expect(image.size.width > 1, "\(latex) is \(image.size.width)pt wide")
+            #expect(image.size.height > 1, "\(latex) is \(image.size.height)pt tall")
+            #expect(inkCount(image) > 0, "\(latex) rasterised to a blank bitmap")
+        }
+    }
+
+    /// A bigger formula must occupy more room than a smaller one — this is
+    /// what catches a measurement that returns a constant or a sentinel.
+    @Test("Size follows the formula")
+    func sizeTracksContent() {
+        InlineMathImage.resetCache()
+        let small = InlineMathImage.image(latex: "x", pointSize: 14, color: .black)
+        let large = InlineMathImage.image(latex: "\\frac{a+b}{c+d}", pointSize: 14, color: .black)
+        guard let small, let large else {
+            Issue.record("rasterisation returned nil for a valid formula")
+            return
+        }
+        #expect(large.size.height > small.size.height)
+    }
+
+    /// The bug this key exists to prevent: glyph colour is baked into the
+    /// bitmap, so a cache that ignores colour serves black-on-black formulas
+    /// after a switch to Dark. `LaTeXMarkdownView` documents that exact
+    /// failure in the MarkdownUI path.
+    @Test("Colour and size are part of the cache key")
+    func appearanceMissesTheCache() {
+        InlineMathImage.resetCache()
+        let black = InlineMathImage.image(latex: "x", pointSize: 14, color: .black)
+        let white = InlineMathImage.image(latex: "x", pointSize: 14, color: .white)
+        let bigger = InlineMathImage.image(latex: "x", pointSize: 22, color: .black)
+        #expect(black !== white, "a colour change reused the previous bitmap")
+        #expect(black !== bigger, "a size change reused the previous bitmap")
+        // …but an identical request must still hit.
+        #expect(black === InlineMathImage.image(latex: "x", pointSize: 14, color: .black))
+    }
+
+    /// An unparseable body renders as the `$…$` the author typed. Returning a
+    /// broken bitmap would paint SwiftMath's red diagnostic into the sentence.
+    @Test("An unparseable formula declines rather than drawing an error")
+    func unparseableDeclines() {
+        InlineMathImage.resetCache()
+        #expect(InlineMathImage.image(latex: "\\notacommand{", pointSize: 14, color: .black) == nil)
+    }
+
+    /// End to end: a sentence with inline math must put an attachment into the
+    /// attributed string, carrying the formula.
+    @Test("The renderer emits an attachment for a math run")
+    func rendererEmitsAttachment() {
+        InlineMathImage.resetCache()
+        var options = MarkdownOptions.assistantTranscript()
+        options.textColor = .black
+        let renderer = MarkdownTextRenderer(options: options)
+        let blocks = MarkdownCompiler()
+            .compile("The value $x_1$ matters.").items
+            .compactMap { item -> MarkdownItem.TextBlock? in
+                if case .text(let block) = item { return block }
+                return nil
+            }
+        let string = renderer.attributedString(for: blocks)
+
+        var found: [String] = []
+        string.enumerateAttribute(
+            .attachment, in: NSRange(location: 0, length: string.length)
+        ) { value, _, _ in
+            if let math = value as? InlineMathAttachment { found.append(math.latex) }
+        }
+        #expect(found == ["x_1"], "attachments found: \(found)")
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/InlineMathRenderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InlineMathRenderTests.swift
@@ -138,5 +138,8 @@ struct InlineMathRenderTests {
             if let math = value as? InlineMathAttachment { found.append(math.latex) }
         }
         #expect(found == ["x_1"], "attachments found: \(found)")
+        renderer.setBlocks(blocks)
+        #expect(renderer.accessibleText == "The value $x_1$ matters.")
+        #expect(!renderer.accessibleText.contains("\u{FFFC}"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/LaTeXCompatibilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaTeXCompatibilityTests.swift
@@ -48,11 +48,16 @@ struct LaTeXCompatibilityTests {
     /// rewrite keyed on the characters `\mod` would corrupt every command
     /// that starts with them. SwiftMath's parser takes the longest run of
     /// letters, so registration cannot.
+    ///
+    /// Only the parse is asserted. A companion `normalized("\\dotsb") ==
+    /// "\\dotsb"` was here and was removed: `normalized` does no textual
+    /// substitution for *any* registered symbol, so that assertion could not
+    /// fail for this implementation — it restated the design instead of
+    /// testing it. What keeps the registrations honest is
+    /// ``argumentCommandsRender``, which fails when they are removed.
     @Test("Registration does not shadow longer commands")
     func registrationDoesNotShadowLongerCommands() {
         #expect(parses("A \\models B"))
-        // Likewise for the other registered names.
-        #expect(LaTeXCompatibility.normalized("\\dotsb") == "\\dotsb")
     }
 
     // MARK: - Environments
@@ -115,6 +120,11 @@ struct LaTeXCompatibilityTests {
         "\\boxed{\\frac{a}{b}}",
         "\\dots",
         "\\lVert x \\rVert",
+        // `\left`/`\right` read a different table inside SwiftMath, one with
+        // no extension point — so this spelling needs the substitution and
+        // not the registration, and the bare form above cannot catch it.
+        "\\left\\lVert x \\right\\rVert",
+        "\\left\\lVert \\frac{a}{b} \\right\\rVert^2",
     ])
     func argumentCommandsRender(_ latex: String) {
         #expect(parses(latex))

--- a/apps/rapid-mac/Tests/RapidTests/LaTeXCompatibilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaTeXCompatibilityTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Testing
+import SwiftMath
+@testable import Rapid
+
+/// Guards the bridge between the LaTeX models write and the subset SwiftMath
+/// parses.
+///
+/// Every case asserts the thing that matters to a reader — *SwiftMath accepts
+/// the result* — rather than the exact string the bridge produced. Asserting
+/// on the rewritten text would freeze an implementation detail: there is more
+/// than one correct spelling of `\pmod{n}` in SwiftMath's dialect, and a
+/// better one should not have to break a test.
+@Suite("LaTeX compatibility bridge") @MainActor
+struct LaTeXCompatibilityTests {
+
+    private func parses(_ latex: String) -> Bool {
+        var error: NSError?
+        let list = MTMathListBuilder.build(
+            fromString: LaTeXCompatibility.normalized(latex), error: &error
+        )
+        return list != nil && error == nil
+    }
+
+    // MARK: - The reported failure
+
+    /// The formula that sent this bug in: a model explaining Fermat's little
+    /// theorem, taken verbatim from `conversations.json`. `\mod` is the whole
+    /// reason the block rendered as monospaced `$$…$$` source.
+    @Test("The reported formula renders")
+    func reportedFormulaRenders() {
+        #expect(parses("a^{\\varphi(p)} \\equiv 1 \\mod p"))
+        #expect(parses("a^{p-1} \\equiv 1 \\mod p"))
+    }
+
+    @Test("The whole mod family renders", arguments: [
+        "a \\mod p",
+        "a \\bmod p",
+        "a \\pmod p",
+        "a \\pmod{n}",
+        "a \\equiv b \\pmod{n^2}",
+    ])
+    func modFamilyRenders(_ latex: String) {
+        #expect(parses(latex))
+    }
+
+    /// The reason `\mod` is registered rather than substituted textually: a
+    /// rewrite keyed on the characters `\mod` would corrupt every command
+    /// that starts with them. SwiftMath's parser takes the longest run of
+    /// letters, so registration cannot.
+    @Test("Registration does not shadow longer commands")
+    func registrationDoesNotShadowLongerCommands() {
+        #expect(parses("A \\models B"))
+        // Likewise for the other registered names.
+        #expect(LaTeXCompatibility.normalized("\\dotsb") == "\\dotsb")
+    }
+
+    // MARK: - Environments
+
+    @Test("Numbered environments render", arguments: [
+        "\\begin{align} a &= b \\\\ c &= d \\end{align}",
+        "\\begin{align} a = b \\\\ c = d \\end{align}",
+        "\\begin{align*} a &= b \\end{align*}",
+        "\\begin{equation} a = b \\end{equation}",
+        "\\begin{equation*} E = mc^2 \\end{equation*}",
+        "\\begin{gather} a = b \\\\ c = d \\end{gather}",
+        "\\begin{array}{cc} a & b \\\\ c & d \\end{array}",
+    ])
+    func numberedEnvironmentsRender(_ latex: String) {
+        #expect(parses(latex))
+    }
+
+    /// The row padding splits on `\\`, which also separates the rows of a
+    /// nested environment — so a body holding one is left alone.
+    ///
+    /// This formula already parses untouched. Splitting it would append a
+    /// column to the inner `matrix`'s first row and break something that
+    /// worked, which is the one outcome a compatibility bridge must never
+    /// produce.
+    @Test("A body with a nested environment is left alone")
+    func nestedEnvironmentIsNotPadded() {
+        let latex = "\\begin{cases} \\begin{matrix} 1 \\\\ 2 \\end{matrix} & a "
+            + "\\\\ 0 & b \\end{cases}"
+        #expect(LaTeXCompatibility.normalized(latex) == latex)
+        #expect(parses(latex))
+    }
+
+    /// SwiftMath demands exactly two columns; LaTeX is happy with one, and a
+    /// one-column `cases` is what gets written when the branches carry no
+    /// condition.
+    @Test("One-column cases is padded, two-column is untouched")
+    func casesColumnPadding() {
+        #expect(parses("\\begin{cases} a \\\\ b \\end{cases}"))
+        let twoColumn = "\\begin{cases} 1 & x > 0 \\\\ 0 & x \\le 0 \\end{cases}"
+        #expect(LaTeXCompatibility.normalized(twoColumn) == twoColumn)
+        #expect(parses(twoColumn))
+    }
+
+    // MARK: - Numbering and argument commands
+
+    @Test("Numbering is stripped", arguments: [
+        "a = b \\tag{1}",
+        "a = b \\tag*{$\\ast$}",
+        "a = b \\notag",
+        "a = b \\nonumber",
+        "\\begin{align} a &= b \\label{eq:one} \\end{align}",
+    ])
+    func numberingIsStripped(_ latex: String) {
+        #expect(parses(latex))
+    }
+
+    @Test("Argument commands render", arguments: [
+        "\\operatorname{lcm}(a, b)",
+        "\\boxed{x = 42}",
+        "\\boxed{\\frac{a}{b}}",
+        "\\dots",
+        "\\lVert x \\rVert",
+    ])
+    func argumentCommandsRender(_ latex: String) {
+        #expect(parses(latex))
+    }
+
+    /// The box is decoration; the answer inside it is not. A rewrite that
+    /// dropped the body along with the rule would be worse than the
+    /// raw-source fallback it replaces.
+    @Test("Unwrapping a command keeps its body")
+    func unwrappingKeepsBody() {
+        #expect(LaTeXCompatibility.normalized("\\boxed{x = 42}").contains("x = 42"))
+        #expect(LaTeXCompatibility.normalized("\\operatorname{lcm}").contains("lcm"))
+    }
+
+    /// A group containing an unmatched escaped brace must still end at its
+    /// own closing brace. `\left\{ … \right.` is where this shows up in
+    /// practice: the `\{` has no `\}` to pair with, so a scanner that counts
+    /// it loses the group and leaves the command in place.
+    @Test("Escaped braces do not close the group early")
+    func escapedBracesDoNotCloseEarly() {
+        let matched = LaTeXCompatibility.normalized("\\boxed{\\{1, 2\\}}")
+        #expect(matched.contains("1, 2"))
+        #expect(!matched.contains("boxed"))
+
+        let unmatched = LaTeXCompatibility.normalized("\\boxed{\\left\\{ x \\right. }")
+        #expect(unmatched.contains("\\left\\{ x \\right."))
+        #expect(!unmatched.contains("boxed"))
+    }
+
+    /// A command name has to end where the scanner thinks it ends.
+    /// `\operatornamewithlimits` is amsmath's, begins with `\operatorname`,
+    /// and means something else — rewriting its prefix turns one formula
+    /// into a different one silently, which is worse than not rewriting.
+    @Test("A longer command is not rewritten through its prefix")
+    func longerCommandIsNotRewrittenThroughItsPrefix() {
+        let latex = "\\operatornamewithlimits{argmax}_x f(x)"
+        #expect(LaTeXCompatibility.normalized(latex) == latex)
+    }
+
+    // MARK: - Degrading safely
+
+    /// A body the bridge cannot read cleanly is handed on untouched, so it
+    /// reaches ``MathView``'s raw-source fallback — the same place it reaches
+    /// today — instead of a rewrite that means something else.
+    @Test("Unreadable bodies pass through unchanged", arguments: [
+        "\\boxed{x = 42",
+        "\\operatorname",
+        "\\tag",
+    ])
+    func unreadableBodiesPassThrough(_ latex: String) {
+        #expect(LaTeXCompatibility.normalized(latex) == latex)
+    }
+
+    /// The overwhelmingly common case: nothing in the formula needs bridging,
+    /// and the bridge is required not to disturb it.
+    @Test("Bodies needing nothing are returned unchanged", arguments: [
+        "E = mc^2",
+        "\\frac{a}{b}",
+        "\\sum_{i=1}^{n} i^2",
+        "\\begin{aligned} a &= b \\end{aligned}",
+        "\\int_0^1 x \\, dx",
+    ])
+    func untouchedBodies(_ latex: String) {
+        #expect(LaTeXCompatibility.normalized(latex) == latex)
+        #expect(parses(latex))
+    }
+}

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -165,6 +165,8 @@ RESPONSE_SHAPES = {
         "The Gaussian integral is\n\n",
         "$$\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$$",
         "\n\nand inline it reads $e^{i\\pi} + 1 = 0$.",
+        "\n\nA bridged congruence is $$a^{p-1} \\equiv 1 \\mod p$$.",
+        "\n\nA bridged alignment is $$\\begin{align}x &= 1 \\\\ y &= \\boxed{2}\\end{align}$$.",
     ],
     "shape:list": [
         "Three things, in order:\n\n",

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2080,7 +2080,8 @@ flow_message_actions() {
 }
 
 flow_math_rendering() {
-    # Artifact-level coverage for #1504/#1576. The fake emits display math;
+    # Artifact-level coverage for #1504/#1576/#2107. The fake emits display
+    # and inline math plus commands absent from vanilla SwiftMath;
     # MathView exposes `Math:` only after SwiftMath parsed and hosted it, while
     # the safe fallback exposes `Unrenderable math:`. This therefore catches
     # both a missing font bundle and a parser/resource regression in the real
@@ -2098,6 +2099,8 @@ flow_math_rendering() {
     # MathBlock latex payload and MathView still owns parse/resource fallback.
     assert_tree_text "$OUT/math-settled.json" "The Gaussian integral is"
     assert_tree_text "$OUT/math-settled.json" 'and inline it reads $e^{i\\pi} + 1 = 0$.'
+    assert_tree_text "$OUT/math-settled.json" "A bridged congruence is"
+    assert_tree_text "$OUT/math-settled.json" "A bridged alignment is"
     if jq -e '(.data.ui_elements | tostring) | contains("$$\\\\int_")' \
         "$OUT/math-settled.json" >/dev/null; then
         die "display math reached the transcript as literal source"


### PR DESCRIPTION
Independent of #2106 — both touch `MarkdownCompiler.swift`, but in different regions, so they merge in either order.

Three layers, all needed before `$x$` renders as mathematics.

## 1. Compile — the sentinel

Inline math was turned back into `$…$` text and handed to the markdown parser. That is exactly what running the segmenter *first* was meant to avoid: `_` is emphasis syntax, so the subscript in `$x_1$` is gone before any math code sees it.

It now carries a private-use sentinel through parsing and swaps back afterwards. Nothing in the sentinel is markdown-significant, so it survives as one contiguous piece of a single run — a formula keeps working inside `**bold**`, inside a list item, and inside a table cell, inheriting the styling and link of the run it came from.

## 2. Render — an image attachment, not a view

`NSTextAttachmentViewProvider` hosts its view inside an `NSTextView`. `MarkdownTextBlockView` draws fragments into its own context instead, so a hosted view would be created and never shown — the same constraint `TypingDotAttachment` documents. ChatGPT can take the view route because its message block *is* a text view; ours is not.

So the formula is rasterised once and carried as an image, which TextKit lays out and draws like any other attachment: it flows with the sentence, wraps with it, and needs nobody to chase its frame.

The cache is keyed on latex **+ point size + colour**. `LaTeXMarkdownView` records what happens when the colour is left out: MarkdownUI's inline image provider keyed on the parsed nodes, an appearance change never re-fired it, and since the glyph colour is baked into the bitmap the reader was left with black-on-black formulas after switching to Dark.

Two measured details, both with a precedent in this repo:
- `fittingSize`, not `intrinsicContentSize` — #131 established that `MTMathUILabel` overrides the former on macOS.
- `cacheDisplay(in:to:)` after `layoutSubtreeIfNeeded()`. Rendering the layer directly crashes *inside SwiftMath* (`MTMathUILabel.swift:238`, force-unwrapped display list) rather than returning an empty bitmap, because only `_layoutSubviews` builds that list.

## 3. Compatibility — why display math was broken

Reported separately: display math rendered as centred monospaced `$$…$$` source. The segmenter was **not** at fault — it recognises all three `$$` shapes (tight, inner spaces, inner newlines). The cause is one layer down: `\mod` is not in SwiftMath's table, and **one unknown command fails the whole formula**, so `MathView` falls back to showing the source.

Measured against 46 commands common in chat output, **15 fail**: `\mod \bmod \pmod`, `\begin{align}` `\begin{equation}` `\begin{array}`, `\operatorname`, `\boxed`, `\dots`, `\tag` `\notag`, one-column `\begin{cases}`, `\lVert`. Fixing only `\mod` would break again on the next message containing `\begin{align}`.

`LaTeXCompatibility` uses two mechanisms:

- **Registration**, through SwiftMath's own `add(latexSymbol:)` extension point. Preferred wherever it fits: the parser takes the longest run of letters after a backslash, so teaching it `mod` cannot misfire on `\models`, whereas a textual substitution would.
- **Source rewriting** for what registration cannot express — environment names, and commands that take an argument.

Every rewrite is lossy and each says what it gives up (`gather` loses centring, `array` loses column alignment, `\boxed` loses its rule). The original source is kept everywhere a person sees it: `MathView`'s fallback text, its accessibility label, and the inline renderer's prose fallback all show what the model actually wrote.

## Tests

`InlineMathCompileTests` (8), `InlineMathRenderTests` (5), `LaTeXCompatibilityTests` (13).

Each guard was break-verified — the bug reintroduced, the specific test confirmed to fail. That caught one of my own tests being decorative: the nested-environment case I first wrote had `&` in every row, so it never reached the guard and passed against an implementation with no guard at all. Replaced with `\begin{cases} \begin{matrix} 1 \\ 2 \end{matrix} & a \\ 0 & b \end{cases}`, a formula that already renders and that the unguarded code would break.

Two guards that measurement justified after the fact:
- Without the command-name boundary check, `\operatornamewithlimits{argmax}` is silently rewritten to `\mathrm{w}ithlimits{argmax}` — different mathematics, no error.
- Without the escaped-brace skip, `\boxed{\left\{ x \right. }` is left unwrapped and falls back to source.

## Not verified

Rendering was verified at the parse level (SwiftMath accepts the bridged source) and by unit test. I have not visually confirmed the typeset output in a running app.

Pre-existing on `main`, unrelated: `MarkdownLinkPerformanceTests` "Adjacent links" and `WebToolsHardeningTests` NXDOMAIN both fail on a clean checkout of the base commit (checked in an isolated worktree).