### PR TITLE
fix(cli): drop hardcoded alias count from unknown-model breadcrumb

### DIFF
--- a/tests/test_unknown_model_help_breadcrumb.py
+++ b/tests/test_unknown_model_help_breadcrumb.py
@@ -1,0 +1,47 @@
+"""Regression for dogfood #2126: the unknown-model help breadcrumb must
+not print a hardcoded alias total that contradicts the ``rapid-mlx
+models`` command it points at.
+
+``list_aliases()`` == ``list_profiles()`` (182), but ``models`` splits
+that registry into tagged sections (chat / audio / video / image) and its
+first header shows only the chat subset (172). Embedding a grand total in
+the breadcrumb therefore guaranteed a mismatch with the first number a
+user lands on. The fix drops the number and lets ``models`` be the single
+source of truth for the per-section counts.
+"""
+
+from __future__ import annotations
+
+import re
+
+from vllm_mlx import cli
+
+
+def _capture_unknown_model_help(capsys, name: str = "totally-unknown-xyz") -> str:
+    cli._print_unknown_model_help(
+        name, full_path_example="mlx-community/Qwen3.5-9B-4bit"
+    )
+    return capsys.readouterr().out
+
+
+def test_breadcrumb_still_points_at_models(capsys):
+    """The help must still route the user to ``rapid-mlx models``."""
+    out = _capture_unknown_model_help(capsys)
+    assert "rapid-mlx models" in out
+    assert "aliases" in out
+
+
+def test_breadcrumb_does_not_embed_a_hardcoded_alias_count(capsys):
+    """Pre-fix this line read ``... to see all 182 aliases`` while
+    ``models`` opened with ``Available models (172 aliases)`` — a visible
+    contradiction. The ``models``-pointer line must carry no standalone
+    integer count that can drift from what ``models`` displays."""
+    out = _capture_unknown_model_help(capsys)
+    models_line = next(
+        (ln for ln in out.splitlines() if "rapid-mlx models" in ln), None
+    )
+    assert models_line is not None, f"no models breadcrumb line in: {out!r}"
+    assert not re.search(r"\d", models_line), (
+        f"breadcrumb must not hardcode an alias count that can contradict "
+        f"`rapid-mlx models`, got: {models_line!r}"
+    )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -528,14 +528,20 @@ def _print_unknown_model_help(name: str, *, full_path_example: str) -> None:
     supported). Now: always show *something* — fuzzy matches when we have
     them, curated popular aliases when we don't.
     """
-    from vllm_mlx.model_aliases import POPULAR_ALIASES, list_aliases, suggest_similar
+    from vllm_mlx.model_aliases import POPULAR_ALIASES, suggest_similar
 
     suggestions = suggest_similar(name)
     if suggestions:
         print(f"  Did you mean: {', '.join(suggestions)}?")
     else:
         print(f"  Try one of: {', '.join(POPULAR_ALIASES)}")
-    print(f"  Run `rapid-mlx models` to see all {len(list_aliases())} aliases,")
+    # No hardcoded alias total here. ``models`` splits the registry into
+    # tagged sections (chat / audio / video / image), each with its own
+    # accurate per-section count, so a single grand total printed here can
+    # only contradict the first header a user lands on (dogfood #2126:
+    # this line said "182 aliases" while ``models`` opened with "172").
+    # Let ``models`` be the single source of truth for the counts.
+    print("  Run `rapid-mlx models` to see all available aliases,")
     print(f"  or pass a full path like: {full_path_example}")
 
 


### PR DESCRIPTION
## Why
The "not a known alias" help printed `Run \`rapid-mlx models\` to see all 182 aliases,` — 182 from `len(list_aliases())`. But the `rapid-mlx models` command it points at splits the registry into tagged sections (chat / audio / video / image) and its first header shows only the chat subset: `Available models (172 aliases)`. A user following the breadcrumb saw "182", landed on "172", and could not reconcile them. Closes #2126.

## What
Drop the hardcoded number from the breadcrumb (`to see all available aliases`) and let `models` be the single source of truth for the per-section counts. Also removes the now-unused `list_aliases` import; future-proof against registry drift.

## Tests
- `tests/test_unknown_model_help_breadcrumb.py`: breadcrumb still routes to `rapid-mlx models` **and** carries no standalone integer that can contradict it. The count assertion fails on main (prints "182") and passes after the fix.

## Notes
Purely cosmetic UX; found during the 0.12.16 release dogfood. Companion to #2125. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)