### PR TITLE
fix(models): restore North Mini repo contracts

### DIFF
--- a/tests/test_cohere2_moe_vendored.py
+++ b/tests/test_cohere2_moe_vendored.py
@@ -102,6 +102,7 @@ def test_checkpoint_profile_defaults_and_conservative_capabilities() -> None:
     assert profile is not None
     assert profile.tool_call_parser is None
     assert profile.reasoning_parser is None
+    assert profile.is_hybrid is False
     assert profile.is_moe is True
     assert profile.supports_spec_decode is False
 
@@ -118,5 +119,6 @@ def test_public_4bit_alias_defaults_and_conservative_capabilities() -> None:
     assert profile.hf_path == "mlx-community/North-Mini-Code-1.0-4bit"
     assert profile.tool_call_parser is None
     assert profile.reasoning_parser is None
+    assert profile.is_hybrid is False
     assert profile.is_moe is True
     assert profile.supports_spec_decode is False

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1,11 +1,13 @@
 {
   "north-mini-code-4bit": {
     "hf_path": "mlx-community/North-Mini-Code-1.0-4bit",
+    "is_hybrid": false,
     "is_moe": true,
     "supports_spec_decode": false
   },
   "north-mini-code-bf16": {
     "hf_path": "mlx-community/North-Mini-Code-1.0-bf16",
+    "is_hybrid": false,
     "is_moe": true,
     "supports_spec_decode": false
   },

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -58,6 +58,8 @@
     "mlx-community/Muse-Glimmer-30B-bf16": 59581776079,
     "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit": 17792571825,
     "mlx-community/Nanbeige4.1-3B-4bit": 2231499570,
+    "mlx-community/North-Mini-Code-1.0-4bit": 18514853287,
+    "mlx-community/North-Mini-Code-1.0-bf16": 60988268172,
     "mlx-community/Phi-3.5-mini-instruct-4bit": 2152081350,
     "mlx-community/Qwen2.5-14B-Instruct-4bit": 8321091241,
     "mlx-community/Qwen3-0.6B-4bit": 351383618,

--- a/vllm_mlx/models/cohere2_moe.py
+++ b/vllm_mlx/models/cohere2_moe.py
@@ -11,6 +11,13 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
+
+# Installing this before any ``mlx_lm`` import protects M5 single-stream
+# devices from mlx-lm's module-load-time thread-local stream capture (#404).
+from .. import _mlx_compat
+
+_mlx_compat.install()
+
 from mlx_lm.models.activations import swiglu
 from mlx_lm.models.base import (
     BaseModelArgs,


### PR DESCRIPTION
Fixes #2146.

## Why is this change necessary?
Three repository-contract tests fail on pristine `main`, masking genuine regressions in every subsequent local full-unit validation. The North-Mini-Code vendor addition omitted the required pre-`mlx_lm` compatibility shim, explicit hybrid capability fields, and model-size manifest entries.

## Summary
- install the MLX hardware-compat shim before the vendored Cohere2-MoE module imports `mlx_lm`
- declare both North-Mini-Code aliases explicitly non-hybrid
- regenerate the model-size manifest for both aliases
- pin the conservative non-hybrid profile behavior in vendored-model tests

## AI assistance disclosure
Codex implemented and reviewed the four changed files. The maintainer verified the generated manifest diff was limited to the two intended repositories and ran the focused contract, vendored-model, lint, and formatting checks below.

## Validation
- `uv run pytest -q tests/test_mlx_compat.py tests/test_model_profiles_ssot.py tests/test_model_sizes.py tests/test_cohere2_moe_vendored.py` (49 passed)
- `uv run ruff check vllm_mlx/models/cohere2_moe.py tests/test_cohere2_moe_vendored.py`
- `uv run ruff format --check vllm_mlx/models/cohere2_moe.py tests/test_cohere2_moe_vendored.py`
- `git diff --check`

## Maintainer affirmation
I can explain every non-generated line on demand. `model_sizes.json` is generated by `scripts/gen_model_sizes.py`; its diff was inspected and contains only the two intended North-Mini-Code entries.