### PR TITLE
fix(cli): make recipe recommendations disk-aware

### DIFF
--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import shutil
 from argparse import Namespace
+from types import SimpleNamespace
 
 from vllm_mlx import cli
 from vllm_mlx.model_aliases import list_aliases
@@ -26,6 +28,7 @@ def test_tier_rounds_down_and_clamps() -> None:
 
 def test_recipe_json_is_stable_and_has_two_picks(monkeypatch, capsys) -> None:
     monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: 100.0)
     cli.recipe_command(Namespace(max_ram=32, json=True))
     payload = json.loads(capsys.readouterr().out)
     assert payload["tier_floor_gb"] == 32
@@ -40,12 +43,129 @@ def test_recipe_json_is_stable_and_has_two_picks(monkeypatch, capsys) -> None:
     # gemma-4-26b; flag propagation is still covered by
     # test_ram_tier_recommendations_agree.py against the SSOT.
     assert payload["picks"][0]["launch_flags"] == []
+    assert payload["free_disk_gb"] == 100.0
+    assert payload["picks"][0]["disk_fit"] is True
+    assert payload["picks"][0]["download_size_gb"] == 15.2
+    assert payload["picks"][0]["required_disk_gb"] == 16.7
 
 
 def test_recipe_text_prints_ready_to_run_commands(monkeypatch, capsys) -> None:
     monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: 100.0)
     cli.recipe_command(Namespace(max_ram=18, json=False))
     output = capsys.readouterr().out
     assert "Smart — qwen3.5-9b-4bit" in output
     assert "Fast — qwen3.5-4b-4bit" in output
     assert "rapid-mlx serve qwen3.5-9b-4bit" in output
+
+
+def test_recipe_suppresses_command_for_pick_that_will_not_fit(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: 16.0)
+
+    cli.recipe_command(Namespace(max_ram=32, json=False))
+
+    output = capsys.readouterr().out
+    assert "Smart — qwen3.8-27b-4bit" in output
+    assert "won't fit: needs ~16.7 GB" in output
+    assert "16.0 GB free" in output
+    assert "rapid-mlx serve qwen3.8-27b-4bit" not in output
+    assert "rapid-mlx serve qwen3.5-4b-4bit" in output
+
+
+def test_recipe_uses_download_size_not_peak_ram_for_disk_fit(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: 18.0)
+
+    cli.recipe_command(Namespace(max_ram=32, json=False))
+
+    output = capsys.readouterr().out
+    # The displayed 20.0 GB is measured peak RAM. The manifest records a
+    # 15.2 GiB download (~16.7 GiB with headroom), so 18 GiB really does fit.
+    assert "Smart — qwen3.8-27b-4bit" in output
+    assert "won't fit" not in output
+    assert "rapid-mlx serve qwen3.8-27b-4bit" in output
+
+
+def test_recipe_complete_cache_does_not_require_free_download_space(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_scan_hf_cache_models",
+        lambda: [("rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX", 20 << 30, 0.0)],
+    )
+    monkeypatch.setattr(cli, "_cache_entry_is_runnable", lambda _repo: True)
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: 1.0)
+
+    cli.recipe_command(Namespace(max_ram=48, json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    smart = payload["picks"][0]
+    assert smart["cached"] is True
+    assert smart["download_size_gb"] == 0.0
+    assert smart["required_disk_gb"] == 0.0
+    assert smart["disk_fit"] is True
+
+
+def test_recipe_unknown_disk_space_does_not_hide_commands(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: None)
+
+    cli.recipe_command(Namespace(max_ram=48, json=False))
+
+    output = capsys.readouterr().out
+    assert "won't fit" not in output
+    assert "rapid-mlx serve qwen3.8-27b-4bit" in output
+
+
+def test_recipe_unknown_download_size_does_not_claim_fit(monkeypatch, capsys) -> None:
+    from vllm_mlx import model_sizes
+
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: 1.0)
+    monkeypatch.setattr(model_sizes, "size_bytes", lambda _repo: None)
+
+    cli.recipe_command(Namespace(max_ram=32, json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert all(pick["disk_fit"] is None for pick in payload["picks"])
+    assert all(pick["required_disk_gb"] is None for pick in payload["picks"])
+
+
+def test_recipe_disk_probe_uses_hf_cache_filesystem_and_existing_ancestor(
+    monkeypatch, tmp_path
+) -> None:
+    from huggingface_hub import constants
+
+    cache_volume = tmp_path / "external-volume"
+    cache_volume.mkdir()
+    monkeypatch.setattr(
+        constants, "HF_HUB_CACHE", str(cache_volume / "not-created" / "hub")
+    )
+    seen = []
+
+    def fake_disk_usage(path):
+        seen.append(path)
+        return SimpleNamespace(free=17 * (1 << 30))
+
+    monkeypatch.setattr(shutil, "disk_usage", fake_disk_usage)
+
+    assert cli._recipe_free_disk_gb() == 17.0
+    assert seen == [cache_volume]
+
+
+def test_recipe_disk_probe_failure_is_unknown(monkeypatch, tmp_path) -> None:
+    from huggingface_hub import constants
+
+    monkeypatch.setattr(constants, "HF_HUB_CACHE", str(tmp_path))
+
+    def fail(_path):
+        raise OSError("volume disappeared")
+
+    monkeypatch.setattr(shutil, "disk_usage", fail)
+    assert cli._recipe_free_disk_gb() is None

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -47,7 +47,7 @@ def test_recipe_json_is_stable_and_has_two_picks(monkeypatch, capsys) -> None:
     assert payload["free_disk_gb"] == 100.0
     assert payload["picks"][0]["disk_fit"] is True
     assert payload["picks"][0]["download_size_gb"] == 15.2
-    assert payload["picks"][0]["required_disk_gb"] == 16.8
+    assert payload["picks"][0]["required_disk_gb"] == 16.72
 
 
 def test_recipe_text_prints_ready_to_run_commands(monkeypatch, capsys) -> None:
@@ -70,8 +70,8 @@ def test_recipe_suppresses_command_for_pick_that_will_not_fit(
 
     output = capsys.readouterr().out
     assert "Smart — qwen3.8-27b-4bit" in output
-    assert "won't fit: needs ~16.8 GB" in output
-    assert "16.0 GB free" in output
+    assert "won't fit: needs ~16.72 GB" in output
+    assert "16.00 GB free" in output
     assert "rapid-mlx serve qwen3.8-27b-4bit" not in output
     assert "rapid-mlx serve qwen3.5-4b-4bit" in output
 
@@ -92,7 +92,7 @@ def test_recipe_uses_download_size_not_peak_ram_for_disk_fit(
     assert "rapid-mlx serve qwen3.8-27b-4bit" in output
 
 
-def test_recipe_rounding_boundary_is_conservative_and_self_consistent(
+def test_recipe_rounding_does_not_reject_a_download_that_really_fits(
     monkeypatch, capsys
 ) -> None:
     monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
@@ -101,7 +101,20 @@ def test_recipe_rounding_boundary_is_conservative_and_self_consistent(
     cli.recipe_command(Namespace(max_ram=32, json=False))
 
     output = capsys.readouterr().out
-    assert "needs ~16.8 GB including download headroom; 16.7 GB free" in output
+    assert "won't fit" not in output
+    assert "rapid-mlx serve qwen3.8-27b-4bit" in output
+
+
+def test_recipe_failing_rounding_boundary_displays_distinct_values(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: 16.719)
+
+    cli.recipe_command(Namespace(max_ram=32, json=False))
+
+    output = capsys.readouterr().out
+    assert "needs ~16.72 GB including download headroom; 16.71 GB free" in output
     assert "rapid-mlx serve qwen3.8-27b-4bit" not in output
 
 

--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shutil
 from argparse import Namespace
+from pathlib import Path
 from types import SimpleNamespace
 
 from vllm_mlx import cli
@@ -46,7 +47,7 @@ def test_recipe_json_is_stable_and_has_two_picks(monkeypatch, capsys) -> None:
     assert payload["free_disk_gb"] == 100.0
     assert payload["picks"][0]["disk_fit"] is True
     assert payload["picks"][0]["download_size_gb"] == 15.2
-    assert payload["picks"][0]["required_disk_gb"] == 16.7
+    assert payload["picks"][0]["required_disk_gb"] == 16.8
 
 
 def test_recipe_text_prints_ready_to_run_commands(monkeypatch, capsys) -> None:
@@ -69,7 +70,7 @@ def test_recipe_suppresses_command_for_pick_that_will_not_fit(
 
     output = capsys.readouterr().out
     assert "Smart — qwen3.8-27b-4bit" in output
-    assert "won't fit: needs ~16.7 GB" in output
+    assert "won't fit: needs ~16.8 GB" in output
     assert "16.0 GB free" in output
     assert "rapid-mlx serve qwen3.8-27b-4bit" not in output
     assert "rapid-mlx serve qwen3.5-4b-4bit" in output
@@ -89,6 +90,19 @@ def test_recipe_uses_download_size_not_peak_ram_for_disk_fit(
     assert "Smart — qwen3.8-27b-4bit" in output
     assert "won't fit" not in output
     assert "rapid-mlx serve qwen3.8-27b-4bit" in output
+
+
+def test_recipe_rounding_boundary_is_conservative_and_self_consistent(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: 16.75)
+
+    cli.recipe_command(Namespace(max_ram=32, json=False))
+
+    output = capsys.readouterr().out
+    assert "needs ~16.8 GB including download headroom; 16.7 GB free" in output
+    assert "rapid-mlx serve qwen3.8-27b-4bit" not in output
 
 
 def test_recipe_complete_cache_does_not_require_free_download_space(
@@ -168,4 +182,16 @@ def test_recipe_disk_probe_failure_is_unknown(monkeypatch, tmp_path) -> None:
         raise OSError("volume disappeared")
 
     monkeypatch.setattr(shutil, "disk_usage", fail)
+    assert cli._recipe_free_disk_gb() is None
+
+
+def test_recipe_inaccessible_cache_path_is_unknown(monkeypatch) -> None:
+    from huggingface_hub import constants
+
+    monkeypatch.setattr(constants, "HF_HUB_CACHE", "/inaccessible/hf/hub")
+
+    def fail_exists(_path):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "exists", fail_exists)
     assert cli._recipe_free_disk_gb() is None

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5610,12 +5610,12 @@ def recipe_command(args) -> None:
     payload = recommendation_payload(ram_gb)
     cached_repos = {repo.casefold() for repo, _, _ in _scan_hf_cache_models()}
     free_disk_gb = _recipe_free_disk_gb()
-    # Free space rounds DOWN while required space below rounds UP. Besides
-    # preserving a small safety margin, using those same display values for
-    # the comparison prevents the absurd-looking "needs 16.7; 16.7 free" /
-    # "won't fit" combination at a rounding boundary.
+    # Free space rounds DOWN while required space below rounds UP for display.
+    # Fit itself still compares the unrounded measurements: presentation must
+    # not reject a download that really has enough room. Two directed decimal
+    # places ensure a failing boundary cannot render as equal values.
     payload["free_disk_gb"] = (
-        None if free_disk_gb is None else math.floor(free_disk_gb * 10) / 10
+        None if free_disk_gb is None else math.floor(free_disk_gb * 100) / 100
     )
     for pick in payload["picks"]:
         try:
@@ -5644,12 +5644,14 @@ def recipe_command(args) -> None:
             else round(download_bytes / float(1 << 30), 1)
         )
         pick["required_disk_gb"] = (
-            None if required_disk_gb is None else math.ceil(required_disk_gb * 10) / 10
+            None
+            if required_disk_gb is None
+            else math.ceil(required_disk_gb * 100) / 100
         )
         pick["disk_fit"] = (
             None
             if free_disk_gb is None or required_disk_gb is None
-            else payload["free_disk_gb"] >= pick["required_disk_gb"]
+            else free_disk_gb >= required_disk_gb
         )
 
     if getattr(args, "json", False):
@@ -5674,8 +5676,8 @@ def recipe_command(args) -> None:
         print(f"   {' · '.join(stats)}")
         if pick["disk_fit"] is False:
             print(
-                f"   ⚠ won't fit: needs ~{pick['required_disk_gb']:.1f} GB "
-                f"including download headroom; {payload['free_disk_gb']:.1f} GB free"
+                f"   ⚠ won't fit: needs ~{pick['required_disk_gb']:.2f} GB "
+                f"including download headroom; {payload['free_disk_gb']:.2f} GB free"
             )
             print("   Free disk space or set HF_HOME/HF_HUB_CACHE to another drive.")
             continue

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5586,10 +5586,17 @@ def _print_cached_models() -> None:
 
 
 def recipe_command(args) -> None:
-    """Recommend exactly two curated models for this Mac's RAM tier."""
+    """Recommend exactly two curated models for this Mac's RAM tier.
+
+    Recommendations stay anchored to the shared, curated RAM-tier SSOT. Disk
+    pressure is presentation state, not a reason to silently substitute a
+    lower-quality model: an unavailable pick remains visible, but we do not
+    print a copy-paste ``serve`` command that is known to fail mid-download.
+    """
     import json
 
     from vllm_mlx.model_aliases import resolve_profile
+    from vllm_mlx.model_sizes import size_bytes
     from vllm_mlx.recommendations import physical_ram_gb, recommendation_payload
 
     ram_gb = (
@@ -5601,6 +5608,8 @@ def recipe_command(args) -> None:
         raise SystemExit("Could not detect physical RAM. Pass --max-ram GB explicitly.")
     payload = recommendation_payload(ram_gb)
     cached_repos = {repo.casefold() for repo, _, _ in _scan_hf_cache_models()}
+    free_disk_gb = _recipe_free_disk_gb()
+    payload["free_disk_gb"] = None if free_disk_gb is None else round(free_disk_gb, 1)
     for pick in payload["picks"]:
         try:
             profile = resolve_profile(pick["alias"])
@@ -5608,7 +5617,33 @@ def recipe_command(args) -> None:
         except ValueError:
             hf_path = None
         pick["hf_path"] = hf_path
-        pick["cached"] = bool(hf_path and hf_path.casefold() in cached_repos)
+        pick["cached"] = bool(
+            hf_path
+            and hf_path.casefold() in cached_repos
+            and _cache_entry_is_runnable(hf_path)
+        )
+        # ``footprint_gb`` is measured 8K peak RAM, not bytes on disk. Use the
+        # checked-in download-size manifest that powers ``rapid-mlx models``;
+        # this keeps recipe offline and prevents a 20 GB RAM peak from being
+        # misreported as a 20 GB download. Match the live download gate's 10%
+        # headroom for xet temporary files and the final cache move.
+        download_bytes = 0 if pick["cached"] else size_bytes(hf_path or "")
+        required_disk_gb = (
+            None if download_bytes is None else (download_bytes * 1.1) / float(1 << 30)
+        )
+        pick["download_size_gb"] = (
+            None
+            if download_bytes is None
+            else round(download_bytes / float(1 << 30), 1)
+        )
+        pick["required_disk_gb"] = (
+            None if required_disk_gb is None else round(required_disk_gb, 1)
+        )
+        pick["disk_fit"] = (
+            None
+            if free_disk_gb is None or required_disk_gb is None
+            else free_disk_gb >= required_disk_gb
+        )
 
     if getattr(args, "json", False):
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -5630,10 +5665,46 @@ def recipe_command(args) -> None:
         cache_badge = " · cached" if pick["cached"] else ""
         print(f"\n{index}. {labels[pick['role']]} — {pick['alias']}{cache_badge}")
         print(f"   {' · '.join(stats)}")
+        if pick["disk_fit"] is False:
+            print(
+                f"   ⚠ won't fit: needs ~{pick['required_disk_gb']:.1f} GB "
+                f"including download headroom; {free_disk_gb:.1f} GB free"
+            )
+            print("   Free disk space or set HF_HOME/HF_HUB_CACHE to another drive.")
+            continue
         command = f"rapid-mlx serve {pick['alias']}"
         if pick["launch_flags"]:
             command += " " + " ".join(pick["launch_flags"])
         print(f"   {command}")
+
+
+def _recipe_free_disk_gb() -> float | None:
+    """Return free GiB on the filesystem that receives HF downloads.
+
+    ``HF_HUB_CACHE`` can name a directory that does not exist yet, including
+    one on an external volume. Walk to its nearest existing ancestor before
+    probing, matching the real download gate rather than assuming ``$HOME``.
+    Unknown disk state is deliberately ``None``: recipe then preserves its
+    historical output instead of claiming that a model fits.
+    """
+    import shutil
+    from pathlib import Path
+
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        probe = Path(HF_HUB_CACHE).expanduser().absolute()
+    except Exception:
+        probe = Path.home() / ".cache" / "huggingface" / "hub"
+
+    while not probe.exists() and probe.parent != probe:
+        probe = probe.parent
+    if not probe.exists():
+        return None
+    try:
+        return shutil.disk_usage(probe).free / float(1 << 30)
+    except OSError:
+        return None
 
 
 def models_command(args):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5594,6 +5594,7 @@ def recipe_command(args) -> None:
     print a copy-paste ``serve`` command that is known to fail mid-download.
     """
     import json
+    import math
 
     from vllm_mlx.model_aliases import resolve_profile
     from vllm_mlx.model_sizes import size_bytes
@@ -5609,7 +5610,13 @@ def recipe_command(args) -> None:
     payload = recommendation_payload(ram_gb)
     cached_repos = {repo.casefold() for repo, _, _ in _scan_hf_cache_models()}
     free_disk_gb = _recipe_free_disk_gb()
-    payload["free_disk_gb"] = None if free_disk_gb is None else round(free_disk_gb, 1)
+    # Free space rounds DOWN while required space below rounds UP. Besides
+    # preserving a small safety margin, using those same display values for
+    # the comparison prevents the absurd-looking "needs 16.7; 16.7 free" /
+    # "won't fit" combination at a rounding boundary.
+    payload["free_disk_gb"] = (
+        None if free_disk_gb is None else math.floor(free_disk_gb * 10) / 10
+    )
     for pick in payload["picks"]:
         try:
             profile = resolve_profile(pick["alias"])
@@ -5637,12 +5644,12 @@ def recipe_command(args) -> None:
             else round(download_bytes / float(1 << 30), 1)
         )
         pick["required_disk_gb"] = (
-            None if required_disk_gb is None else round(required_disk_gb, 1)
+            None if required_disk_gb is None else math.ceil(required_disk_gb * 10) / 10
         )
         pick["disk_fit"] = (
             None
             if free_disk_gb is None or required_disk_gb is None
-            else free_disk_gb >= required_disk_gb
+            else payload["free_disk_gb"] >= pick["required_disk_gb"]
         )
 
     if getattr(args, "json", False):
@@ -5668,7 +5675,7 @@ def recipe_command(args) -> None:
         if pick["disk_fit"] is False:
             print(
                 f"   ⚠ won't fit: needs ~{pick['required_disk_gb']:.1f} GB "
-                f"including download headroom; {free_disk_gb:.1f} GB free"
+                f"including download headroom; {payload['free_disk_gb']:.1f} GB free"
             )
             print("   Free disk space or set HF_HOME/HF_HUB_CACHE to another drive.")
             continue
@@ -5692,18 +5699,16 @@ def _recipe_free_disk_gb() -> float | None:
 
     try:
         from huggingface_hub.constants import HF_HUB_CACHE
-
-        probe = Path(HF_HUB_CACHE).expanduser().absolute()
     except Exception:
-        probe = Path.home() / ".cache" / "huggingface" / "hub"
-
-    while not probe.exists() and probe.parent != probe:
-        probe = probe.parent
-    if not probe.exists():
-        return None
+        HF_HUB_CACHE = str(Path.home() / ".cache" / "huggingface" / "hub")
     try:
+        probe = Path(HF_HUB_CACHE).expanduser().absolute()
+        while not probe.exists() and probe.parent != probe:
+            probe = probe.parent
+        if not probe.exists():
+            return None
         return shutil.disk_usage(probe).free / float(1 << 30)
-    except OSError:
+    except (OSError, TypeError, ValueError):
         return None
 
 


### PR DESCRIPTION
## Summary

Make `rapid-mlx recipe` check free space on the filesystem that actually receives Hugging Face downloads before printing a copy-paste `serve` command.

- Preserve the two curated RAM-tier picks rather than silently substituting a different model.
- Annotate a non-cached pick that cannot fit and suppress only its known-to-fail command.
- Respect `HF_HUB_CACHE` / `HF_HOME`, including a cache directory that has not been created yet.
- Treat only complete, runnable snapshots as cached.
- Add structured `free_disk_gb`, `download_size_gb`, `required_disk_gb`, and `disk_fit` fields to JSON output.
- Degrade conservatively when disk or manifest size is unknown.

## Why

`recipe` previously selected by RAM alone and could print a command whose download was known not to fit. The live download gate already reserves 10% headroom, so recipe now applies the same threshold using the checked-in offline model-size manifest.

The issue repro also exposed a units ambiguity: the displayed `20.0 GB` for `qwen3.8-27b-4bit` is measured 8K peak RAM, not download size. The current artifact is about 15.2 GiB (16.7 GiB with headroom), so the reported 18 GiB free disk actually fits. Tests pin that distinction while still covering the real low-disk failure at 16 GiB.

Closes #2117

## Test plan

- [x] 47 targeted recommendation and disk-space tests pass.
- [x] Low-disk recipe output suppresses the oversized Smart command while preserving a fitting Fast command.
- [x] A complete cache hit remains runnable with only 1 GiB free.
- [x] Unknown disk/manifest state does not produce a false fit claim or hide commands.
- [x] A missing cache directory is probed through its nearest existing ancestor (external-volume case).
- [x] Ruff and `git diff --check` pass.