### PR TITLE
docs(rapid-mac): regenerate userflows.md from the current Sources tree

### DIFF
--- a/apps/rapid-mac/docs/gui-golden-flows.md
+++ b/apps/rapid-mac/docs/gui-golden-flows.md
@@ -61,7 +61,7 @@ covered, and each one names the defect it would have caught:
     lets the user iterate by re-prompting (see **Image generation** below). The
     instruction-edit path is available as a cancellable action and the same
     journey continues through generated-result editing and iterative editing.
-12. `chat-image-attachment` — a vision-language model accepts a PNG through
+12. `chat-document-attachment` — a vision-language model accepts a PNG through
     the Chat composer, renders it in the user turn, and sends typed
     `text` + `image_url` content; the same composer keeps its attachment
     control visible but disabled for a text-only alias and rejects paste/drop.
@@ -84,6 +84,20 @@ were all invisible to journey-shaped tests:
 | `no-dead-controls` | [#1595](https://github.com/raullenchai/Rapid-MLX/pull/1595) dead recovery buttons, [#1608](https://github.com/raullenchai/Rapid-MLX/pull/1608) toggles that reported success without changing value, [#1605](https://github.com/raullenchai/Rapid-MLX/issues/1605) a tray item that reported nowhere | A journey visits the controls it needs; these were the ones nobody scripted |
 | `catalog-integrity` | [#1603](https://github.com/raullenchai/Rapid-MLX/issues/1603) — eight video-generation models offered as chat models, dead-ending *after* a download of up to 64 GB | The picker renders them perfectly; the bug is that they are there at all |
 
+### Full flow roster
+
+The numbered narrative above is selective. The authoritative, complete set of
+flows the harness can run is the dispatch table in `scripts/gui-golden-flows.sh`
+(`case "$FLOW" in …`). As of this checkout that is 26 flows: `fresh-install`,
+`cached-quickstart`, `cached-curated-tradeup`, `download-progress`,
+`settings-persistence`, `settings-mtp`, `chat-restore`, `message-actions`,
+`restored-tools`, `tool-loop-budget`, `chat-depth`, `math-rendering`,
+`slow-stream-stop`, `model-crash-recovery`, `low-memory-choice`, `update-state`,
+`window-close-prompt`, `no-dead-controls`, `catalog-integrity`,
+`browse-all-destination`, `chat-document-attachment`, `image-generation`,
+`dictation`, `audio-readiness`, `resident-load-rejected`, `launch-integrations`.
+`--flow all` runs them in that order.
+
 ### Current baseline
 
 **2026-08-09** — the whole suite (`gui-golden-flows.sh`, no `--flow`) passes on
@@ -95,7 +109,12 @@ worth recording: they were last updated **2026-08-07** (#1666), while
 `Sidebar.Images` landed in #1705 and the attachment control (then photo-only)
 landed in #1723, both on **2026-08-09**. The suite had therefore been red on
 `main` through two merges
-and nobody knew, because it runs by hand and not in CI. Every line in the
+and nobody knew, because at that time it ran by hand and was wired into no
+workflow. It is no longer only run by hand: a `gui-golden-flows` job in
+`.github/workflows/rapid-mac-ci.yml` now builds the real `.app` and runs each
+flow as its own step against `scripts/fake-rapid-mlx.sh` (every flow except
+`chat-depth`, which is explicitly excluded there — its full-transcript
+assertion is invalid on the runner's small window). Every line in the
 refresh diff is one of exactly three things:
 
 | Added | Source |
@@ -238,7 +257,7 @@ low-memory category remains visible.
 
 ### Chat attachments
 
-`chat-image-attachment` covers image input inside the normal Chat tab. This is
+`chat-document-attachment` covers image input inside the normal Chat tab. This is
 separate from `image-generation`: the former asks a VLM to understand an image;
 the latter asks a diffusion model to create one.
 
@@ -452,9 +471,17 @@ trees, actions, fake-sidecar events, logs, and a top-level `result.json`.
 
 ## AX structural baselines
 
-Ten settled states across the five journeys are also fingerprinted as
+Settled states across the journeys are also fingerprinted as
 **structural baselines**, committed under
-`Tests/GUIGoldenFlows/__Snapshots__/<flow>.<state>.txt`. `scripts/ax-baseline.py`
+`Tests/GUIGoldenFlows/__Snapshots__/<flow>.<state>.txt` — currently 32 baseline
+files spanning 12 baseline names (`audio-readiness`, `chat-depth`,
+`chat-restore`, `fresh-install`, `image-generation`, `launch-integrations`,
+`model-crash-recovery`, `onboarding-direction-d`, `settings-mtp`,
+`settings-persistence`, `slow-stream-stop`, `update-state`). All but one are
+runnable flows from the dispatch roster above; `onboarding-direction-d` is a
+baseline-only specimen — it has no `case` entry in `gui-golden-flows.sh` (its
+snapshots are emitted by `baseline` calls, not a `--flow onboarding-direction-d`
+journey). `scripts/ax-baseline.py`
 normalises a raw AX dump into an indented tree and the suite fails on any
 difference, so a PR that removes a button, reparents a control, renames an
 identifier, drops an icon or flips an enabled state produces a reviewable diff

--- a/apps/rapid-mac/docs/userflows.md
+++ b/apps/rapid-mac/docs/userflows.md
@@ -1,467 +1,724 @@
-# User Flows — Manual Smoke Test Reference
+# User Flows — Rapid for macOS
 
-This document is the authoritative reference for every user-facing flow in Rapid for macOS, the contract each flow has to honour, and the result of the most recent end-to-end smoke pass. Future contributors land here before touching the chat surface, server lifecycle, model-management, Connectors, or Quick Ask panel.
+This document maps every user-facing flow in the Rapid-MLX macOS app to the
+source that implements it. It was **regenerated from the current
+`apps/rapid-mac/Sources/` tree**, not patched — an earlier revision had drifted
+far enough from the code to describe features that do not exist (a "Quick Ask"
+global hotkey, a "pop conversation into its own window" surface, a 4-page
+onboarding tour) and to cite files that were deleted or renamed. The rule for
+this file going forward:
+
+> **Every flow, file path, type name, accessibility identifier, setting, and
+> provider named here is verified against current source. Each flow lists the
+> real files it `Touches:`. When something cannot be verified in
+> `Sources/`, it is left out rather than guessed.**
+
+No verification dates or version numbers appear below: they cannot be
+regenerated from source, and stamping them was exactly how the previous file
+came to lie. Treat this as a structural map, not a smoke-test log.
 
 Every entry has the same shape:
 
 - **Trigger** — what the user does
-- **Expected** — what should happen, end-to-end
-- **Touches** — code surfaces involved (paths into the repo)
-- **Last smoke result** — verified, blocked, or known-issue, with date
-- **Known issues** — open bugs filed against this flow
+- **Expected** — what should happen, from source
+- **Touches** — code surfaces involved
 
-> **Contract refresh (2026-08-11).** Flow definitions were reconciled against
-> `main` through **v0.12.9**. Verification dates below remain historical evidence;
-> they do not imply that an older build defines today's surface. The deterministic
-> GUI journeys live in `scripts/gui-golden-flows.sh` and run in CI; flows that still
-> require a physical keyboard or an external service say so explicitly.
-
-The smoke pass that backs the "Last smoke result" column runs against a fresh `Rapid-MLX Desktop.app` built by `scripts/build.sh` and driven by `scripts/walkthrough.sh` (F1–F10 via **AppleScript AXIdentifier** clicks — see the identifier inventory near the end) plus `scripts/release-smoke.sh` for structural launch. Flows that depend on real keyboard or pointer input require macOS Accessibility permission for the terminal hosting the harness, plus a real hardware key on the items that exercise the global Carbon hotkey.
-
-**Driving the UI: use AXIdentifier clicks, not raw coordinates.** `cliclick c:X,Y` lands at the right pixel but does **not** trigger SwiftUI button `onClick` / `.onSubmit` handlers — synthetic `CGEvent`s don't reach SwiftUI's gesture recognizers. Typing (`cliclick t:`) and filling via a control that IS reachable (e.g. an example-prompt chip) work; the send button and Enter/Cmd+Return do not fire from cliclick. Re-confirmed on v0.10.6, 2026-07-21. The supported path is `scripts/walkthrough.sh`, which clicks controls by their `.accessibilityIdentifier` via `System Events`. To verify a chat end-to-end without the GUI send, hit the sidecar directly: the app spawns `…/rapid-mlx … serve <alias> --port 8000`; read its per-launch bearer from the sidecar process env (`RAPID_MLX_API_KEY`, `RAPID_MLX_WATCHDOG_PPID` == app pid) and `curl localhost:8000/v1/chat/completions -H "Authorization: Bearer $KEY"`.
-
----
-
-## Flow 1 — First launch & onboarding
-
-First run has **two distinct surfaces**, shown in order:
-
-**(a) The Quickstart wizard** (`UI/QuickstartView.swift:551`, driven by `QuickstartCoordinator`) — replaced the old single dense setup card in **v0.10.0**. It short-circuits the chat surface for a brand-new user with no model on disk. Three steps (progress dots `total: 3`):
-
-- **Step 0 — Welcome** (`welcomeStep`): brand mark + "WELCOME TO RAPID-MLX / Fast, free AI that runs on your Mac." Primary **Get started** (`Quickstart.GetStarted`) and **Skip for now** (`Quickstart.Skip`, Esc-bound).
-- **Step 1 — Choose your first model** (`chooseModelStep`): a recommended starter card (**`bonsai-1.7b-2bit`**, tool-capable ternary ~0.5 GB — swapped in from the old 0.6B in v0.10.2), "OR PICK A BIGGER ONE" trade-up cards, and **Browse all models →** (`Quickstart.BrowseAll`).
-- **Step 2 — Download / Starting** progress card (`Phase.downloading` → `.starting` → `.ready`): on-brand progress with live percentage and a "runs privately on your Mac" note (v0.10.3). Also handles `lowDiskWarning` and `failed` phases (`Quickstart.Retry`). Starter pulls from the R2 mirror first (zero-config; v0.7.4), with an instant-on path when weights are bundled.
-
-**(b) The OnboardingTour** (`UI/OnboardingTour.swift:89`) — a 4-page centred feature sheet shown **after** the server reaches ready (gated by `OnboardingState.hasSeen`, wired at `ContentView.swift:937`). Pages: (1) Pick a model, (2) Set a system prompt, (3) Tools the model can call, (4) Ask without switching apps (Quick Ask ⌥Space). Skip / Next / Esc fire correctly since v0.8.14. Does not re-show once completed.
-
-**Expected (invariants).**
-
-1. Within ~15 s the SwiftUI scene renders; the main window appears at its default frame (historically 1200×820; a wider default is in use on recent builds).
-2. On a genuinely-first install any stale `sessions.json` from a prior user is archived (v0.8.14) — no stranger's chats in the first view. A fresh session is written with an empty `messages` array and `alias: ""`.
-3. A single `MenuBarExtra` glyph appears (see F7 — consolidated to one icon in v0.8.20; visibility fix v0.10.0).
-4. No crash report lands in `~/Library/Logs/DiagnosticReports/Rapid*`.
-5. The Quick Ask global hotkey registers with `Option+Space`; the chord blob lands in `UserDefaults["rapid.quickask.v1.chord"]`.
-
-**Touches.** `UI/QuickstartView.swift`, `UI/OnboardingComponents.swift`, `UI/OnboardingTour.swift`, `Server/QuickstartCoordinator.*`, `Chat/SessionStore.swift`, `QuickAsk/GlobalHotkey.swift`, `Server/BundledModel.swift`, `scripts/release-smoke.sh`.
-
-**Last smoke result.** Structural launch of v0.10.6 verified 2026-07-21 (cliclick dogfood): app renders, bottom bar reads "Rapid Desktop 0.10.6 — up to date", starter model loads to **Ready**. Wizard step transitions + Skip: re-smoke pending on a truly-fresh Application Support.
-
-**Known issues.** None open. (Historical: the two-surface ordering above is intentional, not a bug.)
+The scene graph is two SwiftUI `Window` scenes declared in
+`RapidApp.swift:271` (`"main"`) and `:431` (`"settings"`); there is no
+`Settings` scene and no extra `WindowGroup`. The app is menu-bar-resident:
+`AppDelegate.applicationShouldTerminateAfterLastWindowClosed` returns `false`
+(`RapidApp.swift:786`) and a single AppKit `NSStatusItem` tray is installed by
+`MenuBarController` (`RapidApp.swift:762`) — there is intentionally **no**
+SwiftUI `MenuBarExtra` (its glyph does not render on macOS 26; see the comment
+at `RapidApp.swift:509`). The `"main"` window's detail pane switches between
+Chat, Images, Audio, and Launch surfaces from the sidebar
+(`SidebarView.swift:6` `enum SidebarSection`; routed in
+`ContentView.swift:604` `detailArea`).
 
 ---
 
-## Flow 2 — Quick Ask global hotkey
+## Flow 1 — First launch & onboarding (Quickstart)
 
-**Trigger.** Press the configured global chord (default `Option+Space`) from anywhere, with or without Rapid frontmost.
+**Trigger.** First run with no chat model on disk.
 
 **Expected.**
 
-1. A non-activating `NSPanel` (720×480) drops in at screen-centre; the caller app keeps focus.
-2. The panel's compose field is first-responder; typing lands in `QuickAskView`.
-3. `Return` submits and the panel streams a reply against the running rapid-mlx server.
-4. `Esc` dismisses the panel; `quickAskEscMonitor` consumes the key without delivering it to the previous app.
+1. A first-run **Quickstart** wizard short-circuits the chat surface, owned by
+   `QuickstartCoordinator` (constructed at `RapidApp.swift:245`) and rendered by
+   `QuickstartView`. It has a welcome step (**Get started** /
+   **Skip**), a model-choice step (a recommended starter plus trade-up cards and
+   **Browse all models**), and a download/starting/ready progress step, with
+   low-disk, low-memory, and failure branches.
+2. The model-choice UI is built from `OnboardingComponents.swift` and
+   `OnboardingModelSelection.swift`; the "Direction D" wide/compact layouts live
+   in `OnboardingDirectionD.swift`.
+3. Low-memory recovery: when the live-memory guard rejects the starter, a
+   sub-1B fallback is offered and **Switch to low-memory** appears only when the
+   fallback clears the danger line (`Quickstart.Memory.SwitchToLowMemory`).
 
-**Touches.** `QuickAsk/GlobalHotkey.swift`, `QuickAsk/QuickAskPanel.swift`, `QuickAsk/QuickAskController.swift`, `QuickAsk/QuickAskConfig.swift`, `QuickAsk/QuickAskChordPreset.swift`, `RapidApp.swift` (`installQuickAskHotkey`).
-
-**Last smoke result.** No user-facing changes v0.7.0→v0.10.6; default chord confirmed still `⌥Space` (`GlobalHotkey.swift:229`). Registration verified 2026-06-13. Real-keystroke fire **requires manual user verification** — see Known Issue 2-A.
-
-**Known issues.**
-
-- **2-A (won't fix, macOS design).** Synthetic `CGEventPost` events do not trigger `RegisterEventHotKey` handlers — Carbon hotkeys only respond to genuine `IOHID` keyboard events. Every automated harness (`cliclick`, `osascript "key code"`, `CGEventPost`) can verify Rapid *registers* the chord but not that pressing it opens the panel. Manual real-keyboard testing is the only path.
-
----
-
-## Flow 3 — Send a chat message (main window)
-
-**Trigger.** With Rapid frontmost, focus the compose editor (click or `Cmd+L`), type, then submit: **`Return`** submits; **`Shift+Return`** inserts a newline; **`Cmd+Return`** also submits (Slack / Linear shape). Up-arrow in an empty field recalls the last user message.
-
-**Expected.**
-
-1. The compose editor receives the keystrokes. It is `ComposeTextEditor` (an `NSViewRepresentable`, `ChatView.swift:3732`) hosting `AutosizingTextView` (the `NSTextView` subclass, `:3689`). Submit is intercepted in `Coordinator.textView(_:doCommandBy:)` (`:3837`) so `Return`/`Cmd+Return` don't double-fire against the send button (which carries no `.keyboardShortcut` by design).
-2. `ChatViewModel.send(_:alias:)` appends a `.user` message and starts a stream against `http://127.0.0.1:8000/v1/chat/completions` (bearer-authed since the per-launch-secret work).
-3. The assistant placeholder appears immediately (`status: .streaming`), press-feedback (spring depress) plays on the send/chips (v0.10.6), and VoiceOver announces stream start + completion (v0.8.20).
-4. SSE chunks arrive on `ChatStreamClient`: `delta.reasoning_content` → `reasoning_content`, `delta.content` → `content`; the UI keeps the tail visible and the composer stays on-screen even once the conversation fills the window (macOS 14/15 clip fixed v0.8.16).
-5. Text scales with the system Dynamic Type setting across the transcript and ~80 text sites (v0.10.6).
-6. On end-of-stream the row flips to `.complete` with a token-count / model footer; no stray machine text is shown when a tool-capable model chose not to call a tool (v0.10.6). Busy / low-memory conditions surface a plain-language message, not a raw error (v0.10.0 / v0.8.19).
-7. `sessions.json` round-trips the new user+assistant pair via the UUID-suffixed atomic write; interrupted `.streaming` rows are cleaned up on next load rather than sticking on "Thinking…" (v0.10.0).
-
-**Touches.** `UI/ChatView.swift` (`ComposeTextEditor`, `AutosizingTextView`, `focusComposeShortcut`, `ChatView.SendOrStopButton`), `Chat/ChatViewModel.swift`, `Chat/ChatStreamClient.swift`, `Chat/SessionStore.swift`.
-
-**Last smoke result.** Engine end-to-end verified 2026-07-21 on v0.10.6: `curl` to the app's sidecar (`:8000`, `qwen3-0.6b-4bit`, bearer) returned a correct completion. GUI keystroke→send is **cliclick-blind** (see the driving note at the top) — drive via `walkthrough.sh` (`ChatView.SendOrStopButton`) or a real keyboard.
-
-**Known issues.**
-
-- **3-A (partial fix landed 2026-06-13, P2 follow-up).** Original report was that Rapid's main `Window` scene didn't appear in the AX hierarchy because `System Events → tell process "Rapid" → count of windows` returned `0`. Subsequent investigation surfaced two facts that re-graded this issue from P1 to P2:
-  1. Under the smoke-pass harness (an SSH+tmux session to the user's local Mac), `System Events → count of windows` also returns `0` for **Calculator** and reports `no app frontmost`. That signal is a remote-execution artifact of the AppleScript scripting bridge through SSH, not a Rapid bug. Conclusion: the System Events probe is not a valid diagnostic in this harness shape.
-  2. Querying the AX surface **directly** via `AXUIElementCopyAttributeValue(AXUIElementCreateApplication(pid), kAXWindowsAttribute, ...)` returns one entry — but that entry resolves to the AXApplication itself rather than the AppKitWindow underneath. `AXMainWindow` / `AXFocusedWindow` / `AXFocusedUIElement` all behave the same way. The SwiftUI scene-graph accessibility-bridge is gated on `AXEnhancedUserInterface` being `true` — VoiceOver flips that on startup, but without VoiceOver running the bridge stays dormant. An external setter receives `-25208` (`kAXErrorNotImplemented` — the AXApplication element implements no settable `AXEnhancedUserInterface` for a foreign process; NOT `-25205` / `kAXErrorAttributeUnsupported` as earlier notes claimed). Per issue #173, on macOS 15+ the *in-process* set returns the same `-25208`, so the bridge stays dormant for non-VoiceOver users there too — the launch-time set is a benign no-op on those releases, not a regression.
-
-  Landed fix (`fix(a11y): pin activation policy + enable AX bridge at launch`): `NSApp.setActivationPolicy(.regular)` plus a self-set of `AXEnhancedUserInterface = true` from inside the app, both in `AppDelegate.applicationDidFinishLaunching`. Post-fix probe confirms both flags take effect (`false → true` and `policy → 0`). The remaining gap — `kAXWindowsAttribute` still returning the AXApplication instead of the AppKitWindow — is a SwiftUI `Window` scene framework limitation that needs deeper work (a custom `NSAccessibilityElement` wrapper around the chat compose `NSTextView` is the likely shape). Sighted users on real keyboard + mouse are unaffected; screen-reader users see an improved surface but not a fully-navigable one.
-- **3-B (open, harness-only, not a launch blocker).** `cliclick`-injected keystrokes do not reach Rapid's compose input when the test harness is an SSH+tmux session. Even after pinning the activation policy and enabling the AX bridge, `NSRunningApplication.activate` and `AXFrontmost = true` both silently no-op from this remote context (the AX `set` call returns success but the value never changes). Conclusion: the OS protects user focus from being stolen by background SSH sessions. The user driving the app locally with a real mouse and keyboard sees none of this — flows 3-7 work for them as designed.
+**Touches.** `UI/QuickstartView.swift`, `UI/OnboardingComponents.swift`,
+`UI/OnboardingModelSelection.swift`, `UI/OnboardingDirectionD.swift`,
+`Server/QuickstartModel.swift`, `RapidApp.swift` (`quickstart`).
 
 ---
 
-## Flow 4 — Settings panel
+## Flow 2 — Telemetry consent (first run)
 
-**Trigger.** `Cmd+,` while Rapid is frontmost, or `Rapid → Settings…`.
+**Trigger.** First launch, once the shell is up, when no telemetry decision has
+been recorded (`ContentView.swift:45`, `TelemetryConsent.needsDecision()`).
 
-**Expected.**
+**Expected.** A consent sheet (`TelemetryConsentView`) offers **Share** /
+**Don't share** (`TelemetryConsent.Share` / `TelemetryConsent.DontShare`); the
+choice is persisted via `TelemetryConsent.record(enabled:)`
+(`ContentView.swift:838`). The decision is later changeable in Settings →
+Privacy (`Settings.Privacy.TelemetryToggle`).
 
-1. The Settings window opens at its last-left size (restored from `NSWindow Frame Settings`).
-2. The category rail is a native, arrow-key-navigable list with VoiceOver
-   semantics. `ForEach(Category.allCases)` renders exactly six categories, in
-   declaration order: **Model Management, Tools, Connectors, Appearance, Privacy,
-   App**. Model Management is the default. The former stand-alone Models tab was
-   folded into it; there is no Permissions, Web Search, Sampling, Quick Ask,
-   Keyboard, or Storage category in this app.
-3. Clicking a category swaps the body. Model preferences and tool enablement use
-   `UserDefaults`; provider secrets use Keychain; connector configuration is
-   persisted by `MCPConfigStore`. Web-search provider settings and browse approval
-   mode are subsections of **Tools**. Updates and the inference-engine path are in
-   **App**.
-4. `Cmd+W` closes Settings without quitting the app.
-
-**Touches.** `UI/SettingsView.swift`, `UI/SettingsModelManagementPanel.swift`,
-`UI/SettingsToolsPanel.swift`, `UI/SettingsConnectorsPanel.swift`,
-`Tools/KeychainStore.swift`, `MCP/MCPConfigStore.swift`.
-
-**Last smoke result.** The six-category contract is pinned by Swift tests and the
-settings GoldenFlow. Persistence paths have focused unit coverage. Physical
-keyboard traversal remains a manual-local check.
-
-**Known issues.** Inherits 3-A / 3-B.
+**Touches.** `UI/TelemetryConsentView.swift`, `UI/ContentView.swift`
+(`decideTelemetry`), `Telemetry/TelemetryConsent.swift`,
+`Telemetry/TelemetryConfig.swift`.
 
 ---
 
-## Flow 5 — Model picker & server start / stop
+## Flow 3 — Send a chat message
 
-**Trigger.** Click the model picker in the chat header, choose an alias, click **Start** / **Download & start** / **Stop** on the status pill.
+**Trigger.** With a model ready, type in the composer and submit.
 
 **Expected.**
 
-1. The picker enumerates cached models via `ModelCatalog`, with a dedicated
-   **Quickstart** row followed by **Recommended for your N GB Mac**. Each RAM tier
-   has one measured smart pick and, where available, one faster/lighter
-   alternative. The remaining catalog is split into runnable **All models** and
-   **Not fit for this Mac** sections; it no longer exposes the retired
-   Default/Speed/Quality/Coding/Vision role matrix.
-2. Selecting an alias updates `ContentView.alias` and persists in the active session's `alias`.
-3. **Start** → `ServerManager.start(alias:)`; the pill transitions `idle → starting → ready(alias)` over ~5–15 s. AutoStart prefers a cached runnable model over a RAM-bucketed default that would trigger a fresh large download (v0.8.14).
-4. The child rapid-mlx process spawns as a process-group leader (`posix_spawn` + `POSIX_SPAWN_SETPGROUP`); shutdown sends `kill(-pgid, SIGTERM)` then `SIGKILL`. An idle-state sidecar crash surfaces and auto-respawns, bounded by a respawn budget so crash loops can't run away; **Stop** reliably stops even mid-respawn (v0.7.14 / v0.7.15).
-5. **Stop** tears the subprocess down without zombies.
+1. `ChatView` hosts the composer and the send/stop control
+   (`ChatView.SendOrStopButton`) and the attachment button
+   (`ChatView.AddAttachments`).
+2. `ChatViewModel` appends the user message and streams a reply from the
+   embedded rapid-mlx sidecar via `ChatStreamClient` over the loopback port
+   (`ChatStreamClient.loopbackURL(port:)`, bearer-authed).
+3. Reasoning-capable models expose their thinking under a per-message
+   disclosure (`ChatView.Message.ReasoningDisclosure.<UUID>`), and tool calls
+   render as chips (`ToolCallChip.*`).
+4. Attachments: the composer accepts document attachments; the button stays
+   visible on a text-only alias but rejects image paste/drop for models without
+   vision (see `docs/gui-golden-flows.md` → `chat-document-attachment`).
 
-**Touches.** `Server/ServerManager.swift` (process-group spawn + shutdown inline ~936–1006), `Server/ModelCatalog.swift`, `UI/ModelPickerBar.swift` (`ModelPickerBar.PrimaryButton`), `UI/ContentView.swift`.
+**Touches.** `UI/ChatView.swift`, `Chat/ChatViewModel.swift`,
+`Chat/ChatStreamClient.swift`, `Chat/ChatFileAttachment.swift`,
+`Chat/ChatMessage.swift`.
 
-**Last smoke result.** Process-group cleanup verified 2026-06-13; qwen3-0.6b-4bit load→Ready verified 2026-07-21 (v0.10.6 dogfood). Picker/Start/Stop click test via `ModelPickerBar.PrimaryButton` — re-smoke pending.
+---
 
-**Known issues.** Inherits 3-A / 3-B.
+## Flow 4 — Message actions
+
+**Trigger.** Hover / focus a transcript message.
+
+**Expected.** Per-message controls carry `ChatView.Message.<action>.<UUID>`
+identifiers (`ChatView.swift:1275`, `actionIdentifier`): **Copy**, **Edit**
+(with `EditField`, `SaveEdit`, `CancelEdit`), **Retry**, **Select text**
+(opens the cross-paragraph `SelectTextSheet`), and **ReasoningDisclosure**.
+
+**Touches.** `UI/ChatView.swift`, `UI/SelectTextSheet.swift`.
+
+---
+
+## Flow 5 — Model picker & two-step lifecycle (Download → Start → Stop)
+
+**Trigger.** Use the model picker in the chat header, then the primary action.
+
+**Expected.**
+
+1. The picker (`ModelPickerBar`) enumerates aliases via `ModelCatalog`, with
+   Quickstart / Recommended / HuggingFace entries
+   (`ModelPickerBar.ModelMenu`, `ModelPickerBar.Alias.<alias>`, etc.).
+2. The single primary button (`ModelPickerBar.PrimaryButton`) is **two-step**:
+   its label is `"Download"` for an alias not yet on disk and `"Start"` once it
+   is cached (`ModelPickerBar.swift:1487` `startButtonLabel =
+   selectedAliasIsCached ? "Start" : "Download"`). When a model is running the
+   same button becomes **Stop model**, which calls `server.stop()`
+   (`ModelPickerBar.swift:1440`) and is disambiguated from the composer's "Stop
+   response" (see the comment at `:1442`).
+3. Readiness gating for image/audio/chat is centralised in `ModelReadiness`;
+   a readiness banner offers the switch action (`Readiness.Action`,
+   `Readiness.Band`).
+
+**Touches.** `UI/ModelPickerBar.swift`, `Server/ServerManager.swift`,
+`Server/ModelCatalog.swift`, `UI/ModelReadiness.swift`,
+`UI/ReadinessBanner.swift`, `UI/ReadinessModelStart.swift`.
 
 ---
 
 ## Flow 6 — Download a model
 
-**Trigger.** Click **Download** on a non-cached alias (picker or Model Management), or `DownloadManager.startDownload(alias:)`.
+**Trigger.** Choose **Download** on an uncached alias (picker or Model
+Management), or a Quickstart download.
 
-**Expected.**
+**Expected.** `DownloadManager` spawns a `rapid-mlx pull <alias>` job; progress
+and cancel/dismiss surface in the download strip
+(`DownloadStrip.Cancel.<alias>`, `DownloadStrip.Dismiss.<alias>`). The models
+folder is honoured (see Flow 12). On success the alias becomes runnable.
 
-1. `DownloadManager.startDownload` re-resolves `ServerLocator.find()` (picks up a `brew upgrade` since launch) then pulls the alias. Source is the **R2 mirror by default** (v0.7.4, faster + rate-limit-free), with the HuggingFace path as fallback.
-2. Progress streams into the UI with per-tick speed + Chrome-style ETA ("683 KB/s · 5 min left", v0.7.12), smooth within a single big shard (v0.7.11), and covers the R2-mirror phase, not just HF (v0.7.9). Multi-hour downloads on slow links are no longer killed at 30 min (deadline became a stall window, v0.7.13).
-3. Cancelling mid-download flips the job to `.cancelled` via the `cancellingProcesses` identity tracker, so a late cancel can't rewrite a normal completion. Quickstart models land in the correct on-disk folder (v0.8.20) and honour a custom models folder (F11).
-4. On success the alias becomes available to the picker + Model Management.
-
-**Touches.** `Server/DownloadManager.swift`, `Server/ServerLocator.swift`, `Server/ModelsFolderPreference.swift`, `Services/ModelCacheActions.swift`.
-
-**Last smoke result.** Subprocess wiring verified 2026-06-13 (`DownloadManagerTests` real-subprocess suite). UI cancel-button click — re-smoke pending (3-B).
-
-**Known issues.** Inherits 3-A / 3-B.
+**Touches.** `Server/DownloadManager.swift`, `UI/DownloadStrip.swift`,
+`Server/ServerLocator.swift`, `Services/ModelCacheActions.swift`.
 
 ---
 
-## Flow 7 — Clean quit (`Cmd+Q`) & menu-bar lifecycle
+## Flow 7 — Conversation management: sidebar, folders, export
 
-**Trigger.** `Cmd+Q` with Rapid frontmost, or **Quit** from the single menu-bar extra.
-
-**Expected.**
-
-1. There is **one** menu-bar (tray) icon (consolidated from two in v0.8.20) exposing open, new chat, live model status, settings, quit; it renders reliably on recent macOS (visibility fix v0.10.0).
-2. `AppDelegate.applicationWillTerminate` runs synchronously on the main thread.
-3. `SessionStore.finalizeStreamingForTermination` flips dangling `.streaming` rows to `.complete` and strips orphan `tool_calls` markers before the flush.
-4. `SessionStore.flushSync` writes the canonical envelope via the UUID-suffixed atomic-replace path.
-5. `ServerManager.shutdownSync` SIGTERMs the whole rapid-mlx process group (SIGKILL after 2 s). A parent-PID watchdog means even force-quit / `kill -9` leaves **no** orphan sidecar holding the port or RAM (v0.8.14). `DownloadManager.shutdownSync` tears down in-flight pulls.
-6. `CrashReporter.recordCleanShutdown` clears the launch marker so the next launch doesn't misclassify the exit.
-
-**Touches.** `RapidApp.swift` (`AppDelegate`, `MenuBarExtra`), `Chat/SessionStore.swift`, `Server/ServerManager.swift`, `Server/DownloadManager.swift`, `Telemetry/CrashReporter.swift`.
-
-**Last smoke result.** Verified 2026-06-13 and again 2026-07-21 (v0.10.6): `osascript quit` exits cleanly, port 8000 released, no orphan rapid-mlx, no crash report. **Instance-scoped teardown caution:** a user may have their own headless `rapid-mlx serve … --port 88xx` running; quit only the GUI app (its watchdog'd sidecar dies with it) — never bare `pkill -f rapid-mlx`.
-
-**Known issues.** None.
-
----
-
-## Flow 8 — Auto-update
-
-**Trigger.** Background poll in `UpdateChecker` finds a release whose `version` is strictly newer than `Bundle.main.shortVersionString`.
+**Trigger.** Sidebar interactions on conversation rows.
 
 **Expected.**
 
-1. The menu-bar extra label changes to "Update available — v\<X.Y.Z\>"; in-app checks are reliable (extra path + clean fallback, v0.10.4).
-2. Clicking opens the **Update Rapid** window offering in-app install via `Installer` plus an "Open release page" fallback. Release notes render as **formatted, CHANGELOG-driven narrative** (v0.8.3 / v0.8.18), not a raw commit list or raw Markdown.
-3. The release-page URL is host-allowlisted; the DMG URL is download-host-allowlisted (rejects HTTP + foreign hosts); the version string is gated by strict-numeric grammar (`"0.5.13.evil"` rejected).
-4. A failed Finder "Replace" on `/Applications` is detected and offers "Open update dialog" (v0.7.7). The "Setup didn't finish" recovery overlay promotes a **"Download update vX.Y.Z"** CTA when a newer release exists (v0.8.14).
+1. **New chat** (`Sidebar.NewChat`); each conversation row carries
+   `Sidebar.Conversation.<UUID>` and a `···` menu
+   (`Sidebar.Conversation.Menu.<UUID>`).
+2. Row actions: **Rename** (`…Action.Rename`,
+   `Sidebar.Conversation.Rename.<UUID>`), **Delete** (`…Action.Delete`,
+   confirmed via `Sidebar.DeleteConversation.{Confirm,Keep}`), **Move to
+   folder** (`…Action.MoveToFolder`, `…MoveToNewFolder`,
+   `…MoveToFolder.Remove`), and **Export** as **Markdown** or **JSON**
+   (`Sidebar.Conversation.Action.Export.{Markdown,JSON}`).
+3. **Folders**: create/rename/delete (`Sidebar.Folder.*`,
+   `Sidebar.DeleteFolder.{Confirm,Keep}`); archived section toggle
+   (`Sidebar.Archived.Toggle`).
+4. Persistence: conversations are stored in `conversations.json` via
+   `ConversationStore` (`Chat/ConversationHistory.swift:92,106`); folders in a
+   separate `folders.json` via `ConversationFolderStore`
+   (`Chat/ConversationFolder.swift:97`). There is **no** `sessions.json` /
+   `SessionStore` in this app.
+5. **Export All Chats…** is a menu command (⇧⌘E) that writes the whole library
+   through `ConversationExportPanel.exportAll` (`RapidApp.swift:399`).
 
-**Touches.** `Updater/UpdateChecker.swift`, `Updater/Installer.swift`, `UI/UpdateInstallView.swift`, `UI/FailedReplaceBanner.swift`, `UI/SettingsView.swift` (App tab: `Settings.App.Update*`).
-
-**Last smoke result.** Validation layer pinned by `UpdateCheckerTests`. End-to-end menu-bar click flow — re-smoke pending (3-B). Live latest.json for 0.10.6 confirmed servable 2026-07-21.
-
-**Known issues.** Inherits 3-B.
+**Touches.** `UI/SidebarView.swift`, `Chat/ConversationHistory.swift`,
+`Chat/ConversationFolder.swift`, `Chat/ConversationExport.swift`,
+`UI/ConversationExportPanel.swift`, `RapidApp.swift` (Export All command).
 
 ---
 
-## Flow 9 — Pop a conversation into its own window
+## Flow 8 — Search conversations
 
-**Trigger.** **File → Open Conversation in New Window** (⇧⌘O), or right-click a session in the sidebar → **Open in New Window**.
+**Trigger.** The sidebar **Search chats** control (`Toolbar.SearchChats`,
+`SidebarView.swift:231`).
+
+**Expected.** A search panel (`ConversationSearchView`,
+`ConversationSearch.Panel`) with a query field (`ConversationSearch.Field`),
+results keyed per conversation (`ConversationSearch.Result.<UUID>`), a clear
+control, an empty state, and a **New chat** shortcut; matching is done by
+`ConversationSearch`.
+
+**Touches.** `UI/ConversationSearchView.swift`, `Chat/ConversationSearch.swift`.
+
+---
+
+## Flow 9 — Settings (eight categories)
+
+**Trigger.** `Cmd+,` or the in-window settings button (`ContentView.Settings`).
+
+**Expected.** The Settings window renders a category rail
+(`Settings.Category.<rawValue>`) with exactly **eight** release categories, in
+declaration order (`SettingsView.swift:59` `enum Category`): **Model
+Management, Instructions, Tools, Connectors, Performance, Appearance, Privacy,
+App**. A ninth **Developer** category exists only under `#if DEBUG`
+(`SettingsView.swift:90`) and is compiled out of release builds. Deep-linking a
+category is done through `SettingsRouter` (`RapidApp.swift:324`).
+
+**Touches.** `UI/SettingsView.swift`, `UI/SettingsRouter.swift`,
+`RapidApp.swift` (`"settings"` scene).
+
+---
+
+## Flow 10 — Custom instructions (global + per-conversation)
+
+**Trigger.** Settings → Instructions, or the compose-row conversation-
+instructions control (`ChatView.ConversationInstructions`).
 
 **Expected.**
 
-1. A new window titled `Conversation` shows the picked session's full transcript, including the hybrid-thinking `reasoning_content` under a collapsed "Thinking" disclosure.
-2. The popped window is pinned to that session UUID for life — switching `activeID` in the main window does not change it (core contract).
-3. `openWindow(id:value:)` with the same UUID reactivates the existing window (value-based dedup), no stacking.
-4. The popped window is read-only (no compose row); a **Reply in Main Window** header button sets `store.activeID` and re-focuses the main window.
-5. Streaming updates flow in automatically (`SessionStore` is `@Observable`, re-resolved per render).
-6. A deleted/unavailable session renders a "Conversation not available" state (with `PoppedConversation.CloseUnavailableWindow`) rather than crashing.
+1. **Global** instructions are applied to every chat, stored in UserDefaults by
+   `CustomInstructionsConfig` (`Chat/CustomInstructionsConfig.swift:9`); the
+   Settings editor exposes `Settings.Instructions.Clear`.
+2. **Per-conversation** instructions travel with history and are edited via
+   `InstructionTextEditor`
+   (`ChatView.ConversationInstructions.{Save,Clear,Cancel}`).
 
-**Touches.** `UI/PoppedConversationView.swift`, `RapidApp.swift` (`WindowGroup("Conversation", …, for: UUID.self)`), `UI/SessionsSidebar.swift`.
-
-**Last smoke result.** No user-facing changes v0.7.0→v0.10.6. Shape verified 2026-06-13 by `PoppedConversationViewTests`. End-to-end open-window flow — re-smoke pending (3-B).
-
-**Known issues.** Inherits 3-A / 3-B. The popped scene uses `WindowGroup` (not `Window`), so its AX hierarchy may differ from the main window's.
+**Touches.** `Chat/CustomInstructionsConfig.swift`,
+`UI/InstructionTextEditor.swift`, `UI/ChatView.swift`.
 
 ---
 
-## Flow 10 — Model Management (library browser)  *(NEW — v0.10.0)*
+## Flow 11 — Per-model performance settings
 
-**Trigger.** **Settings → Model Management** (also reachable from the Quickstart "Browse all models →").
+**Trigger.** Settings → Performance.
 
-**Expected.** A file-manager-style cache inspector separate from the inline picker (`SettingsModelManagementPanel.swift:32`, issue #210):
+**Expected.** A per-model panel (`Settings.Performance.Panel`) with a model
+picker (`Settings.Performance.ModelPicker`; `Settings.Performance.NoModel` when
+none), KV-cache mode (`…KVMode`), prefix cache (`…PrefixCache`), cache budget
+(`…CacheBudget`, `…CacheBudgetAutomatic`), speculative decoding
+(`…SpeculativeDecoding.Enabled`), reset (`…Reset`), and a "restart / applies
+next load" notice (`…RestartNotice`, `…AppliesNextLoad`). Overrides are stored
+by `ModelPerfConfigStore` and merged into launch flags at spawn
+(`ModelPerfConfigStore.swift:107`; wired at `RapidApp.swift:211`).
 
-1. Search + filter (All / Cached / Not cached) + sort (`…Search`, `…Filter`, `…SortMenu`).
-2. One row per alias with a status badge; per-model **Download / Cancel / Delete / Retry** (`…Download.<alias>` etc.); pin favourites via a star (`…Favorite.<alias>`).
-3. A **"Recommended for your N GB Mac"** section (RAM-bucketed role picks, issue #507; `…RecommendedHeader`, `…Recommended.<role>`) with segmented Accuracy / Speed meters (`…MeterLegend`).
-4. A **"Total: X GB across N models"** footer (`…Footer`).
-5. The models folder controls (F11) sit at the top of this panel.
-
-**Touches.** `UI/SettingsModelManagementPanel.swift`, `Services/ModelCacheActions.swift`, `Server/ModelCatalog.swift`, `Server/DownloadManager.swift`.
-
-**Last smoke result.** Definitions current to v0.10.6; re-smoke pending.
-
-**Known issues.** Inherits 3-A / 3-B.
+**Touches.** `UI/SettingsPerformancePanel.swift`,
+`Server/ModelPerfConfigStore.swift`, `Server/ModelPerfConfig.swift`,
+`Server/ServerManager.swift`.
 
 ---
 
-## Flow 11 — Custom models folder  *(NEW — v0.10.0)*
+## Flow 12 — Model Management (library) & models folder
 
-**Trigger.** **Settings → Model Management → models-folder section** (`SettingsModelManagementPanel.swift:202`, issue #503).
+**Trigger.** Settings → Model Management.
+
+**Expected.** A cache inspector: search/filter/sort
+(`Settings.ModelManagement.{Search,Filter,SortMenu,ClearSearch}`), per-alias
+rows (`…Row.<alias>`) with **Download / Cancel / Delete / Retry**
+(`…{Download,Cancel,Delete,Retry}.<alias>`) and favourite pin
+(`…Favorite.<alias>`); a capability-tab split (`…CapabilityTabs`); a
+**Recommended for your Mac** section (`…RecommendedHeader`,
+`…Recommended.{Download,Cancel,Delete,Retry}.<alias>`) with a meter legend
+(`…MeterLegend`); a storage summary/footer (`…StorageSummary`, `…Footer`,
+`…LargestModel`); auto-start and show-all toggles
+(`Settings.Models.{AutoStartOnLaunchToggle,ShowAllModelsToggle}`); and a
+custom-models-folder control (`…ChooseFolder`, `…UseDefaultFolder`,
+`…FolderPath`, `…FolderUnavailable`) backed by `ModelsFolderPreference`.
+
+**Touches.** `UI/SettingsModelManagementPanel.swift`,
+`Server/ModelCatalog.swift`, `Services/ModelCacheActions.swift`,
+`Server/ModelsFolderPreference.swift`, `Server/DownloadManager.swift`.
+
+---
+
+## Flow 13 — Built-in tools & browse approval
+
+**Trigger.** Settings → Tools, then let a tool-capable model call a tool.
 
 **Expected.**
 
-1. **Choose…** (`Settings.ModelManagement.ChooseFolder`) points Rapid at any folder (e.g. an external drive) for downloaded models; **Use default** (`…UseDefaultFolder`) reverts. Current path shown at `…FolderPath`.
-2. Backed by `Server/ModelsFolderPreference.swift`; the new location takes effect on the next model load / download.
-3. If the chosen drive is unplugged, an "unavailable" warning renders (`…FolderUnavailable`) rather than failing silently.
+1. Exactly **three** built-in tools are dispatched by
+   `BuiltinToolRegistry` (`BuiltinToolRegistry.swift:46`): `web_search`,
+   `browse`, and `weather` (an unknown name is refused with the list). Each is
+   individually toggleable (`Settings.Tools.Toggle.<tool>`) with a details
+   disclosure (`Settings.Tools.Details.<name>`,
+   `Settings.Tools.DetailsBody.<name>`).
+2. `weather` (Open-Meteo) needs no approval; `web_search` runs against the
+   configured backend (Flow 14).
+3. `browse` is SSRF-guarded (`BrowseSSRFGuard`) and gated by a per-fetch
+   approval sheet with **three** buttons — **Deny / Always allow / Allow once**
+   (`ToolApproval.Browse.{Deny,AlwaysAllow,Allow}`, `ContentView.swift:1273`).
+   A blanket auto-approve lives at
+   `Settings.Tools.Browse.AutoApproveToggle`.
+4. The app ships no filesystem or shell tools.
 
-**Touches.** `UI/SettingsModelManagementPanel.swift`, `Server/ModelsFolderPreference.swift`, `Server/DownloadManager.swift`, `Server/ModelCatalog.swift`.
-
-**Last smoke result.** Definitions current to v0.10.6; re-smoke pending.
-
-**Known issues.** Inherits 3-A / 3-B.
+**Touches.** `UI/SettingsToolsPanel.swift`, `Tools/BuiltinToolRegistry.swift`,
+`Tools/WebSearchTool.swift`, `Tools/BrowseTool.swift`,
+`Tools/BrowseApprovalStore.swift`, `Tools/BrowseSSRFGuard.swift`,
+`Tools/WeatherTool.swift`, `UI/ContentView.swift` (browse approval sheet).
 
 ---
 
-## Flow 12 — Connectors (MCP)  *(REBUILT — issue #1716)*
+## Flow 14 — Web-search provider configuration
 
-**Trigger.** **Settings → Connectors** (`SettingsConnectorsPanel.swift`).
+**Trigger.** Settings → Tools → web-search backend
+(`Settings.Tools.WebSearch.Backend`).
 
-**Architecture.** The engine hosts the MCP connections (`vllm_mlx/mcp/*`); the app owns
-the config, the visibility and the consent. The app writes
-`~/.config/rapid-mlx/mcp.json`, passes `--mcp-config` at spawn, reads state back over
-`GET /v1/mcp/servers` + `/v1/mcp/tools`, and executes an approved call through
-`POST /v1/mcp/execute`. The engine deliberately does **not** inject MCP tools into
-`/v1/chat/completions` (`MCPClientManager.get_merged_tools` exists and is uncalled), so the
-tool loop stays in `ChatViewModel` and the consent gate can live on screen.
+**Expected.** There are **five** providers, in the order the radio renders
+them (`WebSearchProvider.swift:63` `enum WebSearchProvider`): **Keenable**
+(the zero-setup, keyless default — `WebSearchConfig` defaults to `.keenable`,
+`WebSearchProvider.swift:211`), **Parallel**, **Tavily**, **Brave Search**, and
+**DuckDuckGo** (keyless backstop). Keys, when a provider takes one, are stored
+in the macOS Keychain (per-provider `keychainAccount`), never UserDefaults;
+pasting a key for a key-requiring provider while on a keyless backend
+auto-promotes the selection (`setAPIKey`, `WebSearchProvider.swift:272`).
+
+**Touches.** `Tools/WebSearchProvider.swift`, `UI/SettingsToolsPanel.swift`,
+`Tools/KeychainStore.swift`, `Tools/WebSearchClients.swift`.
+
+---
+
+## Flow 15 — Connectors (MCP)
+
+**Trigger.** Settings → Connectors.
 
 **Expected.**
 
-1. A master **Enable connectors** toggle (`Settings.Connectors.MasterToggle`, opt-in, default off).
-   Off means `--mcp-config` is not passed at all, so the engine has no MCP subsystem — not merely
-   zero servers.
-2. **Add** (`…AddButton`) opens `MCPServerEditorSheet` (name, transport stdio/SSE, command/args/env
-   or URL, per-server enable). Server names are validated against `[A-Za-z0-9_-]{1,32}` and must not
-   contain `__`, because the engine namespaces every tool as `server__tool` and splits on the first
-   `__`: the name has to stay a legal OpenAI function name and an unambiguous namespace half.
-3. Each server row has a status dot, a one-line state (`…Row.Status.<name>`: *Connected · N tools*,
-   the rejection reason, or *Start a model to connect*), an on/off toggle (`…Row.Toggle.<name>`) and
-   an edit/remove menu (`…Row.Menu.<name>`).
-4. Saving calls `POST /v1/mcp/reload`, so an edit applies **without restarting the model**. Only a
-   change to the master toggle needs a restart (the flag is read once at spawn) — that raises the
-   **Restart to apply** banner (`…RestartButton`). A reload that fails raises the same banner rather
-   than silently swallowing the edit.
-5. Connected tools are listed with per-tool switches (`Settings.Connectors.Tool.Toggle.<name>`), each
-   tagged with its source server. A disabled tool is stripped from the request body AND refused at
-   dispatch.
-6. At inference time, the first call to each connector tool raises `MCPToolApprovalSheet`
-   (`ContentView.swift`): "Run \<tool\>?" with the server, the namespaced name, the display-safe
-   arguments, and **Allow once / Always allow / Don't allow**
-   (`ToolApproval.MCP.{Allow,AlwaysAllow,Deny}`). **Always allow** is scoped to that one tool.
-7. A blanket **Auto-approve all tool calls** switch (`…AutoApproveToggle`) plus **Reset** of
-   remembered grants (`…ResetApprovals`) live in the approvals card.
-8. A misbehaving connector cannot take the chat surface down: `init_mcp` is non-fatal and one bad
-   config entry is dropped-and-reported rather than failing the whole load.
+1. A master **Enable connectors** toggle (`Settings.Connectors.MasterToggle`,
+   opt-in). The flag is read once at spawn, so toggling it raises a **Restart
+   to apply** banner (`…RestartButton`).
+2. **Add / edit** a server through `MCPServerEditorSheet` (name, transport,
+   command/URL, env, enable — `Settings.Connectors.Editor.*`). Rows expose
+   status, toggle, and an edit/remove menu (`…Row.{Status,Toggle,Menu,Edit,
+   Remove}.<name>`).
+3. Connected tools have per-tool switches
+   (`Settings.Connectors.Tool.Toggle.<name>`); a blanket auto-approve
+   (`…AutoApproveToggle`) and **Reset approvals** (`…ResetApprovals`) live in
+   the approvals card.
+4. At inference the first call to a connector tool raises an approval sheet
+   with **three** buttons (`ToolApproval.MCP.{Deny,AlwaysAllow,Allow}`,
+   `ContentView.swift:1376`). Editing or removing a server revokes its
+   remembered grant (`MCPToolApprovalStore.revokeGrants`, wired at
+   `RapidApp.swift:187`).
 
 **Touches.** `UI/SettingsConnectorsPanel.swift`, `UI/MCPServerEditorSheet.swift`,
-`UI/ContentView.swift` (`MCPToolApprovalDialog` / `MCPToolApprovalSheet`), `MCP/*`
-(`MCPServerConfig`, `MCPConfigStore`, `MCPCatalog`, `MCPToolApprovalStore`, `MCPToolRegistry`,
-`CompositeToolRegistry`), `Server/ServerManager.swift` (`serveArguments`,
-`mcpConfigPathProvider`), and engine-side `vllm_mlx/server.py` (`init_mcp`, `reload_mcp`),
-`vllm_mlx/routes/mcp_routes.py`, `vllm_mlx/mcp/config.py` (tolerant load).
-
-**Last smoke result.** Unit-covered by `MCPConnectorsTests.swift` (config round-trip, name
-validation, launch-flag gating, approval semantics, dispatch refusal) and
-`tests/test_mcp_resilience.py` (non-fatal init, per-entry isolation, reload). End-to-end
-connector smoke pending.
-
-**Known issues.** The approval sheet's three buttons carry AXIdentifiers, but the sheet is only
-reachable when a real connector is configured and a model actually calls one of its tools — the
-golden-flow harness has no fixture connector, so that step is manual for now.
+`UI/ContentView.swift` (MCP approval sheet), `MCP/MCPConfigStore.swift`,
+`MCP/MCPCatalog.swift`, `MCP/MCPToolApprovalStore.swift`,
+`MCP/MCPToolRegistry.swift`, `MCP/CompositeToolRegistry.swift`,
+`Server/ServerManager.swift` (`mcpConfigPathProvider`).
 
 ---
 
-## Flow 13 — Built-in web tools and browse approval
+## Flow 16 — Images tab (text→image and image edit)
 
-**Trigger.** Enable tools under **Settings → Tools**, then let a tool-capable
-model call `web_search`, `browse`, or `weather`.
+**Trigger.** Sidebar → Images (`Sidebar.Images`).
+
+**Expected.** A dedicated `ImagesView`: empty-state hero
+(`Images.EmptyState`), a model picker filtered to image aliases
+(`Images.ModelPicker`, `Images.Model.<alias>`), aspect/resolution controls
+(`Images.Aspect.<ar>`, `Images.Resolution.<res>`), a readiness switch when the
+sidecar is on another model (`Readiness.Action`), prompt + generate
+(`Images.Prompt`, `Images.Generate`), an in-flight progress card with cancel
+(`Images.Cancel`), a result stage and gallery filmstrip (`Images.Stage`,
+`Images.Gallery`, `Images.Gallery.Thumb.<n>`), and save/edit result actions
+(`Images.Result.{Save,Edit}`). Edit mode imports a source
+(`Images.Edit.Import`, `Images.Edit.Source`) and exits back to generation
+(`Images.Edit.Exit`). rapid-mlx serves one model per process, so selecting an
+image alias reloads the sidecar.
+
+**Touches.** `UI/ImagesView.swift`, `Images/ImageGenViewModel.swift`,
+`Images/ImageClient.swift`.
+
+---
+
+## Flow 17 — Audio tab (speech & transcription)
+
+**Trigger.** Sidebar → Audio (`Sidebar.Audio`).
+
+**Expected.** `AudioView` with a mode switch (`Audio.Mode`) and an empty state
+that can jump to Model Management (`Audio.EmptyState`,
+`Audio.EmptyState.OpenModelManagement`). **Speech (TTS)**: text
+(`Audio.Speech.Text`), voice picker + preview (`Audio.Speech.VoicePicker`,
+`Audio.Speech.PreviewVoice.<voice>`), speed (`Audio.Speech.Speed`), generate /
+play / save (`Audio.Speech.{Generate,Play,Save,LoadVoices}`).
+**Transcription (STT)**: file picker, run, result, copy, save
+(`Audio.Transcription.{FilePicker,Run,Result,Copy,Save}`).
+
+**Touches.** `UI/AudioView.swift`, `Audio/AudioViewModel.swift`,
+`Audio/AudioClient.swift`.
+
+---
+
+## Flow 18 — Dictation (background global hotkey)
+
+**Trigger.** A press-and-hold global hotkey, armed at launch
+(`RapidApp.swift:302`, `dictation.bootstrap()`) so it works with Rapid's window
+closed.
+
+**Expected.** `DictationController` records, transcribes against the sidecar,
+and injects text at the cursor. It is built on a `CGEventTap`
+(`DictationHotkey.swift:4`), needing Microphone and Accessibility grants
+(`Dictation.GrantMicrophone`, `Dictation.GrantAccessibility`). The Dictation
+settings surface (`DictationView`) exposes enable/arm/hotkey/model
+(`Dictation.{Enable,Arm,Hotkey,Model}`), a vocabulary manager
+(`Dictation.{NewTerm,AddTerm,RemoveTerm.<term>,Suggestion.<name>}`), a
+transcript-fix sheet (`Dictation.Fix.*`), and history controls
+(`Dictation.{CopyTranscript,ArchiveAudio,ClearHistory}`).
+
+**Touches.** `Dictation/DictationController.swift`,
+`Dictation/DictationHotkey.swift`, `Dictation/DictationRecorder.swift`,
+`Dictation/DictationInjector.swift`, `Dictation/DictationVocabulary.swift`,
+`Dictation/DictationHistory.swift`, `UI/DictationView.swift`.
+
+---
+
+## Flow 19 — Launch / integrations page
+
+**Trigger.** Sidebar → Launch (`Sidebar.Launch`).
+
+**Expected.** `LaunchView` (`SidebarView.swift:1365`) renders
+`ConnectToolsView`, which lists integration targets from `IntegrationCatalog`
+and offers copy/reveal of connection details
+(`Launch.Integration.Copy.<tool.id>`, `ConnectTools.{Copy,Reveal}.<label>`,
+`ConnectTools.Close`) — i.e. connecting external clients to the local server.
+
+**Touches.** `UI/SidebarView.swift` (`LaunchView`), `UI/ConnectToolsView.swift`,
+`Server/IntegrationCatalog.swift`.
+
+---
+
+## Flow 20 — App updates (Sparkle)
+
+**Trigger.** Background check at launch, or Settings → App.
 
 **Expected.**
 
-1. The three built-in tools are individually enabled or disabled. A disabled
-   tool is omitted from the request and refused again at dispatch.
-2. `web_search` uses DuckDuckGo, Brave, or Tavily as selected under Tools;
-   provider keys are stored in Keychain. `weather` uses Open-Meteo and needs no
-   approval.
-3. `browse` accepts only HTTP(S), rejects private/loopback/reserved destinations
-   before prompting, and shows the display-safe host and complete URL in a
-   per-fetch approval sheet (`ToolApproval.Browse.{Allow,Deny}`). Redirects are
-   checked and approved under the same policy.
-4. **Approve every page automatically** changes browse from per-fetch approval
-   to a persisted blanket mode. This does not approve MCP tools; connector grants
-   remain per tool under **Settings → Connectors**.
-5. The app ships no filesystem tools, shell execution, permissions matrix, or
-   filesystem sandbox. Those capabilities must not be inferred from the engine
-   or from the retired rapid-desktop contract.
+1. Updates are **Sparkle-owned**: `SparkleUpdateController` runs the check,
+   background download, EdDSA verification, and install-on-quit
+   (`RapidApp.swift:334`, gated on `sparkleUpdater.isEnabled`). There is **no**
+   in-app installer type in `Updater/` — the directory is `InstallTracker`,
+   `SparkleUpdateController`, and `UpdateChecker`.
+2. `UpdateChecker` is read-only: it GETs a static manifest and drives the
+   version pill and the Settings → App status
+   (`Settings.App.{Checking,RecheckCTA,UpdateCTA,AutomaticUpdatesToggle}`); it
+   installs nothing (`RapidApp.swift:64`).
+3. `InstallTracker` detects the "Finder Replace into /Applications silently
+   failed because Rapid was still running" footgun; `FailedReplaceBanner`
+   surfaces recovery (`FailedReplace.{OpenUpdate,Dismiss}`).
+4. Manifest URLs are host-allowlisted (`updateReleaseHostAllowlist`,
+   `updateDownloadHostAllowlist`, `RapidApp.swift:16,33`).
 
-**Touches.** `UI/SettingsToolsPanel.swift`, `UI/ContentView.swift`
-(`BrowseApprovalSheet`), `Tools/BuiltinToolRegistry.swift`,
-`Tools/BrowseApprovalStore.swift`, `Tools/BrowseSSRFGuard.swift`,
-`Tools/{WebSearchTool,BrowseTool,WeatherTool}.swift`.
-
-**Last smoke result.** Enable/disable, provider persistence, SSRF refusal, approval
-decisions, redirects, and cancellation are unit-covered; the built-in-tools
-GoldenFlow exercises the rendered settings and chat path.
-
-**Known issues.** DNS rebinding and pagination/result-bound hardening remain in
-#1535. A deliberately declined or failed result can still be mischaracterised by
-weak models; investigation is tracked in #1582.
+**Touches.** `Updater/SparkleUpdateController.swift`,
+`Updater/UpdateChecker.swift`, `Updater/InstallTracker.swift`,
+`UI/FailedReplaceBanner.swift`, `UI/SettingsView.swift` (App category),
+`RapidApp.swift`.
 
 ---
 
-## Flow 14 — In-chat controls: system prompt & tools toggle  *(NEW surface — v0.7.x→v0.10.x)*
+## Flow 21 — Dock-visibility on close & menu-bar residency
 
-**Trigger.** In an active conversation, use the compose-row controls.
+**Trigger.** Close the main window; or use the tray.
 
-**Expected.**
+**Expected.** The first native close reaches a Dock-visibility prompt
+(`MainWindowCloseInterceptor`, installed at `RapidApp.swift:557`) offering keep
+/ hide-on-close plus "don't ask again" (`DockVisibilityPrompt`,
+`DockVisibilityPromptStore`). A persisted "hide always" choice boots the app in
+`.accessory` policy (`RapidApp.swift:695`). The app stays alive behind the
+single `MenuBarController` tray, which exposes open / new chat / status /
+settings / quit; a Dock click re-opens the main window
+(`applicationShouldHandleReopen`, `RapidApp.swift:819`).
 
-1. **Per-conversation system prompt.** A `systemPromptHeader` chip (`ChatView.swift:530`); unset shows a **Set system prompt** link (`:519`) opening `SystemPromptSheet`, persisted per-session via `SessionStore.setSystemPrompt(id:)` and reloaded on session switch.
-2. **Per-turn tools toggle.** A wrench `toolsChip` in the compose row (`ChatView.swift:1688`) opens a popover to enable/disable individual tools for the turn (shows active/count). Web search is **one tool inside this popover** (and Settings → Web Search for provider/keys) — there is **no** separate web-search compose toggle. The empty-state "Search the web" example chip (`:1278`) is a prompt seed, not a toggle.
-3. **Upgrade nudge.** After ~3 messages on the bundled starter, a nudge banner above the composer offers a one-click background upgrade download with dismissal modes (v0.7.2, retuned v0.10.2) — drives F6.
-
-**Touches.** `UI/ChatView.swift` (`systemPromptHeader`, `toolsChip`, `SystemPromptSheet`, upgrade nudge), `Chat/SessionStore.swift`, `Tools/*`.
-
-**Last smoke result.** Definitions current to v0.10.6; re-smoke pending.
-
-**Known issues.** Inherits 3-A / 3-B.
-
----
-
-## Flow 15 — Conversation management: delete, undo, search  *(NEW/expanded)*
-
-**Trigger.** Sidebar interactions on sessions.
-
-**Expected.**
-
-1. **Delete** a conversation via the sidebar; a confirmation sheet (`DeleteSessionConfirmation.swift`, `DeleteSessionConfirm.Sheet` / `…DeleteButton` / `…SkipToggle` "don't ask again").
-2. **Undo delete** (v0.10.6): a "Chat deleted" toast row with an **Undo** button (`Sidebar.UndoDelete`, ⌘Z) briefly restores the conversation.
-3. **Search chats** (`SessionsSidebar.swift:557`): a "Search chats" field filters sessions (`filteredSessions`, logic in `Chat/MessageSearch.swift`); in-chat find is ⌘F (`ChatView.swift:702`).
-4. **Resilience banners:** corrupt `sessions.json` shows a "Show in Finder / Dismiss" banner (`SessionLoadFailureBanner`); a restored session on a since-removed model shows a stale-alias banner (`StaleSessionAliasBanner`); "N chats skipped — restore backup" recovery (v0.8.20, via Storage tab).
-
-**Touches.** `UI/SessionsSidebar.swift`, `UI/DeleteSessionConfirmation.swift`, `Chat/MessageSearch.swift`, `Chat/SessionStore.swift`, `UI/SessionLoadFailureBanner.swift`, `UI/StaleSessionAliasBanner.swift`.
-
-**Last smoke result.** Definitions current to v0.10.6; re-smoke pending. New chat + session switching exercised 2026-07-21 (v0.10.6 dogfood) via `Sidebar.NewChat`.
-
-**Known issues.** Inherits 3-A / 3-B.
+**Touches.** `UI/MainWindowCloseInterceptor.swift`,
+`UI/DockVisibilityPrompt.swift`, `UI/DockVisibilityPromptStore.swift`,
+`UI/MenuBarController.swift`, `RapidApp.swift` (`AppDelegate`).
 
 ---
 
-## Accessibility identifier inventory (for `scripts/walkthrough.sh`)
+## Flow 22 — Clean quit & termination
 
-`walkthrough.sh` clicks controls by `.accessibilityIdentifier` via `System Events` — the supported way to drive the UI (cliclick coordinates don't fire SwiftUI handlers; see the driving note at the top). Keep this inventory in sync when adding/removing identifiers. Current set (file:line → id):
+**Trigger.** `Cmd+Q`, or **Quit** from the tray.
 
-- **Quickstart wizard** — `QuickstartView.swift`: `Quickstart.GetStarted` (:739), `Quickstart.Skip` (:757), `Quickstart.BrowseAll` (:818), `Quickstart.LowDisk.Continue` (:949), `Quickstart.LowDisk.Cancel` (:961), `Quickstart.Retry` (:1000). `OnboardingComponents.swift`: `Quickstart.Footer.Back` (:100), `Quickstart.Footer.Primary` (:114), `Quickstart.Choice.<alias>` (:193 recommended, :241 compact).
-- **Chat** — `ChatView.swift`: `ChatView.SendOrStopButton` (:2211), `ChatView.NotReadyHint` (:1560), `ChatView.toolCallArtifactSuppressed` (:3074), `ChatView.toolNotCalledCaption` (:3114), `…dismiss` (:3127).
-- **Model picker** — `ModelPickerBar.swift`: `ModelPickerBar.PrimaryButton` (:1407/:1417/:1427, three mutually-exclusive states).
-- **Sidebar** — `SessionsSidebar.swift`: `Sidebar.NewChat` (:228), `Sidebar.LoadingSessions` (:262), `EmptySidebar.StartChatting` (:287), `Sidebar.UndoDelete` (:1173). `DeleteSessionConfirmation.swift`: `DeleteSessionConfirm.SkipToggle` (:206), `…DeleteButton` (:226), `…Sheet` (:234).
-- **Footer** — `ContentView.swift`: `Footer.DesktopVersionPill` (:1975).
-- **Settings** — `SettingsView.swift`: `Settings.QuickAsk.LaunchAtLogin` (:569), `Settings.WebSearch.{KeyField,ClearButton,SaveButton}.<providerID>`, `Settings.App.{HideDockOnCloseToggle,ResetDockOnboardingCTA,UpdateHeadline,UpdateCTA,UpToDate,Checking,Unknown,RecheckCTA}`. `SettingsModelManagementPanel.swift`: `Settings.Models.{ShowAllModelsToggle,AutoStartOnLaunchToggle}`.
-- **Model Management** (prefix `Settings.ModelManagement.`) — `SettingsModelManagementPanel.swift`: `FolderPath`, `FolderUnavailable`, `ChooseFolder`, `UseDefaultFolder`, `Search`, `SortMenu`, `Filter`, `RecommendedHeader`, `Recommended.<role>`, `Footer`, `MeterLegend`, `Favorite.<alias>`, `Delete.<alias>`, `Download.<alias>`, `Cancel.<alias>`, `Retry.<alias>`, `Row.<alias>`, `Status.<text>`, plus `Recommended.{Delete,Download,Cancel,Retry}.<alias>`.
-- **Connectors** (prefix `Settings.Connectors.`) — `SettingsConnectorsPanel.swift`: `MasterToggle`, `AutoApproveToggle`, `ResetApprovals`, `RestartButton`, `SubsystemError`, `AddButton`, `ConfirmRemove`, `CancelRemove`, `Row.Status.<name>`, `Row.Toggle.<name>`, `Row.Menu.<name>`, `Row.Edit.<name>`, `Row.Remove.<name>`, `Tool.Toggle.<name>`. `MCPServerEditorSheet.swift` (prefix `Settings.Connectors.Editor.`): `Name`, `Transport`, `Command`, `URL`, `Enabled`, `AddArgument`, `AddEnv`, `Allow`, `Cancel`. Pinned by `AccessibilityIdentifierInventoryTests`.
-- **MCP tool approval sheet** — `ContentView.swift`: `ToolApproval.MCP.Allow`, `ToolApproval.MCP.AlwaysAllow`, `ToolApproval.MCP.Deny`.
-- **Banners / misc** — `FailedReplaceBanner` (`FailedReplaceBanner.swift:90`), `StaleSessionAliasBanner{,.Dismiss}`, `SessionLoadFailureBanner{,.ShowInFinder,.Dismiss}`, `PoppedConversation.CloseUnavailableWindow` (`PoppedConversationView.swift:88`).
+**Expected.** `applicationWillTerminate` runs `runStandardTermination`
+(`RapidApp.swift:938`): stop the in-flight stream, signal then reap the server
+process group and the download children (overlapping grace windows), then flush
+`ConversationStore` and `ConversationFolderStore`. `CrashReporter` clears the
+launch marker so the next launch does not misclassify the exit. A watchdog'd
+sidecar dies with the app; a user's own headless `rapid-mlx serve` is untouched.
 
-- **Settings → Tools** — `SettingsToolsPanel.swift`: `Settings.Tools.Toggle.<tool>` (`web_search`, `browse`, `weather`), `Settings.Tools.WebSearch.Backend` (the radio group) + `Settings.Tools.WebSearch.Backend.<duckduckgo|brave|tavily>`, `Settings.Tools.WebSearch.KeyField.<provider>`, `Settings.Tools.WebSearch.SaveKey.<provider>`, `Settings.Tools.WebSearch.KeyDashboardLink.<provider>` (the "Get a <provider> key" link — only rendered for a provider that has a dashboard URL, which is why it was missed on the first pass), `Settings.Tools.Browse.AutoApproveToggle`.
-- **Settings → Privacy** — `SettingsView.swift`: `Settings.Privacy.TelemetryToggle`, `Settings.Privacy.Link.{PrivacyPolicy,License,Credits}` (each link keyed on the document it opens, not on its label). The toggle re-renders on press as of [#1623](https://github.com/raullenchai/Rapid-MLX/issues/1623); before that it wrote the preference while appearing to snap back — see `docs/gui-golden-flows.md`.
-- **Conversation row controls** — `SidebarView.swift`: `Sidebar.Conversation.{Pin,Unpin}.<UUID>` (hover control, named for the action the press performs), `Sidebar.Conversation.Menu.<UUID>` (the ··· menu button), and its items `Sidebar.Conversation.Action.{Rename,Pin,Unpin,Archive,Unarchive,Delete}` (shared with the right-click menu). Delete confirmation: `Sidebar.DeleteConversation.{Confirm,Keep}`.
-- **Message actions** — `ChatView.swift`: `ChatView.Message.{Copy,Edit,Retry,CancelEdit,SaveEdit}.<message UUID>`.
-- **Tool approval** — `ContentView.swift`: `ToolApproval.Browse.{Allow,Deny}` (the per-fetch `browse` approval). The enclosing sheet is deliberately **unnamed**: an accessibility modifier on a container that is not its own accessibility element applies to the elements it contains, so naming the wrapper risks stamping it over the two buttons. Wait for `ToolApproval.Browse.Allow` to assert the prompt is up.
-
-**No identifier (can't be AX-driven):** nothing on the current surface is known
-to be unreachable. Both browse and MCP approval sheets carry identifiers. The
-app has no sandbox approval prompt because it ships no filesystem or shell tools.
-Reaching the MCP sheet still requires a configured connector that actually calls
-a tool; its controls are addressable even when that external fixture is absent.
-
-**Keeping this inventory from rotting.** The list above used to grow only when someone remembered to add an identifier. It is now defended by a CI gate: `scripts/check_rapid_mac_ax_identifiers.py` (job `accessibility-identifiers` in `.github/workflows/rapid-mac-ci.yml`) fails any PR that *adds* an interactive control under `apps/rapid-mac/Sources/` without `.accessibilityIdentifier(...)`. A control that genuinely cannot carry one opts out with a reasoned, greppable `// ax-exempt: <why>` marker on the control's line or the line above — no such control is known on the current surface (the `confirmationDialog`/`alert` doubt was measured and closed, see above), so `rg ax-exempt apps/rapid-mac` finding nothing is correct. The gate is scoped to added lines, so the *existing* gaps below are not blocked by it; `--audit` enumerates them. See `docs/gui-golden-flows.md` § "The identifier gate".
+**Touches.** `RapidApp.swift` (`runTerminationSequence`,
+`runStandardTermination`), `Server/ServerManager.swift`,
+`Server/DownloadManager.swift`, `Chat/ConversationHistory.swift`,
+`Chat/ConversationFolder.swift`, `Telemetry/CrashReporter.swift`.
 
 ---
 
-## Test harness limits
+## Flow 23 — Appearance / theme
 
-Three "verified" levels, kept distinct so a reviewer doesn't conflate them:
+**Trigger.** Settings → Appearance (`Settings.Appearance.ThemePicker`).
 
-| Level                            | Meaning                                                                                                    |
-|----------------------------------|------------------------------------------------------------------------------------------------------------|
-| **Wire / persistence verified**  | Data structures, file formats, HTTP/SSE shapes round-trip under the unit + integration suite. UI-independent. |
-| **Structural launch verified**   | `scripts/release-smoke.sh` confirms the scene renders, the main window exists in CGWindowList, the app stays alive 15 s, no crash report. |
-| **End-to-end UX verified**       | A real user — or an Accessibility-permitted `walkthrough.sh` AXIdentifier pass on a local login session — drove the flow with mouse + keyboard. |
+**Expected.** A theme override persisted by `AppearanceConfig` and re-applied
+after `NSApp` boots (`RapidApp.swift:718`) so a saved "Light" choice survives a
+dark host.
 
-`walkthrough.sh` raised the ceiling from level 2 by clicking via AXIdentifier instead of coordinates, but full level-3 coverage still depends on the AX bridge (3-A) exposing each control and on running from a **local login session, not SSH+tmux** (3-B). The sidecar HTTP API (bearer from the sidecar env) verifies the chat wire end-to-end independent of the GUI send path.
+**Touches.** `UI/SettingsView.swift` (Appearance), `UI/AppearanceConfig.swift`.
 
 ---
 
-## Open follow-up items
+## Flow 24 — Missing-runtime overlay
 
-- **3-A residual — SwiftUI `Window` scene AX bridge still returns the `AXApplication` instead of the `AppKitWindow`.** `setActivationPolicy(.regular)` + `AXEnhancedUserInterface = true` lands the floor; the deeper bridge (real `AXWindow` with navigable `AXTextArea` / `AXButton` children) still needs custom `NSAccessibilityElement` wrappers. P2 — affects VoiceOver, not sighted keyboard+mouse users. **This gates whether `walkthrough.sh`'s `first button … whose AXIdentifier is …` lookups actually resolve** — verify on a fresh v0.10.6 run before trusting the AXIdentifier walk (an older note recorded these lookups returning empty; confirm current state).
-- **3-B residual — no harness-driven UI test from SSH.** Run the walk on a local login GUI session; cliclick for focus, AXIdentifier `click` for buttons, real keystrokes for submit. cliclick coordinate clicks do NOT fire SwiftUI handlers (re-confirmed v0.10.6).
-- ~~**Approval dialogs lack identifiers.**~~ Closed. The shipped browse and MCP
-  approval sheets carry the identifiers listed above. The retired contract's
-  sandbox prompt never existed in this app because filesystem and shell tools do
-  not ship here.
-- **Manual-only checks.** Physical global-hotkey delivery and local-login keyboard
-  traversal cannot be proven by the unattended AX lane. Keep their dated manual
-  evidence separate from CI GoldenFlow results.
-- **Compose editor doc drift fixed.** `ComposeTextEditor` is the `NSViewRepresentable`; the `NSTextView` subclass it hosts is `AutosizingTextView`. Keep this straight in future edits.
+**Trigger.** The embedded rapid-mlx binary cannot be resolved
+(`ServerState.missing`, routed by `ContentView.mainAreaBranch`,
+`ContentView.swift:1195`).
+
+**Expected.** An install/recovery overlay replaces the chat surface with
+recheck / download-update / quit actions
+(`MissingRuntime.{Recheck,RecheckStatus,DownloadUpdate,Quit}`).
+
+**Touches.** `UI/ContentView.swift` (missing-runtime branch).
+
+---
+
+## Flow 25 — Developer panel (DEBUG only)
+
+**Trigger.** Settings → Developer — **present only in `#if DEBUG` builds**
+(`SettingsView.swift:90`).
+
+**Expected.** State-erasing rehearsal actions (`Settings.Developer.Panel`,
+`…Reonboard`, `…{Confirm,Cancel}Reonboard`) with scoped erase toggles
+(`Settings.Developer.Scope.{Conversations,Preferences,Telemetry}`), driven by
+`ReonboardingReset` (`ReonboardingScope`, `Services/ReonboardingReset.swift`).
+
+**Touches.** `UI/SettingsDeveloperPanel.swift`, `Services/ReonboardingReset.swift`.
+
+---
+
+## Removed in this regeneration (fictional / stale)
+
+These appeared in the prior file and are **not present in `Sources/`**; the
+greps that prove their absence are recorded so a future edit doesn't reintroduce
+them:
+
+- **"Quick Ask" global hotkey / `QuickAskView` / `GlobalHotkey`.** No such type
+  or directory. `grep -rn "struct QuickAskView\|GlobalHotkey" Sources` → none
+  (the string "QuickAsk" survives only in unrelated doc-comments).
+- **"Pop a conversation into its own window" / `PoppedConversationView.swift`.**
+  Absent (`find … -iname "*popped*"` → none). There is one `"main"` window and
+  one `"settings"` window; no per-conversation `WindowGroup`.
+- **`OnboardingTour` 4-page sheet.** No `OnboardingTour.swift`; onboarding is
+  the Quickstart wizard (Flow 1).
+- **`sessions.json` / `SessionStore` / `SessionsSidebar.swift` /
+  `DeleteSessionConfirmation.swift` / `MessageSearch.swift` /
+  `SessionLoadFailureBanner.swift` / `StaleSessionAliasBanner.swift`.** None
+  exist. The store is `conversations.json` via `ConversationStore`
+  (`Chat/ConversationHistory.swift`).
+- **`Updater/Installer.swift` / `UpdateInstallView.swift` / in-app installer.**
+  Absent; updates are Sparkle-only (Flow 20).
+- **Three-provider web search (DDG/Brave/Tavily only).** There are five, with a
+  keyless Keenable default (Flow 14).
+- **Six Settings categories.** There are eight in release (Flow 9).
+- **Dead AX ids** `Settings.QuickAsk.LaunchAtLogin`, `DeleteSessionConfirm.*`,
+  and the two-button `ToolApproval.Browse.{Allow,Deny}` — the browse and MCP
+  approval sheets each carry **three** buttons now.
+
+---
+
+## Accessibility identifier inventory
+
+This is the authoritative AX inventory, generated by scanning
+`.accessibilityIdentifier(...)` string literals in `apps/rapid-mac/Sources/`.
+Identifiers built from interpolation keep their placeholder (e.g. `.<alias>`,
+`.<UUID>`, `.<name>`). Grouped by the file that declares them. When adding or
+removing a control, update this list; the `accessibility-identifiers` CI job
+(`scripts/check_rapid_mac_ax_identifiers.py`) fails any PR that adds an
+interactive control under `Sources/` without an identifier.
+
+**Chat — `UI/ChatView.swift`:** `ChatView.SendOrStopButton`,
+`ChatView.AddAttachments`, `ChatView.ConversationInstructions`,
+`ToolCallChip.<action>`, `ToolCallChip.Toggle.<call.id>`,
+`ChatView.Message.<action>.<UUID>` (action ∈ {`EditField`, `CancelEdit`,
+`SaveEdit`, `Edit`, `Copy`, `SelectText`, `Retry`, `ReasoningDisclosure`}).
+`UI/SelectTextSheet.swift`: `SelectText.Done`. `UI/JumpToBottomButton.swift`:
+`Transcript.JumpToBottom`. `UI/InstructionTextEditor.swift`:
+`ChatView.ConversationInstructions.{Save,Clear,Cancel}`,
+`Settings.Instructions.Clear`, `<id>.Count`.
+
+**ContentView — `UI/ContentView.swift`:** `ContentView.Settings`,
+`ContentView.LogDrawer`, `ContentView.ToggleLogs`, `Footer.DesktopVersionPill`,
+`MemoryWarning.{Confirm,Cancel}`,
+`MissingRuntime.{Recheck,RecheckStatus,DownloadUpdate,Quit}`,
+`ToolApproval.Browse.{Allow,AlwaysAllow,Deny}`,
+`ToolApproval.MCP.{Allow,AlwaysAllow,Deny}`.
+
+**Sidebar — `UI/SidebarView.swift`:** `Sidebar.NewChat`, `Sidebar.Images`,
+`Sidebar.Audio`, `Sidebar.Launch`, `Sidebar.Residency`,
+`Sidebar.ResidentModel.<id>`, `Sidebar.Archived.Toggle`, `Toolbar.SearchChats`,
+`Sidebar.Conversation.<UUID>`, `Sidebar.Conversation.Menu.<UUID>`,
+`Sidebar.Conversation.Rename.<UUID>`,
+`Sidebar.Conversation.Action.{Rename,Delete,MoveToFolder,MoveToNewFolder,
+MoveToFolder.Remove,Export.JSON,Export.Markdown}`,
+`Sidebar.DeleteConversation.{Confirm,Keep}`,
+`Sidebar.Folder.{Action.Rename,Action.Delete,NameField,Toggle.<slug>,
+Prompt.Confirm,Prompt.Cancel}`, `Sidebar.DeleteFolder.{Confirm,Keep}`.
+
+**Conversation search — `UI/ConversationSearchView.swift`:**
+`ConversationSearch.{Panel,Field,Clear,Close,Empty,NewChat,Result.<UUID>}`.
+
+**Model picker — `UI/ModelPickerBar.swift`:** `ModelPickerBar.PrimaryButton`,
+`ModelPickerBar.ModelMenu`, `ModelPickerBar.ModelInfo`,
+`ModelPickerBar.RefreshCatalog`, `ModelPickerBar.Alias.<alias>`,
+`ModelPickerBar.Quickstart.<alias>`, `ModelPickerBar.Recommended.<alias>`,
+`ModelPickerBar.HuggingFace.<repo>`,
+`ModelPickerBar.Context.{Download,Delete}.<alias>`,
+`ModelPickerBar.CustomAlias.{Open,Field,Use,Cancel}`,
+`ModelPickerBar.Delete.{Confirm,Cancel}`. Readiness:
+`UI/ReadinessBanner.swift` `Readiness.Action`; `UI/Components/LifecycleBand.swift`
+`Readiness.Band`. Downloads: `UI/DownloadStrip.swift`
+`DownloadStrip.{Cancel,Dismiss}.<alias>`.
+
+**Quickstart / onboarding — `UI/QuickstartView.swift`:**
+`Quickstart.{GetStarted,Skip,BrowseAll,Ready.StartChatting,ResumeNotice,
+Review.Footnote,Step2.Kicker}`,
+`Quickstart.BrowseAll.{Search,Filter,SortMenu,Sort.<order>,List,Count}`,
+`Quickstart.CachedModel.<alias>`, `Quickstart.YourPick.<alias>`,
+`Quickstart.Download.Cancel`, `Quickstart.Failure.BackToModelSelection`,
+`Quickstart.LowDisk.{Continue,Cancel}`,
+`Quickstart.Memory.{SwitchToLowMemory,LoadAnyway,Cancel}`.
+`UI/OnboardingComponents.swift`: `Quickstart.Choice.<alias>`,
+`Quickstart.CatalogRow.<alias>`. `UI/OnboardingDirectionD.swift`:
+`Quickstart.{Footer.Back,Footer.Primary,Progress,Compare,SelectionSummary,
+Rail.ThisMac,Step2.Kicker,Subject.{Bytes,Percent,Rail,Rate}}`.
+
+**Settings rail / App / Privacy / Appearance — `UI/SettingsView.swift`:**
+`Settings.Category.<rawValue>`,
+`Settings.App.{AutomaticUpdatesToggle,Checking,RecheckCTA,UpdateCTA,
+ExportDiagnostics,HideDockOnCloseToggle,ResetDockOnboardingCTA}`,
+`Settings.Appearance.ThemePicker`, `Settings.Privacy.TelemetryToggle`,
+`Settings.Privacy.Link.{PrivacyPolicy,License,Credits,MTPLX}`.
+
+**Model Management — `UI/SettingsModelManagementPanel.swift`:**
+`Settings.ModelManagement.{Search,ClearSearch,Filter,SortMenu,Sort.<order>,
+Row.<alias>,Status.<text>,Download.<alias>,Cancel.<alias>,Delete.<alias>,
+Retry.<alias>,ConfirmDelete,Favorite.<alias>,KeepOnDisk,CapabilityTabs,
+RecommendedHeader,Recommended.<primary?>,Recommended.Download.<alias>,
+Recommended.Cancel.<alias>,Recommended.Delete.<alias>,Recommended.Retry.<alias>,
+MeterLegend,StorageSummary,LargestModel,Footer,VisibleCount,ChooseFolder,
+UseDefaultFolder,FolderPath,FolderUnavailable}`,
+`Settings.Models.{AutoStartOnLaunchToggle,ShowAllModelsToggle}`.
+
+**Performance — `UI/SettingsPerformancePanel.swift`:**
+`Settings.Performance.{Panel,ModelPicker,NoModel,KVMode,PrefixCache,CacheBudget,
+CacheBudgetAutomatic,SpeculativeDecoding.Enabled,Reset,RestartNotice,
+AppliesNextLoad}`.
+
+**Tools — `UI/SettingsToolsPanel.swift`:**
+`Settings.Tools.Toggle.<function.name>`, `Settings.Tools.Details.<name>`,
+`Settings.Tools.DetailsBody.<name>`, `Settings.Tools.WebSearch.Backend`,
+`Settings.Tools.Browse.AutoApproveToggle`.
+
+**Connectors — `UI/SettingsConnectorsPanel.swift`:**
+`Settings.Connectors.{MasterToggle,AddButton,AutoApproveToggle,ResetApprovals,
+RestartButton,SubsystemError,ConfirmRemove,CancelRemove,
+Row.Status.<name>,Row.Toggle.<name>,Row.Menu.<name>,Row.Edit.<name>,
+Row.Remove.<name>,Tool.Toggle.<name>}`. `UI/MCPServerEditorSheet.swift`:
+`Settings.Connectors.Editor.{Name,Transport,Command,URL,Enabled,Allow,Cancel}`.
+
+**Developer (DEBUG) — `UI/SettingsDeveloperPanel.swift`:**
+`Settings.Developer.{Panel,Reonboard,ConfirmReonboard,CancelReonboard,
+Scope.Conversations,Scope.Preferences,Scope.Telemetry}`.
+
+**Images — `UI/ImagesView.swift`:**
+`Images.{EmptyState,ModelPicker,Model.<alias>,Aspect.<ar>,Resolution,
+Resolution.<res>,Prompt,Generate,Cancel,Stage,Gallery,Gallery.Thumb.<n>,
+Starter.<index>,Result.Save,Result.Edit,Edit.Import,Edit.Source,Edit.Exit}`.
+
+**Audio — `UI/AudioView.swift`:**
+`Audio.{Mode,EmptyState,EmptyState.OpenModelManagement,
+Speech.{Text,VoicePicker,VoiceOption.<voice>,PreviewVoice.<voice>,Speed,
+Generate,Play,Save,LoadVoices},
+Transcription.{FilePicker,Run,Result,Copy,Save}}`.
+
+**Dictation — `UI/DictationView.swift`:**
+`Dictation.{Enable,Arm,Hotkey,Model,NewTerm,AddTerm,RemoveTerm.<term>,
+Suggestion.<name>,Fix,Fix.Heard,Fix.Correction,Fix.Apply,Fix.Cancel,
+CopyTranscript,ArchiveAudio,ClearHistory,GrantMicrophone,GrantAccessibility,
+Error}`.
+
+**Launch / Connect — `UI/ConnectToolsView.swift`:**
+`Launch.Integration.Copy.<tool.id>`, `ConnectTools.{Copy.<label>,Reveal.<label>,
+Close}`.
+
+**Telemetry consent — `UI/TelemetryConsentView.swift`:**
+`TelemetryConsent.{Share,DontShare}`.
+
+**Banners / misc:** `UI/FailedReplaceBanner.swift`
+`FailedReplaceBanner`, `FailedReplace.{OpenUpdate,Dismiss}`;
+`UI/Components/QuietIconButton.swift` `Sheet.Close`; `AboutPanel.swift`
+`About.Link.<label>`.
+
+**Debug-only design specimens — `DevSnapshot.swift`:**
+`DevSnapshot.Specimen.*` (button/toggle/icon style specimens; not a user
+surface).
+
+---
+
+## Notes on driving the UI
+
+The deterministic GUI journeys live in `scripts/gui-golden-flows.sh` and drive
+the app by `AXIdentifier` (see `docs/gui-golden-flows.md`). The dictation
+global-hotkey path (`Dictation/DictationHotkey.swift`) and the dictation/audio
+capture paths depend on real Microphone/Accessibility grants and a local GUI
+login session, so they are exercised by hand rather than in the unattended
+lane. (Audio is sidebar-driven and has no global hotkey — only dictation
+registers one.)


### PR DESCRIPTION
## Why
From the 2026-08-18 documentation dogfood. `docs/userflows.md` billed itself as "the authoritative reference for every user-facing flow" but was imported from the retired rapid-desktop repo and never reconciled — it documented **fictional features and stale files**. Per #2084 it was **regenerated from `apps/rapid-mac/Sources/`, not patched**. Every flow, file ref, AX id, setting, and provider was verified against current source. Closes #2084.

## What
**Fictional flows/refs removed** (grep-proven absent): Quick Ask ⌥Space hotkey / `QuickAskView` / `GlobalHotkey`; "pop conversation into own window" / `PoppedConversationView.swift`; `OnboardingTour`; `sessions.json`/`SessionStore`/`SessionsSidebar.swift`/`Updater/Installer.swift` (real store: `conversations.json` via `ConversationStore`).

**Regenerated** (15 → 25 flows, each with verified `Touches:` refs):
- Two-step Download → Start → Stop lifecycle (`ModelPickerBar.swift`).
- 5 web-search providers, keyless **Keenable** default (`WebSearchProvider.swift`), not 3.
- 8 Settings categories + DEBUG Developer panel (`SettingsView.swift`), not 6.
- Sparkle-only updates; no in-app installer.
- AX inventory rebuilt from real `.accessibilityIdentifier(...)` literals; browse-approval corrected to its real **three** buttons `ToolApproval.Browse.{Allow,AlwaysAllow,Deny}` (`ContentView.swift:1273-1278`).
- New flows for the 0.12.x surface: Images, Audio, Dictation, folders+export, custom instructions, per-model performance, Launch, Developer panel, missing-runtime overlay.
- No invented dates/versions.

**Sibling `gui-golden-flows.md`** (all verified): `chat-image-attachment` → `chat-document-attachment`; corrected the "not in CI" claim (`gui-golden-flows` job at `rapid-mac-ci.yml:234`); "ten settled states" → **32** committed baselines; added the full 26-flow roster.

## Verification
Reviewer spot-checks: 103/112 `.swift` refs resolve to real files (the 9 "missing" are the intentional *removed-fictional* ledger); the 3-button approval, 5-provider, and 8-category claims all confirmed against source; `chat-document-attachment` (4×) real, `chat-image-attachment` (0×) gone.

## Tests
Docs-only — no code paths touched. `[skip-version-bump]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)