### PR TITLE
chore: bump version to 0.12.18

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,43 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.12.18] — 2026-08-20
+
+Regenerating an answer no longer throws the old one away, and dictation
+starts hot instead of stalling at the start of a session.
+
+### Added
+
+- **Every answer you regenerate is kept.** Regenerate, Retry, or edit a
+  prompt, and the previous version stays one click away — a `‹ 2/3 ›`
+  switcher under the bubble steps between the alternatives, and each fork
+  remembers where you left off. Deleting a message now says exactly how
+  many turns it takes with it, including ones on branches you can't
+  currently see. Old conversations are untouched. Contributed by @osdodo.
+- **SVG blocks can show themselves.** When a model answers with an SVG code
+  block, a Preview toggle renders it right in the chat — offscreen, and
+  nothing ever touches the network.
+- **Model campaigns.** When a model worth trying is spotlighted, a banner
+  in chat points you at it — dismiss it once and it stays gone.
+
+### Changed
+
+- **Dictation starts hot.** The first dictation of a session used to pay a
+  hidden one-to-three-second setup after you stopped speaking. That setup
+  now runs when dictation is enabled or a model is picked, so your words
+  land in well under half a second — and when a run is slow, the Dictation
+  tab shows where the time went ("model 1.2 s · asr 0.3 s").
+- **Mixture-of-experts models answer faster.** Two expert projections now
+  run as one GPU launch, and long prompts start streaming sooner thanks to
+  a new prefill kernel for hybrid models.
+
+### Fixed
+
+- Background update progress is visible again while a new version
+  downloads.
+- A model that won't fit in memory opens a read-only Review instead of a
+  dead row, so you can see what it needs before freeing space.
+
 ## [0.12.17] — 2026-08-19
 
 Dictation actually works now — 0.12.16's release build shipped without the

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.17</string>
+	<string>0.12.18</string>
 	<key>CFBundleVersion</key>
-	<string>161</string>
+	<string>162</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.12.18.md
+++ b/docs/release-notes/v0.12.18.md
@@ -1,0 +1,24 @@
+## Highlights
+
+- **Regenerating an answer no longer destroys the old one.** Regenerate,
+  Retry, and prompt edits keep every alternative as a switchable branch —
+  step between them with the `‹ 2/3 ›` control under the bubble. Deleting a
+  turn reports exactly how many turns it removes, and each fork remembers
+  where you left off. Old conversations load unchanged, and a downgrade
+  still shows the transcript you were looking at. Contributed by @osdodo
+  (#2147).
+- **Dictation starts hot.** The catalog lookup and lazy model weight load
+  that used to land inside the first dictation of a session now run at
+  enable / model-pick time; a 30-second clip lands in well under half a
+  second once warm, and the Dictation tab attributes slow runs
+  ("model 1.2 s · asr 0.3 s"). (#2152)
+- **Faster MoE decode.** Expert gate+up projections fused into a single
+  gather_qmm launch (#2151); GDN prompt prefill gets a blocked-seq Metal
+  kernel (#2144).
+- **SVG code blocks render a preview** — offscreen, never on the network
+  (#2148).
+- **New models:** GPT-OSS Puzzle checkpoints (#1224) and North-Mini-Code
+  (Cohere2-MoE) (#1223); North Mini repo contracts restored (#2150).
+- Mac: typed model campaign banner (#2142), background update progress
+  visible again (#2129), WON'T FIT rows open a read-only Review (#2131).
+  CLI: agents list sizes its name column to the widest alias (#2139).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.12.17"
+version = "0.12.18"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Release 0.12.18. Highlights: message branching (#2147, @osdodo), dictation warm path (#2152), MoE gate+up fusion (#2151), GDN prefill kernel (#2144), SVG preview (#2148), campaign banner (#2142), new models (#1223/#1224/#2150).

Bump set: `pyproject.toml` 0.12.18, `Info.plist` 0.12.18/162, rapid-mac `CHANGELOG.md` entry, `docs/release-notes/v0.12.18.md` prose.

Pre-release verification this session: engine sidecar boot/chat/toolcall smoke green; GUI dogfood on an isolated instance — branching (retry → ‹2/2›, switch back, edit-prompt → Version 2/2, delete confirmation + Keep), SVG preview toggle; full `swift test --no-parallel` green except the known pre-existing MarkdownLink failure (fails on stock main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)