### PR TITLE
feat(perf): fuse MoE gate+up expert projections into one gather_qmm

### DIFF
--- a/tests/test_moe_gate_up_fusion.py
+++ b/tests/test_moe_gate_up_fusion.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness gates for the MoE gate+up expert-projection fusion.
+
+The fusion must be BIT-exact — affine quantization packs each output row
+independently, so a concatenated gate+up gather_qmm returns the same
+bytes as two separate calls — and strictly opt-out-able. These tests pin
+byte equality on quantized and unquantized SwitchGLU, the structural
+_can_fuse gate, in-place rewrite semantics (original buffers dropped,
+stock path preserved for unfused instances), idempotency, and the env
+kill-switch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+import mlx.nn as nn
+from mlx_lm.models.switch_layers import QuantizedSwitchLinear, SwitchGLU, SwitchLinear
+
+from vllm_mlx import moe_fusion
+
+# Small MoE geometry: E experts, k active, quantization-friendly dims.
+E, HID, INTER, K = 8, 64, 128, 2
+
+
+class TinyMoE(nn.Module):
+    """Minimal container so fuse_gate_up's module scan finds the layers."""
+
+    def __init__(self, n_layers=2, quantize=True):
+        super().__init__()
+        self.layers = [SwitchGLU(HID, INTER, E) for _ in range(n_layers)]
+        if quantize:
+            nn.quantize(self, group_size=32, bits=4)
+
+
+def _decode_inputs(seed=3, tokens=1):
+    mx.random.seed(seed)
+    x = mx.random.normal((1, tokens, HID)).astype(mx.float16)
+    inds = mx.random.randint(0, E, (1, tokens, K))
+    mx.eval(x, inds)
+    return x, inds
+
+
+def _run_all(model, x, inds):
+    outs = [layer(x, inds) for layer in model.layers]
+    mx.eval(*outs)
+    return outs
+
+
+class TestBitExactness:
+    @pytest.mark.parametrize("quantize", [True, False])
+    def test_fused_output_is_byte_identical(self, quantize):
+        model = TinyMoE(quantize=quantize)
+        mx.eval(model.parameters())
+        x, inds = _decode_inputs()
+        before = _run_all(model, x, inds)
+        n = moe_fusion.fuse_gate_up(model)
+        assert n == 2
+        after = _run_all(model, x, inds)
+        for b, a in zip(before, after):
+            assert bool(mx.array_equal(b, a)), "fusion changed output bytes"
+
+    def test_sorted_path_byte_identical(self):
+        # indices.size >= 64 triggers the gather-sort branch; the fused
+        # call must keep it byte-identical too (prefill / batched decode).
+        model = TinyMoE()
+        mx.eval(model.parameters())
+        x, inds = _decode_inputs(tokens=40)  # 40*2 = 80 >= 64
+        before = _run_all(model, x, inds)
+        assert moe_fusion.fuse_gate_up(model) == 2
+        after = _run_all(model, x, inds)
+        for b, a in zip(before, after):
+            assert bool(mx.array_equal(b, a))
+
+
+class TestRewriteSemantics:
+    def test_originals_dropped_and_container_reused(self):
+        model = TinyMoE()
+        mx.eval(model.parameters())
+        assert moe_fusion.fuse_gate_up(model) == 2
+        for layer in model.layers:
+            assert hasattr(layer, "gate_up_proj")
+            assert not hasattr(layer, "gate_proj")
+            assert not hasattr(layer, "up_proj")
+            # fused output axis is 2*inter
+            assert layer.gate_up_proj["scales"].shape[1] == 2 * INTER
+
+    def test_idempotent(self):
+        model = TinyMoE()
+        mx.eval(model.parameters())
+        assert moe_fusion.fuse_gate_up(model) == 2
+        # second run finds nothing eligible (gate_up_proj present)
+        assert moe_fusion.fuse_gate_up(model) == 0
+
+    def test_unfused_instances_keep_stock_path(self):
+        # A model with a fused layer and a fresh (unfused) layer must run
+        # both correctly through the patched class __call__.
+        model = TinyMoE()
+        mx.eval(model.parameters())
+        assert moe_fusion.fuse_gate_up(model) == 2
+        fresh = SwitchGLU(HID, INTER, E)
+        nn.quantize(fresh, group_size=32, bits=4)
+        mx.eval(fresh.parameters())
+        x, inds = _decode_inputs()
+        out = fresh(x, inds)  # goes through orig_call branch
+        mx.eval(out)
+        assert out.shape == (1, 1, K, HID)
+
+    def test_dense_model_is_noop(self):
+        class Dense(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = nn.Linear(HID, HID)
+
+        assert moe_fusion.fuse_gate_up(Dense()) == 0
+
+
+class TestGates:
+    def test_env_opt_out(self, monkeypatch):
+        monkeypatch.setenv("RAPID_MLX_MOE_GATE_UP_FUSION", "0")
+        model = TinyMoE()
+        mx.eval(model.parameters())
+        assert moe_fusion.fuse_gate_up(model) == 0
+        assert hasattr(model.layers[0], "gate_proj")
+
+    def test_mismatched_quant_params_not_fused(self):
+        # gate and up quantized with different bit widths -> ineligible
+        m4 = TinyMoE(n_layers=1, quantize=False)
+        m8 = TinyMoE(n_layers=1, quantize=False)
+        nn.quantize(m4, group_size=32, bits=4)
+        nn.quantize(m8, group_size=32, bits=8)
+        layer = m4.layers[0]
+        layer.up_proj = m8.layers[0].up_proj
+        mx.eval(m4.parameters())
+        assert isinstance(layer.gate_proj, QuantizedSwitchLinear)
+        assert moe_fusion.fuse_gate_up(m4) == 0
+        assert hasattr(layer, "gate_proj")
+
+    def test_subclass_not_fused(self):
+        # Exact-type gate: a subclass may override __call__ and never read
+        # gate_up_proj, so it must be left alone.
+        class CustomGLU(SwitchGLU):
+            pass
+
+        class Holder(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.glu = CustomGLU(HID, INTER, E)
+
+        model = Holder()
+        nn.quantize(model, group_size=32, bits=4)
+        mx.eval(model.parameters())
+        assert moe_fusion.fuse_gate_up(model) == 0
+        assert hasattr(model.glu, "gate_proj")
+
+
+class TestPlainSwitchLinear:
+    def test_unquantized_fusion_bit_exact_with_bias(self):
+        class BiasMoE(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.glu = SwitchGLU(HID, INTER, E, bias=True)
+
+        model = BiasMoE()
+        layer = model.glu
+        assert isinstance(layer.gate_proj, SwitchLinear)
+        # the additive-bias fusion path must actually be exercised
+        assert "bias" in layer.gate_proj and "bias" in layer.up_proj
+        mx.eval(model.parameters())
+        x, inds = _decode_inputs()
+        before = layer(x, inds)
+        mx.eval(before)
+        assert moe_fusion.fuse_gate_up(model) == 1
+        assert "bias" in layer.gate_up_proj
+        after = layer(x, inds)
+        mx.eval(after)
+        assert bool(mx.array_equal(before, after))

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -138,6 +138,13 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # of that changes. Read by ``vllm_mlx.scheduler._get_request_sampler``
         # only, never by config / aliases / model_auto_config.
         "RAPID_MLX_DISABLE_FUSED_SAMPLER",
+        # Opt-out of the MoE gate+up expert-projection fusion
+        # (vllm_mlx/moe_fusion.py). Same shape as DISABLE_FUSED_SAMPLER —
+        # a bit-exact launch-count optimization on an already-selected
+        # model, not a routing decision: which model loads, which parser
+        # fires, which tier engages — none of that changes. Read by
+        # ``moe_fusion.fuse_gate_up()`` only.
+        "RAPID_MLX_MOE_GATE_UP_FUSION",
         # Opt-out of the blocked-seq GDN prefill Metal kernel
         # (vllm_mlx/gdn_prefill.py). Same shape as DISABLE_FUSED_SAMPLER —
         # a kernel-selection perf toggle computing the exact same

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1310,6 +1310,19 @@ class BatchedEngine(BaseEngine):
                 **load_kwargs,
             ).result()
 
+            # Fuse MoE gate+up expert projections: one gather_qmm launch
+            # instead of two per MoE layer per token, bit-exact (see
+            # vllm_mlx/moe_fusion.py; measured +7% decode on
+            # Qwen3.6-35B-A3B). Runs on the mlx-step worker — the weight
+            # concat touches MLX streams only that thread owns (#170).
+            # Intentionally inside the non-disk-stream branch: the
+            # disk-stream forward reads gate_proj/up_proj directly and its
+            # lazy load never materializes the routed weights. Dense
+            # models are a cheap no-op (no SwitchGLU to find).
+            from ..moe_fusion import fuse_gate_up
+
+            self._model_load_executor.submit(fuse_gate_up, self._model).result()
+
         # 0.9.13 PR-A: new-arch MTP inject dispatcher (Gemma 4 external
         # assistant / Qwen3.5 baked-in MTP). Runs BEFORE the scheduler is
         # built so ``_install_mtp_vendored`` in scheduler.py sees the

--- a/vllm_mlx/moe_fusion.py
+++ b/vllm_mlx/moe_fusion.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fuse MoE routed gate/up expert projections into one ``gather_qmm``.
+
+At single-token decode, mlx-lm's stock ``SwitchGLU`` issues three tiny
+``gather_qmm`` launches per MoE layer (gate, up, down). Affine
+quantization packs each output row independently, so concatenating the
+gate and up expert weights along the output axis and issuing ONE
+``gather_qmm`` over ``[E, 2*inter, hidden]`` is bit-identical to the two
+separate calls while removing one GPU launch per MoE layer per token.
+The same fused weights serve prefill and batched decode unchanged.
+
+Measured on Qwen3.6-35B-A3B-8bit (M3 Ultra): decode 86.4 -> 92.5 tok/s
+(+7.0%) with byte-identical greedy output across the fused 40 layers.
+
+Fusion design adapted from the oMLX project
+(https://github.com/jundot/omlx, Apache-2.0), which ships it default-on
+for the same layer type.
+
+``fuse_gate_up(model)`` runs once post-load: it patches
+``SwitchGLU.__call__`` with a fused-aware branch (class-level, once per
+process, stock path preserved for unfused instances) and rewrites each
+eligible instance in place — the gate module becomes the fused container
+so quantization parameters carry over, and the original gate/up buffers
+are freed layer-by-layer to bound the transient. Instances whose
+gate/up pair fails the structural checks are left untouched. Set
+``RAPID_MLX_MOE_GATE_UP_FUSION=0`` to disable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_CALL_PATCHED = False
+
+
+def _switch_layer_types():
+    """Import lazily so a changed mlx-lm degrades to no-fusion, never a crash."""
+    try:
+        from mlx_lm.models.switch_layers import (
+            QuantizedSwitchLinear,
+            SwitchGLU,
+            SwitchLinear,
+            _gather_sort,
+            _scatter_unsort,
+        )
+    except ImportError:
+        return None
+    return QuantizedSwitchLinear, SwitchGLU, SwitchLinear, _gather_sort, _scatter_unsort
+
+
+def _can_fuse(switch_mlp: Any, quantized_cls, plain_cls) -> bool:
+    """Structural gate: only fuse a gate/up pair the concat math is exact for."""
+    if hasattr(switch_mlp, "gate_up_proj"):
+        return False
+    if not (
+        hasattr(switch_mlp, "gate_proj")
+        and hasattr(switch_mlp, "up_proj")
+        and hasattr(switch_mlp, "down_proj")
+    ):
+        return False
+    gate, up = switch_mlp.gate_proj, switch_mlp.up_proj
+    if type(gate) is not type(up):
+        return False
+    if isinstance(gate, quantized_cls):
+        if (gate.group_size, gate.bits, gate.mode) != (
+            up.group_size,
+            up.bits,
+            up.mode,
+        ):
+            return False
+        if (gate.get("biases") is None) != (up.get("biases") is None):
+            return False
+    elif not isinstance(gate, plain_cls):
+        return False
+    if ("bias" in gate) != ("bias" in up):
+        return False
+    gate_w, up_w = gate["weight"], up["weight"]
+    return gate_w.shape == up_w.shape and gate_w.dtype == up_w.dtype
+
+
+def _fuse_one(switch_mlp: Any, quantized_cls) -> None:
+    gate, up = switch_mlp.gate_proj, switch_mlp.up_proj
+    # Concat order is [gate, up] along the output axis (the HF
+    # gate_up_proj checkpoint convention); the fused call splits in the
+    # same order.
+    fused = {"weight": mx.concatenate([gate["weight"], up["weight"]], axis=1)}
+    if isinstance(gate, quantized_cls):
+        fused["scales"] = mx.concatenate([gate["scales"], up["scales"]], axis=1)
+        if gate.get("biases") is not None:
+            fused["biases"] = mx.concatenate([gate["biases"], up["biases"]], axis=1)
+    if "bias" in gate:
+        fused["bias"] = mx.concatenate([gate["bias"], up["bias"]], axis=-1)
+    mx.eval(list(fused.values()))
+
+    # Reuse the gate module as the fused container so quantization params
+    # and frozen state carry over; deleting gate_proj/up_proj drops the
+    # original buffers.
+    for name, array in fused.items():
+        setattr(gate, name, array)
+    switch_mlp.gate_up_proj = gate
+    del switch_mlp.gate_proj
+    del switch_mlp.up_proj
+
+
+def _make_fused_call(orig_call, gather_sort, scatter_unsort):
+    def fused_call(self, x: mx.array, indices: mx.array) -> mx.array:
+        gate_up = getattr(self, "gate_up_proj", None)
+        if gate_up is None:
+            return orig_call(self, x, indices)
+
+        x = mx.expand_dims(x, (-2, -3))
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        x_gate_up = gate_up(x, idx, sorted_indices=do_sort)
+        x_gate, x_up = mx.split(x_gate_up, 2, axis=-1)
+        x = self.down_proj(
+            self.activation(x_up, x_gate),
+            idx,
+            sorted_indices=do_sort,
+        )
+        if do_sort:
+            x = scatter_unsort(x, inv_order, indices.shape)
+        return x.squeeze(-2)
+
+    return fused_call
+
+
+def _ensure_call_patch(switch_glu_cls, gather_sort, scatter_unsort) -> None:
+    global _CALL_PATCHED
+    if _CALL_PATCHED or getattr(switch_glu_cls, "_rapid_gate_up_fused_call", False):
+        _CALL_PATCHED = True
+        return
+    orig = switch_glu_cls.__call__
+    switch_glu_cls.__call__ = _make_fused_call(orig, gather_sort, scatter_unsort)
+    switch_glu_cls._rapid_gate_up_fused_call = True
+    switch_glu_cls._rapid_gate_up_original_call = orig
+    _CALL_PATCHED = True
+
+
+def fuse_gate_up(model: Any) -> int:
+    """Fuse gate+up expert projections on a loaded MoE model, in place.
+
+    Returns the number of fused ``SwitchGLU`` instances (0 when disabled
+    via ``RAPID_MLX_MOE_GATE_UP_FUSION=0``, mlx-lm is unavailable, or the
+    model has nothing eligible). Dense models are a cheap no-op — the
+    module scan finds no ``SwitchGLU``. Idempotent: already-fused
+    instances carry ``gate_up_proj`` and are skipped by the gate.
+    """
+    if os.environ.get("RAPID_MLX_MOE_GATE_UP_FUSION", "1") == "0":
+        logger.info("[moe_fusion] disabled via RAPID_MLX_MOE_GATE_UP_FUSION=0")
+        return 0
+    layer_types = _switch_layer_types()
+    if layer_types is None:
+        return 0
+    quantized_cls, switch_glu_cls, plain_cls, gather_sort, scatter_unsort = layer_types
+
+    try:
+        modules = [m for _, m in model.named_modules()]
+    except Exception:  # noqa: BLE001 — unusual model containers: no fusion
+        return 0
+    # Exact type only: a subclass may override __call__ and never consult
+    # gate_up_proj, so fusing it would silently waste memory (or worse if
+    # it reads gate_proj directly).
+    targets = [
+        m
+        for m in modules
+        if type(m) is switch_glu_cls and _can_fuse(m, quantized_cls, plain_cls)
+    ]
+    if not targets:
+        return 0
+    _ensure_call_patch(switch_glu_cls, gather_sort, scatter_unsort)
+    for switch_mlp in targets:
+        _fuse_one(switch_mlp, quantized_cls)
+        # The freed gate/up buffers land in the MLX buffer pool. Drain per
+        # fused layer so the load-time transient stays bounded to a single
+        # layer's worth instead of ~2/3 of the whole routed expert set.
+        mx.clear_cache()
+    logger.info("[moe_fusion] gate+up fusion applied: %d MoE layers", len(targets))
+    return len(targets)


### PR DESCRIPTION
## Why

At single-token decode, mlx-lm's stock `SwitchGLU` issues three tiny `gather_qmm` launches per MoE layer (gate, up, down). Affine quantization packs each output row independently, so concatenating the gate and up expert weights along the output axis and issuing **one** `gather_qmm` over `[E, 2*inter, hidden]` is **bit-identical** to the two separate calls while removing one GPU launch per MoE layer per token.

Measured on Qwen3.6-35B-A3B-8bit (M3 Ultra, cache-busted medians, isolated single-server protocol):

| level | baseline | fused | delta |
|---|---|---|---|
| mlx_lm generate decode | 86.4 tok/s | 92.5 tok/s | **+7.0%** |
| server E2E long-prompt decode | 81.4 tok/s | 86.1 tok/s | **+5.8%** |

Correctness: greedy outputs **byte-identical** at every level — layer microbench (`mx.array_equal` on both the decode and gather-sort paths), `mlx_lm.generate` (identical text), and server-level 6-prompt greedy capture (English/code/math/Chinese, identical `content`/`reasoning`/token counts vs a `RAPID_MLX_MOE_GATE_UP_FUSION=0` control server).

Fusion design adapted from the oMLX project (https://github.com/jundot/omlx, Apache-2.0), which ships it default-on for the same layer type. Applies to every stock-`SwitchGLU` MoE the server loads (Qwen3.5/3.6 MoE, Qwen3-MoE family, etc.); dense models are a no-op scan.

## What

- `vllm_mlx/moe_fusion.py` — `fuse_gate_up(model)`: class-level `__call__` patch (once per process, stock path preserved for unfused instances) + in-place instance rewrite (gate module becomes the fused container so quantization params carry over; original gate/up buffers freed per layer with a cache drain to bound the load transient). Structural gate refuses mismatched quantization params, `SwitchGLU` subclasses (exact-type only), and anything without a clean gate/up pair. `RAPID_MLX_MOE_GATE_UP_FUSION=0` opts out.
- `vllm_mlx/engine/batched.py` — invoke post-load on the mlx-step worker (weight concat touches MLX streams only that thread owns, #170), **inside the non-disk-stream branch only**: the disk-stream forward (`disk_stream_patch.py` / `qwen2_moe_forward.py`) reads `gate_proj`/`up_proj` directly and its lazy load never materializes the routed weights, so those lanes keep the stock layout.
- `tests/test_no_out_of_band_routing.py` — register the env var in `ALLOWED_RAPID_MLX_ENV_VARS` (non-routing perf toggle, same shape as `RAPID_MLX_DISABLE_FUSED_SAMPLER`).

## Tests

`tests/test_moe_gate_up_fusion.py` (11 tests): byte equality on decode and gather-sort paths (quantized 4-bit and unquantized, incl. bias), in-place rewrite semantics (originals dropped, container reused), idempotency, unfused-instance stock path through the patched class `__call__`, dense no-op, env opt-out, mismatched-quant-params reject, subclass reject.

## Notes

AI-authored (Claude Opus 4.8), continuing the cross-engine benchmarking session that produced #2144. Benchmark artifacts on mac-studio `~/work/benchout/` (`35b-moefuse.json`, `greedy-35b-{fused,base}.json`).