### PR TITLE
chore: bump version to 0.12.17

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,21 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.17] — 2026-08-19
+
+Dictation actually works now — 0.12.16's release build shipped without the
+microphone permission, so the "Allow…" button did nothing. Update, and macOS
+will ask for the microphone like it should.
+
+### Fixed
+
+- **Speech to Text can be enabled again.** The signed app now carries the
+  microphone entitlement macOS requires. 0.12.16's release build shipped
+  without it, so the permission prompt never appeared and dictation
+  dead-ended at setup — development builds were unaffected, which is why
+  it slipped through. The build pipeline now refuses to sign a release
+  that is missing it.
+
 ## [0.12.16] — 2026-08-19
 
 Dictate into any app from a global hotkey, web search works out of the box,

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.16</string>
+	<string>0.12.17</string>
 	<key>CFBundleVersion</key>
-	<string>160</string>
+	<string>161</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.12.17.md
+++ b/docs/release-notes/v0.12.17.md
@@ -1,0 +1,22 @@
+## Fixes
+
+- **Dictation works now — please update.** The 0.12.16 release build shipped
+  without the macOS microphone entitlement, so Speech to Text's "Allow…"
+  button silently did nothing: no permission prompt ever appeared and the
+  feature dead-ended at setup. The signed app now carries the entitlement,
+  and the build pipeline refuses to sign a release without it, so this
+  class of breakage cannot ship again. (#2134, #2135)
+- Codex over the Responses API can dispatch MCP tools again — the tool
+  namespace is re-attached to `function_call` items instead of being
+  dropped. (#2130)
+- `rapid-mlx serve --port 99999` now fails up front with an actionable
+  error instead of dying mid-boot. (#2127)
+- The unknown-model hint no longer quotes a hardcoded (and drifting) alias
+  count. (#2128)
+
+## Improvements
+
+- `/v1/models` now reports a memory-aware `max_model_len` — clients and
+  agents see the context window your Mac can actually serve, not the
+  model's theoretical maximum — and `rapid-mlx models --json` exposes the
+  same numbers for scripts. (#2122)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.16"
+version = "0.12.17"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Patch release. Headline: **the dictation hotfix** — 0.12.16's notarized build shipped without the microphone entitlement (#2134), so Speech to Text could never be enabled; #2135 adds the entitlement plus a build-time assert on the sealed signature. Also ships since v0.12.16: memory-aware `max_model_len` on `/v1/models` + `models --json` (#2122), Codex MCP namespace dispatch fix (#2130), out-of-range `--port` preflight (#2127), alias-count breadcrumb fix (#2128), release-docs reconciliation (#2123, #2132, #2133).

Bump set: pyproject 0.12.17 · Info.plist 0.12.17/CFBundleVersion 161 · rapid-mac CHANGELOG 0.12.17 section · docs/release-notes/v0.12.17.md (user-voice).

On merge, auto-release tags v0.12.17 + rapid-mac-v0.12.17, the Tier-1 agent gate runs, and the DMG rebuild now hard-fails if the sealed entitlements lack audio-input=true.

## Test plan

- [x] Exact bump-commit subject (`chore: bump version to 0.12.17`) matches auto-release.yml's detect regex
- [x] pyproject version == Info.plist CFBundleShortVersionString == 0.12.17; CFBundleVersion 160→161
- [x] Release-notes claims verified against source PR bodies (#2122 memory-fitted ceiling wording, #2127 example)
- [x] plutil -lint clean on Info.plist; diff CJK scan clean
- [x] Fix efficacy dogfooded: sealed-entitlement A/B variants + superwhisper in-the-wild control (hardened + audio-input=true = the working pattern); build.sh guard proven to reject true/false/absent correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)