### PR TITLE
perf(mac): move dictation model bring-up off the hotkey path [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -32,6 +32,10 @@ final class DictationController {
     private(set) var phase: Phase = .off
     private(set) var lastError: String?
     private(set) var lastLatency: TimeInterval?
+    /// Phase split of ``lastLatency`` ("model 1.2 s · asr 0.3 s"), present
+    /// only when model bring-up took noticeable time. Answers "why was that
+    /// one slow" without a log dive.
+    private(set) var lastLatencyDetail: String?
     private(set) var elapsed: TimeInterval = 0
     /// Set when the TCC row says Accessibility is granted but this process
     /// still cannot install an event tap — i.e. the grant landed after launch.
@@ -221,6 +225,10 @@ final class DictationController {
         accessibilityNeedsRelaunch = false
         lastError = nil
         phase = .idle
+        // Warm the whole lane now — catalog cache, sidecar, STT weights — so
+        // the first hotkey press of the session starts from a hot path. Fire
+        // and forget: enabling must not block on a model coming up.
+        Task { [weak self] in await self?.prewarmModel() }
     }
 
     func disable() {
@@ -283,11 +291,64 @@ final class DictationController {
     /// Loads the model ahead of the first hotkey press. Without this the first
     /// dictation of a session pays for a process swap *and* a possible download
     /// while the user is already talking.
+    ///
+    /// Three costs move off the hotkey path here, in order:
+    /// 1. The alias→repo catalog lookup. On a cache miss ``resolveRepo``
+    ///    spawns `rapid-mlx` CLI subprocesses — one to three SECONDS of cold
+    ///    interpreter — and the old early-return below skipped it exactly when
+    ///    the sidecar was already serving this model, so the most common warm
+    ///    session still paid it inside the first transcription.
+    /// 2. The process swap, when another model is being served.
+    /// 3. The STT weights: the engine loads them lazily on the first
+    ///    transcription of each process lifetime (measured ~1.2 s for
+    ///    parakeet), so ``warmUpEngine()`` sends a beat of silence to make
+    ///    the sidecar pay that now instead of inside the user's first real
+    ///    dictation.
     func prewarmModel() async {
         guard isEnabled, !modelAlias.isEmpty else { return }
-        guard server.servingAlias != modelAlias else { return }
-        _ = await ensureModelServing()
+        _ = await resolveRepo(for: modelAlias)
+        if server.servingAlias != modelAlias {
+            guard await ensureModelServing() else { return }
+        }
+        await warmUpEngine()
     }
+
+    /// Forces the sidecar to load the STT weights by transcribing a beat of
+    /// silence. Skipped whenever a real dictation is underway — the engine
+    /// serialises transcriptions, so a probe would queue in front of it.
+    private func warmUpEngine() async {
+        guard phase == .idle || phase == .off else { return }
+        guard server.servingAlias == modelAlias else { return }
+        _ = try? await client.transcribe(
+            audioData: Self.silentProbeWAV,
+            model: modelAlias,
+            context: nil,
+            port: server.activePort,
+            bearer: server.activeBearer
+        )
+    }
+
+    /// 0.2 s of 16 kHz mono PCM silence — the smallest useful body for
+    /// ``warmUpEngine()``. Same WAV layout ``DictationRecorder`` produces.
+    static let silentProbeWAV: Data = {
+        let sampleCount = 3_200
+        let dataBytes = sampleCount * 2
+        var wav = Data()
+        wav.append(contentsOf: Array("RIFF".utf8))
+        wav.append(UInt32(36 + dataBytes).littleEndianBytes)
+        wav.append(contentsOf: Array("WAVEfmt ".utf8))
+        wav.append(UInt32(16).littleEndianBytes)
+        wav.append(UInt16(1).littleEndianBytes)
+        wav.append(UInt16(1).littleEndianBytes)
+        wav.append(UInt32(16_000).littleEndianBytes)
+        wav.append(UInt32(16_000 * 2).littleEndianBytes)
+        wav.append(UInt16(2).littleEndianBytes)
+        wav.append(UInt16(16).littleEndianBytes)
+        wav.append(contentsOf: Array("data".utf8))
+        wav.append(UInt32(dataBytes).littleEndianBytes)
+        wav.append(Data(count: dataBytes))
+        return wav
+    }()
 
     // MARK: - Hotkey
 
@@ -365,6 +426,10 @@ final class DictationController {
         }
 
         let started = Date()
+        // Phase timing: "how long was that" is unanswerable from one opaque
+        // number when the cost can hide in catalog resolution, a model swap,
+        // or inference. The split is surfaced in the Dictation tab.
+        let ensureStarted = Date()
         guard await ensureModelServing() else {
             lastError = repoByAlias[modelAlias] == nil
                 ? "\(modelAlias) isn't in the audio model catalog. Pick another model."
@@ -372,9 +437,11 @@ final class DictationController {
             return
         }
         guard !Task.isCancelled else { return }
+        let ensureSeconds = Date().timeIntervalSince(ensureStarted)
 
         do {
             let context = vocabulary.contextPrompt
+            let requestStarted = Date()
             let result = try await client.transcribe(
                 audioData: audio,
                 model: modelAlias,
@@ -382,6 +449,7 @@ final class DictationController {
                 port: server.activePort,
                 bearer: server.activeBearer
             )
+            let requestSeconds = Date().timeIntervalSince(requestStarted)
             guard !Task.isCancelled else { return }
 
             let text = Self.tidy(result.text)
@@ -392,6 +460,11 @@ final class DictationController {
 
             let latency = Date().timeIntervalSince(started)
             lastLatency = latency
+            // Only worth spelling out when something besides inference took
+            // real time — a warm run reads better as one number.
+            lastLatencyDetail = ensureSeconds >= 0.1
+                ? String(format: "model %.1f s · asr %.1f s", ensureSeconds, requestSeconds)
+                : nil
             lastError = nil
 
             // Suspend the tap across injection: synthesising ⌘V puts a Command
@@ -480,5 +553,13 @@ final class DictationController {
         if text.hasSuffix("。") { text.removeLast() }
         else if text.hasSuffix(".") && !text.hasSuffix("...") { text.removeLast() }
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private extension FixedWidthInteger {
+    /// The value's little-endian bytes, for hand-assembling the WAV header of
+    /// ``DictationController/silentProbeWAV``.
+    var littleEndianBytes: Data {
+        withUnsafeBytes(of: littleEndian) { Data($0) }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -69,7 +69,10 @@ final class DictationController {
             // renders from has to move with it — otherwise picking a model
             // leaves the Enable switch stuck until something else refreshes.
             refreshReadiness()
-            Task { await prewarmModel() }
+            // Replacing, not joining: a prewarm still in flight here is
+            // warming the PREVIOUS model, and joining it would return with
+            // the new selection never warmed.
+            Task { await prewarmModel(replacingCurrent: true) }
         }
     }
 
@@ -310,22 +313,36 @@ final class DictationController {
     ///    parakeet), so ``warmUpEngine()`` sends a beat of silence to make
     ///    the sidecar pay that now instead of inside the user's first real
     ///    dictation.
-    func prewarmModel() async {
-        // Single-flight. The checks below are MainActor-synchronous, so two
-        // triggers (enable + tab appear + model didSet can all fire close
-        // together) cannot both slip past: the second one joins the task the
-        // first created instead of racing it through the engine's serial STT
-        // lane.
+    /// - Parameter replacingCurrent: pass `true` when the model CHANGED —
+    ///   an in-flight prewarm is then warming the wrong model and must be
+    ///   superseded, not joined. The default joins it: for a same-model
+    ///   trigger (enable + tab appear firing close together) the running
+    ///   flight already covers this call.
+    func prewarmModel(replacingCurrent: Bool = false) async {
+        if replacingCurrent {
+            prewarmTask?.cancel()
+            prewarmTask = nil
+        }
+        // Single-flight. The check-and-assign below is MainActor-synchronous
+        // (no await between them), so concurrent triggers cannot both slip
+        // past: the second joins the task the first created instead of
+        // racing it through the engine's serial STT lane.
         if let running = prewarmTask {
             await running.value
             return
         }
-        let task = Task { [weak self] in
+        var created: Task<Void, Never>!
+        created = Task { [weak self] in
             await self?.performPrewarm()
-            self?.prewarmTask = nil
+            // Only the flight that still OWNS the slot may clear it. A
+            // cancelled predecessor finishing late must not null out the
+            // task a later enable started, or single-flight breaks.
+            if let self, self.prewarmTask == created {
+                self.prewarmTask = nil
+            }
         }
-        prewarmTask = task
-        await task.value
+        prewarmTask = created
+        await created.value
     }
 
     private func performPrewarm() async {

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -98,6 +98,10 @@ final class DictationController {
     private var capturingApp: String?
     private var level: Float = 0
     private var transcribeTask: Task<Void, Never>?
+    /// The in-flight prewarm, retained so ``disable()`` and a hotkey press
+    /// can cancel it and so concurrent triggers join it (single-flight)
+    /// instead of stacking probes in the engine's serial STT lane.
+    private var prewarmTask: Task<Void, Never>?
     /// alias → HuggingFace repo. `ensureServing` needs the repo to fetch a
     /// model that is not on disk yet; passing nil silently limits it to models
     /// already cached.
@@ -234,6 +238,8 @@ final class DictationController {
     func disable() {
         transcribeTask?.cancel()
         transcribeTask = nil
+        prewarmTask?.cancel()
+        prewarmTask = nil
         stopTicking()
         hotkey.stop()
         recorder.shutdown()
@@ -305,10 +311,34 @@ final class DictationController {
     ///    the sidecar pay that now instead of inside the user's first real
     ///    dictation.
     func prewarmModel() async {
+        // Single-flight. The checks below are MainActor-synchronous, so two
+        // triggers (enable + tab appear + model didSet can all fire close
+        // together) cannot both slip past: the second one joins the task the
+        // first created instead of racing it through the engine's serial STT
+        // lane.
+        if let running = prewarmTask {
+            await running.value
+            return
+        }
+        let task = Task { [weak self] in
+            await self?.performPrewarm()
+            self?.prewarmTask = nil
+        }
+        prewarmTask = task
+        await task.value
+    }
+
+    private func performPrewarm() async {
         guard isEnabled, !modelAlias.isEmpty else { return }
-        _ = await resolveRepo(for: modelAlias)
-        if server.servingAlias != modelAlias {
+        let alias = modelAlias
+        _ = await resolveRepo(for: alias)
+        // Actor reentrancy: every await above and below is a window for
+        // disable() or a model change to land. Re-check before each step
+        // that mutates the sidecar or touches the wire.
+        guard !Task.isCancelled, isEnabled, modelAlias == alias else { return }
+        if server.servingAlias != alias {
             guard await ensureModelServing() else { return }
+            guard !Task.isCancelled, isEnabled, modelAlias == alias else { return }
         }
         await warmUpEngine()
     }
@@ -317,15 +347,24 @@ final class DictationController {
     /// silence. Skipped whenever a real dictation is underway — the engine
     /// serialises transcriptions, so a probe would queue in front of it.
     private func warmUpEngine() async {
-        guard phase == .idle || phase == .off else { return }
+        guard phase == .idle else { return }
         guard server.servingAlias == modelAlias else { return }
-        _ = try? await client.transcribe(
-            audioData: Self.silentProbeWAV,
-            model: modelAlias,
-            context: nil,
-            port: server.activePort,
-            bearer: server.activeBearer
-        )
+        do {
+            _ = try await client.transcribe(
+                audioData: Self.silentProbeWAV,
+                model: modelAlias,
+                context: nil,
+                port: server.activePort,
+                bearer: server.activeBearer
+            )
+        } catch is CancellationError {
+            // Expected: a hotkey press or disable() superseded the probe.
+        } catch {
+            // Not user-facing — the cost of a failed probe is only that the
+            // first real dictation pays the weight load again — but leave a
+            // trace so a recurring failure is diagnosable.
+            NSLog("Dictation prewarm probe failed for %@: %@", modelAlias, String(describing: error))
+        }
     }
 
     /// 0.2 s of 16 kHz mono PCM silence — the smallest useful body for
@@ -368,6 +407,12 @@ final class DictationController {
             lastError = "Choose a transcription model first."
             return
         }
+        // A probe still in flight would sit in front of this dictation in the
+        // engine's serial STT lane. Abandon it — if it already reached the
+        // sidecar, the weight load it triggered continues server-side and
+        // benefits the transcription that follows either way.
+        prewarmTask?.cancel()
+        prewarmTask = nil
         do {
             try recorder.startCapture()
         } catch {

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -136,6 +136,11 @@ struct DictationView: View {
         if let latency = controller.lastLatency {
             parts.append(String(format: "%.2f s last", latency))
         }
+        // "why was that one slow" — present only when model bring-up ate
+        // noticeable time, so the common warm line stays short.
+        if let detail = controller.lastLatencyDetail {
+            parts.append(detail)
+        }
         return parts.filter { !$0.isEmpty }.joined(separator: " · ")
     }
 
@@ -301,6 +306,9 @@ struct DictationView: View {
         var parts = [controller.modelAlias]
         if let latency = controller.lastLatency {
             parts.append(String(format: "%.2f s last", latency))
+        }
+        if let detail = controller.lastLatencyDetail {
+            parts.append(detail)
         }
         return parts.joined(separator: " · ")
     }

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -40,6 +40,46 @@ struct DictationTests {
         #expect(DictationController.tidy("。") == "")
     }
 
+    // MARK: - Warm-up probe
+
+    /// The prewarm probe is a hand-assembled WAV; a malformed header would
+    /// turn every prewarm into a silent 400 and the lazy weight-load would
+    /// quietly return to the user's first real dictation. Pins the exact
+    /// layout ``DictationRecorder`` produces: PCM16, mono, 16 kHz, with RIFF
+    /// and data sizes that match the payload.
+    @MainActor
+    @Test("the silent prewarm probe is a valid 16 kHz mono PCM16 WAV")
+    func silentProbeShape() {
+        let wav = DictationController.silentProbeWAV
+        func u32(_ offset: Int) -> UInt32 {
+            wav.subdata(in: offset..<(offset + 4)).withUnsafeBytes {
+                UInt32(littleEndian: $0.loadUnaligned(as: UInt32.self))
+            }
+        }
+        func u16(_ offset: Int) -> UInt16 {
+            wav.subdata(in: offset..<(offset + 2)).withUnsafeBytes {
+                UInt16(littleEndian: $0.loadUnaligned(as: UInt16.self))
+            }
+        }
+        #expect(String(data: wav.prefix(4), encoding: .ascii) == "RIFF")
+        #expect(String(data: wav.subdata(in: 8..<16), encoding: .ascii) == "WAVEfmt ")
+        #expect(String(data: wav.subdata(in: 36..<40), encoding: .ascii) == "data")
+        #expect(u16(20) == 1)              // PCM
+        #expect(u16(22) == 1)              // mono
+        #expect(u32(24) == 16_000)         // sample rate
+        #expect(u32(28) == 32_000)         // byte rate
+        #expect(u16(32) == 2)              // block align
+        #expect(u16(34) == 16)             // bits per sample
+        let payload = u32(40)
+        #expect(u32(4) == 36 + payload)    // RIFF size ties to data size
+        #expect(Int(payload) == wav.count - 44)
+        // A beat of silence: long enough to force the weight load, short
+        // enough to be free.
+        let seconds = Double(payload) / 32_000
+        #expect(seconds > 0.05 && seconds < 1.0)
+        #expect(wav.suffix(Int(payload)).allSatisfy { $0 == 0 })
+    }
+
     // MARK: - Vocabulary
 
     /// The cap is the whole design constraint: measured accuracy falls off past


### PR DESCRIPTION
## What does this PR do?

Cuts the tail latency of daily dictation. A 30 s dictation was taking 1-2 s to land after key release, while warm parakeet inference of 36 s audio measures **0.16 s** server-side — the gap was structural bring-up cost paid inside the user's dictation, not inference:

- **`prewarmModel()` early-returned when the sidecar already served the dictation alias**, so the alias→repo catalog cache stayed empty and the FIRST transcription of a session paid `resolveRepo`'s `rapid-mlx` CLI subprocess spawns (1–3 s of cold interpreter) on the hotkey path. Prewarm now populates the cache unconditionally.
- **The engine loads STT weights lazily on the first transcription of each sidecar lifetime** (measured ~1.2 s for parakeet). Prewarm now sends a 0.2 s silent WAV probe (measured 22–83 ms warm) so the load happens at enable / model-pick time.
- **`enable()` now fires prewarm**, so launching with dictation on warms the whole lane instead of deferring every cost to the first hotkey press.
- **`lastLatency` gains a phase split** (model bring-up vs asr), shown in the Dictation tab only when bring-up took noticeable time — future "why was that one slow" reports become attributable at a glance.

Prewarm is a retained **single-flight** task: concurrent triggers join it, a model change supersedes it (`replacingCurrent: true`), `disable()` and a hotkey press cancel it, and a cancelled flight finishing late cannot clear the slot a newer flight owns (identity-checked cleanup).

## Why is this needed?

Dictation is a daily-driver feature; its perceived speed IS the feature. All of the above costs were invisible (one opaque latency number) and all landed after the user stopped speaking.

## Validation

- `swift test --no-parallel`: 2589 tests, 18/18 dictation suite (1 new: probe WAV layout pinned byte-level). Single failure `Adjacent links keep their own hit targets` fails identically on stock `main` — pre-existing, unrelated.
- Probe WAV validated against Python's `wave` parser (byte-identical reproduction) and against a live parakeet server.
- Codex review iterated to convergence: r1 0B/2M (reentrancy single-flight, disable cancellation), r2 0B/2M (stale-flight slot clear, model-change supersede), r3 **0B/0M**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)