### PR TITLE
docs(mac): finish release docs reconciliation

### DIFF
--- a/.github/workflows/rapid-mac-release.yml
+++ b/.github/workflows/rapid-mac-release.yml
@@ -50,10 +50,8 @@
 # NOTE: Sentry has been removed from the monorepo app; there is no
 # SENTRY_DSN secret here (the desktop workflow had one).
 #
-# NOTE: GitHub only reads workflows from ``.github/workflows`` at the
-# REPOSITORY ROOT. The copy under ``apps/rapid-mac/.github/`` is INERT —
-# it is never scheduled. This file (at the repo root) is the only one that
-# runs. Do not edit the app-local copy expecting it to take effect.
+# NOTE: GitHub reads this workflow from ``.github/workflows`` at the
+# repository root. This is the canonical Rapid Mac release workflow.
 #
 # The temp keychain password is generated at runtime, never stored.
 name: rapid-mac-release

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -67,7 +67,7 @@ exported.
 - Voice notes in Apple formats (M4A, CAF, …) transcribe directly — the app
   transcodes them for the server on the fly.
 
-## [0.12.15] — 2026-08-17
+## [0.12.15] — 2026-08-18
 
 Fixes a bug that could silently truncate files your coding agent writes, adds a
 Developer section to Settings, and brings MTP acceleration to the Qwen 3.8


### PR DESCRIPTION
## Why

PR #2132 landed the core fixes for #2085 and #2087 while this PR was in validation. Two verified drift items remain on main:

- the release workflow comment still directs maintainers away from a nonexistent `apps/rapid-mac/.github/` copy;
- the 0.12.15 changelog date is 2026-08-17 even though the tag/release was published on 2026-08-18, as #2087 noted.

This rebased follow-up contains only those two residual corrections. No workflow behavior changes.

## Test plan

- [x] Verify `rapid-mac-v0.12.15` release publication date via GitHub.
- [x] Verify no `apps/rapid-mac/.github/` workflow copy exists.
- [x] `git diff --check`
- [x] `bash -n apps/rapid-mac/scripts/release-local.sh`