### PR TITLE
chore: remove 4 genuinely-dead private constants

### DIFF
--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -42,8 +42,6 @@ logger = logging.getLogger(__name__)
 _BYTES_PER_MB = 1024 * 1024
 _DEFAULT_MEMORY_PERCENT = 0.20  # 20% of available RAM
 _MIN_MEMORY_BYTES = 100 * _BYTES_PER_MB  # Minimum 100MB
-_MAX_ENTRIES_FALLBACK = 50  # Fallback if memory detection fails
-
 # #1100 codex round 6 (#3): replace-mode stage-then-swap transiently holds BOTH
 # the existing live cache AND the fully-staged new blob until the atomic swap
 # (the DELIBERATE cost of the "corrupt source leaves existing cache intact"
@@ -109,7 +107,6 @@ _TOKENS_FORMAT_VERSION_IN_INDEX = 3  # bumped from 2
 # wire-format width is the only sound way to make tokens.bin portable
 # across the heterogeneous fleet (codex r10-D systematic fix). Writer
 # uses struct.pack into bytes; reader uses struct.unpack_from a slice.
-_TOKEN_STRUCT_FMT = "<i"
 _TOKEN_BYTES = 4
 
 # mlx-lm's prompt-cache serializer forwards the flattened cache state directly

--- a/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
+++ b/vllm_mlx/tool_parsers/ui_tars_tool_parser.py
@@ -375,35 +375,6 @@ def has_ui_tars_system_prompt(messages: list) -> bool:
     return False
 
 
-# Verbs UI-TARS may emit. The set is a superset of the desktop
-# (``COMPUTER_USE_DOUBAO``) and mobile (``MOBILE_USE_DOUBAO``) action
-# spaces in ``codes/ui_tars/prompt.py``. Verbs not in this set are still
-# parsed and surfaced verbatim — we intentionally don't gate on the list
-# so a future UI-TARS revision that adds a verb won't silently drop calls
-# during the upgrade window.
-_KNOWN_VERBS: frozenset[str] = frozenset(
-    {
-        # Desktop / Computer-Use
-        "click",
-        "left_double",
-        "right_single",
-        "drag",
-        "hotkey",
-        "type",
-        "scroll",
-        "wait",
-        "finished",
-        "done",
-        "call_user",
-        # Mobile additions
-        "long_press",
-        "open_app",
-        "press_home",
-        "press_back",
-    }
-)
-
-
 # Action line: ``Action: verb(kwargs)`` — verb identifier, parenthesized
 # args body. Body may span newlines (e.g. ``type(content='line1\nline2')``)
 # but must end on a balanced ``)``. We match minimally and use a manual
@@ -1139,14 +1110,6 @@ def _iter_actions(text: str) -> list[tuple[int, int, str, dict[str, Any]]]:
 # Computer-Use specs don't share a drag wire format, so the single
 # key-mapping pass below has lane-specific drag handling. Centralized
 # here so the two adapters can't drift on key naming.
-
-# Single-point key rename (shared across Anthropic + Responses). The
-# UI-TARS-native ``point`` → spec ``coordinate``. ``start_point`` /
-# ``end_point`` are intentionally OMITTED from this map because the
-# two-point handling is lane-aware (see ``translate_to_*`` helpers).
-_UI_TARS_TO_SPEC_KEY_MAP: dict[str, str] = {
-    "point": "coordinate",
-}
 
 
 def translate_to_anthropic_spec_keys(args: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Why

Continuing the dead-code slimming effort, because carrying unreferenced module constants costs review attention, shows up in grep/coverage noise, and drifts out of sync with the live code paths that superseded them. Repo-wide greps (all file types — tests/examples/docs/scripts — excluding each symbol's own definition line) confirm these four private constants are defined exactly once and referenced nowhere, so removing them is behavior-neutral.

## What

- `vllm_mlx/memory_cache.py`
  - `_MAX_ENTRIES_FALLBACK` — fallback value never referenced.
  - `_TOKEN_STRUCT_FMT` — the fixed 4-byte wire format is already pinned by `_TOKEN_BYTES` and the writer's inline `struct` format literals (`"<i"` / `f"<{n}i"`); this constant took part in no logic.
- `vllm_mlx/tool_parsers/ui_tars_tool_parser.py`
  - `_KNOWN_VERBS` — a documentation-only frozenset whose own comment states it is intentionally non-gating (unseen verbs are surfaced verbatim). Zero references.
  - `_UI_TARS_TO_SPEC_KEY_MAP` — a single-entry `point`→`coordinate` rename map never referenced; the real translation is verb-aware and lives in the `translate_to_*` / point-parsing helpers.

## Verification

- `py_compile` + import smoke pass on both modules.
- Post-removal repo-wide grep (incl. non-`.py`): zero remaining references to any of the four names.
- `test_memory_cache.py`, `test_ui_tars_parser.py`, `test_ui_tars_stream_action_holdback.py` → 211 passed.
- Diff is pure deletion: 2 files, −40 lines, 0 additions.

Authored with AI assistance (Claude Opus 4.8).
