### PR TITLE
test(mac): register AX-only campaign flows

### DIFF
--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -105,6 +105,8 @@ def test_peekaboo_requirement_is_default_deny():
         "no-dead-controls",
         "catalog-integrity",
         "update-state",
+        "update-busy",
+        "campaign-banner",
         "launch-integrations",
         "slow-stream-stop",
         "model-crash-recovery",


### PR DESCRIPTION
## Why

PR #2142 made `update-busy` and `campaign-banner` explicitly Peekaboo-free so they can run unattended with the repository-owned rapid-ax driver. Its static default-deny contract must list the same named flows.

## What changed

- add `update-busy` and `campaign-banner` to the expected Peekaboo-free flow set

## Validation

- `pytest tests/test_gui_preflight_contract.py tests/test_gui_golden_ci_coverage.py tests/test_gui_walk_completeness.py` — 17 passed
- Codex review: no actionable findings
- `git diff --check`

## AI assistance

Codex identified that the final contract-only commit missed the auto-merge boundary of #2142, isolated it onto current main, and revalidated the focused suite.

- [x] I can explain every changed line on demand.
- [x] AI-touched files are disclosed above.
