### PR TITLE
fix(cli): label recipe footprint as RAM to disambiguate from disk need

### DIFF
--- a/tests/test_model_recommendations.py
+++ b/tests/test_model_recommendations.py
@@ -92,6 +92,24 @@ def test_recipe_uses_download_size_not_peak_ram_for_disk_fit(
     assert "rapid-mlx serve qwen3.8-27b-4bit" in output
 
 
+def test_recipe_labels_footprint_as_ram_to_disambiguate_from_disk(
+    monkeypatch, capsys
+) -> None:
+    # The footprint is measured 8K peak RAM, a different axis from the on-disk
+    # download size in the won't-fit line. Labeling it "GB RAM" stops the two
+    # numbers ("20.0 GB" vs "needs ~16.72 GB") from reading as a contradiction.
+    monkeypatch.setattr(cli, "_scan_hf_cache_models", lambda: [])
+    monkeypatch.setattr(cli, "_recipe_free_disk_gb", lambda: 16.0)
+
+    cli.recipe_command(Namespace(max_ram=32, json=False))
+
+    output = capsys.readouterr().out
+    assert "20.0 GB RAM" in output
+    # The unlabeled footprint ("20.0 GB ·") must not survive — the RAM label is
+    # exactly what tells it apart from the disk requirement printed below.
+    assert "20.0 GB ·" not in output
+
+
 def test_recipe_rounding_does_not_reject_a_download_that_really_fits(
     monkeypatch, capsys
 ) -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -5683,7 +5683,11 @@ def recipe_command(args) -> None:
     )
     labels = {"smart": "Smart", "fast": "Fast"}
     for index, pick in enumerate(payload["picks"], start=1):
-        stats = [f"{pick['footprint_gb']:.1f} GB"]
+        # Label the footprint as RAM: it is measured 8K peak memory, a
+        # different axis from the on-disk ``required_disk_gb`` shown in the
+        # won't-fit line below. Without the label the two GB numbers read as
+        # contradictory (e.g. "20.0 GB" then "needs ~16.72 GB").
+        stats = [f"{pick['footprint_gb']:.1f} GB RAM"]
         if pick.get("caveat"):
             stats.append(pick["caveat"])
         else:


### PR DESCRIPTION
## Why

Found while dogfooding release 0.12.16. `rapid-mlx recipe` on a 32 GB Mac with low free disk prints:

```
1. Smart — qwen3.8-27b-4bit
   20.0 GB · 92% capability · ~41 tok/s
   ⚠ won't fit: needs ~16.72 GB including download headroom; 16.23 GB free
```

A new user sees two GB numbers for one model — the larger **20.0 GB** first (unlabeled), then a smaller **needs ~16.72 GB** — and they read as contradictory. The footprint is measured 8K **peak RAM**; the second number is **disk** download need. The distinction is already known in-code (`cli.py:5651` comment "measured 8K peak RAM, not bytes on disk"; the disk-fit test comment "The displayed 20.0 GB is measured peak RAM") but was never surfaced to the reader — only the disk line is labeled.

Closes #2136.

## What

- `cli.py`: label the footprint stat `… GB RAM` (was bare `… GB`), with a comment explaining the axis. Human-facing string only.
- No change to the `recipe` payload or `--json` output (both already carry `footprint_gb`, `required_disk_gb`, `download_size_gb` as distinct fields).

## Tests

- New regression `test_recipe_labels_footprint_as_ram_to_disambiguate_from_disk`: asserts `20.0 GB RAM` appears and the bare `20.0 GB ·` does not. Confirmed it **fails** on pre-fix source and **passes** after.
- Full `tests/test_model_recommendations.py` (15 tests) green; no existing assertion pinned the footprint print format.

## Notes

AI-authored (Claude Opus 4.8), human-reviewed.