### PR TITLE
fix(cli): make first-run guidance actionable

### DIFF
--- a/tests/test_agent_first_class_setup.py
+++ b/tests/test_agent_first_class_setup.py
@@ -203,6 +203,9 @@ def test_agents_footer_counts_agents_and_frameworks_separately(
     out = capsys.readouterr().out
     assert "10 agents + 3 frameworks supported" in out
     assert "13 agents supported" not in out
+    assert "GitHub" in out
+    assert "tools" in out
+    assert "FC = function calling" in out
 
 
 def test_cli_parser_exposes_setup_safety_flags(monkeypatch):

--- a/tests/test_cli_empty_states.py
+++ b/tests/test_cli_empty_states.py
@@ -1,0 +1,39 @@
+"""Focused regression coverage for actionable top-level CLI empty states."""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+
+from vllm_mlx import cli
+
+
+def test_serve_without_model_is_concise_and_points_to_recipe(capsys):
+    with (
+        mock.patch.object(sys, "argv", ["rapid-mlx", "serve"]),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli.main()
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "a model is required" in captured.err
+    assert "rapid-mlx recipe" in captured.err
+    assert "rapid-mlx serve qwen3.5-4b-4bit" in captured.err
+    assert "--kv-cache" not in captured.err
+    assert captured.err.count("\n") == 3
+
+
+def test_serve_help_still_shows_full_reference(capsys):
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["serve", "--help"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "--kv-cache-quantization" in captured.out
+    assert "rapid-mlx recipe" not in captured.err

--- a/tests/test_first_run_guide.py
+++ b/tests/test_first_run_guide.py
@@ -157,6 +157,8 @@ def test_nameplate_cold_cache_no_agent(monkeypatch):
     out = fr.build_nameplate("9.9.9")
     assert "Rapid-MLX 9.9.9" in out
     assert "rapid-mlx chat" in out
+    assert "rapid-mlx recipe" in out
+    assert "Smart + Fast" in out
     assert fr.FIRST_RUN_MODEL in out
     assert fr.FIRST_RUN_MODEL_SIZE in out
     assert "launch --all" in out  # generic signpost when no agent

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -8257,9 +8257,13 @@ def agents_command(args):
         profiles = list_profiles()
         print()
         print("  Supported AI Agents")
-        print("  " + "─" * 56)
+        print(
+            f"  {'name':<15} {'client':<20} {'GitHub':>6}  "
+            f"{'tools':<5}  recommended models"
+        )
+        print("  " + "─" * 78)
         for p in profiles:
-            fc = "FC" if p.needs_function_calling else "  "
+            tools = "FC" if p.needs_function_calling else "—"
             stars = f"{p.stars // 1000}K" if p.stars and p.stars >= 1000 else ""
             if p.recommended_models:
                 shown = p.recommended_models[:3]
@@ -8268,7 +8272,10 @@ def agents_command(args):
                     models += f" +{len(p.recommended_models) - 3}"
             else:
                 models = ""
-            print(f"  {p.name:<15} {p.display_name:<20} {stars:>5}  [{fc}]  {models}")
+            print(
+                f"  {p.name:<15} {p.display_name:<20} {stars:>6}  {tools:<5}  {models}"
+            )
+        print("  FC = function calling")
         print()
         # Frameworks (langchain, pydanticai, smolagents) are libraries
         # you build agents with, not agents themselves — count them
@@ -8885,7 +8892,7 @@ Examples:
         allow_abbrev=False,
     )
     serve_parser.add_argument(
-        "model", type=str, help="Model to serve"
+        "model", nargs="?", type=str, help="Model to serve"
     ).completer = alias_completer
     serve_parser.add_argument(
         "--served-model-name",
@@ -10714,6 +10721,19 @@ def main():
     # Systematic serve-flag passthrough for ``share`` via the standard ``--``
     # end-of-options separator — see ``_parse_args_with_share_passthrough``.
     args = _parse_args_with_share_passthrough(parser, sys.argv[1:])
+    # A missing required positional normally makes argparse print the entire
+    # serve help (dozens of expert flags) before its one actionable error.
+    # Keep the positional optional at parse time so this first-run mistake gets
+    # a short recovery path. Explicit ``serve --help`` still exits from
+    # argparse above and retains the complete reference.
+    if getattr(args, "command", None) == "serve" and not args.model:
+        print("rapid-mlx serve: a model is required.", file=sys.stderr)
+        print("  Pick one for this Mac:  rapid-mlx recipe", file=sys.stderr)
+        print(
+            "  Or start a small one:   rapid-mlx serve qwen3.5-4b-4bit",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     if getattr(args, "command", None) in ("chat", "run"):
         args._model_was_explicit = getattr(args, "model", None) is not None
 

--- a/vllm_mlx/first_run.py
+++ b/vllm_mlx/first_run.py
@@ -210,7 +210,9 @@ def build_nameplate(version: str) -> str:
     # REPL behavior). Cached models are still listed above so a returning user
     # can name one explicitly.
     starter_cached = any(alias == FIRST_RUN_MODEL for alias, _ in cached)
-    rows: list[tuple[str, str]] = []
+    rows: list[tuple[str, str]] = [
+        ("rapid-mlx recipe", "pick Smart + Fast models for this Mac")
+    ]
     if starter_cached:
         rows.append(("rapid-mlx chat", f"{FIRST_RUN_MODEL} — already downloaded"))
     else:


### PR DESCRIPTION
## Summary

- replace the `rapid-mlx serve` missing-model argparse wall with a concise recovery path pointing to `rapid-mlx recipe`
- surface `recipe` in the existing bare-command first-run nameplate
- label the `rapid-mlx agents` popularity and tools columns and explain `FC`

Closes #2115.
Closes #2116.

## Validation

- `pytest -qq tests/test_cli_*.py tests/test_share_cli.py tests/test_model_recommendations.py tests/test_agent_first_class_setup.py tests/test_first_run_guide.py --disable-warnings` — 434 passed
- `ruff check` on changed Python files
- `ruff format --check` on changed Python files
- `git diff --check`
- real CLI smoke: missing-model recovery and full agents table