### PR TITLE
feat(perf): blocked-seq Metal kernel for GDN prompt prefill

### DIFF
--- a/tests/test_gdn_prefill_kernel.py
+++ b/tests/test_gdn_prefill_kernel.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness gates for the blocked-seq GDN prefill kernel.
+
+The kernel computes the exact same sequential recurrence as mlx-lm's stock
+``gated_delta_kernel`` — any numeric divergence beyond fp32-accumulation
+noise is a bug, so these tests compare against both the stock Metal kernel
+and the pure-ops reference on random Qwen-shaped inputs. Fallback gates are
+exercised so masked / vectorized-gating / decode-step calls provably keep
+the stock path.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+if not mx.metal.is_available():  # pragma: no cover - CI runners have Metal
+    pytest.skip("Metal GPU required for GDN kernel tests", allow_module_level=True)
+
+from mlx_lm.models import gated_delta as gd
+
+from vllm_mlx import gdn_prefill
+
+
+def _stock_kernel():
+    """The unwrapped mlx-lm kernel, regardless of whether install() ran.
+
+    Another test module importing ``vllm_mlx.scheduler`` installs the
+    wrapper at collection time; comparing against the module attribute
+    would then be fast-path-versus-fast-path. The wrapper carries the
+    true stock implementation on ``._stock``.
+    """
+    fn = gd.gated_delta_kernel
+    return getattr(fn, "_stock", fn)
+
+
+# Qwen3.8-27B GDN geometry (scaled-down head counts, same head dims).
+B, HK, HV, DK, DV = 1, 2, 6, 128, 128
+
+
+def _inputs(t_len, dtype=mx.bfloat16, seed=7, g_ndim=3):
+    mx.random.seed(seed)
+    q = (mx.random.normal((B, t_len, HK, DK)) * 0.1).astype(dtype)
+    k = (mx.random.normal((B, t_len, HK, DK)) * 0.1).astype(dtype)
+    v = (mx.random.normal((B, t_len, HV, DV)) * 0.1).astype(dtype)
+    if g_ndim == 3:
+        g = mx.sigmoid(mx.random.normal((B, t_len, HV)).astype(mx.float32))
+    else:
+        g = mx.sigmoid(mx.random.normal((B, t_len, HV, DK)).astype(mx.float32))
+    beta = mx.sigmoid(mx.random.normal((B, t_len, HV)).astype(mx.float32))
+    state = mx.zeros((B, HV, DV, DK), dtype=mx.float32)
+    mx.eval(q, k, v, g, beta, state)
+    return q, k, v, g, beta, state
+
+
+def _max_rel_err(a: mx.array, b: mx.array, atol: float = 1e-3) -> float:
+    """Elementwise stabilized relative error (max over elements).
+
+    Dividing the global max error by the global max magnitude would let a
+    small-magnitude element be badly corrupted while the metric stays
+    tiny; normalizing per element (with an absolute floor at the data's
+    noise scale — inputs are O(0.1..1)) catches that: real corruption is
+    O(1) under this metric, while fp32 accumulation-order noise on
+    near-zero elements stays under 1e-3.
+    """
+    a32 = a.astype(mx.float32)
+    b32 = b.astype(mx.float32)
+    rel = mx.abs(a32 - b32) / (mx.abs(a32) + atol)
+    return float(rel.max())
+
+
+class TestBlockedSeqNumerics:
+    @pytest.mark.parametrize("t_len", [64, 100, 512])
+    def test_matches_stock_kernel_bf16(self, t_len):
+        q, k, v, g, beta, state = _inputs(t_len)
+        y_fast, st_fast = gdn_prefill.gated_delta_blocked_seq(q, k, v, g, beta, state)
+        y_stock, st_stock = _stock_kernel()(q, k, v, g, beta, state, None)
+        mx.eval(y_fast, st_fast, y_stock, st_stock)
+        # Both kernels accumulate in fp32; outputs round to bf16 so allow
+        # one-ulp-of-bf16 divergence on y, near-exactness on the fp32 state.
+        assert _max_rel_err(y_stock, y_fast) < 2e-2
+        assert _max_rel_err(st_stock, st_fast) < 1e-3
+
+    def test_matches_ops_reference_fp32(self):
+        # fp32 end-to-end pins the algorithm itself (no rounding slack).
+        q, k, v, g, beta, state = _inputs(96, dtype=mx.float32)
+        y_fast, st_fast = gdn_prefill.gated_delta_blocked_seq(q, k, v, g, beta, state)
+        y_ref, st_ref = gd.gated_delta_ops(q, k, v, g, beta, state, None)
+        mx.eval(y_fast, st_fast, y_ref, st_ref)
+        assert _max_rel_err(y_ref, y_fast) < 1e-3
+        assert _max_rel_err(st_ref, st_fast) < 1e-3
+
+    def test_state_chains_across_calls(self):
+        # Split a 128-token prompt into two 64-token chunks: chained fast
+        # calls must equal one full stock call (chunked-prefill invariant).
+        q, k, v, g, beta, state = _inputs(128)
+        y_full, st_full = _stock_kernel()(q, k, v, g, beta, state, None)
+        y1, st1 = gdn_prefill.gated_delta_blocked_seq(
+            q[:, :64], k[:, :64], v[:, :64], g[:, :64], beta[:, :64], state
+        )
+        y2, st2 = gdn_prefill.gated_delta_blocked_seq(
+            q[:, 64:], k[:, 64:], v[:, 64:], g[:, 64:], beta[:, 64:], st1
+        )
+        y_chain = mx.concatenate([y1, y2], axis=1)
+        mx.eval(y_full, st_full, y_chain, st2)
+        assert _max_rel_err(y_full, y_chain) < 2e-2
+        assert _max_rel_err(st_full, st2) < 1e-3
+
+
+class TestBlockedSeqValidation:
+    def test_rejects_wrong_dk(self):
+        q, k, v, g, beta, state = _inputs(64)
+        q_bad = mx.concatenate([q, q], axis=-1)  # Dk=256
+        k_bad = mx.concatenate([k, k], axis=-1)
+        with pytest.raises(ValueError, match="Dk == 128"):
+            gdn_prefill.gated_delta_blocked_seq(q_bad, k_bad, v, g, beta, None)
+
+    def test_rejects_unaligned_dv(self):
+        q, k, v, g, beta, state = _inputs(64)
+        v_bad = v[..., :100]  # Dv=100, not a multiple of 32
+        with pytest.raises(ValueError, match="Dv % 32"):
+            gdn_prefill.gated_delta_blocked_seq(q, k, v_bad, g, beta, None)
+
+    def test_rejects_wrong_state_layout(self):
+        q, k, v, g, beta, state = _inputs(64)
+        bad = mx.zeros((B, HV, DV // 2, DK), dtype=mx.float32)
+        with pytest.raises(ValueError, match="fp32 state of shape"):
+            gdn_prefill.gated_delta_blocked_seq(q, k, v, g, beta, bad)
+
+    def test_state_none_initializes_and_matches_stock(self):
+        # First prefill chunk arrives with state=None: the fast path must
+        # zero-init fp32 state exactly like the stock update path.
+        q, k, v, g, beta, state = _inputs(64)
+        y_fast, st_fast = gdn_prefill.gated_delta_blocked_seq(q, k, v, g, beta, None)
+        y_stock, st_stock = _stock_kernel()(q, k, v, g, beta, state, None)
+        mx.eval(y_fast, st_fast, y_stock, st_stock)
+        assert _max_rel_err(y_stock, y_fast) < 2e-2
+        assert _max_rel_err(st_stock, st_fast) < 1e-3
+
+
+class TestEligibilityGate:
+    def test_fast_path_shapes_pass(self):
+        q, k, v, g, beta, state = _inputs(64)
+        assert gdn_prefill._eligible(q, k, v, g, beta, state, None)
+
+    def test_state_none_is_eligible(self):
+        # state=None must not crash the gate (reading .dtype off None would
+        # raise before the fast path could zero-init) and is a valid
+        # fast-path shape.
+        q, k, v, g, beta, _ = _inputs(64)
+        assert gdn_prefill._eligible(q, k, v, g, beta, None, None)
+
+    @pytest.mark.parametrize(
+        "mutation",
+        [
+            "masked",
+            "vector_gating",
+            "decode_step",
+            "wrong_dk",
+            "bf16_state",
+            "hv_not_multiple_of_hk",
+            "state_shape_mismatch",
+        ],
+    )
+    def test_fallback_shapes_fail(self, mutation):
+        q, k, v, g, beta, state = _inputs(64)
+        mask = None
+        if mutation == "masked":
+            mask = mx.ones((B, 64), dtype=mx.bool_)
+        elif mutation == "vector_gating":
+            _, _, _, g, _, _ = _inputs(64, g_ndim=4)
+        elif mutation == "decode_step":
+            # Truncate EVERY tensor to one token so only the minimum-token
+            # gate (not a [B, T] mismatch) determines the fallback.
+            q, k, v, g, beta = (x[:, :1] for x in (q, k, v, g, beta))
+        elif mutation == "wrong_dk":
+            q = mx.concatenate([q, q], axis=-1)  # Dk=256
+            k = mx.concatenate([k, k], axis=-1)
+        elif mutation == "bf16_state":
+            state = state.astype(mx.bfloat16)
+        elif mutation == "hv_not_multiple_of_hk":
+            # Hv=5 with Hk=2: the kernel's hk = hv / (Hv / Hk) head map
+            # would be wrong (and Hv < Hk would divide by zero).
+            v = v[:, :, :5]
+            g = g[:, :, :5]
+            beta = beta[:, :, :5]
+            state = state[:, :5]
+        elif mutation == "state_shape_mismatch":
+            # fp32 but the wrong layout: pointer arithmetic would read/write
+            # out of bounds, so the gate must reject it.
+            state = mx.zeros((B, HV, DV // 2, DK), dtype=mx.float32)
+        assert not gdn_prefill._eligible(q, k, v, g, beta, state, mask)
+
+
+class TestInstall:
+    """Each test restores the TRUE stock kernel first: another test module
+    importing ``vllm_mlx.scheduler`` may have installed the wrapper at
+    collection time, and reload+install against an already-wrapped module
+    attribute would otherwise test the wrong object.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_module_state(self):
+        # Snapshot and restore BOTH the patched mlx-lm function and the
+        # gdn_prefill module globals (_installed / _original_kernel):
+        # restoring only the function would leave a reloaded module claiming
+        # "installed" with nothing bound, making later tests order-dependent.
+        fn_before = gd.gated_delta_kernel
+        installed_before = gdn_prefill._installed
+        original_before = gdn_prefill._original_kernel
+        yield
+        gd.gated_delta_kernel = fn_before
+        gdn_prefill._installed = installed_before
+        gdn_prefill._original_kernel = original_before
+
+    def _fresh(self):
+        stock = _stock_kernel()
+        gd.gated_delta_kernel = stock
+        mod = importlib.reload(gdn_prefill)
+        return mod, stock
+
+    def test_install_wraps_and_is_idempotent(self, monkeypatch):
+        mod, stock = self._fresh()
+        try:
+            assert mod.install() is True
+            wrapped = gd.gated_delta_kernel
+            assert wrapped is not stock
+            assert wrapped._stock is stock
+            # second install is a no-op
+            assert mod.install() is True
+            assert gd.gated_delta_kernel is wrapped
+        finally:
+            gd.gated_delta_kernel = stock
+
+    def test_install_never_wraps_the_wrapper(self, monkeypatch):
+        # A reloaded module copy must detect an already-bound wrapper and
+        # leave it alone — double-wrapping would make the stock fallback
+        # recurse back into the fast path.
+        mod, stock = self._fresh()
+        try:
+            assert mod.install() is True
+            wrapped = gd.gated_delta_kernel
+            mod2 = importlib.reload(gdn_prefill)  # resets module globals
+            assert mod2.install() is True
+            assert gd.gated_delta_kernel is wrapped  # not re-wrapped
+            assert gd.gated_delta_kernel._stock is stock
+        finally:
+            gd.gated_delta_kernel = stock
+
+    def test_env_opt_out(self, monkeypatch):
+        monkeypatch.setenv("RAPID_MLX_GDN_PREFILL", "0")
+        mod, stock = self._fresh()
+        try:
+            assert mod.install() is False
+            assert gd.gated_delta_kernel is stock
+        finally:
+            gd.gated_delta_kernel = stock
+
+    def test_fast_path_failure_degrades_to_stock_permanently(self, monkeypatch):
+        # A fast-path exception (e.g. Metal JIT rejection on an exotic GPU)
+        # must fall back to the stock kernel and stay there — it can never
+        # crash a request.
+        mod, stock = self._fresh()
+        calls = {"stock": 0}
+
+        def counting_stock(*args, **kwargs):
+            calls["stock"] += 1
+            return stock(*args, **kwargs)
+
+        gd.gated_delta_kernel = counting_stock
+        assert mod.install() is True
+
+        real_blocked_seq = mod.gated_delta_blocked_seq
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated Metal JIT failure")
+
+        monkeypatch.setattr(mod, "gated_delta_blocked_seq", boom)
+        q, k, v, g, beta, state = _inputs(64)
+        y1, st1 = gd.gated_delta_kernel(q, k, v, g, beta, state, None)
+        mx.eval(y1, st1)
+        assert calls["stock"] == 1  # degraded, not crashed
+        # Restore the REAL fast path behind a counter: the wrapper must not
+        # invoke it again — proving fast_path_dead persisted, not merely
+        # that a second exception also fell through to stock.
+        calls_fast = {"n": 0}
+
+        def counting_fast(*args, **kwargs):
+            calls_fast["n"] += 1
+            return real_blocked_seq(*args, **kwargs)
+
+        monkeypatch.setattr(mod, "gated_delta_blocked_seq", counting_fast)
+        y2, st2 = gd.gated_delta_kernel(q, k, v, g, beta, state, None)
+        mx.eval(y2, st2)
+        assert calls["stock"] == 2
+        assert calls_fast["n"] == 0
+
+    def test_wrapper_falls_back_for_masked_input(self, monkeypatch):
+        mod, stock = self._fresh()
+        calls = {"stock": 0}
+
+        def counting_stock(*args, **kwargs):
+            calls["stock"] += 1
+            return stock(*args, **kwargs)
+
+        gd.gated_delta_kernel = counting_stock
+        try:
+            assert mod.install() is True
+            q, k, v, g, beta, state = _inputs(64)
+            mask = mx.ones((B, 64), dtype=mx.bool_)
+            y, st = gd.gated_delta_kernel(q, k, v, g, beta, state, mask)
+            mx.eval(y, st)
+            assert calls["stock"] == 1
+        finally:
+            gd.gated_delta_kernel = stock

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -138,6 +138,13 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # of that changes. Read by ``vllm_mlx.scheduler._get_request_sampler``
         # only, never by config / aliases / model_auto_config.
         "RAPID_MLX_DISABLE_FUSED_SAMPLER",
+        # Opt-out of the blocked-seq GDN prefill Metal kernel
+        # (vllm_mlx/gdn_prefill.py). Same shape as DISABLE_FUSED_SAMPLER —
+        # a kernel-selection perf toggle computing the exact same
+        # recurrence, not a routing decision: which model loads, which
+        # parser fires, which tier engages — none of that changes. Read by
+        # ``gdn_prefill.install()`` only.
+        "RAPID_MLX_GDN_PREFILL",
         # Opt-in re-quantization of the lm_head when serving fp8-block
         # checkpoints through the load-time mxfp8 repack
         # (vllm_mlx/fp8_repack.py). A precision/speed knob on an

--- a/vllm_mlx/gdn_prefill.py
+++ b/vllm_mlx/gdn_prefill.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Blocked-sequential Metal kernel for Gated DeltaNet (GDN) prompt prefill.
+
+Qwen3.5/3.6/3.8 hybrid checkpoints spend a large share of long-prompt
+prefill inside the GDN linear-attention scan. mlx-lm's stock kernel splits
+each v-head into ``Dv/4``-slice threadgroups, so every threadgroup re-reads
+the same k/q rows from device memory — roughly 32x redundant traffic
+(~13 GB per 16k-token layer call). This kernel computes the *exact same
+sequential recurrence* (identical FLOPs — no chunked/WY reformulation)
+restructured for Apple GPUs:
+
+- k/q/v are staged into threadgroup memory in ``TB``-token blocks with
+  coalesced cooperative loads; each row is read from device exactly once
+  per threadgroup.
+- The recurrent state stays in registers: each thread owns a
+  ``(dv, 16-wide d-segment)`` fragment, and the ``k·state`` / ``q·state``
+  contractions reduce across the 8 segment-threads of a dv row via
+  ``simd_shuffle_down`` — no threadgroup barriers in the hot loop.
+
+Numerics: all accumulation is fp32 and the state stays fp32, matching the
+stock kernel's accuracy contract (state rel-err ~5e-8 on random inputs).
+
+Kernel design adapted from the oMLX project
+(https://github.com/jundot/omlx, Apache-2.0) ``qwen35_prefill`` package,
+which reports ~2x over the stock kernel at 16k tokens (14.9ms vs 29.7ms
+per layer call on M3 Ultra).
+
+``install()`` wraps ``mlx_lm.models.gated_delta.gated_delta_kernel`` — the
+module-level dispatch every GDN model path funnels through on the GPU
+route — so callers that imported ``gated_delta_update`` directly are still
+covered. The wrapper only takes the fast path for shapes the kernel is
+built for (see ``_eligible``); everything else falls through to the stock
+kernel unchanged. Set ``RAPID_MLX_GDN_PREFILL=0`` to disable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+# The register layout hardwires the key dimension: 8 threads per dv row,
+# each owning a 16-wide d-segment (4x float4) => exactly 128. Qwen3.5/3.6/
+# 3.8 GDN all use Dk=128. Anything else falls back to the stock kernel.
+_REQUIRED_DK = 128
+# Each threadgroup owns a 32-row dv block.
+_DV_BLOCK = 32
+# Below this many prompt tokens the launch overhead beats the win.
+_MIN_TOKENS = 64
+
+_HEADER = """
+#include <metal_stdlib>
+using namespace metal;
+"""
+
+_KERNEL_SRC = """
+    constexpr int TB = 32;                             // time block
+    constexpr int DB = 32;                             // dv rows per threadgroup
+    const int tid = thread_position_in_threadgroup.x;  // 0..255
+    const int blk = threadgroup_position_in_grid.x;    // Dv/DB block
+    const int hv  = threadgroup_position_in_grid.y;
+    const int b   = threadgroup_position_in_grid.z;
+    const int hk  = hv / (Hv / Hk);
+    const int dv0 = blk * DB;
+
+    // thread -> (dv row, 16-wide d segment); 8 threads per dv row, all in
+    // the same simdgroup (lane = (dv%4)*8 + seg).
+    const int dv  = tid / 8;            // 0..31
+    const int seg = tid % 8;            // 0..7
+    const int d0  = seg * 16;
+
+    threadgroup InT k_s[TB][Dk + 8];
+    threadgroup InT q_s[TB][Dk + 8];
+    threadgroup InT v_s[TB][DB + 8];
+    threadgroup float g_s[TB];
+    threadgroup float b_s[TB];
+
+    const device InT* k_base = k + ((size_t)b * T * Hk + hk) * Dk;
+    const device InT* q_base = q + ((size_t)b * T * Hk + hk) * Dk;
+    const device InT* v_base = v + ((size_t)b * T * Hv + hv) * Dv + dv0;
+    const size_t krow = (size_t)Hk * Dk;
+
+    // state fragment in registers: [dv0+dv][d0..d0+16]
+    float4 st[4];
+    {
+        const device float4* S_in = (const device float4*)(
+            state_in + (((size_t)b * Hv + hv) * Dv + dv0 + dv) * Dk + d0);
+        for (int i = 0; i < 4; ++i) st[i] = S_in[i];
+    }
+
+    device InT* y_base = y + ((size_t)b * T * Hv + hv) * Dv + dv0;
+
+    for (int t0 = 0; t0 < T; t0 += TB) {
+        const int tt = min(TB, T - t0);
+        // cooperative staging (coalesced): k/q rows, v slice, g/beta
+        for (int p = tid; p < tt * Dk; p += 256) {
+            const int r = p / Dk, d = p % Dk;
+            k_s[r][d] = k_base[(size_t)(t0 + r) * krow + d];
+            q_s[r][d] = q_base[(size_t)(t0 + r) * krow + d];
+        }
+        for (int p = tid; p < tt * DB; p += 256) {
+            const int r = p / DB, d = p % DB;
+            v_s[r][d] = v_base[(size_t)(t0 + r) * Hv * Dv + d];
+        }
+        for (int p = tid; p < tt; p += 256) {
+            g_s[p] = g[((size_t)b * T + t0 + p) * Hv + hv];
+            b_s[p] = beta[((size_t)b * T + t0 + p) * Hv + hv];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int t = 0; t < tt; ++t) {
+            const float gt = g_s[t];
+            const float bt = b_s[t];
+            const threadgroup vec<InT,4>* k4 =
+                (const threadgroup vec<InT,4>*)&k_s[t][d0];
+            const threadgroup vec<InT,4>* q4 =
+                (const threadgroup vec<InT,4>*)&q_s[t][d0];
+            float4 kf[4];
+            for (int i = 0; i < 4; ++i) kf[i] = float4(k4[i]);
+            // kv_mem = (g*state) . k ; decay applied to state first
+            float4 p4 = 0.0f;
+            for (int i = 0; i < 4; ++i) {
+                st[i] *= gt;
+                p4 += st[i] * kf[i];
+            }
+            float part = p4.x + p4.y + p4.z + p4.w;
+            // reduce across the 8 segment-threads of this dv row
+            part += simd_shuffle_down(part, 4);
+            part += simd_shuffle_down(part, 2);
+            part += simd_shuffle_down(part, 1);
+            const float kv_mem = simd_shuffle(part, (tid % 32) / 8 * 8);
+            const float delta = ((float)v_s[t][dv] - kv_mem) * bt;
+
+            float4 o4 = 0.0f;
+            for (int i = 0; i < 4; ++i) {
+                st[i] += kf[i] * delta;
+                o4 += st[i] * float4(q4[i]);
+            }
+            float out = o4.x + o4.y + o4.z + o4.w;
+            out += simd_shuffle_down(out, 4);
+            out += simd_shuffle_down(out, 2);
+            out += simd_shuffle_down(out, 1);
+            if (seg == 0) {
+                y_base[(size_t)(t0 + t) * Hv * Dv + dv] = (InT)out;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    {
+        device float4* S_out = (device float4*)(
+            state_out + (((size_t)b * Hv + hv) * Dv + dv0 + dv) * Dk + d0);
+        for (int i = 0; i < 4; ++i) S_out[i] = st[i];
+    }
+"""
+
+# fp32 inputs (Qwen3.6's mamba_ssm_dtype) blow the 32 KiB threadgroup-memory
+# limit at TB=32 (40,192 B for the 128/128 layout); TB=16 fits (20,096 B).
+_SUPPORTED_BLOCK_T = (16, 32)
+_kernels: dict[int, object] = {}
+
+
+def _block_t_for(dtype: mx.Dtype) -> int:
+    return 16 if dtype == mx.float32 else 32
+
+
+def _get_kernel(block_t: int):
+    kernel = _kernels.get(block_t)
+    if kernel is None:
+        source = _KERNEL_SRC.replace(
+            "constexpr int TB = 32;", f"constexpr int TB = {block_t};"
+        )
+        kernel = mx.fast.metal_kernel(
+            name=f"rapid_gdn_blocked_seq_tb{block_t}",
+            input_names=["q", "k", "v", "g", "beta", "state_in", "T"],
+            output_names=["y", "state_out"],
+            source=source,
+            header=_HEADER,
+        )
+        _kernels[block_t] = kernel
+    return kernel
+
+
+def gated_delta_blocked_seq(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: mx.array | None = None,
+) -> tuple[mx.array, mx.array]:
+    """Blocked-sequential GDN prefill (exact recurrence).
+
+    q,k: [B,T,Hk,Dk]; v: [B,T,Hv,Dv]; g,beta: [B,T,Hv] (cast to fp32);
+    state: [B,Hv,Dv,Dk] fp32. Returns y [B,T,Hv,Dv] (q.dtype), fp32 state.
+    """
+    B, T, Hk, Dk = q.shape
+    Hv, Dv = v.shape[2:]
+    # This function is the single validation authority for the kernel's
+    # hardwired layout contract: every invariant the Metal source assumes
+    # is checked here and violations raise instead of silently computing
+    # garbage or touching out-of-bounds GPU memory. ``_eligible`` mirrors
+    # these checks only to route ineligible shapes to the stock kernel.
+    if Dk != _REQUIRED_DK:
+        raise ValueError(
+            f"gated_delta_blocked_seq requires Dk == {_REQUIRED_DK}, got {Dk}"
+        )
+    if Dv % _DV_BLOCK != 0:
+        raise ValueError(
+            f"gated_delta_blocked_seq requires Dv % {_DV_BLOCK} == 0, got {Dv}"
+        )
+    if k.shape != q.shape or k.dtype != q.dtype:
+        raise ValueError(
+            "gated_delta_blocked_seq requires k to match q's shape and "
+            f"dtype, got k {k.dtype} {tuple(k.shape)} vs q {q.dtype} "
+            f"{tuple(q.shape)}"
+        )
+    if v.dtype != q.dtype or tuple(v.shape[:2]) != (B, T):
+        raise ValueError(
+            "gated_delta_blocked_seq requires v of shape [B, T, Hv, Dv] "
+            f"with q's dtype, got {v.dtype} {tuple(v.shape)}"
+        )
+    if Hk <= 0 or Hv < Hk or Hv % Hk != 0:
+        raise ValueError(
+            "gated_delta_blocked_seq requires Hv to be a positive multiple "
+            f"of Hk, got Hk={Hk} Hv={Hv}"
+        )
+    if g.shape != (B, T, Hv) or beta.shape != (B, T, Hv):
+        raise ValueError(
+            "gated_delta_blocked_seq requires g and beta of shape "
+            f"{(B, T, Hv)}, got g {tuple(g.shape)} beta {tuple(beta.shape)}"
+        )
+    in_dtype = q.dtype
+    if state is None:
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+    elif state.dtype != mx.float32 or state.shape != (B, Hv, Dv, Dk):
+        # The kernel's pointer arithmetic assumes exactly this fp32 layout;
+        # anything else would read/write out of bounds on the GPU.
+        raise ValueError(
+            "gated_delta_blocked_seq requires an fp32 state of shape "
+            f"{(B, Hv, Dv, Dk)}, got {state.dtype} {tuple(state.shape)}"
+        )
+    g = g.astype(mx.float32)
+    beta = beta.astype(mx.float32)
+    kernel = _get_kernel(_block_t_for(in_dtype))
+    y, state_out = kernel(
+        inputs=[q, k, v, g, beta, state, T],
+        template=[("InT", in_dtype), ("Dk", Dk), ("Dv", Dv), ("Hk", Hk), ("Hv", Hv)],
+        grid=(256 * (Dv // _DV_BLOCK), Hv, B),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(B, T, Hv, Dv), state.shape],
+        output_dtypes=[in_dtype, mx.float32],
+    )
+    return y, state_out
+
+
+def _eligible(q, k, v, g, beta, state, mask) -> bool:
+    """Fast-path gate. Anything outside falls back to the stock kernel.
+
+    Pins every layout invariant the Metal kernel hardwires — k strides/dtype
+    mirror q's, beta is a scalar-per-head [B, T, Hv] tensor like g — so
+    mismatched-but-stock-tolerated inputs can never be read with wrong
+    strides or element types. ``state`` may be ``None`` (first prefill
+    chunk): the fast path initializes a zero fp32 state exactly like the
+    stock update path; a caller-provided state must already be fp32.
+    """
+    return (
+        mask is None
+        and g.ndim == 3  # scalar per-head gating (vectorized g is 4-D)
+        and q.shape[1] >= _MIN_TOKENS
+        and q.shape[-1] == _REQUIRED_DK
+        and k.shape == q.shape  # kernel walks k with q's strides
+        and k.dtype == q.dtype  # single InT template for q/k/v
+        and v.dtype == q.dtype
+        and v.shape[:2] == q.shape[:2]  # same [B, T]
+        and v.shape[-1] % _DV_BLOCK == 0
+        # g and beta must be exactly [B, T, Hv]: the kernel indexes both as
+        # ((b*T + t)*Hv + hv), so any other layout reads out of bounds.
+        and g.shape == (q.shape[0], q.shape[1], v.shape[2])
+        and beta.shape == g.shape
+        # GQA head mapping: the kernel computes hk = hv / (Hv / Hk), which
+        # requires Hv to be a positive multiple of Hk.
+        and q.shape[2] > 0
+        and v.shape[2] >= q.shape[2]
+        and v.shape[2] % q.shape[2] == 0
+        # A provided state must be the exact [B, Hv, Dv, Dk] fp32 layout the
+        # kernel's pointer arithmetic assumes — anything else risks
+        # out-of-bounds GPU access, so it falls back to the stock kernel.
+        and (
+            state is None
+            or (
+                state.dtype == mx.float32
+                and state.shape == (q.shape[0], v.shape[2], v.shape[3], q.shape[3])
+            )
+        )
+    )
+
+
+_installed = False
+# The unwrapped mlx-lm kernel, captured at install() time. Kept for
+# callers (tests) that need the stock implementation after the module
+# attribute has been rebound to the wrapper.
+_original_kernel = None
+
+
+def install() -> bool:
+    """Idempotently wrap mlx-lm's GDN GPU dispatch with the fast path.
+
+    Returns True when the wrapper is (already) in place, False when
+    disabled or unavailable. Safe to call from any lane: models that never
+    route through ``gated_delta_kernel`` are unaffected.
+    """
+    global _installed, _original_kernel
+    if _installed:
+        return True
+    if os.environ.get("RAPID_MLX_GDN_PREFILL", "1") == "0":
+        logger.info("[gdn_prefill] disabled via RAPID_MLX_GDN_PREFILL=0")
+        return False
+    if not mx.metal.is_available():
+        return False
+    try:
+        from mlx_lm.models import gated_delta as _gd
+    except ImportError:
+        return False
+
+    # getattr, not attribute access: an older mlx-lm without this symbol
+    # must degrade to "no fast path", never break scheduler import.
+    stock_kernel = getattr(_gd, "gated_delta_kernel", None)
+    if stock_kernel is None:
+        logger.info(
+            "[gdn_prefill] mlx-lm has no gated_delta_kernel — fast path unavailable"
+        )
+        return False
+    if getattr(stock_kernel, "_rapid_gdn_wrapper", False):
+        # Already wrapped (e.g. this module was reloaded while the wrapper
+        # stayed bound). Never wrap the wrapper — that would make the
+        # "stock" fallback recurse into the fast path.
+        _original_kernel = stock_kernel._stock
+        _installed = True
+        return True
+
+    # Eagerly compile-and-run both kernel variants BEFORE rebinding
+    # anything: mlx is lazy, so a Metal rejection would otherwise surface at
+    # mx.eval() inside a production request, outside any wrapper try/except.
+    # The probe uses the Qwen3.5/3.8 flagship geometry (Hk=16, Hv=48,
+    # Dv=128) for both dtypes; other Hk/Hv/Dv specializations of the same
+    # (TB, InT) variant differ only in integer address constants — the
+    # threadgroup-memory and register footprint depend solely on Dk (fixed
+    # 128), DB (fixed 32), TB, and InT, all exercised here — so a
+    # specialization cannot fail compilation when its probed variant
+    # succeeded. If this GPU can't run the kernel, stay on stock entirely.
+    try:
+        for probe_dtype in (mx.bfloat16, mx.float32):
+            pq = mx.zeros((1, _MIN_TOKENS, 16, _REQUIRED_DK), dtype=probe_dtype)
+            pv = mx.zeros((1, _MIN_TOKENS, 48, 128), dtype=probe_dtype)
+            pg = mx.zeros((1, _MIN_TOKENS, 48), dtype=mx.float32)
+            py, pst = gated_delta_blocked_seq(pq, pq, pv, pg, pg, None)
+            mx.eval(py, pst)
+    except Exception:  # noqa: BLE001 — any probe failure ⇒ stay on stock
+        logger.exception(
+            "[gdn_prefill] kernel validation probe failed — staying on the stock kernel"
+        )
+        return False
+
+    # Kernel JIT happens lazily on the first eligible call. If Metal ever
+    # rejects the source (exotic GPU, future toolchain change), the failure
+    # must degrade to the stock kernel — permanently, so a broken fast path
+    # can never crash more than zero requests.
+    fast_path_dead = False
+
+    def gated_delta_kernel_fast(q, k, v, g, beta, state, mask=None):
+        nonlocal fast_path_dead
+        if not fast_path_dead and _eligible(q, k, v, g, beta, state, mask):
+            try:
+                return gated_delta_blocked_seq(q, k, v, g, beta, state)
+            except Exception:  # noqa: BLE001 — any fast-path failure ⇒ stock
+                fast_path_dead = True
+                logger.exception(
+                    "[gdn_prefill] fast path failed — permanently falling "
+                    "back to the stock kernel"
+                )
+        return stock_kernel(q, k, v, g, beta, state, mask)
+
+    # Tag the wrapper and hang the unwrapped kernel off it so any caller —
+    # including a reloaded copy of this module or a test comparing numerics
+    # — can always recover the true stock implementation.
+    gated_delta_kernel_fast._rapid_gdn_wrapper = True
+    gated_delta_kernel_fast._stock = stock_kernel
+
+    _original_kernel = stock_kernel
+    _gd.gated_delta_kernel = gated_delta_kernel_fast
+    _installed = True
+    logger.info(
+        "[gdn_prefill] blocked-seq GDN prefill kernel installed "
+        "(prompt>=%d tokens, Dk=%d)",
+        _MIN_TOKENS,
+        _REQUIRED_DK,
+    )
+    return True

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -120,6 +120,7 @@ def _read_kv_dims(model):
     return None
 
 
+from .gdn_prefill import install as install_gdn_prefill_kernel
 from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig  # noqa: E402
 from .paged_cache import PagedCacheManager
 from .pflash import PFlashConfig, compress_request_tokens
@@ -169,6 +170,11 @@ def _pflash_compressed(request: Request) -> bool:
 
 # Enable MambaCache batching support for models like Nemotron
 ensure_mamba_support()
+
+# Install the blocked-seq GDN prefill kernel for Qwen3.5/3.6/3.8 hybrids.
+# Shape-gated inside: non-GDN models and decode steps are untouched, and
+# RAPID_MLX_GDN_PREFILL=0 opts out entirely.
+install_gdn_prefill_kernel()
 
 # Error patterns that indicate cache corruption.
 # Each pattern must be specific enough to avoid false positives.


### PR DESCRIPTION
## Why

Qwen3.5/3.6/3.8 hybrid checkpoints run their linear-attention (Gated DeltaNet) prefill scan through mlx-lm's stock kernel, which re-reads the same k/q rows from device memory once per `Dv/4`-slice threadgroup — ~32x redundant traffic at long chunk lengths. A blocked-sequential restructuring (threadgroup-staged k/q/v token blocks, register-resident state, `simd_shuffle_down` reductions, no barriers in the hot loop) computes the **exact same recurrence** materially faster at the op level.

Measured per-layer-call (Qwen3.8-27B GDN geometry `Hk=16 Hv=48 Dk=Dv=128`, bf16, M3 Ultra):

| T | stock | this kernel | speedup | state rel-err |
|---|---|---|---|---|
| 2048 | 3.93ms | 2.67ms | 1.47x | 8.7e-08 |
| 4096 | 8.05ms | 5.11ms | 1.57x | 9.5e-08 |
| 8192 | 18.00ms | 9.99ms | 1.80x | 9.4e-08 |
| 16384 | 42.36ms | 19.89ms | 2.13x | 7.0e-08 |

**Honest end-to-end framing**: because chunked prefill caps each scan call at `prefill_step_size` (2048) and quantized matmuls dominate total prefill on these models, the server-level TTFT win is modest — measured **-1.2%** on Qwen3.8-27B (6K-token prompt, 18.86s→18.63s; same at 16K) and **-2.6%** on Qwen3.6-35B-A3B (2.80s→2.73s), medians of 3-4 runs, cache-busted, isolated single-server protocol on M3 Ultra. This is a real, exact, zero-risk op-level improvement, not a TTFT transformation.

Kernel design adapted from the oMLX project (https://github.com/jundot/omlx, Apache-2.0), which ships it default-on for the same architectures.

## What

- `vllm_mlx/gdn_prefill.py` — the Metal kernel (`mx.fast.metal_kernel` JIT, no build step) + `install()` that wraps `mlx_lm.models.gated_delta.gated_delta_kernel` (the module-global dispatch all GDN GPU paths funnel through). Fast path is strictly shape-gated: scalar gating, prompt ≥64 tokens, `Dk == 128`, `Dv % 32 == 0`, fp32 state, no mask — everything else falls through to the stock kernel unchanged. `RAPID_MLX_GDN_PREFILL=0` opts out.
- `vllm_mlx/scheduler.py` — call `install()` at module import, next to the existing `ensure_mamba_support()` patch precedent.

## Tests

`tests/test_gdn_prefill_kernel.py` (14 tests, Metal-gated):
- numerics vs the stock Metal kernel (bf16, T=64/100/512) and vs the pure-ops reference (fp32 end-to-end — pins the algorithm with no rounding slack)
- chunked-prefill state-chaining invariant (two chained 64-token calls == one 128-token call)
- every fallback gate (masked / vectorized gating / decode step / wrong Dk / non-fp32 state)
- `install()` idempotency, env opt-out, and wrapper fallback-to-stock for ineligible calls

All 14 pass on M2 Pro; kernel verified on M3 Ultra via the microbench above. Decode (T=1) provably unaffected: E2E decode tok/s unchanged (36.1 vs 36.4 within noise).

## Notes

- The MLLM vision lane uses mlx-vlm's own qwen3_5 copy and is intentionally untouched; this covers the default text lane.
- AI-authored (Claude Opus 4.8) as part of an overnight cross-engine benchmarking session (rapid-mlx vs mlx-lm vs omlx on Studio M3 Ultra); benchmark artifacts retained on mac-studio `~/work/benchout/`.