### PR TITLE
fix(pr_validate): stress gate judges on warm when cold spread is noisy (#2118)

### DIFF
--- a/scripts/pr_validate/steps/stress_e2e_bench.py
+++ b/scripts/pr_validate/steps/stress_e2e_bench.py
@@ -916,10 +916,27 @@ def _bench_ab_against_base(
         for arm in ("base", "pr")
         for metric in ("cold", "warm")
     }
-    noisy = [
+    # Warm is the steady-state latency users actually live with; if either arm's
+    # WARM capture is noisy the machine genuinely is not quiet enough to judge.
+    #
+    # Cold-start latency is different in kind, not just degree: on the large-model
+    # matrix each round evicts the previous model from the page cache and pays a
+    # fresh per-process Metal kernel compilation, so cold spread is dominated by
+    # intrinsic, non-ambient variance (see #2118 and the artifact note in
+    # ``_measure_bench``). Gating on it made the quiet-machine check structurally
+    # unsatisfiable for high-blast PRs — every run went INCONCLUSIVE while the
+    # measured A/B delta was within noise. So a noisy cold spread no longer blocks:
+    # the warm A/B still decides the verdict, and the cold delta is demoted to
+    # advisory (unmeasurable here) rather than forcing a maintainer merge call.
+    warm_noisy = [
         f"{name} {value:.1f}%"
         for name, value in spreads.items()
-        if value > thresholds[name.rsplit("_", 1)[1]]
+        if name.endswith("_warm") and value > thresholds["warm"]
+    ]
+    cold_noisy = [
+        f"{name} {value:.1f}%"
+        for name, value in spreads.items()
+        if name.endswith("_cold") and value > thresholds["cold"]
     ]
     best = {
         arm: {
@@ -932,6 +949,8 @@ def _bench_ab_against_base(
         metric: (best["pr"][metric] / best["base"][metric] - 1) * 100
         for metric in ("cold", "warm")
     }
+    # Judge cold only when its capture was quiet; otherwise warm alone decides.
+    judged = ("cold", "warm") if not cold_noisy else ("warm",)
     artifact = ctx.artifact_path(f"bench-ab-{_safe_name(choice.model_id)}.json")
     artifact.write_text(
         json.dumps(
@@ -943,28 +962,37 @@ def _bench_ab_against_base(
                 "capture_spread_pct": spreads,
                 "best": best,
                 "delta_pct": delta,
+                "judged_metrics": list(judged),
+                "cold_advisory": bool(cold_noisy),
             },
             indent=2,
         )
     )
     detail = f"cold {delta['cold']:+.1f}%, warm {delta['warm']:+.1f}% vs base"
-    if noisy:
+    if warm_noisy:
+        noisy = warm_noisy + cold_noisy
         return {
             "status": "skip",
             "summary": f"machine not quiet enough to judge ({', '.join(noisy)}); {detail}",
             "artifact": str(artifact),
             "executed": True,
         }
-    if any(delta[m] > thresholds[m] for m in ("cold", "warm")):
+    advisory = ""
+    if cold_noisy:
+        advisory = (
+            f"; cold spread too high to judge ({', '.join(cold_noisy)}) — "
+            "cold delta advisory only, verdict on warm"
+        )
+    if any(delta[m] > thresholds[m] for m in judged):
         return {
             "status": "fail",
-            "summary": f"perf regression confirmed: {detail}",
+            "summary": f"perf regression confirmed: {detail}{advisory}",
             "artifact": str(artifact),
             "executed": True,
         }
     return {
         "status": "pass",
-        "summary": f"not this PR: {detail}",
+        "summary": f"not this PR: {detail}{advisory}",
         "artifact": str(artifact),
         "executed": True,
     }

--- a/tests/test_bench_declines_on_a_busy_machine.py
+++ b/tests/test_bench_declines_on_a_busy_machine.py
@@ -204,22 +204,55 @@ def test_steady_contention_cancels(monkeypatch, tmp_path):
     assert "not this PR" in result["summary"], result["summary"]
 
 
-def test_a_noisy_base_arm_cannot_waive_a_regression(monkeypatch, tmp_path):
-    """An inflated base is the denominator — as dangerous as a noisy PR arm."""
+def test_a_noisy_base_warm_arm_cannot_waive_a_regression(monkeypatch, tmp_path):
+    """An inflated base WARM is the denominator — as dangerous as a noisy PR arm.
+
+    Warm is the authoritative metric (see #2118): a noisy warm capture on either
+    arm means the machine is not quiet enough to trust the steady-state number,
+    so the A/B declines rather than risk waiving a regression through an inflated
+    denominator.
+    """
     result, _, _ = _harness(
-        monkeypatch, tmp_path, [(350, 400), (250, 400)], [(350, 400)] * 2
+        monkeypatch, tmp_path, [(250, 560), (250, 400)], [(250, 400)] * 2
     )
     assert result["status"] == "skip", result
     assert "not quiet enough" in result["summary"], result["summary"]
-    assert "base_cold" in result["summary"], result["summary"]
+    assert "base_warm" in result["summary"], result["summary"]
 
 
-def test_a_noisy_pr_arm_also_declines(monkeypatch, tmp_path):
+def test_a_noisy_pr_warm_arm_also_declines(monkeypatch, tmp_path):
     result, _, _ = _harness(
-        monkeypatch, tmp_path, [(250, 400)] * 2, [(350, 400), (250, 400)]
+        monkeypatch, tmp_path, [(250, 400)] * 2, [(250, 560), (250, 400)]
     )
     assert result["status"] == "skip", result
-    assert "pr_cold" in result["summary"], result["summary"]
+    assert "pr_warm" in result["summary"], result["summary"]
+
+
+def test_cold_noise_alone_is_advisory_not_inconclusive(monkeypatch, tmp_path):
+    """#2118: cold-start spread is intrinsic on the large-model matrix (page-cache
+    eviction + Metal kernel compile), so a noisy cold spread with a quiet warm
+    capture no longer forces INCONCLUSIVE. The warm A/B decides; cold is advisory.
+    """
+    result, _, _ = _harness(
+        monkeypatch, tmp_path, [(250, 400), (600, 400)], [(250, 400), (600, 400)]
+    )
+    assert result["status"] == "pass", result
+    assert "not this PR" in result["summary"], result["summary"]
+    assert "advisory" in result["summary"], result["summary"]
+    assert "verdict on warm" in result["summary"], result["summary"]
+
+
+def test_a_warm_regression_survives_cold_noise(monkeypatch, tmp_path):
+    """Cold noise must not waive a real WARM regression. With cold noisy on both
+    arms but warm quiet and clearly slower on the PR, the gate still fails — the
+    cold delta is merely demoted to advisory, not the verdict.
+    """
+    result, _, _ = _harness(
+        monkeypatch, tmp_path, [(250, 400), (600, 400)], [(250, 500), (600, 500)]
+    )
+    assert result["status"] == "fail", result
+    assert "regression confirmed" in result["summary"], result["summary"]
+    assert "advisory" in result["summary"], result["summary"]
 
 
 def test_both_arms_see_matched_prompt_sets(monkeypatch, tmp_path):


### PR DESCRIPTION
## Why

Closes #2118. The `stress_e2e_bench` quiet-machine check compares the max/min spread of `cold_request_ms_median` **and** `warm_request_ms_median` across A/B rounds against a ~5% threshold, and returns INCONCLUSIVE if either is noisy.

Cold-start latency on the large-model matrix is dominated by two intrinsic (not ambient) sources: page-cache eviction between rounds — the 4-large-model matrix guarantees eviction — and per-process Metal kernel compilation. So the cold spread structurally exceeds ~5% for high-blast PRs, and because max/min spread is monotonic in sample count, adding rounds only makes it worse. The gate became **unsatisfiable**: `#2108` and `#2109` both landed only via a maintainer merge call after 6 attempts across quiet and busy machines all returned INCONCLUSIVE with cold spreads of 9–23%, while the measured A/B deltas were within ±0.6% every time and warm was clean.

## What

Warm is the steady-state latency users live with — make it authoritative (issue direction #1):

- Only a noisy **warm** capture (either arm) forces INCONCLUSIVE — an inflated warm denominator can still waive a real regression, so that case correctly declines.
- A noisy **cold** spread no longer blocks. The warm A/B decides the verdict; the cold delta is demoted to **advisory** (genuinely unmeasurable on this hardware) and the summary says so.
- `judged` metrics = `("cold", "warm")` when cold is quiet, `("warm",)` when cold is noisy — so a cold regression is still caught when the cold capture is trustworthy, and a warm regression is still caught even amid cold noise.
- The artifact now records `judged_metrics` and `cold_advisory`.

No safety loss: the only outcome that changes is cold-noisy runs, which previously produced INCONCLUSIVE (a deferral to a human), not a verdict.

## Tests

- Rewrote the two `_noisy_*_arm` tests around **warm** (the now-authoritative metric) — a noisy warm base/PR arm still declines.
- Added `test_cold_noise_alone_is_advisory_not_inconclusive` (cold noisy, warm quiet → PASS with advisory) and `test_a_warm_regression_survives_cold_noise` (cold noisy, warm regressed → FAIL on warm). Both **fail on the pre-fix code** (verified by reverting the source: 2 failed → skip vs fail/pass).
- Full file 18 passed; related bench/pr_validate suites 67 passed; ruff check + format clean.

Authored with AI assistance (Claude Opus 4.8).
