### PR TITLE
fix(cli): size the agents-list name column to the widest alias

### DIFF
--- a/tests/test_agents_list_alignment.py
+++ b/tests/test_agents_list_alignment.py
@@ -1,0 +1,53 @@
+"""Regression: the `rapid-mlx agents` roster must keep its columns aligned
+even when an agent name is as wide as (or wider than) the name column's old
+hardcoded 15-char width.
+
+`deepseek-harness` is 16 chars. With the pre-fix `{p.name:<15}` the name
+overflowed its field, consumed the single separator space, and shifted the
+client / GitHub / tools columns one character right *on that row only* — a
+ragged table. The column is now sized to the widest alias, so every row lines
+up under the header.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from vllm_mlx import cli
+
+
+def _profile(name: str, display: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        display_name=display,
+        stars=1000,
+        needs_function_calling=True,
+        recommended_models=["qwen3.5-9b-4bit"],
+        kind="agent",
+    )
+
+
+def test_agents_list_client_column_aligns_for_max_width_name(monkeypatch, capsys):
+    # A short name and a name exactly at the old 15-char boundary + 1.
+    profiles = [
+        _profile("claude-code", "Claude Code"),
+        _profile("deepseek-harness", "DeepSeek Harness"),
+    ]
+    monkeypatch.setattr("vllm_mlx.agents.list_profiles", lambda: profiles)
+
+    cli.agents_command(
+        SimpleNamespace(agent_name=None, base_url="http://localhost:8000")
+    )
+    out = capsys.readouterr().out
+
+    header = next(line for line in out.splitlines() if "client" in line)
+    short_row = next(line for line in out.splitlines() if "Claude Code" in line)
+    long_row = next(line for line in out.splitlines() if "DeepSeek Harness" in line)
+
+    # The client column must start at the same offset on the header, a short
+    # name row, and the widest name row — otherwise the table is ragged.
+    assert (
+        header.index("client")
+        == short_row.index("Claude Code")
+        == long_row.index("DeepSeek Harness")
+    )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -8399,13 +8399,21 @@ def agents_command(args):
     # No agent specified → list all profiles
     if not agent_name:
         profiles = list_profiles()
+        # Size the name column to the widest alias so a name that meets or
+        # exceeds the old hardcoded 15 (e.g. "deepseek-harness", 16 chars)
+        # can't eat its own separator space and shift every later column
+        # right on that one row. Floor at 15 so short rosters keep the
+        # familiar layout.
+        name_w = max(15, max((len(p.name) for p in profiles), default=15))
         print()
         print("  Supported AI Agents")
         print(
-            f"  {'name':<15} {'client':<20} {'GitHub':>6}  "
+            f"  {'name':<{name_w}} {'client':<20} {'GitHub':>6}  "
             f"{'tools':<5}  recommended models"
         )
-        print("  " + "─" * 78)
+        # Grow the divider in step with the name column so it doesn't fall
+        # short of the header once a long alias widens the table.
+        print("  " + "─" * (78 + name_w - 15))
         for p in profiles:
             tools = "FC" if p.needs_function_calling else "—"
             stars = f"{p.stars // 1000}K" if p.stars and p.stars >= 1000 else ""
@@ -8417,7 +8425,8 @@ def agents_command(args):
             else:
                 models = ""
             print(
-                f"  {p.name:<15} {p.display_name:<20} {stars:>6}  {tools:<5}  {models}"
+                f"  {p.name:<{name_w}} {p.display_name:<20} "
+                f"{stars:>6}  {tools:<5}  {models}"
             )
         print("  FC = function calling")
         print()


### PR DESCRIPTION
## Why

Found while dogfooding release 0.12.16. `rapid-mlx agents` renders a ragged row for the 16-char alias `deepseek-harness`:

```
  name            client               GitHub  tools  recommended models
  claude-code     Claude Code            140K  FC     ...
  deepseek-harness DeepSeek Harness         1K  FC     ...   <- shifted 1 col right
```

The name column used a hardcoded `{p.name:<15}` (header + rows). Because `deepseek-harness` is one char past 15, Python's `<15` neither truncates nor pads it — the name eats its separator space and every later column on that row slides one character right. Any alias name ≥ 15 chars trips this.

Closes #2138.

## What

- `cli.py` `agents_command`: compute `name_w = max(15, max(len(p.name) for p in profiles))` once and use `{…:<{name_w}}` for both the header and each row. Floored at 15 so short rosters keep the familiar layout; grows automatically for any future long alias instead of needing the constant bumped.

## Tests

- New `tests/test_agents_list_alignment.py`: renders a short + a 16-char name and asserts the client column starts at the same offset on the header and both rows. Confirmed it **fails** on pre-fix source (offset 18 vs 19) and **passes** after.
- 54 agents-adjacent tests (`test_agent_first_class_setup`, `test_deepseek_harness_profile`, `test_first_run_guide`, new file) green.

## Notes

Human-facing table formatting only — no profile data or command behavior changes. AI-authored (Claude Opus 4.8), human-reviewed.