### PR TITLE
feat(models): memory-aware max_model_len on /v1/models + models --json

### DIFF
--- a/tests/test_cli_models_json.py
+++ b/tests/test_cli_models_json.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx models --json`` — machine-readable output that replaces
+scraping the fixed-width text table (which the desktop app and the DSH
+provider both otherwise parse by column).
+
+Structure, not values: aliases and cache contents change per release and per
+machine, so the tests pin the SHAPE (keys, types, section split) and that the
+command emits a single valid JSON document with no banner leaking onto stdout.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from vllm_mlx.cli import (
+    _available_models_json_payload,
+    _cached_models_json_payload,
+    models_command,
+)
+
+
+def test_available_payload_shape() -> None:
+    payload = _available_models_json_payload()
+    assert set(payload) == {"text", "audio", "video", "image"}
+    assert all(isinstance(payload[k], list) for k in payload)
+    # There is always at least one text alias in the registry.
+    assert payload["text"], "expected at least one text alias"
+    entry = payload["text"][0]
+    for key in (
+        "alias",
+        "hf_path",
+        "size_bytes",
+        "tool_call_parser",
+        "reasoning_parser",
+        "is_hybrid",
+        "is_moe",
+        "supports_spec_decode",
+        "modality",
+    ):
+        assert key in entry, f"text entry missing {key!r}"
+    assert isinstance(entry["is_hybrid"], bool)
+    assert isinstance(entry["is_moe"], bool)
+    assert entry["size_bytes"] is None or isinstance(entry["size_bytes"], int)
+
+
+def test_available_sections_are_split_by_modality() -> None:
+    payload = _available_models_json_payload()
+    # No text alias should carry a generative modality, and vice versa.
+    assert all(e["modality"] not in ("video-gen", "image-gen") for e in payload["text"])
+    assert all(e["modality"] == "video-gen" for e in payload["video"])
+    assert all(e["modality"] == "image-gen" for e in payload["image"])
+    assert all(e["modality"] == "audio" for e in payload["audio"])
+
+
+def test_cached_payload_shape() -> None:
+    payload = _cached_models_json_payload()
+    assert set(payload) == {"cached", "count", "total_bytes"}
+    assert isinstance(payload["cached"], list)
+    assert payload["count"] == len(payload["cached"])
+    assert isinstance(payload["total_bytes"], int)
+    # Biggest-first ordering.
+    sizes = [m["size_bytes"] for m in payload["cached"]]
+    assert sizes == sorted(sizes, reverse=True)
+    for m in payload["cached"]:
+        assert set(m) >= {"alias", "repo", "size_bytes", "state", "external"}
+        assert m["state"] in {"ok", "unmapped", "incomplete", "external"}
+        # alias is only meaningful for a runnable, registry-mapped entry.
+        if m["state"] != "ok":
+            assert m["alias"] is None
+
+
+def test_command_emits_single_valid_json_available(capfd) -> None:
+    models_command(SimpleNamespace(cached=False, json=True))
+    out = capfd.readouterr().out
+    doc = json.loads(out)  # raises if a banner leaked onto stdout
+    assert "text" in doc
+
+
+def test_command_emits_single_valid_json_cached(capfd) -> None:
+    models_command(SimpleNamespace(cached=True, json=True))
+    out = capfd.readouterr().out
+    doc = json.loads(out)
+    assert "cached" in doc and "total_bytes" in doc

--- a/tests/test_model_card_client_contract.py
+++ b/tests/test_model_card_client_contract.py
@@ -10,10 +10,12 @@ file. Two consumers depend on that today:
   advertise graded reasoning to DeepSeek Harness (#1984).
 * **Out-of-tree** — the native Rapid-MLX provider for DSH
   (``raullenchai/rapid-mlx-dsh-provider``) reads ``context_window``,
-  ``reasoning_parser`` and ``capabilities`` to answer Harness's
-  ``resolveModel()``. That value feeds ``dsh-compaction-basic``, which
-  multiplies the capacity we report by its threshold ratio to decide when
-  to compact a session.
+  ``max_model_len``, ``reasoning_parser`` and ``capabilities`` to answer
+  Harness's ``resolveModel()``. The capacity it reports feeds
+  ``dsh-compaction-basic``, which multiplies it by its threshold ratio to
+  decide when to compact a session; the provider prefers ``max_model_len``
+  (the memory-fitted ceiling) over ``context_window`` (the native window)
+  when present, so both are part of the contract.
 
 The out-of-tree consumer is the reason this file exists. Renaming or
 dropping one of these fields is a silent break for it: nothing in this
@@ -39,7 +41,8 @@ from vllm_mlx.api.models import ModelInfo
 #: deliberate act that should be visible in review, which is the point.
 CLIENT_FIELDS: dict[str, str] = {
     "id": "route identity; the model id sent back on a request",
-    "context_window": "real capacity — drives DSH compaction thresholds",
+    "context_window": "native window — the model's own max context",
+    "max_model_len": "memory-fitted capacity — the preferred DSH compaction basis",
     "reasoning_parser": "whether the model can emit reasoning at all",
     "tool_call_parser": "whether it can emit OpenAI-shape tool_calls",
     "capabilities": "text / tools / vision, for request shaping",
@@ -48,7 +51,12 @@ CLIENT_FIELDS: dict[str, str] = {
 
 #: Fields whose ``None`` must reach the wire as an explicit ``null``.
 #: See ``test_null_extensions_are_serialized_not_dropped`` for why.
-TRISTATE_FIELDS = ("reasoning_parser", "tool_call_parser", "context_window")
+TRISTATE_FIELDS = (
+    "reasoning_parser",
+    "tool_call_parser",
+    "context_window",
+    "max_model_len",
+)
 
 
 @pytest.mark.parametrize("field", sorted(CLIENT_FIELDS))

--- a/tests/test_projected_memory_max_context.py
+++ b/tests/test_projected_memory_max_context.py
@@ -30,7 +30,20 @@ DENSE_ARGS = SimpleNamespace(
 PER_TOKEN = 2 * 28 * 8 * 128 * 2  # 229_376 bytes/token
 
 
-def _make_scheduler(model, util=0.0):
+def _make_scheduler(
+    model,
+    util=0.0,
+    *,
+    sched_per_tok=0,
+    sched_fixed=0,
+    sched_slot=0,
+    sched_window=0,
+):
+    """A Scheduler stub. The scheduler's cached KV terms default to 0 so the
+    method takes the ``_read_kv_dims`` fallback (the mlx-lm ``.args`` case);
+    pass ``sched_per_tok`` etc. to exercise the primary "prefer the scheduler's
+    own resolved terms" path instead.
+    """
     sched = Scheduler.__new__(Scheduler)
     sched.model = model
     sched.config = SimpleNamespace(
@@ -38,6 +51,11 @@ def _make_scheduler(model, util=0.0):
         metal_cap_kv_bytes_per_token=0,
         kv_cache_dtype="bf16",
     )
+    sched._kv_bytes_per_token_resolved = True
+    sched._kv_bytes_per_token = sched_per_tok
+    sched._kv_fixed_baseline_bytes = sched_fixed
+    sched._kv_sliding_slot_bytes = sched_slot
+    sched._kv_sliding_window = sched_window
     return sched
 
 
@@ -63,6 +81,26 @@ def test_read_kv_dims_from_mlx_args() -> None:
 
 def test_read_kv_dims_none_for_stub_model() -> None:
     assert _read_kv_dims(SimpleNamespace()) is None
+
+
+def test_read_kv_dims_prefers_text_tower_over_decoy_outer() -> None:
+    """A multimodal shape carries decoy vision dims on the outer config and the
+    real text-tower dims under ``text_config`` — the text tower must win, or
+    max_model_len would be computed from the wrong architecture."""
+    outer = SimpleNamespace(
+        num_hidden_layers=40,  # decoy vision-tower depth
+        num_key_value_heads=16,
+        head_dim=80,
+        text_config=SimpleNamespace(
+            num_hidden_layers=28,
+            num_key_value_heads=8,
+            head_dim=128,
+            dtype="bfloat16",
+        ),
+    )
+    dims = _read_kv_dims(SimpleNamespace(args=outer))
+    assert dims is not None
+    assert dims[:3] == (28, 8, 128)
 
 
 def test_native_window_fits_returns_native(monkeypatch) -> None:
@@ -108,6 +146,17 @@ def test_configured_utilization_is_honored(monkeypatch) -> None:
     sched = _make_scheduler(SimpleNamespace(args=DENSE_ARGS), util=0.5)
     _stub_mx(monkeypatch, base_bytes=base, resident_bytes=0)
     assert sched.projected_memory_max_context(10**6) == int(base * 0.5) // PER_TOKEN
+
+
+def test_prefers_scheduler_resolved_terms(monkeypatch) -> None:
+    """When the scheduler already resolved its footprint terms (config-backed
+    models, and where the operator KV override applies), use THOSE — so the
+    advertised ceiling matches admission — not a re-derivation. Proven by a
+    model exposing no dims at all: a fallback to _read_kv_dims would be None."""
+    base = 2_550_000_000
+    sched = _make_scheduler(SimpleNamespace(), sched_per_tok=PER_TOKEN)
+    _stub_mx(monkeypatch, base_bytes=base, resident_bytes=0)
+    assert sched.projected_memory_max_context(40960) == int(base * 0.90) // PER_TOKEN
 
 
 def test_none_when_no_dims(monkeypatch) -> None:

--- a/tests/test_projected_memory_max_context.py
+++ b/tests/test_projected_memory_max_context.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``Scheduler.projected_memory_max_context`` — the memory-fitted context
+ceiling behind the ``/v1/models`` ``max_model_len`` field.
+
+The method is exercised in isolation: a Scheduler built via ``__new__`` (so no
+engine spin-up) with just the two attributes it reads (``model``, ``config``),
+and a stubbed ``mx`` so the device-memory budget and residency are
+deterministic. That keeps the test on the arithmetic — dim resolution, the
+architecture-aware footprint, and the binary-search inversion — not on the
+host GPU.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.scheduler import Scheduler, _read_kv_dims
+
+# Qwen3-0.6B-ish dense dims — the real shape that first surfaced the
+# ``.args``-not-``.config`` gap this method has to handle.
+DENSE_ARGS = SimpleNamespace(
+    num_hidden_layers=28,
+    num_key_value_heads=8,
+    head_dim=128,
+    dtype="bfloat16",
+)
+# 2 (K+V) * layers * kv_heads * head_dim * dtype_bytes(bf16=2)
+PER_TOKEN = 2 * 28 * 8 * 128 * 2  # 229_376 bytes/token
+
+
+def _make_scheduler(model, util=0.0):
+    sched = Scheduler.__new__(Scheduler)
+    sched.model = model
+    sched.config = SimpleNamespace(
+        gpu_memory_utilization=util,
+        metal_cap_kv_bytes_per_token=0,
+        kv_cache_dtype="bf16",
+    )
+    return sched
+
+
+def _stub_mx(monkeypatch, *, base_bytes, resident_bytes, metal=True):
+    fake = SimpleNamespace(
+        metal=SimpleNamespace(is_available=lambda: metal),
+        device_info=lambda: {"max_recommended_working_set_size": base_bytes},
+        get_active_memory=lambda: resident_bytes,
+    )
+    monkeypatch.setattr("vllm_mlx.scheduler.mx", fake)
+
+
+def test_read_kv_dims_from_mlx_args() -> None:
+    """mlx-lm models carry dims on ``.args``, not ``.config`` — the case the
+    scheduler's own cached path misses."""
+    model = SimpleNamespace(args=DENSE_ARGS)  # no ``.config`` attribute
+    dims = _read_kv_dims(model)
+    assert dims is not None
+    layers, kv_heads, head_dim, cfg = dims
+    assert (layers, kv_heads, head_dim) == (28, 8, 128)
+    assert cfg is DENSE_ARGS
+
+
+def test_read_kv_dims_none_for_stub_model() -> None:
+    assert _read_kv_dims(SimpleNamespace()) is None
+
+
+def test_native_window_fits_returns_native(monkeypatch) -> None:
+    """When the whole native window fits the budget, report the native window
+    (memory is not the binding constraint)."""
+    sched = _make_scheduler(SimpleNamespace(args=DENSE_ARGS))
+    _stub_mx(monkeypatch, base_bytes=100 * 10**9, resident_bytes=0)
+    assert sched.projected_memory_max_context(40960) == 40960
+
+
+def test_memory_capped_below_native(monkeypatch) -> None:
+    """A budget too small for the native window returns the largest T that
+    fits — the exact inverse of the per-token footprint."""
+    base = 2_550_000_000
+    sched = _make_scheduler(SimpleNamespace(args=DENSE_ARGS))
+    _stub_mx(monkeypatch, base_bytes=base, resident_bytes=0)
+    available = int(base * 0.90)  # util defaults to 0.90 when cap disabled
+    expected = available // PER_TOKEN  # dense: footprint(T) = PER_TOKEN * T
+    result = sched.projected_memory_max_context(40960)
+    assert result == expected
+    assert 0 < result < 40960
+
+
+def test_resident_weights_reduce_the_ceiling(monkeypatch) -> None:
+    """Already-resident bytes (weights + live cache) come out of the budget."""
+    base = 20 * 10**9
+    sched = _make_scheduler(SimpleNamespace(args=DENSE_ARGS))
+    _stub_mx(monkeypatch, base_bytes=base, resident_bytes=10 * 10**9)
+    available = int(base * 0.90) - 10 * 10**9
+    assert sched.projected_memory_max_context(1_000_000) == available // PER_TOKEN
+
+
+def test_capped_at_native_even_with_huge_budget(monkeypatch) -> None:
+    sched = _make_scheduler(SimpleNamespace(args=DENSE_ARGS))
+    _stub_mx(monkeypatch, base_bytes=10**12, resident_bytes=0)
+    assert sched.projected_memory_max_context(5000) == 5000
+
+
+def test_configured_utilization_is_honored(monkeypatch) -> None:
+    """When the operator set a Metal cap fraction, use it (not the 0.90
+    reporting default)."""
+    base = 10 * 10**9
+    sched = _make_scheduler(SimpleNamespace(args=DENSE_ARGS), util=0.5)
+    _stub_mx(monkeypatch, base_bytes=base, resident_bytes=0)
+    assert sched.projected_memory_max_context(10**6) == int(base * 0.5) // PER_TOKEN
+
+
+def test_none_when_no_dims(monkeypatch) -> None:
+    sched = _make_scheduler(SimpleNamespace())  # stub model, no dims
+    _stub_mx(monkeypatch, base_bytes=100 * 10**9, resident_bytes=0)
+    assert sched.projected_memory_max_context(40960) is None
+
+
+def test_none_when_metal_unavailable(monkeypatch) -> None:
+    sched = _make_scheduler(SimpleNamespace(args=DENSE_ARGS))
+    _stub_mx(monkeypatch, base_bytes=100 * 10**9, resident_bytes=0, metal=False)
+    assert sched.projected_memory_max_context(40960) is None
+
+
+def test_none_when_budget_exhausted(monkeypatch) -> None:
+    """Residency at or above the budget → no headroom → None, not 0."""
+    base = 10 * 10**9
+    sched = _make_scheduler(SimpleNamespace(args=DENSE_ARGS))
+    _stub_mx(monkeypatch, base_bytes=base, resident_bytes=int(base * 0.90))
+    assert sched.projected_memory_max_context(40960) is None
+
+
+@pytest.mark.parametrize("native", [None, 0, -5])
+def test_no_native_hint_uses_generous_ceiling(monkeypatch, native) -> None:
+    """Without a usable native cap the search still terminates and returns a
+    positive fit."""
+    base = 2_550_000_000
+    sched = _make_scheduler(SimpleNamespace(args=DENSE_ARGS))
+    _stub_mx(monkeypatch, base_bytes=base, resident_bytes=0)
+    result = sched.projected_memory_max_context(native)
+    assert result == int(base * 0.90) // PER_TOKEN

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2430,6 +2430,23 @@ class ModelInfo(BaseModel):
     # guard uses, so the value the client sees lines up with the
     # cap the server will actually enforce. Issue #363.
     context_window: int | None = None
+    # Memory-aware served context ceiling — the largest context that
+    # actually FITS on this machine given the loaded weights plus the
+    # unified-memory KV-cache budget, capped at ``context_window``.
+    # Named ``max_model_len`` to match the de-facto convention vLLM
+    # established and SGLang copied (both put it on the OpenAI model
+    # card as a vendor extension), so any client that already reads
+    # vLLM's ``max_model_len`` gets our value for free. Where vLLM and
+    # SGLang crash when their configured ``max_model_len`` won't fit KV
+    # memory, on unified memory we can compute the fitted ceiling and
+    # report it instead. Sourced from the scheduler's own admission
+    # projection (``Scheduler.projected_memory_max_context`` →
+    # ``_estimate_request_kv_bytes``), so it lines up with what the
+    # server would actually admit. Advisory and re-derived per call
+    # from current residency; ``None`` when no engine is loaded for
+    # the id or the estimate can't be formed, and it serializes as
+    # JSON ``null`` (no ``exclude_none``) like the other extensions.
+    max_model_len: int | None = None
     # Capability tags advertised on the wire. Currently used to mark
     # the configured embedding model with ``"embedding"`` so clients
     # can discover which entry is wired to ``/v1/embeddings`` without

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5714,6 +5714,120 @@ def _recipe_free_disk_gb() -> float | None:
         return None
 
 
+def _cached_models_json_payload() -> dict:
+    """Structured form of the ``models --cached`` view — the same rows the
+    text table renders, with stable keys instead of fixed-width columns.
+
+    Sizes are raw bytes; ``state`` is one of ``ok`` / ``unmapped`` /
+    ``incomplete`` / ``external`` mirroring the alias column's parenthesized
+    tags; ``alias`` is ``None`` for any non-``ok`` row (those are not
+    launchable by alias). Sorted biggest-first, like the table.
+    """
+    import time as _time
+
+    from vllm_mlx.model_aliases import list_profiles
+
+    rows = _scan_hf_cache_models()
+    external_rows = _scan_external_model_dirs()
+    runnable_hub_repos = {repo for repo, _, _ in rows if _cache_entry_is_runnable(repo)}
+    external_rows = [r for r in external_rows if r[0] not in runnable_hub_repos]
+
+    profiles = list_profiles()
+    hf_to_alias: dict[str, str] = {}
+    for alias, p in profiles.items():
+        hf_to_alias.setdefault(p.hf_path, alias)
+
+    now = _time.time()
+    tagged = [(*row, False) for row in rows] + [(*row, True) for row in external_rows]
+    models = []
+    total_bytes = 0
+    for repo, size, mtime, is_external in tagged:
+        total_bytes += size
+        if is_external:
+            alias, state = None, "external"
+        elif not _cache_entry_is_runnable(repo):
+            alias, state = None, "incomplete"
+        else:
+            mapped = hf_to_alias.get(repo)
+            alias, state = (mapped, "ok") if mapped is not None else (None, "unmapped")
+        models.append(
+            {
+                "alias": alias,
+                "repo": repo,
+                "size_bytes": int(size),
+                "modified_epoch": int(mtime) if mtime and mtime > 0 else None,
+                "age_seconds": int(max(0, now - mtime))
+                if mtime and mtime > 0
+                else None,
+                "state": state,
+                "external": is_external,
+            }
+        )
+    models.sort(key=lambda m: -m["size_bytes"])
+    return {"cached": models, "count": len(models), "total_bytes": int(total_bytes)}
+
+
+def _available_models_json_payload() -> dict:
+    """Structured form of the default ``models`` view: every alias with the
+    profile facts the table shows, split by modality (text / audio / video /
+    image) exactly as the text sections are. Sizes are download bytes from the
+    checked-in manifest (``None`` when unknown); no per-invocation HF I/O.
+    """
+    from vllm_mlx.model_aliases import list_profiles
+    from vllm_mlx.model_sizes import size_bytes
+
+    all_profiles = list_profiles()
+
+    def _modality(p) -> str:
+        return getattr(p, "modality", "text") or "text"
+
+    def _profile_dict(alias, p) -> dict:
+        raw = None
+        try:
+            raw = size_bytes(p.hf_path)
+        except Exception:
+            raw = None
+        return {
+            "alias": alias,
+            "hf_path": p.hf_path,
+            "size_bytes": int(raw) if isinstance(raw, int) and raw > 0 else None,
+            "tool_call_parser": p.tool_call_parser,
+            "reasoning_parser": p.reasoning_parser,
+            "is_hybrid": bool(getattr(p, "is_hybrid", False)),
+            "is_moe": bool(getattr(p, "is_moe", False)),
+            "supports_spec_decode": bool(getattr(p, "supports_spec_decode", False)),
+            "modality": _modality(p),
+        }
+
+    text, video, image = {}, {}, {}
+    for alias, p in all_profiles.items():
+        bucket = {"video-gen": video, "image-gen": image}.get(_modality(p), text)
+        bucket[alias] = p
+
+    payload = {
+        "text": [_profile_dict(a, text[a]) for a in sorted(text)],
+        "video": [_profile_dict(a, video[a]) for a in sorted(video)],
+        "image": [_profile_dict(a, image[a]) for a in sorted(image)],
+        "audio": [],
+    }
+    try:
+        from vllm_mlx.audio.registry import list_audio_aliases
+
+        payload["audio"] = [
+            {
+                "alias": e.alias,
+                "hf_id": e.hf_id,
+                "kind": e.type,
+                "family": e.family,
+                "modality": "audio",
+            }
+            for e in list_audio_aliases()
+        ]
+    except Exception:
+        payload["audio"] = []
+    return payload
+
+
 def models_command(args):
     """List available model aliases with their per-model profile capabilities.
 
@@ -5730,6 +5844,17 @@ def models_command(args):
     from vllm_mlx._version_check import print_staleness_warning_if_any
     from vllm_mlx.model_aliases import list_profiles
     from vllm_mlx.model_sizes import format_size
+
+    # JSON mode emits ONLY the payload on stdout — no staleness banner, no
+    # table — so a caller can pipe it straight into a parser.
+    if getattr(args, "json", False):
+        import json as _json
+
+        if getattr(args, "cached", False):
+            print(_json.dumps(_cached_models_json_payload()))
+        else:
+            print(_json.dumps(_available_models_json_payload()))
+        return
 
     print_staleness_warning_if_any()
 
@@ -10255,6 +10380,14 @@ Examples:
         default=False,
         help="Only list models that are downloaded to the local HuggingFace "
         "cache (alias, HF repo, size on disk, last modified).",
+    )
+    models_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit the model list as machine-readable JSON instead of the "
+        "human table (stable keys; pairs with --cached). Prefer this over "
+        "scraping the text columns.",
     )
     recipe_parser = subparsers.add_parser(
         "recipe", help="Recommend the smart and fast models for this Mac"

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -27,6 +27,104 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _engine_for(model_id: str):
+    """Return the live engine actually loaded for ``model_id``, or ``None``.
+
+    Single-model serve exposes the one engine on ``cfg.engine`` and only for
+    the served ``model_name``/``model_alias``; multi-model serve looks the
+    entry up in the registry index and guards ``entry.matches(model_id)`` so a
+    ``get_entry`` default-fallback never advertises the wrong engine for an
+    unloaded alias. Shared by ``_resolve_context_window`` and
+    ``_resolve_max_model_len`` so both read the exact same engine.
+    """
+    cfg = get_config()
+    if cfg.model_registry is not None:
+        try:
+            entry = cfg.model_registry.get_entry(model_id)
+        except KeyError:
+            entry = None
+        if entry is not None and entry.matches(model_id):
+            return entry.engine
+        return None
+    candidate = getattr(cfg, "engine", None)
+    if candidate is not None:
+        served = {cfg.model_name, cfg.model_alias} - {None}
+        if model_id in served:
+            return candidate
+    return None
+
+
+def _scheduler_of(engine):
+    """Walk the engine backend graph to a ``Scheduler`` exposing
+    ``projected_memory_max_context``, or ``None``.
+
+    The production ``BatchedEngine`` keeps the text ``Scheduler`` two hops in,
+    at ``._engine.engine.scheduler`` (its ``_engine`` is an ``AsyncEngineCore``
+    wrapper whose inner ``EngineCore`` owns the scheduler — see
+    ``BatchedEngine`` abort-path comment); an MLLM-active serve exposes it as
+    ``._mllm_scheduler``; plainer/synthetic engines expose ``.scheduler`` (or
+    ``.engine.scheduler``) directly. Collect every candidate and return the
+    first that is actually a Scheduler (has the probe method), so a wrapper
+    that merely forwards attributes can't shadow the real one.
+    """
+    candidates = []
+    mllm = getattr(engine, "_mllm_scheduler", None)
+    if mllm is not None:
+        candidates.append(mllm)
+    inner = getattr(engine, "_engine", None)
+    for holder in (
+        engine,
+        inner,
+        getattr(inner, "engine", None),
+        getattr(engine, "engine", None),
+    ):
+        if holder is None:
+            continue
+        sched = getattr(holder, "scheduler", None)
+        if sched is not None:
+            candidates.append(sched)
+    for candidate in candidates:
+        if callable(getattr(candidate, "projected_memory_max_context", None)):
+            return candidate
+    return None
+
+
+def _resolve_max_model_len(model_id: str, native_context: int | None) -> int | None:
+    """Return the memory-aware served context ceiling for ``model_id`` (the
+    ``max_model_len`` card field), or ``None`` when no live engine is loaded or
+    the estimate can't be formed.
+
+    Delegates the arithmetic to ``Scheduler.projected_memory_max_context`` so
+    the advertised number is the scheduler's own admission projection; here we
+    only resolve the live engine (same one ``context_window`` came from) and
+    its scheduler, and stay best-effort: any failure falls through to ``None``
+    rather than 500-ing the listing.
+    """
+    engine = _engine_for(model_id)
+    if engine is None:
+        return None
+    scheduler = _scheduler_of(engine)
+    if scheduler is None:
+        return None
+    probe = getattr(scheduler, "projected_memory_max_context", None)
+    if not callable(probe):
+        return None
+    try:
+        value = probe(native_context)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "max_model_len probe failed for %s: %s", model_id, exc, exc_info=False
+        )
+        return None
+    if not isinstance(value, int) or value <= 0:
+        return None
+    # Defensive cap: the scheduler already bounds by ``native_context``, but
+    # never advertise a memory ceiling larger than the model's own window.
+    if isinstance(native_context, int) and native_context > 0:
+        value = min(value, native_context)
+    return value
+
+
 def _resolve_context_window(model_id: str) -> int | None:
     """Return the engine-advertised max prompt-token context window for
     ``model_id`` when an engine is loaded for it, else ``None``.
@@ -70,25 +168,7 @@ def _resolve_context_window(model_id: str) -> int | None:
     # so the comparison is explicit and the relationship to the
     # helper's fallback constant is obvious to future readers.
     _DOS_SENTINEL_FLOOR = 4_194_304
-    engine = None
-    cfg = get_config()
-    if cfg.model_registry is not None:
-        try:
-            entry = cfg.model_registry.get_entry(model_id)
-        except KeyError:
-            entry = None
-        # ``get_entry`` falls back to the default entry on miss — guard
-        # that the entry we got actually matches ``model_id`` so the
-        # listing doesn't advertise the default engine's cap for every
-        # unloaded alias.
-        if entry is not None and entry.matches(model_id):
-            engine = entry.engine
-    else:
-        candidate = getattr(cfg, "engine", None)
-        if candidate is not None:
-            served = {cfg.model_name, cfg.model_alias} - {None}
-            if model_id in served:
-                engine = candidate
+    engine = _engine_for(model_id)
     if engine is None:
         return None
     try:
@@ -796,6 +876,10 @@ def _build_model_info(model_id: str) -> ModelInfo:
     # failures fall through to ``None`` and the client uses its own
     # per-family fallback. See ``_resolve_context_window`` docstring.
     context_window = _resolve_context_window(model_id)
+    # Memory-aware served ceiling (vLLM/SGLang-style ``max_model_len``),
+    # capped at ``context_window``. Best-effort like the window itself:
+    # ``None`` when no engine is loaded or the estimate can't be formed.
+    max_model_len = _resolve_max_model_len(model_id, context_window)
     # F-K-CAPABILITIES-OMIT-AUDIO: per-lane audio status snapshot, or
     # ``None`` when the deep probe never ran (e.g.
     # ``RAPID_MLX_AUDIO_DEEP_PROBE`` unset). Identical value is
@@ -845,6 +929,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
                 modality=_reported_modality_for_embedding(),
                 capabilities=["embedding"],
                 context_window=context_window,
+                max_model_len=max_model_len,
                 audio_lanes=audio_lanes,
             )
         sampling = (
@@ -865,6 +950,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
             modality=_reported_modality_for_embedding(),
             capabilities=["embedding"],
             context_window=context_window,
+            max_model_len=max_model_len,
             audio_lanes=audio_lanes,
         )
 
@@ -905,6 +991,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
                     tool_call_parser=eff_tool,
                     reasoning_parser=eff_reasoning,
                     context_window=context_window,
+                    max_model_len=max_model_len,
                     audio_lanes=audio_lanes,
                 )
         except Exception:  # noqa: BLE001
@@ -916,6 +1003,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
             tool_call_parser=eff_tool,
             reasoning_parser=eff_reasoning,
             context_window=context_window,
+            max_model_len=max_model_len,
             audio_lanes=audio_lanes,
         )
     # ``recommended_sampling`` lives on the dataclass as a tuple of
@@ -956,6 +1044,7 @@ def _build_model_info(model_id: str) -> ModelInfo:
         modality=_reported_modality(model_id, profile.modality, profile.is_text_only),
         capabilities=capabilities,
         context_window=context_window,
+        max_model_len=max_model_len,
         audio_lanes=audio_lanes,
     )
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -62,11 +62,15 @@ def _read_kv_dims(model):
 
     mlx-lm models expose the HF dims on ``.args`` (a ModelArgs dataclass), not
     a ``.config``; multimodal checkpoints nest the text tower under
-    ``text_config``. Walk both holders and both nesting levels — the same
-    source chain ``service.helpers.get_model_max_context`` uses — and return
-    the first that yields a usable layer/kv-head/head-dim triple plus the
-    config object those dims came from (so ``estimate_kv_footprint`` reads its
-    hybrid structural fields, e.g. ``layer_types``, from the SAME place).
+    ``text_config`` and may carry DECOY vision dims on the outer config. This
+    only runs when the scheduler's own config-based terms could not resolve,
+    but it still mirrors the admission path's tower selection so it can't pick
+    the wrong one: a config whose OWN ``layer_types`` validates against its OWN
+    ``num_hidden_layers`` (``_pick_structural_config``'s rule) wins, then the
+    nested ``text_config``, then the outer holder (dense: neither validates and
+    only the outer carries dims). Returns the triple plus the config the dims
+    came from, so ``estimate_kv_footprint`` reads its hybrid structural fields
+    from the SAME place.
     """
 
     def _pos_int(value):
@@ -76,25 +80,43 @@ def _read_kv_dims(model):
             return None
         return ivalue if ivalue > 0 else None
 
-    holders = (getattr(model, "config", None), getattr(model, "args", None))
-    for holder in holders:
+    def _dims_of(cfg):
+        if cfg is None:
+            return None
+        layers = _pos_int(_cfg_get(cfg, "num_hidden_layers"))
+        kv_heads = _pos_int(_cfg_get(cfg, "num_key_value_heads")) or _pos_int(
+            _cfg_get(cfg, "num_attention_heads")
+        )
+        head_dim = _pos_int(_cfg_get(cfg, "head_dim"))
+        if head_dim is None:
+            hidden = _pos_int(_cfg_get(cfg, "hidden_size"))
+            heads = _pos_int(_cfg_get(cfg, "num_attention_heads"))
+            if hidden and heads:
+                head_dim = hidden // heads
+        if layers and kv_heads and head_dim:
+            return layers, kv_heads, head_dim, cfg
+        return None
+
+    for holder in (getattr(model, "config", None), getattr(model, "args", None)):
         if holder is None:
             continue
-        for cfg in (holder, _cfg_get(holder, "text_config")):
+        text_cfg = _cfg_get(holder, "text_config")
+        # 1) The structural tower: the config whose own layer_types validates
+        #    against its own num_hidden_layers (the text tower for a hybrid).
+        for cfg in (holder, text_cfg):
             if cfg is None:
                 continue
-            layers = _pos_int(_cfg_get(cfg, "num_hidden_layers"))
-            kv_heads = _pos_int(_cfg_get(cfg, "num_key_value_heads")) or _pos_int(
-                _cfg_get(cfg, "num_attention_heads")
-            )
-            head_dim = _pos_int(_cfg_get(cfg, "head_dim"))
-            if head_dim is None:
-                hidden = _pos_int(_cfg_get(cfg, "hidden_size"))
-                heads = _pos_int(_cfg_get(cfg, "num_attention_heads"))
-                if hidden and heads:
-                    head_dim = hidden // heads
-            if layers and kv_heads and head_dim:
-                return layers, kv_heads, head_dim, cfg
+            n = _pos_int(_cfg_get(cfg, "num_hidden_layers"))
+            if n and _valid_layer_types(_cfg_get(cfg, "layer_types"), n):
+                dims = _dims_of(cfg)
+                if dims is not None:
+                    return dims
+        # 2) No validating layer_types (dense / non-hybrid multimodal): prefer
+        #    the nested text tower over the outer (possibly-decoy) config.
+        for cfg in (text_cfg, holder):
+            dims = _dims_of(cfg)
+            if dims is not None:
+                return dims
     return None
 
 
@@ -4963,34 +4985,47 @@ class Scheduler:
         field absent rather than advertising a fabricated cap.
         """
         try:
-            # Architecture-aware KV footprint of one sequence. The scheduler's
-            # cached terms (``_resolve_kv_bytes_per_token``) read
-            # ``self.model.config``, which mlx-lm models do NOT expose — they
-            # carry the dims on ``.args`` — so resolve them permissively here
-            # (the same source chain ``get_model_max_context`` walks) and run
-            # the exact hybrid-aware estimator the admission projection uses.
-            dims = _read_kv_dims(self.model)
-            if dims is None:
-                return None
-            num_layers, kv_heads, head_dim, struct_cfg = dims
-            dtype_bytes = self._infer_kv_dtype_bytes(struct_cfg)
-            uniform_per_token = 2 * num_layers * kv_heads * head_dim * dtype_bytes
-            if uniform_per_token <= 0:
-                return None
-            estimate = estimate_kv_footprint(
-                struct_cfg,
-                dtype_bytes=dtype_bytes,
-                uniform_per_token_bytes=uniform_per_token,
-                base_num_layers=num_layers,
-                base_kv_heads=kv_heads,
-                base_head_dim=head_dim,
-            )
-            per_tok = estimate.per_token_growth_bytes
-            fixed_baseline = estimate.fixed_baseline_bytes
-            sliding_slot_bytes = estimate.sliding_slot_bytes
-            sliding_window = estimate.sliding_window
+            # Prefer the scheduler's OWN resolved footprint terms so the
+            # advertised ceiling can never diverge from what admission would
+            # actually charge: these honor the operator
+            # ``metal_cap_kv_bytes_per_token`` override and use
+            # ``_pick_structural_config`` to select the right tower on
+            # multimodal/hybrid configs. They are populated whenever the model
+            # exposes a ``.config`` (the admission path's own source).
+            per_tok = self._resolve_kv_bytes_per_token()
+            fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
+            sliding_slot_bytes = self._kv_sliding_slot_bytes
+            sliding_window = self._kv_sliding_window
             if per_tok <= 0 and fixed_baseline <= 0 and sliding_slot_bytes <= 0:
-                return None
+                # The scheduler could not resolve terms — mlx-lm models expose
+                # dims on ``.args``, not ``.config``, so its config-only read
+                # yields 0 (and the admission cap is likewise a no-op there, so
+                # there is nothing to diverge from). Fall back to reading the
+                # dims off the model and running the SAME hybrid-aware
+                # estimator, preferring the text tower over any decoy outer
+                # config (``_read_kv_dims``).
+                dims = _read_kv_dims(self.model)
+                if dims is None:
+                    return None
+                num_layers, kv_heads, head_dim, struct_cfg = dims
+                dtype_bytes = self._infer_kv_dtype_bytes(struct_cfg)
+                uniform_per_token = 2 * num_layers * kv_heads * head_dim * dtype_bytes
+                if uniform_per_token <= 0:
+                    return None
+                estimate = estimate_kv_footprint(
+                    struct_cfg,
+                    dtype_bytes=dtype_bytes,
+                    uniform_per_token_bytes=uniform_per_token,
+                    base_num_layers=num_layers,
+                    base_kv_heads=kv_heads,
+                    base_head_dim=head_dim,
+                )
+                per_tok = estimate.per_token_growth_bytes
+                fixed_baseline = estimate.fixed_baseline_bytes
+                sliding_slot_bytes = estimate.sliding_slot_bytes
+                sliding_window = estimate.sliding_window
+                if per_tok <= 0 and fixed_baseline <= 0 and sliding_slot_bytes <= 0:
+                    return None
 
             if not mx.metal.is_available():
                 return None

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -54,6 +54,50 @@ from .kv_estimation import (  # noqa: E402
     estimate_kv_footprint,
     rotating_cache_slots,
 )
+
+
+def _read_kv_dims(model):
+    """Permissively resolve ``(num_layers, kv_heads, head_dim, struct_cfg)``
+    from a loaded model, or ``None``.
+
+    mlx-lm models expose the HF dims on ``.args`` (a ModelArgs dataclass), not
+    a ``.config``; multimodal checkpoints nest the text tower under
+    ``text_config``. Walk both holders and both nesting levels — the same
+    source chain ``service.helpers.get_model_max_context`` uses — and return
+    the first that yields a usable layer/kv-head/head-dim triple plus the
+    config object those dims came from (so ``estimate_kv_footprint`` reads its
+    hybrid structural fields, e.g. ``layer_types``, from the SAME place).
+    """
+
+    def _pos_int(value):
+        try:
+            ivalue = int(value)
+        except (TypeError, ValueError):
+            return None
+        return ivalue if ivalue > 0 else None
+
+    holders = (getattr(model, "config", None), getattr(model, "args", None))
+    for holder in holders:
+        if holder is None:
+            continue
+        for cfg in (holder, _cfg_get(holder, "text_config")):
+            if cfg is None:
+                continue
+            layers = _pos_int(_cfg_get(cfg, "num_hidden_layers"))
+            kv_heads = _pos_int(_cfg_get(cfg, "num_key_value_heads")) or _pos_int(
+                _cfg_get(cfg, "num_attention_heads")
+            )
+            head_dim = _pos_int(_cfg_get(cfg, "head_dim"))
+            if head_dim is None:
+                hidden = _pos_int(_cfg_get(cfg, "hidden_size"))
+                heads = _pos_int(_cfg_get(cfg, "num_attention_heads"))
+                if hidden and heads:
+                    head_dim = hidden // heads
+            if layers and kv_heads and head_dim:
+                return layers, kv_heads, head_dim, cfg
+    return None
+
+
 from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig  # noqa: E402
 from .paged_cache import PagedCacheManager
 from .pflash import PFlashConfig, compress_request_tokens
@@ -4884,6 +4928,121 @@ class Scheduler:
         """
         self._resolve_kv_bytes_per_token()
         return self._kv_fixed_baseline_bytes
+
+    def projected_memory_max_context(
+        self, native_context: int | None = None
+    ) -> int | None:
+        """Largest context length whose projected KV footprint fits this
+        device's memory budget right now, or ``None`` when it can't be
+        estimated.
+
+        This is the number behind the ``max_model_len`` model-card field:
+        vLLM/SGLang expose ``max_model_len`` as the served ceiling but crash
+        if it won't fit KV memory; on unified-memory Apple silicon we can go
+        one better and REPORT the memory-fitted ceiling instead of aborting.
+
+        The footprint is the exact per-request projection the admission gate
+        uses (``_estimate_request_kv_bytes``), so the advertised number lines
+        up with what the scheduler would actually admit::
+
+            footprint(T) = fixed_baseline
+                           + per_token_growth * T
+                           + sliding_slot_bytes * rotating_cache_slots(window, T)
+
+        Budget = device working set × utilization − currently-resident bytes.
+        Utilization is the operator's ``gpu_memory_utilization`` when a Metal
+        cap is configured, else a conservative reporting default so the field
+        is populated on the default (cap-disabled) config too. Residency is a
+        point-in-time ``get_active_memory()`` reading — weights plus any live
+        KV/prefix cache — so the number reflects what could be added NOW; it
+        is advisory, re-derived per call, and capped at ``native_context``.
+
+        Returns ``None`` (not a guess) on any failure — a stub/unknown model
+        with no resolvable footprint, no Metal device, or a non-positive
+        budget — so the ``/v1/models`` builder falls through to leaving the
+        field absent rather than advertising a fabricated cap.
+        """
+        try:
+            # Architecture-aware KV footprint of one sequence. The scheduler's
+            # cached terms (``_resolve_kv_bytes_per_token``) read
+            # ``self.model.config``, which mlx-lm models do NOT expose — they
+            # carry the dims on ``.args`` — so resolve them permissively here
+            # (the same source chain ``get_model_max_context`` walks) and run
+            # the exact hybrid-aware estimator the admission projection uses.
+            dims = _read_kv_dims(self.model)
+            if dims is None:
+                return None
+            num_layers, kv_heads, head_dim, struct_cfg = dims
+            dtype_bytes = self._infer_kv_dtype_bytes(struct_cfg)
+            uniform_per_token = 2 * num_layers * kv_heads * head_dim * dtype_bytes
+            if uniform_per_token <= 0:
+                return None
+            estimate = estimate_kv_footprint(
+                struct_cfg,
+                dtype_bytes=dtype_bytes,
+                uniform_per_token_bytes=uniform_per_token,
+                base_num_layers=num_layers,
+                base_kv_heads=kv_heads,
+                base_head_dim=head_dim,
+            )
+            per_tok = estimate.per_token_growth_bytes
+            fixed_baseline = estimate.fixed_baseline_bytes
+            sliding_slot_bytes = estimate.sliding_slot_bytes
+            sliding_window = estimate.sliding_window
+            if per_tok <= 0 and fixed_baseline <= 0 and sliding_slot_bytes <= 0:
+                return None
+
+            if not mx.metal.is_available():
+                return None
+            info = mx.device_info()
+            base = int(
+                info.get("max_recommended_working_set_size", info.get("memory_size", 0))
+                or 0
+            )
+            if base <= 0:
+                return None
+
+            util = float(getattr(self.config, "gpu_memory_utilization", 0.0) or 0.0)
+            if util <= 0.0:
+                # The Metal admission cap is disabled by default, but the
+                # reporting field should still be populated. 0.90 mirrors the
+                # engine's allocation-side default working-set fraction.
+                util = 0.90
+            budget = int(base * util)
+            resident = int(mx.get_active_memory())
+            available = budget - resident
+            if available <= 0:
+                return None
+
+            def _footprint(tokens: int) -> int:
+                return (
+                    fixed_baseline
+                    + per_tok * tokens
+                    + sliding_slot_bytes * rotating_cache_slots(sliding_window, tokens)
+                )
+
+            # Search up to the native window when known (the field is capped
+            # there anyway), else a generous ceiling covering 1M-context models.
+            upper = (
+                native_context
+                if isinstance(native_context, int) and native_context > 0
+                else 8_000_000
+            )
+            if _footprint(upper) <= available:
+                # Memory is not the binding constraint — the native window fits.
+                return upper
+            # Monotonic non-decreasing footprint → binary-search the largest T.
+            lo, hi = 0, upper
+            while lo < hi:
+                mid = (lo + hi + 1) // 2
+                if _footprint(mid) <= available:
+                    lo = mid
+                else:
+                    hi = mid - 1
+            return lo if lo > 0 else None
+        except Exception:  # noqa: BLE001
+            # Never let a memory-probe failure break the models endpoint.
+            return None
 
     def _estimate_request_kv_bytes(self, request: Request) -> int:
         """Project KV-cache memory the new request would consume.


### PR DESCRIPTION
## Why

Two related gaps in what the server tells a client:

1. **`/v1/models` advertised `context_window` (the model's NATIVE window) but not what actually fits on THIS machine.** On unified-memory Apple silicon the real ceiling is device memory (weights + KV cache). The out-of-tree DSH provider (`raullenchai/rapid-mlx-dsh-provider`) times compaction off the capacity we report, so a native window that can't fit memory makes it compact too late. vLLM/SGLang expose `max_model_len` on the OpenAI model card for exactly this role — a documented vendor extension (OpenAI SDKs parse extras with `extra="allow"`) — but theirs is only the config ceiling and they **crash** when it won't fit KV memory. We report the **memory-fitted** ceiling instead.

2. **`rapid-mlx models` had no machine-readable output.** The desktop app and the DSH provider both scrape its fixed-width text table; a column shift silently drops rows. `--json` gives them stable keys.

## What

- **`Scheduler.projected_memory_max_context(native)`** — largest `T` whose KV footprint fits `device_working_set × util − resident_bytes`, using the **same** architecture-aware projection the admission gate uses (`estimate_kv_footprint`: per-token growth + sliding-window + recurrent baseline), inverted by binary search, capped at the native window. Dims come from a new `_read_kv_dims` — mlx-lm exposes them on `.args`, not `.config`, which is why the scheduler's own cached KV terms read 0 for these models. Returns `None` (never a guess) on any failure.
- **`ModelInfo.max_model_len: int | None`** — additive vendor extension beside `context_window`; serialized (no `exclude_none`) so present-null vs absent is preserved. Populated in `routes/models._build_model_info` via `_resolve_max_model_len` → `_scheduler_of` (walks `BatchedEngine` → `AsyncEngineCore` → `EngineCore`). `_engine_for` is extracted and shared with `_resolve_context_window` (no behavior change).
- **`rapid-mlx models --json`** (and `--cached --json`) — structured payloads for the available (text/audio/video/image) and cached views. JSON mode emits only the document (no staleness banner) so it pipes cleanly. The text format is untouched — the desktop parser still works.
- Contract test pins `max_model_len` as a tri-state field the provider reads.

## Verification

- **32 new unit tests** (footprint inversion incl. memory-capped / native-fits / budget-exhausted / hybrid dims; `--json` shape both views; contract) + **275 existing** model/kv/metal-cap/cli tests green.
- **End to end on a live server** (18 GB M-series): `/v1/models` now carries `max_model_len` (40960 for `qwen3-0.6b-8bit` — native fits memory); `models --json` and `--cached --json` emit valid documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)