### PR TITLE
docs: fill server docs coverage gaps — serve flags, env vars, endpoint index [skip-version-bump]

### DIFF
--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -24,28 +24,108 @@ rapid-mlx serve qwen3.5-9b-4bit --port 8000 --use-paged-cache
 
 ## Server Options
 
+The most consequential `rapid-mlx serve` flags. The exhaustive list — every
+flag visible in `rapid-mlx serve --help`, grouped by category — lives in the
+[CLI reference](../reference/cli.md#rapid-mlx-serve).
+
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--port` | Server port | 8000 |
 | `--host` | Server host (loopback-only by default; pass `0.0.0.0` to expose on LAN) | 127.0.0.1 |
-| `--api-key` | API key for authentication | None |
+| `--listen-fd` | Adopt a pre-bound listening socket (3-1023) from a supervisor instead of binding; `--host`/`--port` are then ignored (see the socket-activation section below) | None |
+| `--log-level` | Log level for Python logging and uvicorn (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | INFO |
+| `--served-model-name` | Model name reported by the API; when unset the `model` argument is used | None |
+| `--api-key` | API key for authentication (falls back to `RAPID_MLX_API_KEY`) | None |
+| `--cors-origins` | Allowed CORS origins (also via `RAPID_MLX_CORS_ALLOW_ORIGINS`) | `*` (all origins) |
+| `--trusted-hosts` | Opt-in Host-header allowlist; non-matching requests get HTTP 400 | None (not enforced) |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | 0 |
+| `--max-request-bytes` | Max HTTP request body size; oversized requests get HTTP 413 before parsing (0 disables) | 8 MiB (8388608) |
 | `--timeout` | Request timeout in seconds | 1800 |
+| `--max-num-seqs` | Max concurrent sequences | 256 |
+| `--max-concurrent-requests` | Admission cap on in-flight requests (queued + running); excess requests get HTTP 503 with `Retry-After` | 256 |
+| `--prefill-batch-size` | Max prompts prefilled together in one cold wave; lower for better first-token latency under concurrent cold load | 8 |
+| `--completion-batch-size` | Completion batch size | 32 |
+| `--prefill-step-size` | Chunk size for prompt prefill processing | 2048 |
+| `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit (0.0-1.0) | 0.90 |
+| `--kv-cache-dtype` | KV cache dtype (`bf16`, `int8`, `int4`); int8/int4 shrink the KV cache 2x/4x at a long-context decode cost. See the [CLI reference](../reference/cli.md#kv-cache-dtype-and-quantization) for the full quantization family (`--kv-cache-quantization*`, `--kv-cache-turboquant*`). | bf16 |
+| `--enable-prefix-cache` / `--disable-prefix-cache` | Toggle prefix caching for repeated prompts | enabled |
+| `--prefix-cache-index` | Prefix-cache lookup index: `radix` (token trie) or `hash` (legacy) | radix |
 | `--use-paged-cache` | Enable paged KV cache | False |
 | `--cache-memory-mb` | Cache memory limit in MB | Auto |
 | `--cache-memory-percent` | Fraction of RAM for cache | 0.20 |
 | `--idle-cache-clear-seconds` | Clear reusable KV cache after idle time; model weights remain loaded | Disabled |
 | `--max-tokens` | Default max tokens | 32768 |
-| `--default-temperature` | Default temperature when not specified | None |
+| `--default-temperature` | Default temperature when not specified (companions: `--default-top-k`, `--default-min-p`, `--default-repetition-penalty`, `--default-presence-penalty`, `--default-frequency-penalty`) | None |
 | `--default-top-p` | Default top_p when not specified | None |
 | `--stream-interval` | Tokens per stream chunk | 1 |
 | `--mcp-config` | Path to MCP config file | None |
 | `--reasoning-parser` | Reasoning parser (`qwen3`, `deepseek_r1`, `deepseek_r1_distill`, `deepseek_v4`, `gemma4`, `glm4`, `gpt_oss`, `harmony`, `hy3`/`hy_v3`, `minimax`, `muse`, `ui_tars`, `vibethinker`). Auto-detected from the alias profile; explicit flag overrides. There is no literal `auto` value — omit the flag for auto-detection. | None (auto-detected) |
-| `--embedding-model` | Pre-load an embedding model at startup (requires `pip install 'rapid-mlx[embeddings]'`) | None |
+| `--embedding-model` | Pre-load an embedding model at startup (requires `pip install 'rapid-mlx[embeddings]'`; companions: `--embedding-max-length`, `--embedding-overflow-policy`) | None |
 | `--enable-auto-tool-choice` | Enable automatic tool calling | False |
 | `--tool-call-parser` | Tool call parser (see [Tool Calling](tool-calling.md)) | None |
+| `--mllm` / `--no-mllm` | Force multimodal (vision) loading / force text-only loading, overriding auto-detection | auto-detect |
+| `--enable-audio` | Mount `/v1/audio/*` routes on a text-only server (audio-capable models auto-mount them) | False |
+| `--disk-stream` | Stream MoE routed-expert weights from disk instead of holding them resident (opt-in; budget via `--disk-stream-cache-gb`) | False |
+| `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB (multi-model serving); LRU idle unpinned models are evicted first; 0 disables (companion: `--resident-model-idle-ttl`) | 0 |
+| `--pflash` | PFlash long-prompt prefill compression (`off`, `auto`, `always`); tuning knobs in the [CLI reference](../reference/cli.md#pflash-long-prompt-compression) | `always` for verified aliases, `off` otherwise |
 
 ## API Endpoints
+
+### Endpoint Index
+
+The complete route surface. Endpoints with a detailed section in this guide
+are marked; multimodal and MCP surfaces link to their own guides.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/chat/completions` | POST | Chat completion, streaming and non-streaming (detailed below) |
+| `/v1/completions` | POST | Text completion (detailed below) |
+| `/v1/responses` | POST | OpenAI Responses API (the surface Codex CLI uses) |
+| `/v1/messages` | POST | Anthropic Messages API — Claude Code / OpenCode compatible (detailed below) |
+| `/v1/messages/count_tokens` | POST | Count input tokens for an Anthropic-format request (detailed below) |
+| `/v1/embeddings` | POST | Text embeddings — see the [Embeddings Guide](embeddings.md) |
+| `/v1/models` | GET | List available models (detailed below) |
+| `/v1/models/{id}` | GET | Metadata for a single model |
+| `/v1/models/residency` | GET | Residency status of every model loaded in the process |
+| `/v1/models/load` | POST | Load an additional model into the running server |
+| `/v1/models/{id}/pin` | PUT | Pin a resident model so it is never auto-evicted |
+| `/v1/models/{id}` | DELETE | Unload a resident (non-startup) model |
+| `/v1/audio/speech` | POST | Text-to-speech — see the [Audio Guide](audio.md) |
+| `/v1/audio/transcriptions` | POST | Speech-to-text — see the [Audio Guide](audio.md) |
+| `/v1/audio/translations` | POST | Speech translation to English — see the [Audio Guide](audio.md) |
+| `/v1/audio/music` | POST | Music generation — see the [Audio Guide](audio.md) |
+| `/v1/audio/voices` | GET | List available TTS voices — see the [Audio Guide](audio.md) |
+| `/v1/images/generations` | POST | Image generation |
+| `/v1/images/edits` | POST | Image editing |
+| `/v1/images/progress` | GET | Denoise progress of the in-flight image render (`step / total`) |
+| `/v1/images/cancel` | POST | Stop the in-flight image render at the next denoise step |
+| `/v1/videos` | POST / GET | Start a video-generation job / list jobs — see the [Video Generation Guide](video-generation.md) |
+| `/v1/videos/capabilities` | GET | Video-lane capability report |
+| `/v1/videos/{id}` | GET / DELETE | Video job status / delete a job and its artifact |
+| `/v1/videos/{id}/content` | GET | Download the finished video |
+| `/v1/mcp/tools` | GET | List tools discovered from the MCP config — see the [MCP Tools Guide](mcp-tools.md) |
+| `/v1/mcp/servers` | GET | List configured MCP servers |
+| `/v1/mcp/status` | GET | MCP subsystem status (including init errors) |
+| `/v1/mcp/execute` | POST | Execute an MCP tool by name |
+| `/v1/mcp/reload` | POST | Re-read the MCP config file without a server restart |
+| `/v1/status` | GET | Real-time server statistics (detailed below) |
+| `/v1/cache/stats` | GET | Cache statistics |
+| `/v1/cache/clear` | POST | Clear reusable prompt KV state without unloading model weights |
+| `/v1/cache/export` | POST | Export the prefix cache to a disk snapshot |
+| `/v1/cache/import` | POST | Import a previously exported prefix-cache snapshot |
+| `/v1/cache/info` | GET | Read the manifest of an exported cache snapshot |
+| `/v1/requests/{id}/cancel` | POST | Cancel an active or queued request by its `chatcmpl-...` id (`DELETE /v1/requests/{id}` is an alias) |
+| `/health` | GET | Full health view (queries engine stats on every hit) |
+| `/health/ready` | GET | Readiness — 503 until model load and warmup complete |
+| `/healthz` | GET | Constant-cost liveness probe (k8s convention; 503 while draining) |
+| `/readyz` | GET | Alias for `/health/ready` |
+| `/livez` | GET | Process liveness only (does not check model readiness) |
+| `/metrics` | GET | Prometheus metrics |
+
+The `/v1/audio/*` routes are mounted when the loaded model is audio-capable
+or `--enable-audio` is passed; on a plain text-only server they return 404.
+Image and video routes are always mounted and answer with a structured 409
+when no image/video model is loaded.
 
 ### Chat Completions
 
@@ -416,6 +496,7 @@ Stop reasons:
 | `end_turn` | Model finished naturally |
 | `tool_use` | Model wants to call a tool |
 | `max_tokens` | Hit the `max_tokens` limit |
+| `stop_sequence` | A user-supplied `stop_sequences` entry matched; the matched string is returned in the response's `stop_sequence` field (which is `null` for every other stop reason) |
 
 #### Using with Claude Code
 
@@ -761,7 +842,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/rapid-mlx serve mlx-community/Qwen3-0.6B-8bit \
+ExecStart=/usr/local/bin/rapid-mlx serve qwen3.5-27b-4bit \
   --use-paged-cache --port 8000
 Restart=always
 
@@ -844,7 +925,7 @@ at the argparse layer.
 For production with 50+ concurrent users:
 
 ```bash
-rapid-mlx serve mlx-community/Qwen3-0.6B-8bit \
+rapid-mlx serve qwen3.5-27b-4bit \
   --use-paged-cache \
   --api-key your-secret-key \
   --rate-limit 60 \

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -131,7 +131,7 @@ are the argparse defaults from `vllm_mlx/cli.py`.
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--force-disk-check` | Skip the pre-flight disk-space check; use only when the HF cache lives on a different filesystem (e.g. external drive via `HF_HOME`) | off |
+| `--force-disk-check` | Proceed even when the pre-flight disk-space check fails — the check still runs and prints its numbers, but a shortfall becomes a warning instead of an abort (the download will likely fail mid-way) | off |
 | `--disk-stream` | Stream MoE routed-expert weights from disk instead of holding them resident (opt-in; only architectures registered in `vllm_mlx.registry`) | off |
 | `--disk-stream-cache-gb` | Byte budget (GB) for the disk-stream expert LRU cache; only used with `--disk-stream` | 1.0 |
 | `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB; loading another model evicts the least-recently-used idle unpinned model first. 0 disables. | 0 (disabled) |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,15 +8,24 @@
 | `rapid-mlx chat` | Interactive chat REPL with a model |
 | `rapid-mlx bench` | Run performance benchmarks |
 | `rapid-mlx models` | List available model aliases |
+| `rapid-mlx ls` | List models in the local HuggingFace cache (alias for `models --cached`) |
 | `rapid-mlx recipe` | Recommend the Smart and Fast models for this Mac's RAM |
 | `rapid-mlx info` | Show the per-model profile for an alias or repo |
 | `rapid-mlx pull` | Download a model into the HuggingFace cache |
 | `rapid-mlx rm` | Remove a cached model |
+| `rapid-mlx alias` | Manage user-owned model aliases (`set` / `remove` / `list`) |
 | `rapid-mlx ps` | List running rapid-mlx servers |
+| `rapid-mlx share` | Expose a local model behind a public URL via rapidmlx.com |
+| `rapid-mlx launch` | One-shot bootstrap: patch an IDE/agent client config to use rapid-mlx |
+| `rapid-mlx connect` | Show the server's connection info and wire up a tool |
 | `rapid-mlx agents` | List, configure, and test agent integrations |
 | `rapid-mlx doctor` | Run self-diagnostic / regression harness |
 | `rapid-mlx telemetry` | Manage anonymous usage telemetry (opt-in) |
 | `rapid-mlx upgrade` | Upgrade rapid-mlx (brew / pip / install.sh) |
+| `rapid-mlx version` | Show version number |
+| `rapid-mlx help <cmd>` | Show help for a subcommand |
+
+Run `rapid-mlx <cmd> --help` for the full flag list of any subcommand.
 
 Agent integrations can be configured without hand-editing dotfiles:
 
@@ -33,10 +42,6 @@ rapid-mlx agents continue --setup
 Use `--yes` for an explicitly non-interactive apply. `--no-check` skips only
 the post-write server health/model check; preview, merge, backup, and atomic
 write behavior are unchanged.
-| `rapid-mlx version` | Show version number |
-| `rapid-mlx help <cmd>` | Show help for a subcommand |
-
-Run `rapid-mlx <cmd> --help` for the full flag list of any subcommand.
 
 ## `rapid-mlx serve`
 
@@ -50,33 +55,169 @@ rapid-mlx serve <model> [options]
 
 ### Options
 
+Every flag visible in `rapid-mlx serve --help`, grouped by category. Defaults
+are the argparse defaults from `vllm_mlx/cli.py`.
+
+#### Network and process
+
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--port` | Server port | 8000 |
-| `--host` | Server host (loopback-only by default; pass `0.0.0.0` to expose on LAN) | 127.0.0.1 |
-| `--api-key` | API key for authentication | None |
+| `--host` | Server host (loopback-only by default; pass `0.0.0.0` to expose on LAN — review the auth posture first) | 127.0.0.1 |
+| `--listen-fd` | File descriptor of a pre-bound listening socket (3-1023) for socket activation (launchd/systemd/parent-process supervision). When set, `--host`/`--port` are ignored for binding. | None |
+| `--log-level` | Log level for Python logging and uvicorn (`DEBUG`, `INFO`, `WARNING`, `ERROR`; case-insensitive) | INFO |
+| `--served-model-name` | Model name reported by the API; when unset the `model` argument is used | None |
+| `--watchdog-ppid` | Self-terminate when the parent process with this PID dies (defeats orphaned sidecars). Falls back to `RAPID_MLX_WATCHDOG_PPID`; 0 / unset disables. | None (disabled) |
+
+#### Security and limits
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--api-key` | API key for authentication; falls back to `RAPID_MLX_API_KEY` (inline value wins when both are set); if neither is set, no auth is required | None |
+| `--cors-origins` | Allowed CORS origins (space-separated); also settable via `RAPID_MLX_CORS_ALLOW_ORIGINS` (comma-separated) | `*` (all origins) |
+| `--trusted-hosts` | Opt-in Host-header allowlist (DNS-rebinding hardening): non-matching requests get HTTP 400. Space- or comma-separated; also settable via `RAPID_MLX_TRUSTED_HOSTS`. | None (not enforced) |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | 0 |
+| `--max-request-bytes` | Maximum HTTP request body size in bytes; larger requests are rejected with HTTP 413 before JSON parsing. 0 disables. Falls back to `RAPID_MLX_MAX_REQUEST_BYTES`. | 8 MiB (8388608) |
 | `--timeout` | Request timeout in seconds | 1800 |
-| `--cache-memory-mb` | Cache memory limit in MB | Auto |
-| `--cache-memory-percent` | Fraction of RAM for cache | 0.20 |
-| `--idle-cache-clear-seconds` | Clear reusable KV cache after idle time; model weights remain loaded | Disabled |
-| `--no-memory-aware-cache` | Use legacy entry-count cache | False |
-| `--use-paged-cache` | Enable paged KV cache | False |
-| `--max-tokens` | Default max tokens | 32768 |
-| `--stream-interval` | Tokens per stream chunk | 1 |
-| `--mcp-config` | Path to MCP config file | None |
-| `--paged-cache-block-size` | Tokens per cache block | 64 |
-| `--max-cache-blocks` | Maximum cache blocks | 1000 |
+
+#### Admission and batching
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--max-num-seqs` | Max concurrent sequences | 256 |
+| `--max-concurrent-requests` | Admission cap on in-flight requests (queued + running); when exceeded, new requests get HTTP 503 with `Retry-After` | 256 |
+| `--prefill-batch-size` | Max prompts prefilled together in one cold wave; lower it to cut first-token latency under concurrent cold load, at an aggregate-throughput cost on large MoE models | 8 |
+| `--completion-batch-size` | Completion batch size | 32 |
+| `--prefill-step-size` | Chunk size for prompt prefill processing; larger values use more memory but can improve prefill throughput | 2048 |
+| `--stream-interval` | Tokens to batch before streaming (1 = smooth, higher = throughput) | 1 |
+| `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit and emergency cache-clear threshold (0.0-1.0); increase to 0.95 for very large (200GB+) models | 0.90 |
+
+#### Prefix, KV, and response caching
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--enable-prefix-cache` | Enable prefix caching for repeated prompts | enabled |
+| `--disable-prefix-cache` | Disable prefix caching | off |
+| `--prefix-cache-index` | Prefix-cache lookup index: `radix` (token trie, surfaces dedup-bytes-saved on `/metrics`) or `hash` (legacy bisect path) | radix |
+| `--prefix-cache-size` | Max entries in the prefix cache (legacy entry-count mode only) | 100 |
+| `--cache-memory-mb` | Cache memory limit in MB | Auto (~20% of RAM) |
+| `--cache-memory-percent` | Fraction of available RAM for cache when auto-detecting | 0.20 |
+| `--idle-cache-clear-seconds` | Clear reusable prefix/KV cache after this many idle seconds; model weights remain loaded. 0 disables. Falls back to `RAPID_MLX_IDLE_CACHE_CLEAR_SECONDS`. | Disabled |
+| `--no-memory-aware-cache` | Use the legacy entry-count cache instead of the memory-aware cache | off |
 | `--hybrid-cache-entries` | Opt-in trim-free prefix reuse: retain N non-trimmable prefix-cache entries (stable prefix + new suffix each turn) for hybrid (GatedDeltaNet/Mamba) and sliding-window (Gemma 4, GPT-OSS) models. 0 disables. | 0 |
 | `--response-cache-entries` | Opt-in response cache: retain N fully-computed greedy (`temperature 0` / `top_k 1`) chat completions; a completely repeated request returns the stored completion with zero GPU decode. 0 disables. | 0 |
-| `--max-num-seqs` | Max concurrent sequences | 256 |
-| `--gpu-memory-utilization` | Fraction of device memory for Metal allocation limit (0.0-1.0) | 0.90 |
-| `--default-temperature` | Default temperature when not specified in request | None |
-| `--default-top-p` | Default top_p when not specified in request | None |
-| `--reasoning-parser` | Reasoning parser (`qwen3`, `deepseek_r1`, `deepseek_r1_distill`, `deepseek_v4`, `gemma4`, `glm4`, `gpt_oss`, `harmony`, `hy3`/`hy_v3`, `minimax`, `muse`, `ui_tars`, `vibethinker`). Auto-detected from the alias profile; explicit flag overrides. There is no literal `auto` value — omit the flag for auto-detection. | None (auto-detected) |
-| `--embedding-model` | Pre-load an embedding model at startup (requires `pip install 'rapid-mlx[embeddings]'`) | None |
-| `--enable-auto-tool-choice` | Enable automatic tool calling | False |
+| `--pin-system-prompt` | Auto-pin the system prompt in the prefix cache so memory pressure cannot evict it | off |
+| `--use-paged-cache` | Enable paged KV cache (experimental) | off |
+| `--paged-cache-block-size` | Tokens per cache block | 64 |
+| `--max-cache-blocks` | Maximum cache blocks | 1000 |
+
+#### KV cache dtype and quantization
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--kv-cache-dtype` | KV cache dtype (`bf16`, `int8`, `int4`). int8/int4 shrink the KV cache 2x/4x for memory-constrained hosts, but dequant-on-read costs decode throughput at long context (measured -27% int4 / -36% int8 at 16k). Sliding-window (Gemma 3, GPT-OSS) and MLA (DeepSeek V3+, Kimi K2.5) models auto-downgrade to bf16. | bf16 |
+| `--reasoning` | Reasoning profile: pins `--kv-cache-dtype` to int8 regardless of the dtype flag (sub-4-bit KV drops accuracy on AIME-class math) | off |
+| `--kv-cache-quantization` | Deprecated alias of `--kv-cache-dtype int8`; wins when both flags are passed (backwards compatibility) | off |
+| `--kv-cache-quantization-bits` | Bit width for KV cache quantization (4 or 8) | 8 |
+| `--kv-cache-quantization-group-size` | Group size for KV cache quantization | 64 |
+| `--kv-cache-min-quantize-tokens` | Minimum tokens for quantization to apply | 256 |
+| `--kv-cache-turboquant` | TurboQuant KV-cache compression (experimental). Bare flag = `v4` (V-only 3-4 bit Lloyd-Max, K in FP16); `k8v4` = K 8-bit Walsh-Hadamard + V 4-bit mix (~4.6x KV compression on dense models); `none` = explicit off-switch overriding alias-driven auto-resolution. Mutually exclusive with `--kv-cache-quantization`. | None (alias-driven) |
+| `--kv-cache-turboquant-bits` | V-side bit width for TurboQuant (3 or 4); ignored in `k8v4` mode (V pinned to 4-bit) | Auto by head_dim (3-bit for >=96, 4-bit for 64) |
+| `--kv-cache-turboquant-group-size` | Group size for TurboQuant V-side quantization | 32 |
+| `--kv-disk-checkpoint-interval` | Token interval at which the scheduler snapshots KV state to `~/.cache/rapid-mlx/kv_checkpoints/`. 0 disables. Write-only today and each snapshot blocks decode for O(context) — enable only for external tooling that consumes the files. Disk cap via `RAPID_MLX_KV_CHECKPOINT_MAX_BYTES`. | 0 (disabled) |
+| `--metal-cap-kv-bytes-per-token` | Override the per-token KV-cache size (bytes) the admission gate projects. Set when running a quantized KV cache so long prompts are not spuriously 503'd; under-setting risks the OOM cliff the gate prevents. 0 auto-derives an architecture-aware fp16 figure. | 0 (auto) |
+
+#### Model loading, residency, and modalities
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--force-disk-check` | Skip the pre-flight disk-space check; use only when the HF cache lives on a different filesystem (e.g. external drive via `HF_HOME`) | off |
+| `--disk-stream` | Stream MoE routed-expert weights from disk instead of holding them resident (opt-in; only architectures registered in `vllm_mlx.registry`) | off |
+| `--disk-stream-cache-gb` | Byte budget (GB) for the disk-stream expert LRU cache; only used with `--disk-stream` | 1.0 |
+| `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB; loading another model evicts the least-recently-used idle unpinned model first. 0 disables. | 0 (disabled) |
+| `--resident-model-idle-ttl` | Evict idle unpinned secondary models after this many seconds. 0 disables. | 0 (disabled) |
+| `--mllm` | Force-load as multimodal (vision) even if the name doesn't match auto-detection, and hard-fail instead of silently auto-degrading to text-only when the checkpoint ships no usable vision tower | off |
+| `--no-mllm` / `--text-only` | Force-load as text-only even when auto-detection would route to the multimodal path (escape hatch for incomplete vision-tower checkpoints) | off |
+| `--vision-min-pixels` | Minimum pixels for dynamic-resolution VLM image processors; 0 keeps the model default | 0 |
+| `--vision-max-pixels` | Maximum pixels for dynamic-resolution VLM image processors (lower trades image detail for lower TTFT and memory); 0 keeps the model default | 0 |
+| `--enable-audio` | Mount the `/v1/audio/*` routes even when the loaded model is text-only (side-car deployments). Audio-capable models auto-mount the routes. | off |
+
+#### Generation defaults
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--max-tokens` | Default max tokens for generation | 32768 |
+| `--default-temperature` | Default temperature when not specified in request | None (model default) |
+| `--default-top-p` | Default top_p when not specified in request | None (model default) |
+| `--default-top-k` | Default top_k when not specified in request | None (model default) |
+| `--default-min-p` | Default min_p when not specified in request | None (model default) |
+| `--default-repetition-penalty` | Default repetition_penalty when not specified in request | None (model default) |
+| `--default-presence-penalty` | Default presence_penalty when not specified in request | None (model default) |
+| `--default-frequency-penalty` | Default frequency_penalty when not specified in request | None (model default) |
+
+#### Tool calling and reasoning
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--enable-auto-tool-choice` | Enable automatic tool calling | off |
 | `--tool-call-parser` | Tool call parser (e.g. `hermes`, `llama`, `deepseek`, `deepseek_v31`, `glm47`, `gemma4`, `minimax`, `kimi`, `harmony`, `qwen3_coder_xml`). Auto-detected from the model name; explicit flag overrides (a literal `auto` is also accepted). | None (auto-detected) |
+| `--no-tool-call-parser` | Force-disable tool-call parser auto-detection from the alias profile; mutually exclusive with `--tool-call-parser` | off |
+| `--enable-tool-logits-bias` | Bias logits toward structural tool-call tokens for faster generation; only active when `--tool-call-parser` is set (currently supports minimax) | off |
+| `--reasoning-parser` | Reasoning parser (`qwen3`, `deepseek_r1`, `deepseek_r1_distill`, `deepseek_v4`, `gemma4`, `glm4`, `gpt_oss`, `harmony`, `hy3`/`hy_v3`, `minimax`, `muse`, `ui_tars`, `vibethinker`). Auto-detected from the alias profile; explicit flag overrides. There is no literal `auto` value — omit the flag for auto-detection. | None (auto-detected) |
+| `--no-reasoning-parser` | Force-disable reasoning-parser auto-detection from the alias profile (unlike `--no-thinking`, only skips the auto-config step); mutually exclusive with `--reasoning-parser` | off |
+| `--no-thinking` | Disable the reasoning/thinking parser even if auto-detected; thinking tokens appear as regular content | off |
+| `--relocate-mid-conversation-system` | Keep a mid-conversation system message at its position (folded into the next user turn) instead of hoisting it into the leading system block; preserves the prefix cache for clients that inject reminders mid-session | off |
+
+#### Profile overrides and engine toggles
+
+Escape hatches for when the per-alias profile's auto-detection misfires; each
+binary auto-routing decision has a force-on and force-off pair.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--force-hybrid` | Force-treat the model as a hybrid (linear-attention / Mamba) architecture; disables spec/suffix decode paths that are unsound on hybrids. Mutually exclusive with `--no-hybrid`. | off |
+| `--no-hybrid` | Force-treat the model as non-hybrid (full attention) so spec/suffix decode stays available. Mutually exclusive with `--force-hybrid`. | off |
+| `--force-spec-decode` | Force-enable speculative-decode eligibility even when the profile says unsupported (risky on hybrids). Mutually exclusive with `--no-spec-decode`. | off |
+| `--no-spec-decode` | Force-disable speculative-decode eligibility (suffix / MTP / DFlash / DDTree). Mutually exclusive with `--force-spec-decode`. | off |
+| `--force-openai-harmony-streaming` | Force-on the HarmonyStreamingRouter upgrade even when the compat gate would reject (debug only). Mutually exclusive with `--no-openai-harmony-streaming`. | off |
+| `--no-openai-harmony-streaming` | Skip the HarmonyStreamingRouter upgrade and use the legacy harmony state machine on matched-vocab gpt-oss tokenizers. Mutually exclusive with `--force-openai-harmony-streaming`. | off |
+| `--gc-control` | Pause Python GC during generation to avoid latency spikes | enabled |
+| `--no-gc-control` | Disable GC control (allow normal Python GC during generation) | off |
+
+#### Speculative decoding
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--speculative-config` | vLLM-style speculative decoding JSON config (`dflash`, `ddtree`, `mtp`, `suffix`, ...); see [Speculative Decoding Options](configuration.md#speculative-decoding-options) | None |
+
+#### Embeddings
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--embedding-model` | Pre-load an embedding model at startup (requires `pip install 'rapid-mlx[embeddings]'`) | None |
+| `--embedding-max-length` | Max input length (tokens) for the embedding model; `auto` derives it from the model's declared maximum, or pass a positive integer for a lower operational ceiling. Inputs above the limit follow `--embedding-overflow-policy` (never truncated silently). | auto |
+| `--embedding-overflow-policy` | Overflow handling: `truncate` (discards the tail, logs a warning, increments the `rapid_mlx_embedding_truncations_total` metric) or `error` (HTTP 400 with observed and allowed token counts) | truncate |
+
+#### PFlash long-prompt compression
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--pflash` | PFlash long-prompt prefill compression: `off`, `auto`, `always` | `always` for verified aliases (Qwen3.5 / Qwen3.6 family), `off` otherwise |
+| `--pflash-threshold` | Minimum prompt tokens before `--pflash auto` compresses | 32768 |
+| `--pflash-keep-ratio` | Fraction of prompt tokens to keep when compressing; unset resolves a per-alias override if pinned, else 0.20 | None (per-alias or 0.20) |
+| `--pflash-min-keep-tokens` | Minimum tokens to keep when compressing | 2048 |
+| `--pflash-sink-tokens` | Leading prompt tokens always kept | 256 |
+| `--pflash-tail-tokens` | Trailing prompt tokens always kept | 2048 |
+| `--pflash-block-size` | Middle-token scoring block size | 128 |
+| `--pflash-query-window` | Trailing query window used to score middle blocks | 512 |
+| `--pflash-stride-blocks` | Keep every Nth middle block as an anchor during scoring (0 disables anchors) | 8 |
+| `--pflash-include-tools` | Allow compression on prompts with tool definitions (skipped by default for tool-call reliability) | off |
+
+#### MCP
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--mcp-config` | Path to MCP configuration file (JSON/YAML) for tool integration | None |
 
 #### Deprecated (no-op) flags
 
@@ -95,6 +236,12 @@ removal in a future release. Drop them from new commands.
 | `--draft-model`, `--num-draft-tokens` | `--speculative-config` |
 | `--specprefill`, `--specprefill-threshold`, `--specprefill-keep-pct`, `--specprefill-draft-model` | none — prototype removed |
 | `--chunked-prefill-tokens` | none — native `prefill_step_size` is used |
+
+Separately, the legacy per-method speculative-decoding flags (`--enable-dflash`,
+`--enable-ddtree`, `--enable-mtp`, `--suffix-decoding`, and their companions)
+are hidden deprecated aliases that still work — they normalize into the same
+config path as `--speculative-config`. Prefer `--speculative-config` in new
+commands.
 
 ### Examples
 
@@ -252,6 +399,7 @@ rapid-mlx chat [model] [options]
 | `--ready-timeout` | Seconds to wait for the spawned server to become ready | 600 |
 | `--response-timeout` | Seconds to wait for a single response | 600 |
 | `--mcp-config` | Load MCP tools into this chat agent | *(none)* |
+| `--mcp-max-rounds` | Maximum tool-call rounds per turn when `--mcp-config` is set; multi-step tasks may need more | 8 |
 | `--disable-prefix-cache` | Disable reusable on-disk prefix caching for a server spawned by `chat` | off |
 
 > The REPL defaults to `--no-think` because reasoning models (Qwen3.5, etc.)
@@ -288,8 +436,9 @@ When attaching with `--port` or `--base-url` and no model argument, `chat`
 discovers the model from the server's `/v1/models` response. An explicit model
 argument always wins.
 
-In-REPL slash commands: `/help`, `/reset` (alias `/clear`), `/model <alias>`,
-`/save <path>` (write conversation to markdown), `/exit` (alias `/quit`).
+In-REPL slash commands: `/help` (alias `/?`), `/reset` (alias `/clear`),
+`/model <alias>`, `/save <path>` (write conversation to markdown), `/exit`
+(aliases `/quit`, `/bye`).
 Type `"""` on its own line to start/end a multi-line block (pasting code).
 
 MCP belongs to the chat process: it discovers and executes the configured
@@ -299,7 +448,32 @@ need the chat's MCP configuration.
 
 ## Environment Variables
 
-| Variable | Description |
-|----------|-------------|
-| `VLLM_MLX_TEST_MODEL` | Model for tests |
-| `HF_TOKEN` | HuggingFace token |
+Operator-facing `RAPID_MLX_*` variables read by the server and CLI. A CLI
+flag always wins over its env-var fallback when both are set.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RAPID_MLX_API_KEY` | unset (no auth) | Bearer API key fallback for `serve --api-key`; the inline flag value wins. `rapid-mlx share` uses the env form so the key never lands in `argv`. |
+| `RAPID_MLX_TRUSTED_HOSTS` | unset (not enforced) | Comma-separated Host-header allowlist fallback for `--trusted-hosts`; non-matching requests get HTTP 400 |
+| `RAPID_MLX_CORS_ALLOW_ORIGINS` | unset (wildcard `*`) | Comma-separated CORS origin allowlist; `--cors-origins` wins when both are set. Unset = friendly wildcard default with a startup notice; set-but-empty parses fail closed (no CORS middleware). |
+| `RAPID_MLX_CORS_ALLOW_METHODS` / `_HEADERS` / `_MAX_AGE` / `_CREDENTIALS` | `POST,GET,OPTIONS` / `Content-Type,Authorization,X-Rapid-MLX-Internal` / `3600` / off | Fine-tune the CORS policy when origins come from the env var (the CLI `--cors-origins` path keeps legacy wide-open methods/headers). Credentials are always forced off with a wildcard origin, per the Fetch spec. |
+| `RAPID_MLX_MAX_REQUEST_BYTES` | 8388608 (8 MiB) | Request-body size cap fallback for `--max-request-bytes`; oversized bodies get HTTP 413 before parsing. 0 disables. |
+| `RAPID_MLX_SSE_KEEPALIVE_SECONDS` | 20 | Interval for SSE keepalive comment lines during silent prefill (defeats proxy idle timeouts). 0 disables the heartbeat. |
+| `RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS` | 15 | Max idle seconds between request-body chunks (slowloris defense); exceeded connections get HTTP 408. 0 disables. |
+| `RAPID_MLX_IDLE_CACHE_CLEAR_SECONDS` | 0 (disabled) | Fallback for `--idle-cache-clear-seconds`: clear reusable KV state after this many idle seconds, keeping model weights loaded. An explicit CLI value (including 0) wins. |
+| `RAPID_MLX_WATCHDOG_PPID` | unset (disabled) | Fallback for `--watchdog-ppid`: self-terminate when the parent with this PID dies |
+| `RAPID_MLX_TELEMETRY` | unset | Telemetry kill switch: `0` / `false` / `no` / `off` / empty force-disables telemetry regardless of stored consent. Truthy values do NOT force-enable (consent is interactive-only). |
+| `RAPID_MLX_KV_CHECKPOINT_MAX_BYTES` | 21474836480 (20 GiB) | Disk cap for `~/.cache/rapid-mlx/kv_checkpoints/` when `--kv-disk-checkpoint-interval` is enabled; oldest files evicted first. Read at scan time, so it can change without a restart. |
+| `RAPID_MLX_PREFIX_CACHE_MAX_BYTES` | unset (heuristic) | Hard byte cap on prefix-cache memory (positive integer). Unset, blank, or invalid values fall back to the heuristic limit (logged once). |
+| `RAPID_MLX_MAX_GENERATION_TOKENS` | unset (no ceiling) | Opt-in hard ceiling on per-request `max_tokens`; requests above it are rejected at validation. Invalid or non-positive values are treated as unset. Read per request. |
+| `RAPID_MLX_STRICT_JSON_SCHEMA` | enabled | Strict post-generate `json_schema` enforcement; set `0`/`off`/`false`/`no`/`disable`/`disabled` to fall back to legacy prompt-injection-only behavior |
+| `RAPID_MLX_CONSTRAIN_TOOLS` | on (`1`) | Grammar-constrained tool calling; see the [configuration reference](configuration.md#environment-variables) for the full contract |
+| `RAPID_MLX_MCP_CONFIG` | unset | Path to the MCP config file; `--mcp-config` sets it for the server process, and it is honored at boot when the flag is absent |
+| `RAPID_MLX_AUTO_PULL` | unset | Set `1`/`true`/`yes` to auto-confirm model downloads (skips the interactive size prompt) |
+| `RAPID_MLX_MODEL_MIRROR` | `https://models.rapidmlx.com` | Model download mirror base URL; set to an empty string to force downloads from Hugging Face |
+| `RAPID_MLX_EXTRA_MODEL_ROOTS` | unset | Extra local directories to resolve models from, separated by `os.pathsep` (`:` on macOS/Linux), or a JSON array of paths |
+| `RAPID_MLX_DEFAULT_MODEL` | `qwen3.5-4b-4bit` | Default model alias used by `rapid-mlx launch` when `--model` is not given |
+| `RAPID_MLX_DISABLE_VERSION_CHECK` | unset | Set to any non-empty value to skip the interactive new-version check |
+| `RAPID_MLX_TRUST_REMOTE_CODE` | unset | Set `0`/`false`/`no`/`off` to force `trust_remote_code=False` process-wide for tokenizer loading |
+| `VLLM_MLX_TEST_MODEL` | unset | Model for tests |
+| `HF_TOKEN` | unset | HuggingFace token for gated/private repos |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,44 +2,102 @@
 
 ## Server Configuration
 
+The tables below cover the consequential `rapid-mlx serve` options by
+category. The exhaustive flag list (every flag visible in
+`rapid-mlx serve --help`) lives in the [CLI reference](cli.md#rapid-mlx-serve).
+
 ### Basic Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--host` | Server host address (loopback-only by default; pass `0.0.0.0` to expose on LAN) | `127.0.0.1` |
 | `--port` | Server port | `8000` |
+| `--listen-fd` | File descriptor of a pre-bound listening socket (3-1023) for socket activation; when set, `--host`/`--port` are ignored for binding | None |
+| `--log-level` | Log level for Python logging and uvicorn (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` |
+| `--served-model-name` | Model name reported by the API; when unset the `model` argument is used | None |
 | `--max-tokens` | Default max tokens | `32768` |
 | `--default-temperature` | Default temperature when not specified in request | None |
 | `--default-top-p` | Default top_p when not specified in request | None |
+| `--default-top-k` | Default top_k when not specified in request | None |
+| `--default-min-p` | Default min_p when not specified in request | None |
+| `--default-repetition-penalty` | Default repetition_penalty when not specified in request | None |
+| `--default-presence-penalty` | Default presence_penalty when not specified in request | None |
+| `--default-frequency-penalty` | Default frequency_penalty when not specified in request | None |
 
 ### Security Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--api-key` | API key for authentication | None |
+| `--api-key` | API key for authentication (falls back to `RAPID_MLX_API_KEY`) | None |
+| `--cors-origins` | Allowed CORS origins (space-separated; also via `RAPID_MLX_CORS_ALLOW_ORIGINS`) | `*` (all origins) |
+| `--trusted-hosts` | Opt-in Host-header allowlist; non-matching requests get HTTP 400 (also via `RAPID_MLX_TRUSTED_HOSTS`) | None (not enforced) |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | `0` |
+| `--max-request-bytes` | Max HTTP request body size in bytes; oversized requests get HTTP 413 before parsing. 0 disables. (also via `RAPID_MLX_MAX_REQUEST_BYTES`) | 8 MiB (8388608) |
 | `--timeout` | Request timeout in seconds | `1800` |
 
-### Batching Options
+### Admission and Batching Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--stream-interval` | Tokens per stream chunk | `1` |
 | `--max-num-seqs` | Max concurrent sequences | `256` |
+| `--max-concurrent-requests` | Admission cap on in-flight requests (queued + running); excess requests get HTTP 503 with `Retry-After` | `256` |
+| `--prefill-batch-size` | Max prompts prefilled together in one cold wave; lower for better first-token latency under concurrent cold load | `8` |
+| `--completion-batch-size` | Completion batch size | `32` |
+| `--prefill-step-size` | Chunk size for prompt prefill processing | `2048` |
+| `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit (0.0-1.0) | `0.90` |
 
 ### Cache Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
+| `--enable-prefix-cache` / `--disable-prefix-cache` | Toggle prefix caching for repeated prompts | enabled |
+| `--prefix-cache-index` | Prefix-cache lookup index: `radix` (token trie) or `hash` (legacy bisect) | `radix` |
 | `--cache-memory-mb` | Cache memory limit in MB | Auto |
 | `--cache-memory-percent` | Fraction of RAM for cache | `0.20` |
 | `--idle-cache-clear-seconds` | Clear reusable KV cache after idle time; model weights remain loaded | Disabled |
 | `--no-memory-aware-cache` | Use legacy entry-count cache | `false` |
+| `--pin-system-prompt` | Auto-pin the system prompt in the prefix cache to prevent eviction under memory pressure | `false` |
 | `--use-paged-cache` | Enable paged KV cache | `false` |
 | `--paged-cache-block-size` | Tokens per block | `64` |
 | `--max-cache-blocks` | Maximum blocks | `1000` |
 | `--hybrid-cache-entries` | Opt-in: retain N non-trimmable prefix-cache entries for prefix-extension reuse (stable prefix + new suffix each turn). Covers hybrid recurrent-state (GatedDeltaNet/Mamba) and sliding-window (Gemma 4, GPT-OSS) models. `0` disables. | `0` |
 | `--response-cache-entries` | Opt-in: retain N fully-computed greedy (`temperature 0` / `top_k 1`) chat completions; a completely repeated request returns the stored completion with zero GPU decode. Sampled requests are never cached. `0` disables. | `0` |
+
+### KV Cache Quantization Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--kv-cache-dtype` | KV cache dtype (`bf16`, `int8`, `int4`). int8/int4 shrink the KV cache 2x/4x for memory-constrained hosts at a decode-throughput cost at long context; sliding-window and MLA models auto-downgrade to bf16. | `bf16` |
+| `--reasoning` | Pins `--kv-cache-dtype` to int8 (reasoning-accuracy profile) | `false` |
+| `--kv-cache-quantization` | Deprecated alias of `--kv-cache-dtype int8`; wins when both are passed | `false` |
+| `--kv-cache-quantization-bits` | Bit width for KV cache quantization (4 or 8) | `8` |
+| `--kv-cache-quantization-group-size` | Group size for KV cache quantization | `64` |
+| `--kv-cache-min-quantize-tokens` | Minimum tokens for quantization to apply | `256` |
+| `--kv-cache-turboquant` | TurboQuant KV compression (experimental): bare = `v4` (V-only), `k8v4` (K 8-bit + V 4-bit mix), `none` (explicit off overriding alias auto-resolution). Mutually exclusive with `--kv-cache-quantization`. | None (alias-driven) |
+| `--kv-cache-turboquant-bits` | V-side bit width (3 or 4); ignored in `k8v4` mode | Auto by head_dim |
+| `--kv-cache-turboquant-group-size` | Group size for TurboQuant V-side quantization | `32` |
+| `--kv-disk-checkpoint-interval` | Token interval for KV snapshots to `~/.cache/rapid-mlx/kv_checkpoints/`; write-only, blocks decode per snapshot — external tooling only. `0` disables. | `0` |
+| `--metal-cap-kv-bytes-per-token` | Override the projected per-token KV size (bytes) in the admission gate; set when running a quantized KV cache. `0` auto-derives an fp16 figure. | `0` (auto) |
+
+### Model Loading and Residency Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--disk-stream` | Stream MoE routed-expert weights from disk instead of holding them resident (opt-in; registered architectures only) | `false` |
+| `--disk-stream-cache-gb` | Byte budget (GB) for the disk-stream expert LRU cache | `1.0` |
+| `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB; LRU idle unpinned models are evicted first. `0` disables. | `0` |
+| `--resident-model-idle-ttl` | Evict idle unpinned secondary models after this many seconds. `0` disables. | `0` |
+| `--mllm` / `--no-mllm` | Force multimodal (vision) loading / force text-only loading, overriding auto-detection | auto-detect |
+| `--enable-audio` | Mount `/v1/audio/*` routes on a text-only server (audio-capable models auto-mount them) | `false` |
+
+### PFlash Options
+
+PFlash long-prompt prefill compression. Defaults to `always` for verified
+aliases (Qwen3.5 / Qwen3.6 family) and `off` otherwise; tune with
+`--pflash off|auto|always`, `--pflash-threshold` (32768), and the
+`--pflash-*` keep/scoring knobs — see the
+[CLI reference](cli.md#pflash-long-prompt-compression) for the full table.
 
 ### Tool Calling Options
 
@@ -59,6 +117,8 @@
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--embedding-model` | Pre-load an embedding model at startup (requires `pip install 'rapid-mlx[embeddings]'`) | None |
+| `--embedding-max-length` | Max input length (tokens); `auto` derives it from the model's declared maximum, or pass a positive integer for a lower ceiling | `auto` |
+| `--embedding-overflow-policy` | Handling for over-length inputs: `truncate` (logged + metric, never silent) or `error` (HTTP 400 with observed/allowed counts) | `truncate` |
 
 ### Speculative Decoding Options
 
@@ -274,12 +334,46 @@ Create `mcp.json`:
 
 ## Environment Variables
 
+### Server-side variables
+
+Operator-facing `RAPID_MLX_*` variables read by the server and CLI. A CLI
+flag always wins over its env-var fallback when both are set.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RAPID_MLX_API_KEY` | unset (no auth) | Bearer API key fallback for `serve --api-key`; the inline flag value wins. `rapid-mlx share` uses the env form so the key never lands in `argv`. |
+| `RAPID_MLX_TRUSTED_HOSTS` | unset (not enforced) | Comma-separated Host-header allowlist fallback for `--trusted-hosts`; non-matching requests get HTTP 400 |
+| `RAPID_MLX_CORS_ALLOW_ORIGINS` | unset (wildcard `*`) | Comma-separated CORS origin allowlist; `--cors-origins` wins when both are set. Unset = friendly wildcard default with a startup notice; set-but-empty parses fail closed (no CORS middleware). |
+| `RAPID_MLX_CORS_ALLOW_METHODS` / `_HEADERS` / `_MAX_AGE` / `_CREDENTIALS` | `POST,GET,OPTIONS` / `Content-Type,Authorization,X-Rapid-MLX-Internal` / `3600` / off | Fine-tune the CORS policy when origins come from the env var (the CLI `--cors-origins` path keeps legacy wide-open methods/headers). Credentials are always forced off with a wildcard origin, per the Fetch spec. |
+| `RAPID_MLX_MAX_REQUEST_BYTES` | 8388608 (8 MiB) | Request-body size cap fallback for `--max-request-bytes`; oversized bodies get HTTP 413 before parsing. 0 disables. |
+| `RAPID_MLX_SSE_KEEPALIVE_SECONDS` | 20 | Interval for SSE keepalive comment lines during silent prefill (defeats proxy idle timeouts). 0 disables the heartbeat. |
+| `RAPID_MLX_BODY_RECEIVE_TIMEOUT_SECONDS` | 15 | Max idle seconds between request-body chunks (slowloris defense); exceeded connections get HTTP 408. 0 disables. |
+| `RAPID_MLX_IDLE_CACHE_CLEAR_SECONDS` | 0 (disabled) | Fallback for `--idle-cache-clear-seconds`: clear reusable KV state after this many idle seconds, keeping model weights loaded. An explicit CLI value (including 0) wins. |
+| `RAPID_MLX_WATCHDOG_PPID` | unset (disabled) | Fallback for `--watchdog-ppid`: self-terminate when the parent with this PID dies |
+| `RAPID_MLX_TELEMETRY` | unset | Telemetry kill switch: `0` / `false` / `no` / `off` / empty force-disables telemetry regardless of stored consent. Truthy values do NOT force-enable (consent is interactive-only). |
+| `RAPID_MLX_KV_CHECKPOINT_MAX_BYTES` | 21474836480 (20 GiB) | Disk cap for `~/.cache/rapid-mlx/kv_checkpoints/` when `--kv-disk-checkpoint-interval` is enabled; oldest files evicted first. Read at scan time, so it can change without a restart. |
+| `RAPID_MLX_PREFIX_CACHE_MAX_BYTES` | unset (heuristic) | Hard byte cap on prefix-cache memory (positive integer). Unset, blank, or invalid values fall back to the heuristic limit (logged once). |
+| `RAPID_MLX_MAX_GENERATION_TOKENS` | unset (no ceiling) | Opt-in hard ceiling on per-request `max_tokens`; requests above it are rejected at validation. Invalid or non-positive values are treated as unset. Read per request. |
+| `RAPID_MLX_STRICT_JSON_SCHEMA` | enabled | Strict post-generate `json_schema` enforcement; set `0`/`off`/`false`/`no`/`disable`/`disabled` to fall back to legacy prompt-injection-only behavior |
+| `RAPID_MLX_CONSTRAIN_TOOLS` | on (`1`) | Grammar-constrained tool calling (best-effort). Set to `0`/`off`/`false` to opt out. When enabled AND a `--tool-call-parser` is set AND a request sends `tools` with `tool_choice="required"` or a named function, the server compiles a grammar that constrains generation so a completed tool call names a real tool with schema-valid arguments in the family wire format. Requests without tools, or with `tool_choice="auto"`/`"none"`, are always unaffected. **Best-effort fallback:** the request silently falls back to the free-form-then-parse path (no hard error, no structural guarantee) when the `[guided]` extra (`llguidance`) is not installed, the model's tokenizer cannot back an `LLTokenizer`, the grammar fails to compile, or the parser family declares no structural info. `parallel_tool_calls=false` narrows the grammar to exactly one call. Note: the structural guarantee holds only for a call the model runs to a grammar-accepted completion — a `max_tokens` cutoff mid-call can still truncate the arguments and yield invalid JSON. |
+| `RAPID_MLX_MCP_CONFIG` | unset | Path to the MCP config file; `--mcp-config` sets it for the server process, and it is honored at boot when the flag is absent |
+| `RAPID_MLX_AUTO_PULL` | unset | Set `1`/`true`/`yes` to auto-confirm model downloads (skips the interactive size prompt) |
+| `RAPID_MLX_MODEL_MIRROR` | `https://models.rapidmlx.com` | Model download mirror base URL; set to an empty string to force downloads from Hugging Face |
+| `RAPID_MLX_EXTRA_MODEL_ROOTS` | unset | Extra local directories to resolve models from, separated by `os.pathsep` (`:` on macOS/Linux), or a JSON array of paths |
+| `RAPID_MLX_DEFAULT_MODEL` | `qwen3.5-4b-4bit` | Default model alias used by `rapid-mlx launch` when `--model` is not given |
+| `RAPID_MLX_DISABLE_VERSION_CHECK` | unset | Set to any non-empty value to skip the interactive new-version check |
+| `RAPID_MLX_TRUST_REMOTE_CODE` | unset | Set `0`/`false`/`no`/`off` to force `trust_remote_code=False` process-wide for tokenizer loading |
+| `VLLM_MLX_TEST_MODEL` | unset | Default model for tests |
+| `HF_TOKEN` | unset | HuggingFace authentication token |
+
+### Client-side (SDK) variables
+
+These are read by client SDKs, not by the rapid-mlx server:
+
 | Variable | Description |
 |----------|-------------|
-| `VLLM_MLX_TEST_MODEL` | Default model for tests |
-| `HF_TOKEN` | HuggingFace authentication token |
-| `OPENAI_API_KEY` | Set to any value for SDK compatibility |
-| `RAPID_MLX_CONSTRAIN_TOOLS` | Grammar-constrained tool calling (best-effort). **On by default** (`1`); set to `0`/`off`/`false` to opt out. When enabled AND a `--tool-call-parser` is set AND a request sends `tools` with `tool_choice="required"` or a named function, the server compiles a grammar that constrains generation so a completed tool call names a real tool with schema-valid arguments in the family wire format. Requests without tools, or with `tool_choice="auto"`/`"none"`, are always unaffected. **Best-effort fallback:** the request silently falls back to the free-form-then-parse path (no hard error, no structural guarantee) when the `[guided]` extra (`llguidance`) is not installed, the model's tokenizer cannot back an `LLTokenizer`, the grammar fails to compile, or the parser family declares no structural info. `parallel_tool_calls=false` narrows the grammar to exactly one call. Note: the structural guarantee holds only for a call the model runs to a grammar-accepted completion — a `max_tokens` cutoff mid-call can still truncate the arguments and yield invalid JSON. |
+| `OPENAI_API_KEY` | Read by the OpenAI SDK, not the server. Set to any value when the server runs without `--api-key`; must match the server key when one is set. |
+| `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY` | Read by Anthropic SDK clients (e.g. Claude Code) to point at the rapid-mlx `/v1/messages` endpoint |
 
 ## Example Configurations
 
@@ -292,7 +386,7 @@ rapid-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
 ### Production (Multiple Users)
 
 ```bash
-rapid-mlx serve mlx-community/Qwen3-0.6B-8bit \
+rapid-mlx serve qwen3.5-27b-4bit \
   --use-paged-cache \
   --api-key your-secret-key \
   --rate-limit 60 \
@@ -333,7 +427,7 @@ rapid-mlx serve mlx-community/Qwen3-4B-4bit \
 ### High Throughput
 
 ```bash
-rapid-mlx serve mlx-community/Qwen3-0.6B-8bit \
+rapid-mlx serve qwen3.5-27b-4bit \
   --stream-interval 5 \
   --max-num-seqs 256
 ```


### PR DESCRIPTION
## Summary

Issue #2081 (2026-08-18 documentation dogfood): large undocumented surface across the three server docs. This PR fills the gaps; every value written was verified against source, not memory.

**Serve flags (docs/reference/cli.md)** — the options table documented ~20 of ~94 visible flags. It is now exhaustive: every non-suppressed `add_argument` in the serve parser plus the `_add_pflash_args` family, grouped into 11 category tables (network/process, security/limits, admission/batching, caching, KV dtype+quantization, model loading/residency/modalities, generation defaults, tool calling/reasoning, profile overrides, speculative, embeddings, pflash, MCP), each with the argparse-literal default from `vllm_mlx/cli.py`. Computed defaults (`--kv-cache-turboquant-bits`, `--pflash`, `--pflash-keep-ratio`, `--max-request-bytes`) are described behaviorally instead of inventing numbers. Hidden `argparse.SUPPRESS` flags stay out of the visible tables; a note covers the legacy spec-decode aliases.

**Env vars (cli.md + configuration.md)** — tables grew from 2/4 rows to the full operator roster with name, default, and behavior: `RAPID_MLX_API_KEY`, `TRUSTED_HOSTS`, `CORS_ALLOW_ORIGINS` (+ `_METHODS/_HEADERS/_MAX_AGE/_CREDENTIALS` family), `MAX_REQUEST_BYTES`, `SSE_KEEPALIVE_SECONDS`, `BODY_RECEIVE_TIMEOUT_SECONDS`, `IDLE_CACHE_CLEAR_SECONDS`, `WATCHDOG_PPID`, `TELEMETRY`, `KV_CHECKPOINT_MAX_BYTES`, `PREFIX_CACHE_MAX_BYTES`, `MAX_GENERATION_TOKENS`, `STRICT_JSON_SCHEMA`, `CONSTRAIN_TOOLS`, `MCP_CONFIG`, `AUTO_PULL`, `MODEL_MIRROR`, `EXTRA_MODEL_ROOTS`, `DEFAULT_MODEL`, `DISABLE_VERSION_CHECK`, `TRUST_REMOTE_CODE`. `OPENAI_API_KEY` is relabeled as a client/SDK-side variable (new client-side table). Semantics verified in `vllm_mlx/config/server_config.py:142-192`, `vllm_mlx/server.py` (CORS/trusted-hosts resolution), `vllm_mlx/telemetry/state.py:316-325`, `vllm_mlx/runtime/disk_kv_checkpoint.py:124-127`, `vllm_mlx/engine_core.py:316-324`, `vllm_mlx/memory_cache.py:772-800`, `vllm_mlx/api/models.py:659-686`, `vllm_mlx/api/strict_json_schema.py:43-66`, `vllm_mlx/_mirror.py:56,460`, `vllm_mlx/model_aliases.py:686-822`, `vllm_mlx/utils/tokenizer.py:20-40`, `vllm_mlx/launch/cli.py:85`, `vllm_mlx/_version_check.py:93`.

**Endpoint index (docs/guides/server.md)** — new complete route table enumerated from `vllm_mlx/routes/*` and `vllm_mlx/server.py` router wiring: `/v1/responses`, `/metrics`, all 5 `/v1/audio/*` routes, `/v1/images/*` (4), `/v1/videos*` (6), `/v1/models/{id}` + 4 residency routes, `/healthz`/`/readyz`/`/livez`/`/health`/`/health/ready`, `/v1/cache/stats|clear|export|import|info`, `/v1/requests/{id}/cancel` (+ DELETE alias), `/v1/mcp/*` (5), with one-line descriptions, deep links to the audio/video/embeddings/MCP guides, and mounting notes (audio conditional; images/videos 409 when unloaded).

**Smaller items** — (a) Anthropic `stop_reason` table gains `stop_sequence` (verified `vllm_mlx/api/anthropic_adapter.py:694-749`: set iff a user stop sequence matched; `stop_sequence` field carries the matched string). (b) chat `--mcp-max-rounds` documented, default 8 (`vllm_mlx/cli.py:10346-10354`). (c) REPL slash list gains `/bye` (alias of `/exit`/`/quit`) and `/?` (alias of `/help`) (`vllm_mlx/cli.py:7772-7774`). (d) cli.md Commands table restructured — the agents-setup prose no longer splits the table, so the version/help rows rejoin it; missing subcommands `ls`, `alias`, `share`, `launch`, `connect` added. (e) Production recipes in server.md (systemd + 50-user) and configuration.md (production + high-throughput) now use `qwen3.5-27b-4bit` (present in `vllm_mlx/aliases.json`) instead of `Qwen3-0.6B-8bit`.

## Test plan

- [x] `python3.12 -m pytest tests/test_docs_cli_defaults.py tests/test_tool_calling_doc_table.py -q` — 6 passed (pins serve `--timeout`, bench `--num-prompts`/`--max-tokens` cells and the tool-parser table)
- [x] `python3.12 -m pytest tests/test_branding.py -q` — 2 passed (scans the docs tree)
- [x] `python3.12 -m ruff check .` and `python3.12 -m ruff format --check .` — clean (docs-only change)
- [x] CJK grep over the diff (`git diff | grep -P '[CJK ranges]'`) — empty
- [x] AST cross-check script: every visible serve flag in `vllm_mlx/cli.py` (94 incl. the `--text-only` alias and pflash family) appears in the cli.md serve section — OK
- [x] Markdown table pipe-count histogram per file — consistent column counts, no split tables

Closes #2081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)