### PR TITLE
fix(responses): re-attach MCP namespace to function_call for Codex dispatch

### DIFF
--- a/tests/test_responses_adapter.py
+++ b/tests/test_responses_adapter.py
@@ -21,6 +21,7 @@ from vllm_mlx.api.models import (
     Usage,
 )
 from vllm_mlx.api.responses_adapter import (
+    _build_tool_call_output_item,
     _convert_status,
     _convert_text_format,
     _convert_tool_choice,
@@ -353,6 +354,298 @@ class TestNormalizeResponsesToolTypes:
         with pytest.raises(Exception) as exc_info:
             validate_responses_tool_types(tools)
         assert "unsupported_tool_type" in str(exc_info.value)
+
+
+class TestNamespaceReattachmentMapping:
+    """Issue #2114: ``normalize_responses_tool_types`` returns a
+    ``{function_name: namespace}`` mapping so the flattened function tools
+    can carry their originating MCP namespace back to Codex for routing.
+    Flattening otherwise discards the namespace identity, leaving the
+    model's ``function_call`` unqualified (``lookup`` instead of
+    ``mcp__example.lookup``).
+    """
+
+    def test_single_namespace_returns_mapping(self):
+        tools = [
+            {
+                "type": "namespace",
+                "name": "mcp__example",
+                "tools": [{"type": "function", "name": "lookup"}],
+            },
+        ]
+        mapping = normalize_responses_tool_types(tools)
+        assert mapping == {"lookup": "mcp__example"}
+        # Flatten still happened.
+        assert [t["type"] for t in tools] == ["function"]
+        assert tools[0]["name"] == "lookup"
+
+    def test_multiple_children_all_mapped(self):
+        tools = [
+            {
+                "type": "namespace",
+                "name": "mcp__example",
+                "tools": [
+                    {"type": "function", "name": "lookup"},
+                    {"type": "function", "name": "search"},
+                ],
+            },
+        ]
+        mapping = normalize_responses_tool_types(tools)
+        assert mapping == {"lookup": "mcp__example", "search": "mcp__example"}
+
+    def test_collision_two_namespaces_same_name_omitted(self):
+        """MCP tool names are unique only WITHIN one server — two
+        namespaces may both legally contain ``lookup``. A naive
+        name→namespace dict would silently pick one server. The mapping
+        OMITS the ambiguous name entirely so no misrouting occurs; the
+        emitted ``function_call`` degrades to the pre-#2114 unqualified
+        shape rather than routing to the wrong server.
+        """
+        tools = [
+            {
+                "type": "namespace",
+                "name": "mcp__alpha",
+                "tools": [{"type": "function", "name": "lookup"}],
+            },
+            {
+                "type": "namespace",
+                "name": "mcp__beta",
+                "tools": [{"type": "function", "name": "lookup"}],
+            },
+        ]
+        mapping = normalize_responses_tool_types(tools)
+        # ``lookup`` is ambiguous → omitted (documented decision).
+        assert "lookup" not in mapping
+        assert mapping == {}
+        # Both namespaces still flattened — the request is not rejected.
+        assert [t["type"] for t in tools] == ["function", "function"]
+
+    def test_collision_partial_only_ambiguous_name_omitted(self):
+        """A collision on one name must not poison the sibling names. Two
+        namespaces share ``lookup`` but each has a unique second tool —
+        those unique names remain unambiguously attributable.
+        """
+        tools = [
+            {
+                "type": "namespace",
+                "name": "mcp__alpha",
+                "tools": [
+                    {"type": "function", "name": "lookup"},
+                    {"type": "function", "name": "alpha_only"},
+                ],
+            },
+            {
+                "type": "namespace",
+                "name": "mcp__beta",
+                "tools": [
+                    {"type": "function", "name": "lookup"},
+                    {"type": "function", "name": "beta_only"},
+                ],
+            },
+        ]
+        mapping = normalize_responses_tool_types(tools)
+        assert mapping == {
+            "alpha_only": "mcp__alpha",
+            "beta_only": "mcp__beta",
+        }
+        assert "lookup" not in mapping
+
+    def test_top_level_and_namespace_collision_omitted(self):
+        """A bare name shared by a top-level (namespace-less) function AND
+        a namespaced function is ambiguous — we cannot tell which the
+        model meant, so it is omitted.
+        """
+        tools = [
+            {"type": "function", "name": "lookup"},
+            {
+                "type": "namespace",
+                "name": "mcp__example",
+                "tools": [{"type": "function", "name": "lookup"}],
+            },
+        ]
+        mapping = normalize_responses_tool_types(tools)
+        assert mapping == {}
+
+    def test_direct_tool_absent_from_mapping(self):
+        """A direct (non-namespace) function tool contributes NO namespace
+        — regression guard for shape (c): direct-user requests must never
+        gain a spurious ``namespace``.
+        """
+        tools = [{"type": "function", "name": "lookup"}]
+        mapping = normalize_responses_tool_types(tools)
+        assert mapping == {}
+
+    def test_nameless_namespace_not_attributable(self):
+        """A namespace with a missing/empty ``name`` yields an
+        unattributable origin — its children are never attached.
+        """
+        tools = [
+            {
+                "type": "namespace",
+                "tools": [{"type": "function", "name": "lookup"}],
+            },
+        ]
+        mapping = normalize_responses_tool_types(tools)
+        assert mapping == {}
+        # Still flattened (the shape is valid, only the name is absent).
+        assert [t["type"] for t in tools] == ["function"]
+
+    def test_empty_tools_returns_empty_mapping(self):
+        assert normalize_responses_tool_types(None) == {}
+        assert normalize_responses_tool_types([]) == {}
+
+    def test_non_dict_function_child_does_not_raise(self):
+        """A namespaced child whose ``function`` is a truthy non-dict
+        (``"function": "lookup"``) must NOT raise AttributeError during
+        mapping-build — it degrades to no attachment and is left for
+        validation, not a 500."""
+        tools = [
+            {
+                "type": "namespace",
+                "name": "mcp__example",
+                "tools": [{"type": "function", "function": "lookup"}],
+            },
+        ]
+        # No exception; the child has no resolvable name → omitted.
+        mapping = normalize_responses_tool_types(tools)
+        assert mapping == {}
+
+    def test_non_string_name_does_not_raise(self):
+        """A non-string ``name`` (``[]``) must not be used as a dict key
+        (unhashable → TypeError → 500). It is unresolvable → omitted,
+        leaving the bad shape for validation."""
+        # Namespaced child with a list name.
+        ns_tools = [
+            {
+                "type": "namespace",
+                "name": "mcp__example",
+                "tools": [{"type": "function", "name": []}],
+            },
+        ]
+        assert normalize_responses_tool_types(ns_tools) == {}
+        # Top-level function tool with a list name.
+        top_tools = [{"type": "function", "name": {"bad": "shape"}}]
+        assert normalize_responses_tool_types(top_tools) == {}
+
+
+class TestNamespaceOnFunctionCallItem:
+    """Issue #2114: the built ``function_call`` output item carries the
+    re-attached namespace, and serialization omits it when absent.
+    """
+
+    def _tool_call(self, name="lookup", args='{"q":"ping"}'):
+        return ToolCall(
+            id="call_abc",
+            type="function",
+            function=FunctionCall(name=name, arguments=args),
+        )
+
+    def test_build_item_attaches_namespace(self):
+        item = _build_tool_call_output_item(
+            self._tool_call(),
+            uses_computer_use=False,
+            namespace_by_tool={"lookup": "mcp__example"},
+        )
+        assert item.type == "function_call"
+        assert item.namespace == "mcp__example"
+        # exclude_none serialization surfaces it.
+        dumped = json.loads(item.model_dump_json(exclude_none=True))
+        assert dumped["namespace"] == "mcp__example"
+        assert dumped["name"] == "lookup"
+
+    def test_build_item_no_namespace_when_mapping_absent(self):
+        """Direct request (no mapping) — regression shape (c): NO
+        ``namespace`` field on the wire.
+        """
+        item = _build_tool_call_output_item(
+            self._tool_call(),
+            uses_computer_use=False,
+            namespace_by_tool=None,
+        )
+        assert item.namespace is None
+        dumped = json.loads(item.model_dump_json(exclude_none=True))
+        assert "namespace" not in dumped
+
+    def test_build_item_no_namespace_for_ambiguous_name(self):
+        """A collision-omitted name is simply absent from the mapping, so
+        ``.get`` returns None and no namespace is attached.
+        """
+        item = _build_tool_call_output_item(
+            self._tool_call(name="lookup"),
+            uses_computer_use=False,
+            namespace_by_tool={"search": "mcp__other"},  # lookup omitted
+        )
+        assert item.namespace is None
+
+    def test_nonstream_openai_to_responses_attaches_namespace(self):
+        """End-to-end non-streaming path: ``openai_to_responses`` threads
+        the mapping into the ``function_call`` output item, and the JSON
+        envelope carries ``namespace``.
+        """
+        response = ChatCompletionResponse(
+            id="cmpl_x",
+            model="test-model",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        content=None,
+                        tool_calls=[self._tool_call()],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=Usage(
+                prompt_tokens=1,
+                completion_tokens=1,
+                total_tokens=2,
+            ),
+        )
+        request = ResponsesRequest(model="test-model", input="hi")
+        result = openai_to_responses(
+            response,
+            model="test-model",
+            request=request,
+            created_at=0,
+            namespace_by_tool={"lookup": "mcp__example"},
+        )
+        fc = [it for it in result.output if it.type == "function_call"]
+        assert len(fc) == 1
+        assert fc[0].namespace == "mcp__example"
+        envelope = json.loads(result.model_dump_json(exclude_none=True))
+        emitted = [o for o in envelope["output"] if o["type"] == "function_call"][0]
+        assert emitted["namespace"] == "mcp__example"
+
+    def test_nonstream_no_namespace_without_mapping(self):
+        """Regression shape (c): non-streaming direct request emits NO
+        ``namespace`` field.
+        """
+        response = ChatCompletionResponse(
+            id="cmpl_x",
+            model="test-model",
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=AssistantMessage(
+                        content=None,
+                        tool_calls=[self._tool_call()],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=Usage(
+                prompt_tokens=1,
+                completion_tokens=1,
+                total_tokens=2,
+            ),
+        )
+        request = ResponsesRequest(model="test-model", input="hi")
+        result = openai_to_responses(
+            response, model="test-model", request=request, created_at=0
+        )
+        envelope = json.loads(result.model_dump_json(exclude_none=True))
+        emitted = [o for o in envelope["output"] if o["type"] == "function_call"][0]
+        assert "namespace" not in emitted
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_responses_sse_event_order.py
+++ b/tests/test_responses_sse_event_order.py
@@ -363,3 +363,93 @@ class TestResponsesStreamEventOrder:
             f"Event ordering violated. Landmarks (in expected order): "
             f"{landmarks}. Names: {names}"
         )
+
+
+class TestResponsesStreamNamespaceReattachment:
+    """Issue #2114: the streaming ``function_call`` items must carry the
+    originating MCP ``namespace`` so Codex routes the call to the right
+    server. A single ``mcp__example`` namespace group with a lone
+    ``lookup`` function + ``tool_choice="required"`` drives the forced
+    synthesis path, so the fake engine (which emits no tool call) still
+    produces a ``function_call`` — exercising the inline stream emitter.
+    """
+
+    def _namespace_payload(self):
+        return _stream_payload(
+            tool_choice="required",
+            tools=[
+                {
+                    "type": "namespace",
+                    "name": "mcp__example",
+                    "description": "Example MCP namespace",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "lookup",
+                            "description": "Look up a value",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"q": {"type": "string"}},
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+
+    def test_stream_function_call_carries_namespace(self, responses_client):
+        client = responses_client.client
+        with client.stream(
+            "POST",
+            "/v1/responses",
+            json=self._namespace_payload(),
+            headers=HEADERS,
+        ) as resp:
+            body = "".join(resp.iter_text())
+        events = _parse_sse(body)
+        fc_items = [
+            data["item"]
+            for name, data in events
+            if name in ("response.output_item.added", "response.output_item.done")
+            and data.get("item", {}).get("type") == "function_call"
+        ]
+        # Both the added (in_progress) and done items must appear.
+        assert len(fc_items) == 2, f"expected 2 function_call items, got {fc_items}"
+        assert all(it["name"] == "lookup" for it in fc_items)
+        # Every emitted function_call carries the originating namespace.
+        assert all(it.get("namespace") == "mcp__example" for it in fc_items), fc_items
+
+    def test_stream_direct_tool_emits_no_namespace(self, responses_client):
+        """Regression shape (c): a direct (non-namespace) tool must NOT
+        gain a spurious ``namespace`` on the streaming surface.
+        """
+        payload = _stream_payload(
+            tool_choice="required",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "lookup",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                }
+            ],
+        )
+        client = responses_client.client
+        with client.stream(
+            "POST",
+            "/v1/responses",
+            json=payload,
+            headers=HEADERS,
+        ) as resp:
+            body = "".join(resp.iter_text())
+        events = _parse_sse(body)
+        fc_items = [
+            data["item"]
+            for name, data in events
+            if name in ("response.output_item.added", "response.output_item.done")
+            and data.get("item", {}).get("type") == "function_call"
+        ]
+        assert len(fc_items) == 2, f"expected 2 function_call items, got {fc_items}"
+        assert all("namespace" not in it for it in fc_items), fc_items

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -120,7 +120,32 @@ def _raise_unsupported_tool_type(tool_type: str) -> None:
     )
 
 
-def normalize_responses_tool_types(tools: list[dict] | None) -> None:
+def _flatten_tool_name(entry: dict) -> str | None:
+    """Resolve a function tool's bare name for the #2114 re-attachment
+    mapping, tolerating malformed client input.
+
+    Prefers the Responses-shape top-level ``name``, falling back to the
+    Chat-Completions nested ``function.name``. Returns ``None`` unless the
+    resolved value is a non-empty ``str``. Malformed client input — a
+    non-dict ``function`` value (``"function": "lookup"``) or a non-string
+    ``name`` (``"name": []``) — must NOT raise here: an ``AttributeError``
+    or an unhashable-key ``TypeError`` during normalization would turn a
+    bad request into a 500 instead of leaving it for
+    ``validate_responses_tool_types`` to reject with the proper 400
+    envelope.
+    """
+    name = entry.get("name")
+    if isinstance(name, str) and name:
+        return name
+    fn = entry.get("function")
+    if isinstance(fn, dict):
+        fn_name = fn.get("name")
+        if isinstance(fn_name, str) and fn_name:
+            return fn_name
+    return None
+
+
+def normalize_responses_tool_types(tools: list[dict] | None) -> dict[str, str]:
     """Rewrite alias tool-type names to the canonical spec name in-place.
 
     The route calls this BEFORE :func:`validate_responses_tool_types`
@@ -168,9 +193,35 @@ def normalize_responses_tool_types(tools: list[dict] | None) -> None:
     removes it too, so the invalid request becomes an empty success.
     Codex's real ``multi_agent_v1`` group only ever contains function
     tools, so this stricter contract matches its actual wire format.
+
+    Namespace re-attachment mapping (issue #2114): flattening discards
+    the namespace identity, but Codex needs the originating namespace to
+    route the model's ``function_call`` back to the right MCP server
+    (``mcp__example.lookup`` vs a bare ``lookup``). This function returns
+    a ``{function_name: namespace}`` mapping built from the ORIGINAL
+    request (before flattening erases it) so the output builders
+    (:func:`_build_tool_call_output_item` on the non-stream path and the
+    inlined streaming emitter in ``routes/responses.py``) can re-attach a
+    ``namespace`` field to each emitted ``function_call`` item. Only the
+    namespaces that actually get flattened contribute entries — a
+    malformed / preserved ``namespace`` entry never reaches the model, so
+    its children are excluded.
+
+    Collision handling: MCP tool names are unique only WITHIN one server,
+    so two namespaces may both legally contain ``lookup``. A bare name is
+    included in the mapping ONLY when it resolves to exactly ONE
+    namespace. If the same bare name appears under >1 namespace, OR under
+    both a namespace AND a top-level (namespace-less) function tool, the
+    origin is genuinely ambiguous — we cannot know which server the model
+    meant, so the name is OMITTED from the mapping and NO ``namespace``
+    is attached to its ``function_call``. This never mis-routes: an
+    ambiguous name degrades to the pre-#2114 unqualified shape rather than
+    silently picking the wrong server. A namespace entry with a missing /
+    empty ``name`` likewise contributes an unattributable occurrence,
+    so its children are never attached.
     """
     if not tools:
-        return
+        return {}
     # Hosted tool types the local engine cannot run; Codex includes some
     # of these by default. Drop them rather than 400 the whole request —
     # BUT only when the original request carries a ``namespace`` entry
@@ -198,6 +249,13 @@ def normalize_responses_tool_types(tools: list[dict] | None) -> None:
     # with canonical ``type == "function"`` — otherwise a hosted-typed
     # child would silently flow through the drop-hosted step below and
     # collapse the tools list.
+    # Track, per bare function name, the set of origins it flattened from
+    # (issue #2114). A real namespace name contributes that name; a
+    # top-level (namespace-less) function tool contributes ``None``. A
+    # name with exactly one distinct, non-``None`` origin is unambiguously
+    # attributable; anything else is a collision and is dropped below.
+    ns_occurrences: dict[str, set[str | None]] = {}
+
     flattened: list = []
     for t in tools:
         if isinstance(t, dict) and t.get("type") == "namespace":
@@ -211,6 +269,12 @@ def normalize_responses_tool_types(tools: list[dict] | None) -> None:
                     for sub in sub_tools
                 )
             ):
+                ns_raw = t.get("name")
+                ns_key = ns_raw if isinstance(ns_raw, str) and ns_raw else None
+                for sub in sub_tools:
+                    sub_name = _flatten_tool_name(sub)
+                    if sub_name:
+                        ns_occurrences.setdefault(sub_name, set()).add(ns_key)
                 flattened.extend(sub_tools)
                 continue
             # Malformed / empty / non-function-child namespace → leave
@@ -218,6 +282,13 @@ def normalize_responses_tool_types(tools: list[dict] | None) -> None:
             flattened.append(t)
             continue
         flattened.append(t)
+        # A top-level (namespace-less) function tool sharing a bare name
+        # with a namespaced tool makes that name ambiguous — record a
+        # ``None`` origin so the resolver below refuses to attach.
+        if isinstance(t, dict) and _canonicalize_tool_type(t.get("type")) == "function":
+            top_name = _flatten_tool_name(t)
+            if top_name:
+                ns_occurrences.setdefault(top_name, set()).add(None)
 
     # Pass 2 — drop hosted noise ONLY when the request is Codex-shaped.
     # A direct-user request with ``[function, web_search]`` or
@@ -243,6 +314,15 @@ def normalize_responses_tool_types(tools: list[dict] | None) -> None:
         canonical = _canonicalize_tool_type(ttype)
         if canonical != ttype:
             t["type"] = canonical
+
+    # Resolve the re-attachment mapping: keep only names with exactly ONE
+    # distinct, non-``None`` origin (issue #2114). Collisions (>1
+    # namespace, or namespace + top-level) resolve to no attachment.
+    return {
+        name: next(iter(origins))
+        for name, origins in ns_occurrences.items()
+        if len(origins) == 1 and next(iter(origins)) is not None
+    }
 
 
 def validate_responses_tool_types(tools: list[dict] | None) -> None:
@@ -769,6 +849,7 @@ def openai_to_responses(
     model: str,
     request: ResponsesRequest,
     created_at: int,
+    namespace_by_tool: dict[str, str] | None = None,
 ) -> ResponsesResponse:
     """
     Convert an OpenAI Chat Completions response to a Responses-API
@@ -791,6 +872,12 @@ def openai_to_responses(
     a ``function.name == "computer"`` call, emit a ``computer_call``
     item instead of ``function_call`` so the OpenAI Computer-Use SDK
     contract is honoured.
+
+    ``namespace_by_tool`` (issue #2114) is the ``{function_name:
+    namespace}`` mapping returned by
+    :func:`normalize_responses_tool_types`; it is threaded to
+    :func:`_build_tool_call_output_item` so each emitted ``function_call``
+    re-attaches the MCP namespace Codex needs for routing.
     """
     output: list[ResponsesOutputItem] = []
     choice = response.choices[0] if response.choices else None
@@ -894,7 +981,9 @@ def openai_to_responses(
             )
 
         for tc in choice.message.tool_calls or []:
-            output.append(_build_tool_call_output_item(tc, uses_computer_use))
+            output.append(
+                _build_tool_call_output_item(tc, uses_computer_use, namespace_by_tool)
+            )
 
     status = _convert_status(choice.finish_reason if choice else None)
 
@@ -959,7 +1048,9 @@ def _build_reasoning_output_item(
 
 
 def _build_tool_call_output_item(
-    tool_call, uses_computer_use: bool
+    tool_call,
+    uses_computer_use: bool,
+    namespace_by_tool: dict[str, str] | None = None,
 ) -> ResponsesOutputItem:
     """Translate one OpenAI ``ToolCall`` to a Responses-API output item.
 
@@ -969,6 +1060,14 @@ def _build_tool_call_output_item(
     ``computer_call`` envelope per Ana C-06. The ``action`` field is
     parsed from the JSON arguments string and surfaced in the
     OpenAI-documented shape ``{"type": <verb>, ...kwargs}``.
+
+    ``namespace_by_tool`` (issue #2114) is the ``{function_name:
+    namespace}`` mapping returned by
+    :func:`normalize_responses_tool_types`. When the emitted tool call's
+    bare name is present, its originating MCP namespace is re-attached so
+    Codex can route the ``function_call`` to the right server. Names not
+    in the map (direct tools, or ambiguous collisions) leave ``namespace``
+    at ``None``, which ``model_dump_json(exclude_none=True)`` omits.
     """
     if uses_computer_use and (tool_call.function.name or "") == "computer":
         action = _parse_computer_action(tool_call.function.arguments or "")
@@ -987,6 +1086,7 @@ def _build_tool_call_output_item(
         name=tool_call.function.name,
         arguments=tool_call.function.arguments or "",
         status="completed",
+        namespace=(namespace_by_tool or {}).get(tool_call.function.name or ""),
     )
 
 

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -501,6 +501,15 @@ class ResponsesOutputItem(BaseModel):
     call_id: str | None = None
     name: str | None = None
     arguments: str | None = None
+    # function_call — MCP namespace (issue #2114). Codex groups MCP tools
+    # under ``{"type":"namespace","name":"mcp__x","tools":[...]}``; the
+    # model calls the bare function name and Codex needs the originating
+    # namespace to route the call to the right MCP server. Populated from
+    # the flattened-namespace mapping built by
+    # ``normalize_responses_tool_types``. Left ``None`` (and omitted under
+    # ``model_dump_json(exclude_none=True)``) for direct/non-namespace
+    # tools and for bare names that map ambiguously to >1 namespace.
+    namespace: str | None = None
     # reasoning — OpenAI Responses spec, output[i].type=="reasoning":
     #   {"type":"reasoning","id":"rs_...","summary":[{"type":"summary_text","text":"..."}]}
     # ``encrypted_content`` is omitted unless include=["reasoning.encrypted_content"]

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -912,7 +912,13 @@ async def create_response(request: Request):
     # name) but normalising up-front means downstream Computer-Use
     # detectors, the adapter's input-item builder, and any future tool
     # type-keyed dispatch can read ``tools[i].type`` directly.
-    normalize_responses_tool_types(responses_request.tools)
+    # issue #2114: flattening a Codex ``namespace`` group erases which MCP
+    # server each function came from. Capture the ``{function_name:
+    # namespace}`` mapping here (built from the ORIGINAL tools, before the
+    # in-place flatten discards the namespace identity) and thread it to
+    # the streaming / non-streaming output builders so each emitted
+    # ``function_call`` re-attaches its originating namespace for routing.
+    namespace_by_tool = normalize_responses_tool_types(responses_request.tools)
     cfg_for_priming = get_config()
     priming_tool_parser = cfg_for_priming.tool_call_parser
     if priming_tool_parser is None:
@@ -1388,6 +1394,7 @@ async def create_response(request: Request):
                         explicit_no_thinking=explicit_no_thinking,
                         request_id_holder=_resp_rid_holder,
                         heartbeat_state=_resp_heartbeat_state,
+                        namespace_by_tool=namespace_by_tool,
                     ),
                     request,
                     engine=engine,
@@ -1410,6 +1417,7 @@ async def create_response(request: Request):
             responses_request,
             request,
             explicit_no_thinking=explicit_no_thinking,
+            namespace_by_tool=namespace_by_tool,
         )
     finally:
         _release_admission_unless_committed(engine, _admission_committed)
@@ -1493,6 +1501,7 @@ async def _non_stream(
     request: Request,
     *,
     explicit_no_thinking: bool = False,
+    namespace_by_tool: dict[str, str] | None = None,
 ) -> Response:
     cfg = get_config()
     created_at = int(time.time())
@@ -2238,6 +2247,7 @@ async def _non_stream(
         model=cfg.model_name or responses_request.model,
         request=responses_request,
         created_at=created_at,
+        namespace_by_tool=namespace_by_tool,
     )
     return Response(
         content=responses_response.model_dump_json(exclude_none=True),
@@ -2386,6 +2396,7 @@ async def _stream_responses_with_nonprogress_retry(
     explicit_no_thinking: bool = False,
     request_id_holder: list | None = None,
     heartbeat_state: dict[str, object] | None = None,
+    namespace_by_tool: dict[str, str] | None = None,
 ) -> AsyncIterator[str]:
     """Hide one DeepSeek reasoning-only stop behind a bounded retry.
 
@@ -2407,6 +2418,7 @@ async def _stream_responses_with_nonprogress_retry(
             explicit_no_thinking=explicit_no_thinking,
             request_id_holder=request_id_holder,
             heartbeat_state=heartbeat_state,
+            namespace_by_tool=namespace_by_tool,
         ):
             yield event
         return
@@ -2464,6 +2476,7 @@ async def _stream_responses_with_nonprogress_retry(
         created_at_override=public_created_at,
         sequence_counter=attempt_sequence,
         emit_initial_lifecycle=False,
+        namespace_by_tool=namespace_by_tool,
     ):
         if committed:
             if heartbeat_state is not None:
@@ -2525,6 +2538,7 @@ async def _stream_responses_with_nonprogress_retry(
         created_at_override=public_created_at,
         sequence_counter=public_sequence,
         emit_initial_lifecycle=False,
+        namespace_by_tool=namespace_by_tool,
     ):
         yield event
 
@@ -2617,6 +2631,7 @@ async def _stream_responses(
     created_at_override: int | None = None,
     sequence_counter: list[int] | None = None,
     emit_initial_lifecycle: bool = True,
+    namespace_by_tool: dict[str, str] | None = None,
 ) -> AsyncIterator[str]:
     """Stream a Responses-API SSE event sequence Codex CLI can parse.
 
@@ -4634,19 +4649,27 @@ async def _stream_responses(
                 completed_output.append(cu_done_item)
             else:
                 fc_id = f"fc_{uuid.uuid4().hex[:24]}"
+                # issue #2114: re-attach the originating MCP namespace so
+                # Codex routes the call to the right server. Absent for
+                # direct tools and ambiguous name collisions (the mapping
+                # only carries unambiguously-attributable names).
+                fc_namespace = (namespace_by_tool or {}).get(tc.function.name or "")
+                fc_added_item = {
+                    "type": "function_call",
+                    "id": fc_id,
+                    "call_id": tc.id,
+                    "name": tc.function.name,
+                    "arguments": "",
+                    "status": "in_progress",
+                }
+                if fc_namespace:
+                    fc_added_item["namespace"] = fc_namespace
                 yield _emit(
                     "response.output_item.added",
                     {
                         "type": "response.output_item.added",
                         "output_index": tool_output_index,
-                        "item": {
-                            "type": "function_call",
-                            "id": fc_id,
-                            "call_id": tc.id,
-                            "name": tc.function.name,
-                            "arguments": "",
-                            "status": "in_progress",
-                        },
+                        "item": fc_added_item,
                     },
                 )
                 # Codex CLI accepts the args as a single delta — we don't
@@ -4671,6 +4694,8 @@ async def _stream_responses(
                     "arguments": tc.function.arguments or "",
                     "status": "completed",
                 }
+                if fc_namespace:
+                    fc_done_item["namespace"] = fc_namespace
                 yield _emit(
                     "response.output_item.done",
                     {


### PR DESCRIPTION
## Why
Codex CLI submits MCP tools grouped under `{"type":"namespace","name":"mcp__x","tools":[{"type":"function",...}]}` entries. `normalize_responses_tool_types` flattens each namespace into its child function tools so the allowlist gate accepts the request (PR #993), **but it discarded the namespace identity**. When the model then called the function, Rapid-MLX emitted a bare `function_call` (`name:"lookup"`, no `namespace`), so Codex could not route the call back to the originating MCP server and reported `unsupported call: lookup`. Closes #2114.

## What
- `normalize_responses_tool_types` now **returns** a `{function_name: namespace}` mapping, built during the existing Pass-1 flatten (still mutates `tools` in place).
- The route captures it and threads it through **both** output paths: non-stream (`_non_stream` → `openai_to_responses` → `_build_tool_call_output_item`) and stream (retry wrapper → `_stream_responses` → the inline emitter, both `added` and `done` items).
- `ResponsesOutputItem` gains optional `namespace: str | None = None`, omitted under `exclude_none`.
- Name resolution centralised in `_flatten_tool_name`, tolerant of malformed input (non-dict `function`, non-string `name`) so bad shapes reach the 400 validation path instead of 500-ing.

## Collision safety
MCP names are unique only within one server. A bare name is attached **only** when it resolves to exactly one namespace; collisions omit the attachment, degrading to the pre-#2114 unqualified shape rather than mis-routing.

## Tests
Mapping build + all collision cases + malformed-shape hardening; non-stream emission; streaming `added`+`done` items via the fake-engine route harness. 15 assertions fail on pre-fix source and pass after; no-regression guards hold both ways. 108 responses adapter+SSE tests pass; ruff clean.

## Notes
Real user report on 0.12.15 (M3 Ultra) with a standalone `/v1/responses` reproduction. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)