### PR TITLE
fix(mac): show background update progress

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -463,6 +463,12 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/update-state
 
+      - name: 'Golden flow: update-busy'
+        continue-on-error: true
+        run: ./scripts/gui-golden-flows.sh --flow update-busy
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/update-busy
+
       - name: 'Golden flow: launch-integrations'
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow launch-integrations
@@ -483,7 +489,7 @@ jobs:
           from pathlib import Path
 
           root = Path(os.environ["GOLDEN_ROOT"])
-          expected = 25
+          expected = 26
           results = sorted(root.glob("*/result.json"))
           failures = []
           for path in results:
@@ -525,7 +531,7 @@ jobs:
           set -uo pipefail
           mkdir -p "$SCRATCH/snapshots"
           cp Tests/GUIGoldenFlows/__Snapshots__/*.txt "$SCRATCH/snapshots/"
-          for flow in fresh-install settings-persistence settings-mtp chat-restore slow-stream-stop model-crash-recovery update-state image-generation audio-readiness launch-integrations; do
+          for flow in fresh-install settings-persistence settings-mtp chat-restore slow-stream-stop model-crash-recovery update-state update-busy image-generation audio-readiness launch-integrations; do
             RAPID_GUI_BASELINE_DIR="$SCRATCH/snapshots" \
             RAPID_GUI_GOLDEN_OUT="$SCRATCH/run/$flow" \
               ./scripts/gui-golden-flows.sh --flow "$flow" --update-baselines || true

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -233,8 +233,31 @@ struct RapidApp: App {
             customInstructions: customInstructionsConfig,
             server: manager
         )
-        let updateChecker = UpdateChecker()
-        let sparkleUpdateController = SparkleUpdateController()
+        // Deterministic AX fixture for the otherwise release-only state where
+        // Sparkle is already downloading in the background. Requiring both
+        // variables keeps this inert in every normal/dev launch.
+        let updateBusyFixture = ProcessInfo.processInfo.environment["RAPID_GUI_GOLDEN_MODE"] == "1"
+            && ProcessInfo.processInfo.environment["RAPID_GUI_UPDATE_BUSY_FIXTURE"] == "1"
+        let updateFetcher: UpdateChecker.Fetcher?
+        if updateBusyFixture {
+            updateFetcher = {
+                UpdateChecker.Release(
+                    schemaVersion: 1,
+                    version: "99.0.0",
+                    tagName: "rapid-mac-v99.0.0",
+                    htmlURL: "https://rapidmlx.com/desktop",
+                    notes: "Golden-flow update fixture.",
+                    publishedAt: "2026-08-19T00:00:00Z",
+                    dmgURL: "https://dl.rapidmlx.com/rapid-mac-v99.0.0.dmg"
+                )
+            }
+        } else {
+            updateFetcher = nil
+        }
+        let updateChecker = UpdateChecker(fetcher: updateFetcher)
+        let sparkleUpdateController = SparkleUpdateController(
+            fixtureState: updateBusyFixture ? .busy : nil
+        )
         let downloadsInstance = DownloadManager(binaryPath: manager.binaryPath)
         // #253: let ``ServerManager.start(alias:)`` await any in-flight
         // background pull for the same alias before spawning serve.

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -953,14 +953,27 @@ struct SettingsView: View {
                 // uses, so a compromised manifest cannot turn this into a
                 // phishing redirect.
                 if sparkleUpdater.isEnabled {
-                    Button {
-                        sparkleUpdater.checkForUpdates()
-                    } label: {
-                        Label("Update Rapid-MLX", systemImage: "arrow.down.circle.fill")
+                    if sparkleUpdater.canCheckForUpdates {
+                        Button {
+                            sparkleUpdater.checkForUpdates()
+                        } label: {
+                            Label("Update Rapid-MLX", systemImage: "arrow.down.circle.fill")
+                        }
+                        .buttonStyle(.rapidPrimary)
+                        .help("Opens the updater to download and install this release.")
+                        .accessibilityIdentifier("Settings.App.UpdateCTA")
+                    } else {
+                        HStack(spacing: RapidTheme.Space.sm) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Update in progress…")
+                                .font(RapidFont.bodyEmphasis)
+                        }
+                        .foregroundStyle(RapidTheme.textSecondary)
+                        .help("Rapid-MLX is checking or downloading the update in the background.")
+                        .accessibilityElement(children: .combine)
+                        .accessibilityIdentifier("Settings.App.UpdateBusy")
                     }
-                    .buttonStyle(.rapidPrimary)
-                    .help("Opens the updater to download and install this release.")
-                    .accessibilityIdentifier("Settings.App.UpdateCTA")
                 } else if let releaseURL = ContentView.missingOverlayDownloadURL(
                     for: appUpdater.availableUpdate
                 ) {

--- a/apps/rapid-mac/Sources/Rapid/Updater/SparkleUpdateController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/SparkleUpdateController.swift
@@ -14,17 +14,38 @@ import Sparkle
 @MainActor
 @Observable
 final class SparkleUpdateController {
+    enum FixtureState {
+        case busy
+    }
+
     private var standardController: SPUStandardUpdaterController?
+    private var canCheckObservation: NSKeyValueObservation?
     private(set) var isStarted = false
     private(set) var automaticallyDownloadsUpdates: Bool
+    /// Mirrors Sparkle's KVO-compliant state so SwiftUI never presents an
+    /// enabled control whose action Sparkle is required to ignore. In
+    /// particular, `canCheckForUpdates` is false while an automatic appcast or
+    /// update download is running in the background.
+    private(set) var canCheckForUpdates: Bool
+    private let fixtureState: FixtureState?
 
     let isEnabled: Bool
 
     init(
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
-        checksEnabled: Bool = UpdateChecker.updateChecksEnabled()
+        checksEnabled: Bool = UpdateChecker.updateChecksEnabled(),
+        fixtureState: FixtureState? = nil
     ) {
-        isEnabled = checksEnabled && Self.hasValidConfiguration(infoDictionary)
+        self.fixtureState = fixtureState
+        isEnabled = fixtureState != nil || (checksEnabled && Self.hasValidConfiguration(infoDictionary))
+        // Preserve the pre-start contract: an enabled production controller
+        // is actionable until Sparkle starts and publishes its real KVO
+        // state. The deterministic busy fixture is the sole exception.
+        if case .busy = fixtureState {
+            canCheckForUpdates = false
+        } else {
+            canCheckForUpdates = isEnabled
+        }
         automaticallyDownloadsUpdates = isEnabled
             ? (UserDefaults.standard.object(forKey: "SUAutomaticallyUpdate") as? Bool ?? true)
             : false
@@ -35,6 +56,10 @@ final class SparkleUpdateController {
     /// downloaded update is installed when Rapid next quits normally.
     func start() {
         guard isEnabled, !isStarted else { return }
+        if fixtureState != nil {
+            isStarted = true
+            return
+        }
         let controller = SPUStandardUpdaterController(
             startingUpdater: false,
             updaterDelegate: nil,
@@ -42,7 +67,16 @@ final class SparkleUpdateController {
         )
         standardController = controller
         controller.startUpdater()
-        automaticallyDownloadsUpdates = controller.updater.automaticallyDownloadsUpdates
+        let updater = controller.updater
+        automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
+        canCheckForUpdates = updater.canCheckForUpdates
+        canCheckObservation = updater.observe(\.canCheckForUpdates, options: [.initial, .new]) {
+            [weak self] _, change in
+            guard let value = change.newValue else { return }
+            Task { @MainActor [weak self] in
+                self?.canCheckForUpdates = value
+            }
+        }
         isStarted = true
     }
 
@@ -52,11 +86,8 @@ final class SparkleUpdateController {
     func checkForUpdates() {
         guard isEnabled else { return }
         if !isStarted { start() }
+        guard canCheckForUpdates else { return }
         standardController?.checkForUpdates(nil)
-    }
-
-    var canCheckForUpdates: Bool {
-        isEnabled && (standardController?.updater.canCheckForUpdates ?? true)
     }
 
     func setAutomaticallyDownloadsUpdates(_ enabled: Bool) {

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -1,0 +1,102 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Readiness.Action" desc="Start" enabled=true
+          AXStaticText value=text enabled=true
+          AXScrollArea
+            AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddAttachments" desc="Add attachments" help="Add PDF, CSV, or TXT files" enabled=true
+          AXButton id="ChatView.ConversationInstructions" desc="Conversation instructions" help="Conversation instructions" enabled=true
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
+      AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+      AXButton id="Toolbar.SearchChats" desc="Search chats" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true
+  AXWindow subrole=AXStandardWindow id="settings" title="Settings"
+    AXGroup subrole=AXHostingView
+      AXScrollArea
+        AXOutline desc="Settings categories" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.modelManagement" desc="Model Management" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.instructions" desc="Instructions" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.tools" desc="Tools" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.performance" desc="Performance" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.privacy" desc="Privacy" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.app" desc="App" enabled=true
+          AXRow subrole=AXOutlineRow
+            AXCell enabled=true
+              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
+          AXColumn id="ListColumn"
+      AXScrollArea
+        AXHeading desc="Rapid-MLX, Self-update for Rapid-MLX. New releases bundle the latest models, performance improvements, and bug fixes." enabled=true
+        AXHeading desc="Version" enabled=true
+        AXStaticText value=text enabled=true
+        AXStaticText value=text enabled=true
+        AXStaticText value=text enabled=true
+        AXStaticText value=text enabled=true
+        AXHeading desc="Updates" enabled=true
+        AXCheckBox id="Settings.App.AutomaticUpdatesToggle" desc="Automatically download updates" help="Downloaded updates are installed when Rapid-MLX quits." value=bool:true enabled=true
+        AXStaticText id="Settings.App.UpdateHeadline" value=text enabled=true
+        AXBusyIndicator id="Settings.App.UpdateBusy" desc="Update in progress…" help="Rapid-MLX is checking or downloading the update in the background., Rapid-MLX is checking or downloading the update in the background." value=number enabled=true
+        AXHeading desc="Release notes" enabled=true
+        AXScrollArea
+          AXStaticText value=text enabled=true
+        AXHeading desc="Diagnostics, Save a support report to share if something goes wrong. Includes your app version, Mac model, and recent logs — no prompts, files, or personal data." enabled=true
+        AXButton id="Settings.App.ExportDiagnostics" desc="Export diagnostics…" enabled=true
+        AXHeading desc="Window, Choose what happens when you close the main window. Rapid-MLX keeps running in the menu bar either way — this only affects whether the Dock icon stays visible." enabled=true
+        AXCheckBox subrole=AXToggle id="Settings.App.HideDockOnCloseToggle" desc="Hide Dock icon when closing window" help="Rapid-MLX remains available from the menu bar." value=bool:false enabled=true
+        AXButton id="Settings.App.ResetDockOnboardingCTA" desc="Reset onboarding alerts" enabled=true
+        AXScrollBar value=number enabled=true
+          AXValueIndicator value=number
+          AXButton subrole=AXIncrementArrow
+          AXButton subrole=AXDecrementArrow
+          AXButton subrole=AXIncrementPage
+          AXButton subrole=AXDecrementPage
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXZoomButton enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/SparkleUpdateControllerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SparkleUpdateControllerTests.swift
@@ -14,7 +14,20 @@ struct SparkleUpdateControllerTests {
         ]))
     }
 
-    @Test("local build without injected public key stays on legacy updater")
+    @MainActor
+    @Test("enabled controller remains actionable before Sparkle starts")
+    func enabledBeforeStart() {
+        let controller = SparkleUpdateController(infoDictionary: [
+            "SUFeedURL": "https://dl.rapidmlx.com/appcast.xml",
+            "SUPublicEDKey": publicKey,
+        ])
+
+        #expect(controller.isEnabled)
+        #expect(!controller.isStarted)
+        #expect(controller.canCheckForUpdates)
+    }
+
+    @Test("local build without injected public key keeps Sparkle disabled")
     func missingPublicKey() {
         #expect(!SparkleUpdateController.hasValidConfiguration([
             "SUFeedURL": "https://dl.rapidmlx.com/appcast.xml",
@@ -44,5 +57,21 @@ struct SparkleUpdateControllerTests {
             checksEnabled: false
         )
         #expect(!controller.isEnabled)
+    }
+
+    @MainActor
+    @Test("golden busy fixture mirrors a background Sparkle session without starting Sparkle")
+    func busyFixture() {
+        let controller = SparkleUpdateController(
+            infoDictionary: [:],
+            checksEnabled: false,
+            fixtureState: .busy
+        )
+
+        #expect(controller.isEnabled)
+        #expect(!controller.canCheckForUpdates)
+        controller.start()
+        #expect(controller.isStarted)
+        #expect(!controller.canCheckForUpdates)
     }
 }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -39,7 +39,7 @@ Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 Flows: fresh-install, cached-quickstart, cached-curated-tradeup, download-progress, settings-persistence, settings-mtp, chat-restore, message-actions, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
-       update-state, window-close-prompt, no-dead-controls, catalog-integrity,
+       update-state, update-busy, window-close-prompt, no-dead-controls, catalog-integrity,
        browse-all-destination, chat-document-attachment, image-generation, dictation, audio-readiness, all
 
 Most named regression flows drive the app through the accessibility API alone.
@@ -2451,6 +2451,36 @@ flow_update_state() {
     cleanup_persona
 }
 
+# A signed release can discover the new version through Rapid's lightweight
+# manifest while Sparkle is already fetching that same update in the
+# background. Sparkle rejects a second foreground check in this state. The UI
+# must expose the real busy state instead of leaving an enabled orange button
+# whose click is silently ignored.
+flow_update_busy() {
+    start_persona update-busy \
+        RAPID_GUI_GOLDEN_MODE=1 \
+        RAPID_GUI_UPDATE_BUSY_FIXTURE=1
+    dismiss_first_run
+    open_settings
+    see_main "$OUT/settings.json"
+    press "$OUT/settings.json" Settings.Category.app "$OUT/open-app.json"
+    wait_identifier Settings.App.UpdateBusy "$OUT/app-panel.json"
+
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "Settings.App.UpdateBusy"
+                    and (.description | contains("Update in progress")))' \
+        "$OUT/app-panel.json" >/dev/null \
+        || die "background Sparkle session has no visible progress feedback"
+    if jq -e '.data.ui_elements[]?
+              | select(.identifier == "Settings.App.UpdateCTA")' \
+             "$OUT/app-panel.json" >/dev/null; then
+        die "background Sparkle session still exposes the no-op update CTA"
+    fi
+    baseline "update-busy.app-panel" "$OUT/app-panel.json"
+    log "  background update replaces the no-op CTA with truthful progress"
+    cleanup_persona
+}
+
 flow_window_close_prompt() {
     # #1590: the prompt, persistence store and delegate proxy all existed, but
     # no WindowAccessor ever attached the proxy to the real main NSWindow.
@@ -4505,6 +4535,7 @@ case "$FLOW" in
     model-crash-recovery) flow_model_crash_recovery ;;
     low-memory-choice) flow_low_memory_choice ;;
     update-state) flow_update_state ;;
+    update-busy) flow_update_busy ;;
     window-close-prompt) flow_window_close_prompt ;;
     no-dead-controls) flow_no_dead_controls ;;
     catalog-integrity) flow_catalog_integrity ;;
@@ -4532,6 +4563,7 @@ case "$FLOW" in
         flow_model_crash_recovery
         flow_low_memory_choice
         flow_update_state
+        flow_update_busy
         flow_window_close_prompt
         flow_no_dead_controls
         flow_catalog_integrity


### PR DESCRIPTION
## Why

Settings showed an enabled **Update Rapid-MLX** button while Sparkle was already checking or downloading automatically. Sparkle documents `canCheckForUpdates == false` for that state and silently ignores a second foreground check, so the button appeared broken. This was reproduced against the installed 0.12.15 app updating to 0.12.16: Sparkle's Autoupdate/Updater processes and the downloaded 169 MB archive were present, but pressing the CTA produced no visible response.

## Fix

- Observe Sparkle's KVO-compliant `canCheckForUpdates` state.
- Show **Update in progress…** while Sparkle owns an active background operation instead of exposing a no-op CTA.
- Restore the foreground update CTA as soon as Sparkle reports it can accept one.
- Keep unsigned local builds on the existing release-page fallback.

## Test plan

- [x] `swift test --package-path apps/rapid-mac --filter SparkleUpdateControllerTests`
- [x] New AX golden flow `update-busy` passes twice (record + comparison); it asserts busy feedback is visible and `Settings.App.UpdateCTA` is absent.
- [x] Local debug app bundle builds and passes strict code-sign verification.
- [x] `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- [x] `git diff --check`