### PR TITLE
feat(mac): add typed model campaign banner

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -469,6 +469,12 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/update-busy
 
+      - name: 'Golden flow: campaign-banner'
+        continue-on-error: true
+        run: ./scripts/gui-golden-flows.sh --flow campaign-banner
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/campaign-banner
+
       - name: 'Golden flow: launch-integrations'
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow launch-integrations
@@ -489,7 +495,7 @@ jobs:
           from pathlib import Path
 
           root = Path(os.environ["GOLDEN_ROOT"])
-          expected = 26
+          expected = 27
           results = sorted(root.glob("*/result.json"))
           failures = []
           for path in results:
@@ -531,7 +537,7 @@ jobs:
           set -uo pipefail
           mkdir -p "$SCRATCH/snapshots"
           cp Tests/GUIGoldenFlows/__Snapshots__/*.txt "$SCRATCH/snapshots/"
-          for flow in fresh-install settings-persistence settings-mtp chat-restore slow-stream-stop model-crash-recovery update-state update-busy image-generation audio-readiness launch-integrations; do
+          for flow in fresh-install settings-persistence settings-mtp chat-restore slow-stream-stop model-crash-recovery update-state update-busy campaign-banner image-generation audio-readiness launch-integrations; do
             RAPID_GUI_BASELINE_DIR="$SCRATCH/snapshots" \
             RAPID_GUI_GOLDEN_OUT="$SCRATCH/run/$flow" \
               ./scripts/gui-golden-flows.sh --flow "$flow" --update-baselines || true

--- a/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/DownloadManager.swift
@@ -86,6 +86,8 @@ final class DownloadManager {
         let alias: String
         let progress: DownloadProgress
         fileprivate(set) var status: Status
+        /// Cache generation created by a successful pull, if completed.
+        fileprivate(set) var completedCacheGeneration: UInt?
         let hfPath: String?
         let totalBytes: Int64?
         let source: DownloadSource
@@ -127,6 +129,7 @@ final class DownloadManager {
             self.alias = alias
             self.progress = DownloadProgress()
             self.status = .running
+            self.completedCacheGeneration = nil
             self.hfPath = hfPath
             self.totalBytes = totalBytes
             self.source = source
@@ -696,10 +699,11 @@ final class DownloadManager {
         switch reason {
         case .exit where status == 0:
             job.failureKind = nil
-            job.status = .completed
             // Weights just landed: every catalog snapshot in the app is
             // now stale.
             markCacheChanged()
+            job.completedCacheGeneration = cacheGeneration
+            job.status = .completed
         case .exit:
             recordFailure(job: job, alias: alias, signal: false)
         case .uncaughtSignal:

--- a/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
@@ -30,7 +30,11 @@ struct Campaign: Equatable, Sendable {
             }
         }
     }
-    enum DownloadState: Equatable, Sendable { case running, completed, retryable }
+    enum DownloadState: Equatable, Sendable {
+        case running
+        case completed(cacheGeneration: UInt)
+        case retryable
+    }
 
     static func actionState(
         download: DownloadState?,
@@ -40,6 +44,7 @@ struct Campaign: Equatable, Sendable {
         currentGeneration: UInt
     ) -> ActionState {
         if download == .running { return .inProgress }
+        if download == .completed(cacheGeneration: currentGeneration) { return .completed }
         if catalogGeneration != currentGeneration { return .checking }
         if isCached { return .completed }
         return catalogLoaded ? .idle : .checking

--- a/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
@@ -9,6 +9,7 @@ struct Campaign: Equatable, Sendable {
         case pullModel(alias: String, hfRepo: String?)
     }
     enum ActionState: Equatable, Sendable {
+        case checking
         case idle
         case inProgress
         case completed
@@ -16,6 +17,7 @@ struct Campaign: Equatable, Sendable {
         var isEnabled: Bool { self == .idle }
         func label(fallback: String) -> String {
             switch self {
+            case .checking: "Checking…"
             case .idle: fallback
             case .inProgress: "Downloading…"
             case .completed: "Downloaded"

--- a/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
@@ -8,6 +8,20 @@ struct Campaign: Equatable, Sendable {
     enum Action: Equatable, Sendable {
         case pullModel(alias: String, hfRepo: String?)
     }
+    enum ActionState: Equatable, Sendable {
+        case idle
+        case inProgress
+        case completed
+
+        var isEnabled: Bool { self == .idle }
+        func label(fallback: String) -> String {
+            switch self {
+            case .idle: fallback
+            case .inProgress: "Downloading…"
+            case .completed: "Downloaded"
+            }
+        }
+    }
 
     let id: String
     let kind: Kind
@@ -32,15 +46,12 @@ struct Campaign: Equatable, Sendable {
         environment["RAPID_GUI_CAMPAIGN_PREVIEW"] == "1" ? .preview : nil
     }
 
-    static func shouldAcknowledgePull(started: Bool, isDownloading: Bool) -> Bool {
-        started || isDownloading
-    }
-
     var dismissalKey: String { "Rapid.campaign.dismissed.\(id)" }
 }
 
 struct CampaignBanner: View {
     let campaign: Campaign
+    let actionState: Campaign.ActionState
     let onAction: (Campaign.Action) -> Void
     let onDismiss: () -> Void
 
@@ -64,8 +75,9 @@ struct CampaignBanner: View {
 
             Spacer(minLength: RapidTheme.Space.md)
 
-            Button(campaign.actionLabel) { onAction(campaign.action) }
+            Button(actionState.label(fallback: campaign.actionLabel)) { onAction(campaign.action) }
                 .buttonStyle(.rapidPrimaryCompact)
+                .disabled(!actionState.isEnabled)
                 .accessibilityIdentifier("Campaign.Action")
 
             Button {

--- a/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
@@ -34,9 +34,7 @@ struct Campaign: Equatable, Sendable {
         currentGeneration: UInt
     ) -> ActionState {
         if download == .running { return .inProgress }
-        if download == .completed, catalogGeneration < currentGeneration {
-            return .completed
-        }
+        if catalogGeneration != currentGeneration { return .checking }
         if isCached { return .completed }
         return catalogLoaded ? .idle : .checking
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
@@ -24,6 +24,22 @@ struct Campaign: Equatable, Sendable {
             }
         }
     }
+    enum DownloadState: Equatable, Sendable { case running, completed, retryable }
+
+    static func actionState(
+        download: DownloadState?,
+        isCached: Bool,
+        catalogLoaded: Bool,
+        catalogGeneration: UInt,
+        currentGeneration: UInt
+    ) -> ActionState {
+        if download == .running { return .inProgress }
+        if download == .completed, catalogGeneration < currentGeneration {
+            return .completed
+        }
+        if isCached { return .completed }
+        return catalogLoaded ? .idle : .checking
+    }
 
     let id: String
     let kind: Kind

--- a/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
@@ -5,8 +5,14 @@ import SwiftUI
 /// URL or execute a command: every action must be a case the client knows.
 struct Campaign: Equatable, Sendable {
     enum Kind: String, Sendable { case newModel }
+    enum Model: Equatable, Sendable {
+        case qwen35_35B4Bit
+
+        var alias: String { "qwen3.5-35b-4bit" }
+        var hfRepo: String { "mlx-community/Qwen3.5-35B-A3B-4bit" }
+    }
     enum Action: Equatable, Sendable {
-        case pullModel(alias: String, hfRepo: String?)
+        case pullModel(Model)
     }
     enum ActionState: Equatable, Sendable {
         case checking
@@ -52,10 +58,7 @@ struct Campaign: Equatable, Sendable {
         title: "Qwen3.5 35B is ready",
         body: "A smarter agentic model, tuned for Rapid-MLX. Download it now and keep working locally.",
         actionLabel: "Download model",
-        action: .pullModel(
-            alias: "qwen3.5-35b-4bit",
-            hfRepo: "mlx-community/Qwen3.5-35B-A3B-4bit"
-        )
+        action: .pullModel(.qwen35_35B4Bit)
     )
 
     static func previewFromEnvironment(_ environment: [String: String]) -> Campaign? {

--- a/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CampaignBanner.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// A deliberately small, typed slice of the future update-manifest campaign.
+/// The server may choose copy, but it cannot ask the app to open an arbitrary
+/// URL or execute a command: every action must be a case the client knows.
+struct Campaign: Equatable, Sendable {
+    enum Kind: String, Sendable { case newModel }
+    enum Action: Equatable, Sendable {
+        case pullModel(alias: String, hfRepo: String?)
+    }
+
+    let id: String
+    let kind: Kind
+    let title: String
+    let body: String
+    let actionLabel: String
+    let action: Action
+
+    static let preview = Campaign(
+        id: "model-qwen35-35b-202608",
+        kind: .newModel,
+        title: "Qwen3.5 35B is ready",
+        body: "A smarter agentic model, tuned for Rapid-MLX. Download it now and keep working locally.",
+        actionLabel: "Download model",
+        action: .pullModel(
+            alias: "qwen3.5-35b-4bit",
+            hfRepo: "mlx-community/Qwen3.5-35B-A3B-4bit"
+        )
+    )
+
+    static func previewFromEnvironment(_ environment: [String: String]) -> Campaign? {
+        environment["RAPID_GUI_CAMPAIGN_PREVIEW"] == "1" ? .preview : nil
+    }
+
+    static func shouldAcknowledgePull(started: Bool, isDownloading: Bool) -> Bool {
+        started || isDownloading
+    }
+
+    var dismissalKey: String { "Rapid.campaign.dismissed.\(id)" }
+}
+
+struct CampaignBanner: View {
+    let campaign: Campaign
+    let onAction: (Campaign.Action) -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: RapidTheme.Space.md) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(RapidTheme.brandAmber)
+                .frame(width: 32, height: 32)
+                .background(RapidTheme.brandAmberTint, in: RoundedRectangle(cornerRadius: RapidTheme.Radius.row))
+
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
+                Text(campaign.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(RapidTheme.textPrimary)
+                Text(campaign.body)
+                    .font(.system(size: 12))
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: RapidTheme.Space.md)
+
+            Button(campaign.actionLabel) { onAction(campaign.action) }
+                .buttonStyle(.rapidPrimaryCompact)
+                .accessibilityIdentifier("Campaign.Action")
+
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .help("Dismiss")
+            .accessibilityLabel("Dismiss announcement")
+            .accessibilityIdentifier("Campaign.Dismiss")
+        }
+        .padding(.horizontal, RapidTheme.Space.lg)
+        .padding(.vertical, RapidTheme.Space.sm)
+        .background(RapidTheme.surfaceRaised)
+        .overlay(alignment: .bottom) { Rectangle().fill(RapidTheme.hairline).frame(height: 1) }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("Campaign.Banner")
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -66,6 +66,7 @@ struct ContentView: View {
     @State private var catalogLoaded: Bool = false
     /// FU-1: persisted opt-out for the launch-time auto-start path.
     @AppStorage(AutoStartPreference.storageKey) private var autoStartOnLaunch: Bool = AutoStartPreference.defaultValue
+    @State private var campaign: Campaign? = Campaign.previewFromEnvironment(ProcessInfo.processInfo.environment)
 
     var body: some View {
         // Capture the identity owned by this alert render. A delayed dismiss
@@ -291,6 +292,15 @@ struct ContentView: View {
             // but was never mounted, so a failed Finder replacement was
             // detected and then silently discarded.
             FailedReplaceBanner()
+            if let campaign,
+               !telemetryConsentPending,
+               !UserDefaults.standard.bool(forKey: campaign.dismissalKey) {
+                CampaignBanner(
+                    campaign: campaign,
+                    onAction: performCampaignAction,
+                    onDismiss: { dismissCampaign(campaign) }
+                )
+            }
             NavigationSplitView {
                 SidebarView(
                 selection: $section,
@@ -381,6 +391,24 @@ struct ContentView: View {
     }
 
     // MARK: - Readiness (the one shared lifecycle value)
+
+    private func performCampaignAction(_ action: Campaign.Action) {
+        switch action {
+        case .pullModel(let alias, let hfRepo):
+            let started = downloads.startDownload(alias: alias, hfPath: hfRepo)
+            if Campaign.shouldAcknowledgePull(
+                started: started,
+                isDownloading: downloads.isDownloading(alias)
+            ), let campaign {
+                dismissCampaign(campaign)
+            }
+        }
+    }
+
+    private func dismissCampaign(_ dismissed: Campaign) {
+        UserDefaults.standard.set(true, forKey: dismissed.dismissalKey)
+        campaign = nil
+    }
 
     /// The window's single readiness value.
     ///

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -64,6 +64,8 @@ struct ContentView: View {
     /// "this alias is not downloaded" from "we don't know yet", which
     /// are different sentences and different next steps.
     @State private var catalogLoaded: Bool = false
+    /// Cache generation represented by ``catalogEntries``.
+    @State private var catalogGeneration: UInt = 0
     /// FU-1: persisted opt-out for the launch-time auto-start path.
     @AppStorage(AutoStartPreference.storageKey) private var autoStartOnLaunch: Bool = AutoStartPreference.defaultValue
     @State private var campaign: Campaign? = Campaign.previewFromEnvironment(ProcessInfo.processInfo.environment)
@@ -406,6 +408,8 @@ struct ContentView: View {
             if let job = downloads.job(for: alias) {
                 switch job.status {
                 case .running: return .inProgress
+                case .completed where catalogGeneration < downloads.cacheGeneration:
+                    return .completed
                 case .completed, .failed, .cancelled: break
                 }
             }
@@ -530,12 +534,14 @@ struct ContentView: View {
 
     private func refreshCatalogSnapshot() async {
         guard let binary = server.binaryPath else { return }
+        let generation = downloads.cacheGeneration
         let loaded = await ModelCatalogCache.shared.entries(
             binary: binary,
-            generation: downloads.cacheGeneration
+            generation: generation
         )
         guard !Task.isCancelled else { return }
         catalogEntries = loaded
+        catalogGeneration = generation
         catalogLoaded = true
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -403,12 +403,17 @@ struct ContentView: View {
     private func campaignActionState(for campaign: Campaign) -> Campaign.ActionState {
         switch campaign.action {
         case .pullModel(let alias, _):
-            guard let job = downloads.job(for: alias) else { return .idle }
-            switch job.status {
-            case .running: return .inProgress
-            case .completed: return .completed
-            case .failed, .cancelled: return .idle
+            if let job = downloads.job(for: alias) {
+                switch job.status {
+                case .running: return .inProgress
+                case .completed: return .completed
+                case .failed, .cancelled: break
+                }
             }
+            if catalogEntries.first(where: { $0.alias == alias })?.cached == true {
+                return .completed
+            }
+            return catalogLoaded ? .idle : .checking
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -297,6 +297,7 @@ struct ContentView: View {
                !UserDefaults.standard.bool(forKey: campaign.dismissalKey) {
                 CampaignBanner(
                     campaign: campaign,
+                    actionState: campaignActionState(for: campaign),
                     onAction: performCampaignAction,
                     onDismiss: { dismissCampaign(campaign) }
                 )
@@ -395,12 +396,18 @@ struct ContentView: View {
     private func performCampaignAction(_ action: Campaign.Action) {
         switch action {
         case .pullModel(let alias, let hfRepo):
-            let started = downloads.startDownload(alias: alias, hfPath: hfRepo)
-            if Campaign.shouldAcknowledgePull(
-                started: started,
-                isDownloading: downloads.isDownloading(alias)
-            ), let campaign {
-                dismissCampaign(campaign)
+            _ = downloads.startDownload(alias: alias, hfPath: hfRepo)
+        }
+    }
+
+    private func campaignActionState(for campaign: Campaign) -> Campaign.ActionState {
+        switch campaign.action {
+        case .pullModel(let alias, _):
+            guard let job = downloads.job(for: alias) else { return .idle }
+            switch job.status {
+            case .running: return .inProgress
+            case .completed: return .completed
+            case .failed, .cancelled: return .idle
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -405,18 +405,19 @@ struct ContentView: View {
     private func campaignActionState(for campaign: Campaign) -> Campaign.ActionState {
         switch campaign.action {
         case .pullModel(let alias, _):
-            if let job = downloads.job(for: alias) {
-                switch job.status {
-                case .running: return .inProgress
-                case .completed where catalogGeneration < downloads.cacheGeneration:
-                    return .completed
-                case .completed, .failed, .cancelled: break
-                }
+            let downloadState: Campaign.DownloadState? = switch downloads.job(for: alias)?.status {
+            case .running: .running
+            case .completed: .completed
+            case .failed, .cancelled: .retryable
+            case nil: nil
             }
-            if catalogEntries.first(where: { $0.alias == alias })?.cached == true {
-                return .completed
-            }
-            return catalogLoaded ? .idle : .checking
+            return Campaign.actionState(
+                download: downloadState,
+                isCached: catalogEntries.first(where: { $0.alias == alias })?.cached == true,
+                catalogLoaded: catalogLoaded,
+                catalogGeneration: catalogGeneration,
+                currentGeneration: downloads.cacheGeneration
+            )
         }
     }
 
@@ -539,7 +540,7 @@ struct ContentView: View {
             binary: binary,
             generation: generation
         )
-        guard !Task.isCancelled else { return }
+        guard !Task.isCancelled, generation == downloads.cacheGeneration else { return }
         catalogEntries = loaded
         catalogGeneration = generation
         catalogLoaded = true

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -397,14 +397,15 @@ struct ContentView: View {
 
     private func performCampaignAction(_ action: Campaign.Action) {
         switch action {
-        case .pullModel(let alias, let hfRepo):
-            _ = downloads.startDownload(alias: alias, hfPath: hfRepo)
+        case .pullModel(let model):
+            _ = downloads.startDownload(alias: model.alias, hfPath: model.hfRepo)
         }
     }
 
     private func campaignActionState(for campaign: Campaign) -> Campaign.ActionState {
         switch campaign.action {
-        case .pullModel(let alias, _):
+        case .pullModel(let model):
+            let alias = model.alias
             let downloadState: Campaign.DownloadState? = switch downloads.job(for: alias)?.status {
             case .running: .running
             case .completed: .completed

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -406,8 +406,7 @@ struct ContentView: View {
             if let job = downloads.job(for: alias) {
                 switch job.status {
                 case .running: return .inProgress
-                case .completed: return .completed
-                case .failed, .cancelled: break
+                case .completed, .failed, .cancelled: break
                 }
             }
             if catalogEntries.first(where: { $0.alias == alias })?.cached == true {

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -408,7 +408,10 @@ struct ContentView: View {
             let alias = model.alias
             let downloadState: Campaign.DownloadState? = switch downloads.job(for: alias)?.status {
             case .running: .running
-            case .completed: .completed
+            case .completed:
+                downloads.job(for: alias)?.completedCacheGeneration.map {
+                    .completed(cacheGeneration: $0)
+                } ?? .retryable
             case .failed, .cancelled: .retryable
             case nil: nil
             }

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/campaign-banner.visible.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/campaign-banner.visible.txt
@@ -1,0 +1,45 @@
+# rapid-mac AX structural baseline v1
+AXApplication title="Rapid-MLX"
+  AXWindow subrole=AXStandardWindow id="main" title="Rapid-MLX"
+    AXGroup subrole=AXHostingView
+      AXGroup id="Campaign.Banner" enabled=true
+        AXImage id="sparkles" desc="Sparkle" enabled=true
+        AXStaticText value=text enabled=true
+        AXStaticText value=text enabled=true
+        AXButton id="Campaign.Action" desc="Download model" enabled=true
+        AXButton id="Campaign.Dismiss" desc="Dismiss announcement" help="Dismiss" enabled=true
+      AXSplitGroup id="main, SidebarNavigationSplitView"
+        AXGroup subrole=AXHostingView
+          AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
+          AXButton id="Sidebar.Images" desc="Images" enabled=true
+          AXButton id="Sidebar.Audio" desc="Audio" enabled=true
+          AXButton id="Sidebar.Launch" desc="Launch" enabled=true
+        AXSplitter value=number enabled=false
+        AXGroup subrole=AXHostingView
+          AXStaticText value=text enabled=true
+          AXStaticText value=text enabled=true
+          AXGroup desc="<model> isn't running, It's already downloaded — starting takes a few seconds." enabled=true
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
+            AXButton id="Readiness.Action" desc="Start" enabled=true
+          AXStaticText value=text enabled=true
+          AXScrollArea
+            AXTextArea id="rapid.chat.compose" desc="Message compose field" value=empty
+          AXButton id="ChatView.AddPhotos" desc="Add photos" help="This model doesn't support images" enabled=false
+          AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
+          AXButton id="info.circle" desc="Show model details" help="Show model details" enabled=true
+          AXButton id="ChatView.SendOrStopButton" desc="Send message" help="Start <model> before sending." enabled=false
+      AXButton desc="Settings" help="Settings — ⌘," enabled=true
+      AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
+      AXUnknown desc="Server status" enabled=true
+      AXUnknown desc="Tokens per second: no data yet" enabled=true
+      AXUnknown desc="CPU <percent>" enabled=true
+      AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory tight: <size> used out of <size>" enabled=true
+      AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version>" help="Rapid-MLX <version>. Click to open Settings → App." enabled=true
+    AXToolbar
+      AXButton desc="Hide Sidebar" enabled=true
+    AXButton subrole=AXCloseButton enabled=true
+    AXButton subrole=AXFullScreenButton help="this button also has an action to zoom the window" enabled=true
+    AXButton subrole=AXMinimizeButton enabled=true
+    AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
@@ -34,9 +34,9 @@ struct CampaignTests {
         "campaign action resolves download and catalog races",
         arguments: [
             (Optional(Campaign.DownloadState.running), false, true, UInt(1), UInt(1), Campaign.ActionState.inProgress),
-            (Optional(.completed), false, true, UInt(1), UInt(2), .checking),
-            (Optional(.completed), true, true, UInt(1), UInt(2), .checking),
-            (Optional(.completed), false, true, UInt(2), UInt(2), .idle),
+            (Optional(.completed(cacheGeneration: 2)), false, true, UInt(1), UInt(2), .completed),
+            (Optional(.completed(cacheGeneration: 1)), true, true, UInt(1), UInt(2), .checking),
+            (Optional(.completed(cacheGeneration: 1)), false, true, UInt(2), UInt(2), .idle),
             (Optional(.retryable), false, true, UInt(2), UInt(2), .idle),
             (Optional<Campaign.DownloadState>.none, true, true, UInt(2), UInt(2), .completed),
             (Optional<Campaign.DownloadState>.none, false, false, UInt(0), UInt(0), .checking),

--- a/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import Rapid
+
+@Suite("Campaign MVP")
+struct CampaignTests {
+    @Test("preview is opt-in and carries a typed pull action")
+    func previewFixture() {
+        #expect(Campaign.previewFromEnvironment([:]) == nil)
+        let campaign = Campaign.previewFromEnvironment(["RAPID_GUI_CAMPAIGN_PREVIEW": "1"])
+        #expect(campaign?.id == "model-qwen35-35b-202608")
+        #expect(campaign?.action == .pullModel(
+            alias: "qwen3.5-35b-4bit",
+            hfRepo: "mlx-community/Qwen3.5-35B-A3B-4bit"
+        ))
+    }
+
+    @Test("dismissal is namespaced by immutable campaign id")
+    func dismissalKey() {
+        #expect(Campaign.preview.dismissalKey == "Rapid.campaign.dismissed.model-qwen35-35b-202608")
+    }
+
+    @Test("campaign action stays retryable unless the pull starts")
+    func actionAcknowledgement() {
+        #expect(!Campaign.shouldAcknowledgePull(started: false, isDownloading: false))
+        #expect(Campaign.shouldAcknowledgePull(started: true, isDownloading: false))
+        #expect(Campaign.shouldAcknowledgePull(started: false, isDownloading: true))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
@@ -8,10 +8,9 @@ struct CampaignTests {
         #expect(Campaign.previewFromEnvironment([:]) == nil)
         let campaign = Campaign.previewFromEnvironment(["RAPID_GUI_CAMPAIGN_PREVIEW": "1"])
         #expect(campaign?.id == "model-qwen35-35b-202608")
-        #expect(campaign?.action == .pullModel(
-            alias: "qwen3.5-35b-4bit",
-            hfRepo: "mlx-community/Qwen3.5-35B-A3B-4bit"
-        ))
+        #expect(campaign?.action == .pullModel(.qwen35_35B4Bit))
+        #expect(Campaign.Model.qwen35_35B4Bit.alias == "qwen3.5-35b-4bit")
+        #expect(Campaign.Model.qwen35_35B4Bit.hfRepo == "mlx-community/Qwen3.5-35B-A3B-4bit")
     }
 
     @Test("dismissal is namespaced by immutable campaign id")

--- a/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
@@ -21,6 +21,8 @@ struct CampaignTests {
 
     @Test("campaign action copy reflects transient download state")
     func actionPresentation() {
+        #expect(!Campaign.ActionState.checking.isEnabled)
+        #expect(Campaign.ActionState.checking.label(fallback: "Download model") == "Checking…")
         #expect(Campaign.ActionState.idle.isEnabled)
         #expect(Campaign.ActionState.idle.label(fallback: "Download model") == "Download model")
         #expect(!Campaign.ActionState.inProgress.isEnabled)

--- a/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
@@ -35,7 +35,8 @@ struct CampaignTests {
         "campaign action resolves download and catalog races",
         arguments: [
             (Optional(Campaign.DownloadState.running), false, true, UInt(1), UInt(1), Campaign.ActionState.inProgress),
-            (Optional(.completed), false, true, UInt(1), UInt(2), .completed),
+            (Optional(.completed), false, true, UInt(1), UInt(2), .checking),
+            (Optional(.completed), true, true, UInt(1), UInt(2), .checking),
             (Optional(.completed), false, true, UInt(2), UInt(2), .idle),
             (Optional(.retryable), false, true, UInt(2), UInt(2), .idle),
             (Optional<Campaign.DownloadState>.none, true, true, UInt(2), UInt(2), .completed),

--- a/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
@@ -19,10 +19,13 @@ struct CampaignTests {
         #expect(Campaign.preview.dismissalKey == "Rapid.campaign.dismissed.model-qwen35-35b-202608")
     }
 
-    @Test("campaign action stays retryable unless the pull starts")
-    func actionAcknowledgement() {
-        #expect(!Campaign.shouldAcknowledgePull(started: false, isDownloading: false))
-        #expect(Campaign.shouldAcknowledgePull(started: true, isDownloading: false))
-        #expect(Campaign.shouldAcknowledgePull(started: false, isDownloading: true))
+    @Test("campaign action copy reflects transient download state")
+    func actionPresentation() {
+        #expect(Campaign.ActionState.idle.isEnabled)
+        #expect(Campaign.ActionState.idle.label(fallback: "Download model") == "Download model")
+        #expect(!Campaign.ActionState.inProgress.isEnabled)
+        #expect(Campaign.ActionState.inProgress.label(fallback: "Download model") == "Downloading…")
+        #expect(!Campaign.ActionState.completed.isEnabled)
+        #expect(Campaign.ActionState.completed.label(fallback: "Download model") == "Downloaded")
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CampaignTests.swift
@@ -30,4 +30,32 @@ struct CampaignTests {
         #expect(!Campaign.ActionState.completed.isEnabled)
         #expect(Campaign.ActionState.completed.label(fallback: "Download model") == "Downloaded")
     }
+
+    @Test(
+        "campaign action resolves download and catalog races",
+        arguments: [
+            (Optional(Campaign.DownloadState.running), false, true, UInt(1), UInt(1), Campaign.ActionState.inProgress),
+            (Optional(.completed), false, true, UInt(1), UInt(2), .completed),
+            (Optional(.completed), false, true, UInt(2), UInt(2), .idle),
+            (Optional(.retryable), false, true, UInt(2), UInt(2), .idle),
+            (Optional<Campaign.DownloadState>.none, true, true, UInt(2), UInt(2), .completed),
+            (Optional<Campaign.DownloadState>.none, false, false, UInt(0), UInt(0), .checking),
+        ]
+    )
+    func actionResolution(
+        download: Campaign.DownloadState?,
+        isCached: Bool,
+        catalogLoaded: Bool,
+        catalogGeneration: UInt,
+        currentGeneration: UInt,
+        expected: Campaign.ActionState
+    ) {
+        #expect(Campaign.actionState(
+            download: download,
+            isCached: isCached,
+            catalogLoaded: catalogLoaded,
+            catalogGeneration: catalogGeneration,
+            currentGeneration: currentGeneration
+        ) == expected)
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DownloadManagerTests.swift
@@ -227,6 +227,7 @@ struct DownloadManagerTests {
 
         #expect(flag.fired)
         #expect(mgr.job(for: "bonsai-1.7b-2bit")?.status == .completed)
+        #expect(job.completedCacheGeneration == mgr.cacheGeneration)
     }
 
     @Test("Non-zero exit → failed status with a generic message (raw stderr is never surfaced)")

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2500,11 +2500,11 @@ flow_campaign_banner() {
     local action_pid_1=$!
     "$AX_DRIVER" press "$APP_PID" Campaign.Action > "$OUT/campaign-action-2.json" 2>/dev/null &
     local action_pid_2=$!
-    wait "$action_pid_1" || die "first rapid campaign activation failed"
-    wait "$action_pid_2" || die "second rapid campaign activation failed"
-    jq -s -e 'all(.[]; .success == true)' \
+    wait "$action_pid_1" || true
+    wait "$action_pid_2" || true
+    jq -s -e 'any(.[]; .success == true)' \
         "$OUT/campaign-action-1.json" "$OUT/campaign-action-2.json" >/dev/null \
-        || die "rapid campaign activations did not both reach AXPress"
+        || die "neither rapid campaign activation reached AXPress"
     wait_fake_event \
         '.event == "command" and .subcommand == "pull" and .alias == "qwen3.5-35b-4bit"' \
         "campaign CTA did not start the allowlisted model pull"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2488,7 +2488,7 @@ flow_campaign_banner() {
     start_persona campaign-banner \
         RAPID_GUI_CAMPAIGN_PREVIEW=1 RAPIDMLX_NO_UPDATE_CHECK=1
     dismiss_first_run
-    wait_identifier Campaign.Banner "$OUT/campaign-visible.json"
+    wait_identifier_enabled Campaign.Action "$OUT/campaign-visible.json"
     assert_tree_text "$OUT/campaign-visible.json" "Qwen3.5 35B is ready"
     jq -e '.data.ui_elements[]? | select(.identifier == "Campaign.Action" and .enabled == true)' \
         "$OUT/campaign-visible.json" >/dev/null \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2494,7 +2494,14 @@ flow_campaign_banner() {
         "$OUT/campaign-visible.json" >/dev/null \
         || die "campaign CTA is absent or disabled"
     baseline campaign-banner.visible "$OUT/campaign-visible.json"
-    press "$OUT/campaign-visible.json" Campaign.Dismiss "$OUT/campaign-dismiss.json"
+    press "$OUT/campaign-visible.json" Campaign.Action "$OUT/campaign-action.json"
+    wait_fake_event \
+        '.event == "command" and .subcommand == "pull" and .alias == "qwen3.5-35b-4bit"' \
+        "campaign CTA did not start the allowlisted model pull"
+    [[ "$(jq -s '[.[] | select(.event == "command" and .subcommand == "pull" and .alias == "qwen3.5-35b-4bit")] | length' "$OUT/fake-events.jsonl")" == 1 ]] \
+        || die "campaign CTA started the model pull more than once"
+    wait_identifier Campaign.Dismiss "$OUT/campaign-after-action.json"
+    press "$OUT/campaign-after-action.json" Campaign.Dismiss "$OUT/campaign-dismiss.json"
     for _ in {1..40}; do
         see_main "$OUT/campaign-dismissed.json"
         if ! jq -e '.data.ui_elements[]? | select(.identifier == "Campaign.Banner")' \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -76,7 +76,7 @@ die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
 pb() { peekaboo "$@" --bridge-socket "$BRIDGE"; }
 flow_requires_screen_recording() {
     case "$FLOW" in
-        all|campaign-banner) return 0 ;;
+        all) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -2494,10 +2494,6 @@ flow_campaign_banner() {
         "$OUT/campaign-visible.json" >/dev/null \
         || die "campaign CTA is absent or disabled"
     baseline campaign-banner.visible "$OUT/campaign-visible.json"
-    pb app switch --to "PID:$APP_PID" --verify --json > "$OUT/campaign-focus.json"
-    pb image --window-id "$MAIN_WINDOW_ID" --path "$OUT/campaign-visible.png" --json \
-        > "$OUT/campaign-image.json"
-
     press "$OUT/campaign-visible.json" Campaign.Dismiss "$OUT/campaign-dismiss.json"
     for _ in {1..40}; do
         see_main "$OUT/campaign-dismissed.json"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2494,7 +2494,17 @@ flow_campaign_banner() {
         "$OUT/campaign-visible.json" >/dev/null \
         || die "campaign CTA is absent or disabled"
     baseline campaign-banner.visible "$OUT/campaign-visible.json"
-    press "$OUT/campaign-visible.json" Campaign.Action "$OUT/campaign-action.json"
+    # Race two genuine AX activations against SwiftUI's disabled-state update.
+    # DownloadManager must coalesce them to one pull even if both actions enter.
+    "$AX_DRIVER" press "$APP_PID" Campaign.Action > "$OUT/campaign-action-1.json" 2>/dev/null &
+    local action_pid_1=$!
+    "$AX_DRIVER" press "$APP_PID" Campaign.Action > "$OUT/campaign-action-2.json" 2>/dev/null &
+    local action_pid_2=$!
+    wait "$action_pid_1" || die "first rapid campaign activation failed"
+    wait "$action_pid_2" || die "second rapid campaign activation failed"
+    jq -s -e 'all(.[]; .success == true)' \
+        "$OUT/campaign-action-1.json" "$OUT/campaign-action-2.json" >/dev/null \
+        || die "rapid campaign activations did not both reach AXPress"
     wait_fake_event \
         '.event == "command" and .subcommand == "pull" and .alias == "qwen3.5-35b-4bit"' \
         "campaign CTA did not start the allowlisted model pull"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -99,7 +99,7 @@ flow_requires_screen_recording() {
 # unattended without taking on any of that.
 flow_requires_peekaboo() {
     case "$FLOW" in
-        fresh-install|cached-quickstart|cached-curated-tradeup|download-progress|settings-persistence|settings-mtp|chat-restore|message-actions|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|launch-integrations) return 1 ;;
+        fresh-install|cached-quickstart|cached-curated-tradeup|download-progress|settings-persistence|settings-mtp|chat-restore|message-actions|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|update-busy|campaign-banner|launch-integrations) return 1 ;;
         slow-stream-stop|model-crash-recovery|low-memory-choice|chat-document-attachment|image-generation|dictation|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
         *) return 0 ;;
     esac

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -39,7 +39,7 @@ Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 Flows: fresh-install, cached-quickstart, cached-curated-tradeup, download-progress, settings-persistence, settings-mtp, chat-restore, message-actions, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
-       update-state, update-busy, window-close-prompt, no-dead-controls, catalog-integrity,
+       update-state, update-busy, campaign-banner, window-close-prompt, no-dead-controls, catalog-integrity,
        browse-all-destination, chat-document-attachment, image-generation, dictation, audio-readiness, all
 
 Most named regression flows drive the app through the accessibility API alone.
@@ -76,7 +76,7 @@ die() { printf '[gui-golden] FAIL: %s\n' "$*" >&2; exit 1; }
 pb() { peekaboo "$@" --bridge-socket "$BRIDGE"; }
 flow_requires_screen_recording() {
     case "$FLOW" in
-        all) return 0 ;;
+        all|campaign-banner) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -2481,6 +2481,46 @@ flow_update_busy() {
     cleanup_persona
 }
 
+flow_campaign_banner() {
+    # This flow owns campaign state, not the live release channel. Keep the
+    # footer deterministic so a newly published app version cannot invalidate
+    # the campaign's structural baseline.
+    start_persona campaign-banner \
+        RAPID_GUI_CAMPAIGN_PREVIEW=1 RAPIDMLX_NO_UPDATE_CHECK=1
+    dismiss_first_run
+    wait_identifier Campaign.Banner "$OUT/campaign-visible.json"
+    assert_tree_text "$OUT/campaign-visible.json" "Qwen3.5 35B is ready"
+    jq -e '.data.ui_elements[]? | select(.identifier == "Campaign.Action" and .enabled == true)' \
+        "$OUT/campaign-visible.json" >/dev/null \
+        || die "campaign CTA is absent or disabled"
+    baseline campaign-banner.visible "$OUT/campaign-visible.json"
+    pb app switch --to "PID:$APP_PID" --verify --json > "$OUT/campaign-focus.json"
+    pb image --window-id "$MAIN_WINDOW_ID" --path "$OUT/campaign-visible.png" --json \
+        > "$OUT/campaign-image.json"
+
+    press "$OUT/campaign-visible.json" Campaign.Dismiss "$OUT/campaign-dismiss.json"
+    for _ in {1..40}; do
+        see_main "$OUT/campaign-dismissed.json"
+        if ! jq -e '.data.ui_elements[]? | select(.identifier == "Campaign.Banner")' \
+            "$OUT/campaign-dismissed.json" >/dev/null; then
+            break
+        fi
+        sleep 0.25
+    done
+    ! jq -e '.data.ui_elements[]? | select(.identifier == "Campaign.Banner")' \
+        "$OUT/campaign-dismissed.json" >/dev/null \
+        || die "campaign remained visible after dismissal"
+
+    relaunch_persona
+    dismiss_first_run
+    see_main "$OUT/campaign-relaunched.json"
+    ! jq -e '.data.ui_elements[]? | select(.identifier == "Campaign.Banner")' \
+        "$OUT/campaign-relaunched.json" >/dev/null \
+        || die "dismissed campaign returned after relaunch"
+    log "  campaign banner renders one typed CTA and remembers dismissal"
+    cleanup_persona
+}
+
 flow_window_close_prompt() {
     # #1590: the prompt, persistence store and delegate proxy all existed, but
     # no WindowAccessor ever attached the proxy to the real main NSWindow.
@@ -4536,6 +4576,7 @@ case "$FLOW" in
     low-memory-choice) flow_low_memory_choice ;;
     update-state) flow_update_state ;;
     update-busy) flow_update_busy ;;
+    campaign-banner) flow_campaign_banner ;;
     window-close-prompt) flow_window_close_prompt ;;
     no-dead-controls) flow_no_dead_controls ;;
     catalog-integrity) flow_catalog_integrity ;;
@@ -4564,6 +4605,7 @@ case "$FLOW" in
         flow_low_memory_choice
         flow_update_state
         flow_update_busy
+        flow_campaign_banner
         flow_window_close_prompt
         flow_no_dead_controls
         flow_catalog_integrity


### PR DESCRIPTION
## Why

Rapid Desktop needs a safe, dismissible surface for model announcements without allowing remote copy to execute arbitrary URLs or commands. This MVP establishes a client-typed campaign action and an opt-in preview seam before connecting a live manifest.

## What changed

- add a typed new-model campaign banner whose payload-free model case is a compile-time client allowlist
- persist explicit dismissal by immutable campaign ID
- represent catalog-checking, downloading, downloaded, retryable failure, and post-deletion states without duplicate pulls
- tag successful pulls with their cache generation and reject superseded asynchronous catalog snapshots
- keep the preview disabled unless `RAPID_GUI_CAMPAIGN_PREVIEW=1`
- add focused Swift tests and a deterministic, CI-enforced GUI flow that races rapid CTA activations and proves exactly one pull

## Validation

- focused Swift tests — 5 passed (CampaignTests plus DownloadManager completion-generation coverage)
- GUI CI contract tests — 8 passed
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `git diff --check`
- Codex review iterated after every fix to consecutive rounds with no actionable findings
- full pytest: 17,888 passed; 3 failures reproduced unchanged on a clean `origin/main` worktree:
  - `tests/test_mlx_compat.py::test_every_mlx_lm_consumer_installs_shim`
  - `tests/test_model_profiles_ssot.py::test_every_alias_has_explicit_profile_fields`
  - `tests/test_model_sizes.py::test_every_text_alias_has_a_manifest_entry`

## Necessity

Without this typed client boundary, a future campaign manifest would either have no desktop surface or require unsafe arbitrary actions. This establishes the constrained UX contract and regression coverage.

## AI assistance

Codex migrated the WIP onto current `main`, resolved integration conflicts, reviewed all eight changed files over multiple rounds, and implemented findings around retryability, allowlisting, cached/deleted models, asynchronous catalog generations, duplicate activation, and golden-flow determinism. Human-verifiable evidence is listed above.

- [x] I can explain every non-generated line on demand.
- [x] AI-touched files are disclosed above.
