### PR TITLE
feat(aliases): add qwen-image (mflux) image-gen alias

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -144,7 +144,11 @@ final class ImageGenViewModel {
     }
 
     static func seedSteps(for alias: String) -> Int {
-        if alias.localizedCaseInsensitiveContains("qwen-image-edit") { return 20 }
+        // Non-distilled Qwen-Image denoises for ~20 steps (both the base
+        // text-to-image model and the edit variant) — matching the engine's
+        // per-family default, so the bar isn't scaled for a 4-step turbo run
+        // that is actually a 20-step one.
+        if alias.localizedCaseInsensitiveContains("qwen-image") { return 20 }
         return alias.localizedCaseInsensitiveContains("z-image") ? 8 : 4
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -28,4 +28,16 @@ struct ImageGenerationPhaseTests {
         )
         #expect(ImageGenViewModel.nextPhase(from: .preparing, progress: idle) == .preparing)
     }
+
+    @Test("Progress-bar seed steps match each family's engine default")
+    func seedStepsMatchEngineDefaults() {
+        // The bar is scaled from these before the server reports a live
+        // total; a turbo-sized seed on a 20-step model makes the bar slam to
+        // full and sit there. Values mirror _DEFAULT_STEPS_BY_FAMILY in
+        // vllm_mlx/image/engine.py.
+        #expect(ImageGenViewModel.seedSteps(for: "qwen-image") == 20)
+        #expect(ImageGenViewModel.seedSteps(for: "qwen-image-edit") == 20)
+        #expect(ImageGenViewModel.seedSteps(for: "z-image-turbo") == 8)
+        #expect(ImageGenViewModel.seedSteps(for: "flux2-klein-4b") == 4)
+    }
 }

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1402,9 +1402,12 @@ def test_mflux_local_snapshot_rejects_unpinned_repo_revision(tmp_path, monkeypat
     Codex review (PR #2157): without this, an alias only ever resolves
     whatever ``refs/main`` currently points to — an upstream force-push or
     account compromise on the repo would silently change the weights a
-    fresh pull fetches, with nothing to notice. A cache that resolves to a
-    SHA other than the registered pin must be treated the same as "not
-    vouched for", exactly like an incomplete snapshot.
+    fresh pull fetches, with nothing to notice. A pinned repo resolves
+    straight to ``snapshots/<pinned_revision>`` (see the next test's
+    docstring for why refs/main can't be used here); a fully-seeded
+    snapshot at any OTHER sha — even with refs/main pointing at it, as a
+    pre-pin cache or a compromised upstream would leave it — must not be
+    mistaken for the pinned one.
     """
     repo = "mflux-community/qwen-image-mflux-q6"
     assert repo in gate.IMAGE_MODEL_REVISIONS
@@ -1425,6 +1428,34 @@ def test_mflux_local_snapshot_accepts_the_pinned_revision(tmp_path, monkeypatch)
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / "models--mflux-community--qwen-image-mflux-q6"
     _seed_mflux_snapshot(repo_root, pinned_sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    resolved = gate.mflux_local_snapshot(repo)
+    assert resolved is not None
+    assert resolved.endswith(pinned_sha)
+    assert gate.mflux_missing_weights(repo) == []
+
+
+def test_mflux_local_snapshot_accepts_pinned_revision_without_refs_main(
+    tmp_path, monkeypatch
+):
+    """A pinned commit resolves even with no ``refs/main`` at all.
+
+    Codex review (PR #2157): ``snapshot_download(repo, revision=<commit
+    SHA>)`` — what a cold pull of a pinned repo does — caches the commit
+    under its own ``snapshots/<sha>`` directory WITHOUT necessarily moving
+    ``refs/main``; that ref only advances when a branch name (like
+    ``main``) is resolved, not an explicit commit. Resolving a pinned repo
+    through ``refs/main`` would then never recognize its own freshly
+    downloaded snapshot and re-download on every subsequent warm start.
+    """
+    repo = "mflux-community/qwen-image-mflux-q6"
+    pinned_sha = gate.IMAGE_MODEL_REVISIONS[repo]
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mflux-community--qwen-image-mflux-q6"
+    _seed_mflux_snapshot(repo_root, pinned_sha)
+    (repo_root / "refs" / "main").unlink()
 
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1396,6 +1396,44 @@ def test_mflux_missing_weights_reports_non_string_index_without_raising(
     ]
 
 
+def test_mflux_local_snapshot_rejects_unpinned_repo_revision(tmp_path, monkeypatch):
+    """A pinned repo's cache must match the pin, not merely exist.
+
+    Codex review (PR #2157): without this, an alias only ever resolves
+    whatever ``refs/main`` currently points to — an upstream force-push or
+    account compromise on the repo would silently change the weights a
+    fresh pull fetches, with nothing to notice. A cache that resolves to a
+    SHA other than the registered pin must be treated the same as "not
+    vouched for", exactly like an incomplete snapshot.
+    """
+    repo = "mflux-community/qwen-image-mflux-q6"
+    assert repo in gate.IMAGE_MODEL_REVISIONS
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mflux-community--qwen-image-mflux-q6"
+    _seed_mflux_snapshot(repo_root, "1" * 40)  # NOT the pinned sha
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.mflux_local_snapshot(repo) is None
+    assert gate.mflux_missing_weights(repo) is None
+
+
+def test_mflux_local_snapshot_accepts_the_pinned_revision(tmp_path, monkeypatch):
+    """The exact pinned commit resolves normally — pinning isn't a fail-closed trap."""
+    repo = "mflux-community/qwen-image-mflux-q6"
+    pinned_sha = gate.IMAGE_MODEL_REVISIONS[repo]
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mflux-community--qwen-image-mflux-q6"
+    _seed_mflux_snapshot(repo_root, pinned_sha)
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    resolved = gate.mflux_local_snapshot(repo)
+    assert resolved is not None
+    assert resolved.endswith(pinned_sha)
+    assert gate.mflux_missing_weights(repo) == []
+
+
 def _seed_blob(blobs_dir, name: str, *, size: int, age_seconds: float = 0.0):
     blobs_dir.mkdir(parents=True, exist_ok=True)
     path = blobs_dir / name

--- a/tests/test_qwen_image_alias.py
+++ b/tests/test_qwen_image_alias.py
@@ -210,10 +210,29 @@ def test_scales_sibling_is_refused_even_with_a_plausible_shape(
     # Belt-and-suspenders: a quantization scheme that happens to keep the
     # embedding's own shape at [vocab, hidden] is still caught by the
     # scales/biases siblings every quantized linear/embedding carries.
+    #
+    # Key convention verified against the real filipstrand shard this check
+    # exists to catch: MLX names scales/biases as siblings of the MODULE
+    # prefix (``encoder.embed_tokens.scales``), not nested under
+    # ``.weight`` (NOT ``encoder.embed_tokens.weight.scales``, which
+    # convention never produces).
     snapshot = _make_snapshot(
         tmp_path,
         {"shape": [152064, 3584], "dtype": "F16"},
-        weight_map_extra={"encoder.embed_tokens.weight.scales": "0.safetensors"},
+        weight_map_extra={"encoder.embed_tokens.scales": "0.safetensors"},
+    )
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
+        engine._verify_text_encoder_not_quantized()
+
+
+def test_biases_sibling_alone_is_also_refused(tmp_path, monkeypatch) -> None:
+    # scales and biases are independent siblings in the real convention —
+    # pin biases separately so a fix that only checks one doesn't regress.
+    snapshot = _make_snapshot(
+        tmp_path,
+        {"shape": [152064, 3584], "dtype": "F16"},
+        weight_map_extra={"encoder.embed_tokens.biases": "0.safetensors"},
     )
     engine = _engine_for_family_check(monkeypatch, snapshot)
     with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
@@ -229,7 +248,7 @@ def test_scales_sibling_in_a_different_shard_is_still_refused(
     snapshot = _make_snapshot(
         tmp_path,
         {"shape": [152064, 3584], "dtype": "F16"},
-        weight_map_extra={"encoder.embed_tokens.weight.scales": "1.safetensors"},
+        weight_map_extra={"encoder.embed_tokens.scales": "1.safetensors"},
     )
     engine = _engine_for_family_check(monkeypatch, snapshot)
     with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
@@ -368,3 +387,25 @@ def test_missing_index_does_not_raise(tmp_path, monkeypatch) -> None:
     empty_snapshot.mkdir()
     engine = _engine_for_family_check(monkeypatch, empty_snapshot)
     engine._verify_text_encoder_not_quantized()  # no-op, must not raise
+
+
+def test_no_verdict_completeness_skips_the_text_encoder_check(
+    tmp_path, monkeypatch
+) -> None:
+    # ``mflux_missing_weights`` returning ``None`` means "no verdict" — not
+    # a registered alias, or nothing cached — and ``not missing`` is True
+    # for BOTH ``[]`` and ``None``, so an earlier version of
+    # ``_verify_weights_complete`` ran the structural text-encoder check on
+    # a `None` verdict too. That is wrong even when the check WOULD have
+    # found something to object to: no completeness verdict means no
+    # standing to inspect internals yet. A quantized-shaped text encoder
+    # sitting behind a ``None`` verdict must NOT raise.
+    snapshot = _make_snapshot(tmp_path, {"shape": [152064, 672], "dtype": "U32"})
+    engine = ImageGenerationEngine("mflux-community/qwen-image-mflux-q6")
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_missing_weights", lambda _repo: None
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda _repo: str(snapshot)
+    )
+    engine._verify_weights_complete()  # no-op, must not raise

--- a/tests/test_qwen_image_alias.py
+++ b/tests/test_qwen_image_alias.py
@@ -268,6 +268,34 @@ def test_oversized_header_length_is_rejected_without_reading_it(tmp_path) -> Non
     assert ImageGenerationEngine._read_safetensors_header(str(shard)) is None
 
 
+def test_header_length_past_the_8_byte_prefix_is_rejected(tmp_path) -> None:
+    # header_len is measured from AFTER the 8-byte length prefix, so the
+    # budget is file_size - 8, not the raw file size. A file truncated by up
+    # to 8 bytes (only trailing JSON padding lost) must still be rejected
+    # rather than appear to "fit".
+    shard = tmp_path / "0.safetensors"
+    payload = json.dumps({"encoder.embed_tokens.weight": {"shape": [1, 1]}}).encode()
+    shard.write_bytes(struct.pack("<Q", len(payload)) + payload)
+    shard.write_bytes(shard.read_bytes()[:-1])  # drop the last byte
+    assert ImageGenerationEngine._read_safetensors_header(str(shard)) is None
+
+
+def test_malformed_shapes_are_rejected_despite_a_matching_last_dimension(
+    tmp_path, monkeypatch
+) -> None:
+    # A bare `shape[-1] == 3584` check would accept nonsense like a rank-1
+    # shape, a zero dimension, or a non-integer entry as long as the last
+    # element happened to equal 3584. A genuine embedding shape is rank-2
+    # with two positive integers.
+    for index, bad_shape in enumerate(([3584], [0, 3584], ["x", 3584], [True, 3584])):
+        snapshot = _make_snapshot(
+            tmp_path / str(index), {"shape": bad_shape, "dtype": "F16"}
+        )
+        engine = _engine_for_family_check(monkeypatch, snapshot)
+        with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
+            engine._verify_text_encoder_not_quantized()
+
+
 def test_shard_reached_via_symlink_is_accepted(tmp_path, monkeypatch) -> None:
     # A Hugging Face hub cache's snapshot files ARE symlinks into a sibling
     # blobs/ directory — the real shape this check runs against in

--- a/tests/test_qwen_image_alias.py
+++ b/tests/test_qwen_image_alias.py
@@ -324,15 +324,23 @@ def test_shard_reached_via_symlink_is_accepted(tmp_path, monkeypatch) -> None:
 def test_shard_path_traversal_is_rejected(tmp_path, monkeypatch) -> None:
     # A shard name escaping text_encoder/ (path traversal, or an absolute
     # path elsewhere on disk) must not be trusted even though it would
-    # resolve to a real file.
-    outside = tmp_path / "outside.safetensors"
+    # resolve to a real, well-formed file. The escape target below is a
+    # REAL, VALID shard — if the traversal guard were ever removed, this
+    # would resolve and pass the shape check, so the test would go red
+    # instead of staying accidentally green (the bug caught in review: an
+    # earlier version put the escape target where "../outside.safetensors"
+    # does NOT actually resolve, so the test passed only because the file
+    # was missing, whether or not the guard did anything).
+    snapshot = _make_snapshot(
+        tmp_path, {"shape": [152064, 3584], "dtype": "F16"}
+    )  # baseline valid shard, then override the index to point outside
+    # "../outside.safetensors" from text_encoder/ resolves to snapshot/ —
+    # one level out, not two — so the escape target has to live there.
+    outside = snapshot / "outside.safetensors"
     _write_safetensors_header(
         outside,
         {"encoder.embed_tokens.weight": {"shape": [152064, 3584], "dtype": "F16"}},
     )
-    snapshot = _make_snapshot(
-        tmp_path, {"shape": [152064, 3584], "dtype": "F16"}
-    )  # baseline valid shard, then override the index to point outside
     (snapshot / "text_encoder" / "model.safetensors.index.json").write_text(
         json.dumps(
             {"weight_map": {"encoder.embed_tokens.weight": "../outside.safetensors"}}

--- a/tests/test_qwen_image_alias.py
+++ b/tests/test_qwen_image_alias.py
@@ -4,8 +4,28 @@
 The mflux backend already understands the ``qwen-image`` family
 (``vllm_mlx/image/engine.py``); this alias is what makes
 ``rapid-mlx serve qwen-image`` resolve to it without the caller having
-to type the raw Hugging Face path. These tests guard the two things a
-data-only alias can still get wrong:
+to type the raw Hugging Face path.
+
+Repo choice, and why it is NOT ``filipstrand/Qwen-Image-mflux-6bit``
+(the community's most-downloaded Qwen-Image mflux conversion): that repo
+quantizes the text encoder to 6-bit (packed ``embed_tokens.weight`` shape
+``[152064, 672]`` instead of the full-precision ``[152064, 3584]``), but
+the mflux version this project pins (0.18.1) hardcodes
+``skip_quantization=True`` for the Qwen text encoder ("quantization causes
+significant semantic degradation" per mflux's own weight definition) and
+never dequantizes it on load. The result is silent runtime corruption, not
+a load-time error: the model builds, ``generate()`` runs, and crashes deep
+in the text encoder's RMSNorm with a shape mismatch
+(``[broadcast_shapes] Shapes (3584) and (1,50,672)``) — reproduced live
+against this project's pinned mflux before this alias was pointed
+elsewhere. ``mflux-community/qwen-image-mflux-q6`` (uploaded 2026-08-16,
+current at the time of pinning) keeps the text encoder full-precision
+(verified: zero ``scale``/``bias`` keys, correct ``[152064, 3584]`` embed
+shape) and was confirmed end-to-end: both a plain text-to-image prompt and
+a text-rendering prompt ("RAPID MLX" on a sign) produced correct images
+with this project's pinned mflux.
+
+These tests guard the things a data-only alias can still get wrong:
 
   1. It routes to the mflux image lane (``modality == "image-gen"``),
      not the default text lane.
@@ -13,6 +33,9 @@ data-only alias can still get wrong:
      loader takes the ``model_path`` branch instead of pulling the
      ~57 GB canonical ``Qwen/Qwen-Image`` weights and quantizing on
      load (which would also error against an already-quantized repo).
+  3. The pinned repo is specifically NOT one with a quantized text
+     encoder — see above. A future re-pin (e.g. chasing a smaller
+     download) must not silently reintroduce the corruption.
 """
 
 from __future__ import annotations
@@ -23,19 +46,31 @@ from vllm_mlx.runtime.resident_models import estimate_model_bytes
 
 _GIB = 1024**3
 
+# The specific repo this alias must NOT point at: its text encoder is
+# quantized in a way the pinned mflux version cannot load correctly (see
+# module docstring). Regression pin for "someone re-pins to a smaller
+# download and silently reintroduces broken generation".
+_KNOWN_INCOMPATIBLE_REPO = "filipstrand/Qwen-Image-mflux-6bit"
+
 
 def test_qwen_image_alias_routes_to_image_lane() -> None:
     profile = resolve_profile("qwen-image")
     assert profile is not None
     assert profile.modality == "image-gen"
-    assert profile.hf_path == "filipstrand/Qwen-Image-mflux-6bit"
+    assert profile.hf_path == "mflux-community/qwen-image-mflux-q6"
+
+
+def test_qwen_image_alias_does_not_point_at_the_known_broken_repo() -> None:
+    profile = resolve_profile("qwen-image")
+    assert profile.hf_path != _KNOWN_INCOMPATIBLE_REPO
 
 
 def test_qwen_image_alias_declares_a_memory_floor() -> None:
-    # 6-bit Qwen-Image (~23 GB on disk) needs headroom to stay resident;
-    # the gate keeps it off Macs that cannot hold it.
+    # Full-precision text encoder + 6-bit transformer measured ~40.2 GiB
+    # peak RSS during a real generation (`/usr/bin/time -l`, 512x512).
+    # The floor gates it off Macs that cannot hold that resident.
     profile = resolve_profile("qwen-image")
-    assert getattr(profile, "min_memory_gb", None) == 24
+    assert getattr(profile, "min_memory_gb", None) == 48
 
 
 def test_qwen_image_repo_is_detected_as_qwen_image_family() -> None:
@@ -50,7 +85,7 @@ def test_qwen_image_repo_is_prequantized_so_no_full_weight_pull() -> None:
 
 def test_qwen_image_resident_estimate_is_not_the_bare_default() -> None:
     # The alias carries no digit params, so without a known-image entry the
-    # fallback would charge the 4 GB default and mis-admit a ~23 GB model.
+    # fallback would charge the 4 GB default and mis-admit a ~29 GB model.
     # Both the alias and the pinned repo id must resolve to the real charge.
     for name in ("qwen-image", resolve_profile("qwen-image").hf_path):
-        assert estimate_model_bytes(name) == int(18.0 * _GIB)
+        assert estimate_model_bytes(name) == int(40.2 * _GIB)

--- a/tests/test_qwen_image_alias.py
+++ b/tests/test_qwen_image_alias.py
@@ -20,13 +20,25 @@ in the text encoder's RMSNorm with a shape mismatch
 against this project's pinned mflux before this alias was pointed
 elsewhere. ``mflux-community/qwen-image-mflux-q6`` (uploaded 2026-08-16,
 commit ``c628fe4392d963557c3013c2709e6d3b67bca79d`` at the time of
-pinning — the alias tracks the mutable ``main`` ref, not this SHA;
-``aliases.json`` has no revision-pin field today, and adding one is a
-system-wide change out of scope here) keeps the text encoder
-full-precision (verified: zero ``scale``/``bias`` keys, correct
-``[152064, 3584]`` embed shape) and was confirmed end-to-end: both a
-plain text-to-image prompt and a text-rendering prompt ("RAPID MLX" on a
-sign) produced correct images with this project's pinned mflux.
+pinning) keeps the text encoder full-precision (verified: zero
+``scale``/``bias`` keys, correct ``[152064, 3584]`` embed shape) and was
+confirmed end-to-end: both a plain text-to-image prompt and a
+text-rendering prompt ("RAPID MLX" on a sign) produced correct images
+with this project's pinned mflux.
+
+Revision pinning: ``aliases.json`` has no revision-pin field (adding one
+across every alias/modality would be a system-wide schema change out of
+scope here), so the commit above is enforced separately — a code-only
+pin table, ``_download_gate.IMAGE_MODEL_REVISIONS``, mirroring
+``video/wan.py``'s ``WAN_REVISIONS``. Without it, this alias would only
+ever resolve whatever ``refs/main`` currently points to (see
+``_resolved_snapshot_sha``), so an upstream force-push or account
+compromise on ``mflux-community``'s repo — plausible given the
+provenance caveat below — would silently change the weights a fresh
+pull fetches next. A cached snapshot that resolves to any other commit
+is treated as unvouched-for, exactly like an incomplete download; a cold
+pull fetches the pinned commit explicitly rather than whatever ``main``
+is at pull time.
 
 Provenance: the ``mflux-community`` HF account has published ~50 repos
 as a systematic multi-family, multi-bitwidth conversion pipeline (krea-2,
@@ -122,6 +134,59 @@ def test_qwen_image_resident_estimate_is_not_the_bare_default() -> None:
     # Both the alias and the pinned repo id must resolve to the real charge.
     for name in ("qwen-image", resolve_profile("qwen-image").hf_path):
         assert estimate_model_bytes(name) == int(55.7 * _GIB)
+
+
+# MARK: - Revision pinning for a cold (not-yet-cached) pull
+#
+# ``mflux_local_snapshot`` (exercised in test_download_gate.py) already
+# refuses to vouch for a cached snapshot that doesn't match the registered
+# pin. These tests cover the other half: when there is nothing cached to
+# vouch for at all, ``_model_path_for_mflux`` must fetch the pinned commit
+# itself rather than let mflux resolve and download whatever ``main``
+# currently is.
+
+
+def test_model_path_for_mflux_forces_pinned_revision_on_cold_pull(
+    monkeypatch,
+) -> None:
+    from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
+
+    repo = "mflux-community/qwen-image-mflux-q6"
+    pinned_sha = IMAGE_MODEL_REVISIONS[repo]
+    engine = ImageGenerationEngine(repo)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda _repo: None
+    )
+    calls = []
+
+    def _fake_snapshot_download(repo_id, revision=None):
+        calls.append((repo_id, revision))
+        return "/fake/snapshot/dir"
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _fake_snapshot_download)
+
+    assert engine._model_path_for_mflux() == "/fake/snapshot/dir"
+    assert calls == [(repo, pinned_sha)]
+
+
+def test_model_path_for_mflux_falls_back_to_bare_repo_when_unpinned(
+    monkeypatch,
+) -> None:
+    # A prequantized repo with no entry in IMAGE_MODEL_REVISIONS keeps
+    # today's behavior: hand mflux the bare repo id and let it resolve +
+    # download normally, rather than raising or refusing.
+    engine = ImageGenerationEngine("filipstrand/Z-Image-Turbo-mflux-4bit")
+    assert engine._prequantized is True
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda _repo: None
+    )
+
+    def _unexpected_download(*_args, **_kwargs):
+        raise AssertionError("must not download an unpinned repo itself")
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _unexpected_download)
+
+    assert engine._model_path_for_mflux() == "filipstrand/Z-Image-Turbo-mflux-4bit"
 
 
 # MARK: - Structural guard against a quantized text encoder
@@ -387,6 +452,26 @@ def test_missing_index_does_not_raise(tmp_path, monkeypatch) -> None:
     empty_snapshot.mkdir()
     engine = _engine_for_family_check(monkeypatch, empty_snapshot)
     engine._verify_text_encoder_not_quantized()  # no-op, must not raise
+
+
+def test_index_present_but_key_wholly_absent_fails_closed(
+    tmp_path, monkeypatch
+) -> None:
+    # A readable, non-empty index that simply never mentions
+    # `encoder.embed_tokens.weight` (as opposed to `_make_snapshot`'s shard
+    # naming the key but the shard's own header omitting it, covered by
+    # `test_shard_present_but_key_absent_fails_closed`) must not be read as
+    # "nothing to check" — codex review: silently passing here let a
+    # differently packaged or renamed quantized encoder bypass the guard.
+    snapshot = tmp_path / "snapshot"
+    text_encoder = snapshot / "text_encoder"
+    text_encoder.mkdir(parents=True)
+    (text_encoder / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"some.other.tensor": "0.safetensors"}})
+    )
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    with pytest.raises(ImageRuntimeError, match="does not expose the expected"):
+        engine._verify_text_encoder_not_quantized()
 
 
 def test_no_verdict_completeness_skips_the_text_encoder_check(

--- a/tests/test_qwen_image_alias.py
+++ b/tests/test_qwen_image_alias.py
@@ -143,19 +143,34 @@ def _write_safetensors_header(path, header: dict) -> None:
 
 
 def _make_snapshot(
-    tmp_path, embed_header_entry: dict, *, extra_keys: dict | None = None
+    tmp_path,
+    embed_header_entry: dict | None,
+    *,
+    weight_map_extra: dict | None = None,
+    write_shard: bool = True,
 ):
+    """A synthetic ``text_encoder/`` layout: an index naming
+    ``encoder.embed_tokens.weight``'s shard, plus (usually) that shard's
+    header. ``weight_map_extra`` adds sibling entries to the INDEX (real
+    quantization scale/bias keys land there, possibly in a different shard
+    than the weight itself — see the check's docstring); ``write_shard=False``
+    exercises the index naming a shard that never materializes.
+    """
     snapshot = tmp_path / "snapshot"
     text_encoder = snapshot / "text_encoder"
     text_encoder.mkdir(parents=True)
     shard_name = "0.safetensors"
+    weight_map = {"encoder.embed_tokens.weight": shard_name}
+    if weight_map_extra:
+        weight_map.update(weight_map_extra)
     (text_encoder / "model.safetensors.index.json").write_text(
-        json.dumps({"weight_map": {"encoder.embed_tokens.weight": shard_name}})
+        json.dumps({"weight_map": weight_map})
     )
-    header = {"encoder.embed_tokens.weight": embed_header_entry}
-    if extra_keys:
-        header.update(extra_keys)
-    _write_safetensors_header(text_encoder / shard_name, header)
+    if write_shard:
+        header = {}
+        if embed_header_entry is not None:
+            header["encoder.embed_tokens.weight"] = embed_header_entry
+        _write_safetensors_header(text_encoder / shard_name, header)
     return snapshot
 
 
@@ -198,12 +213,102 @@ def test_scales_sibling_is_refused_even_with_a_plausible_shape(
     snapshot = _make_snapshot(
         tmp_path,
         {"shape": [152064, 3584], "dtype": "F16"},
-        extra_keys={
-            "encoder.embed_tokens.weight.scales": {
-                "shape": [152064, 56],
-                "dtype": "F16",
-            }
-        },
+        weight_map_extra={"encoder.embed_tokens.weight.scales": "0.safetensors"},
+    )
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
+        engine._verify_text_encoder_not_quantized()
+
+
+def test_scales_sibling_in_a_different_shard_is_still_refused(
+    tmp_path, monkeypatch
+) -> None:
+    # The sibling check reads the INDEX's full weight_map, not one shard's
+    # header — a quantized embedding whose scales/biases were split into a
+    # separate shard from the weight itself must not slip past.
+    snapshot = _make_snapshot(
+        tmp_path,
+        {"shape": [152064, 3584], "dtype": "F16"},
+        weight_map_extra={"encoder.embed_tokens.weight.scales": "1.safetensors"},
+    )
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
+        engine._verify_text_encoder_not_quantized()
+
+
+def test_shard_named_by_index_but_missing_on_disk_fails_closed(
+    tmp_path, monkeypatch
+) -> None:
+    # The index makes an explicit claim about where this tensor lives; if
+    # that claim doesn't resolve to a real file, that is itself suspicious
+    # and must refuse rather than silently skip the check.
+    snapshot = _make_snapshot(tmp_path, None, write_shard=False)
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
+        engine._verify_text_encoder_not_quantized()
+
+
+def test_shard_present_but_key_absent_fails_closed(tmp_path, monkeypatch) -> None:
+    # The index names a shard for embed_tokens.weight, but that shard's own
+    # header doesn't actually contain it — inconsistent with what the index
+    # promised, so this must not be read as "nothing to check".
+    snapshot = _make_snapshot(tmp_path, embed_header_entry=None)
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
+        engine._verify_text_encoder_not_quantized()
+
+
+def test_oversized_header_length_is_rejected_without_reading_it(tmp_path) -> None:
+    # A corrupt or hostile shard could claim a multi-gigabyte header to force
+    # a multi-gigabyte read before JSON parsing ever runs. The length prefix
+    # is checked against an absolute cap BEFORE the file is read further.
+    shard = tmp_path / "0.safetensors"
+    oversized = ImageGenerationEngine._SAFETENSORS_HEADER_MAX_BYTES + 1
+    shard.write_bytes(struct.pack("<Q", oversized))
+    assert ImageGenerationEngine._read_safetensors_header(str(shard)) is None
+
+
+def test_shard_reached_via_symlink_is_accepted(tmp_path, monkeypatch) -> None:
+    # A Hugging Face hub cache's snapshot files ARE symlinks into a sibling
+    # blobs/ directory — the real shape this check runs against in
+    # production. A resolve()-then-compare-parents guard walks straight out
+    # of text_encoder_dir through that symlink and false-positives on every
+    # real cached checkpoint (caught live against mflux-community's repo);
+    # the string-only guard must accept this shape.
+    snapshot = tmp_path / "snapshot"
+    text_encoder = snapshot / "text_encoder"
+    text_encoder.mkdir(parents=True)
+    blobs = tmp_path / "blobs"
+    blobs.mkdir()
+    real_file = blobs / "deadbeef"
+    _write_safetensors_header(
+        real_file,
+        {"encoder.embed_tokens.weight": {"shape": [152064, 3584], "dtype": "F16"}},
+    )
+    (text_encoder / "0.safetensors").symlink_to(real_file)
+    (text_encoder / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"encoder.embed_tokens.weight": "0.safetensors"}})
+    )
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    engine._verify_text_encoder_not_quantized()  # must not raise
+
+
+def test_shard_path_traversal_is_rejected(tmp_path, monkeypatch) -> None:
+    # A shard name escaping text_encoder/ (path traversal, or an absolute
+    # path elsewhere on disk) must not be trusted even though it would
+    # resolve to a real file.
+    outside = tmp_path / "outside.safetensors"
+    _write_safetensors_header(
+        outside,
+        {"encoder.embed_tokens.weight": {"shape": [152064, 3584], "dtype": "F16"}},
+    )
+    snapshot = _make_snapshot(
+        tmp_path, {"shape": [152064, 3584], "dtype": "F16"}
+    )  # baseline valid shard, then override the index to point outside
+    (snapshot / "text_encoder" / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {"weight_map": {"encoder.embed_tokens.weight": "../outside.safetensors"}}
+        )
     )
     engine = _engine_for_family_check(monkeypatch, snapshot)
     with pytest.raises(ImageRuntimeError, match="quantized text encoder"):

--- a/tests/test_qwen_image_alias.py
+++ b/tests/test_qwen_image_alias.py
@@ -169,6 +169,89 @@ def test_model_path_for_mflux_forces_pinned_revision_on_cold_pull(
     assert calls == [(repo, pinned_sha)]
 
 
+def _seed_pinned_download(cache_root, repo_id: str, sha: str, *, omit_shard=False):
+    """A cache layout shaped like what ``snapshot_download(repo,
+    revision=<commit sha>)`` actually leaves behind for a pinned repo:
+    ``snapshots/<sha>`` populated, deliberately with NO ``refs/main`` (an
+    explicit-commit download doesn't move it — see
+    ``test_mflux_local_snapshot_accepts_pinned_revision_without_refs_main``
+    in test_download_gate.py) — so ``_verify_weights_complete()``, called
+    right after the fake download, gets a real verdict from the same code
+    path a genuine cold pull would.
+    """
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    snap = repo_root / "snapshots" / sha
+    (snap / "tokenizer").mkdir(parents=True)
+    (snap / "tokenizer" / "tokenizer.json").write_text("{}")
+    for component in ("transformer", "vae"):
+        component_dir = snap / component
+        component_dir.mkdir()
+        (component_dir / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": {"a": "0.safetensors"}})
+        )
+        (component_dir / "0.safetensors").write_bytes(b"weights")
+    text_encoder_dir = snap / "text_encoder"
+    text_encoder_dir.mkdir()
+    (text_encoder_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"encoder.embed_tokens.weight": "0.safetensors"}})
+    )
+    if not omit_shard:
+        _write_safetensors_header(
+            text_encoder_dir / "0.safetensors",
+            {"encoder.embed_tokens.weight": {"shape": [152064, 3584], "dtype": "F16"}},
+        )
+    return str(snap)
+
+
+def test_model_path_for_mflux_verifies_a_freshly_pinned_download(
+    tmp_path, monkeypatch
+) -> None:
+    # Codex review (PR #2157): a cold pinned pull bypassed
+    # `_verify_weights_complete()` entirely — it ran (as a no-op, nothing
+    # was cached yet) *before* `_model_path_for_mflux()` did the actual
+    # download, so the freshly downloaded snapshot was handed straight to
+    # mflux unverified. This is the passing half: a complete, unquantized
+    # download must resolve normally, verification included.
+    from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
+
+    repo = "mflux-community/qwen-image-mflux-q6"
+    pinned_sha = IMAGE_MODEL_REVISIONS[repo]
+    cache_root = tmp_path / "hf-cache"
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda repo_id, revision=None: _seed_pinned_download(
+            cache_root, repo_id, revision
+        ),
+    )
+
+    engine = ImageGenerationEngine(repo)
+    path = engine._model_path_for_mflux()
+    assert path is not None
+    assert path.endswith(pinned_sha)
+
+
+def test_model_path_for_mflux_rejects_a_freshly_pinned_incomplete_download(
+    tmp_path, monkeypatch
+) -> None:
+    # The failing half: a download that lands incomplete (interrupted,
+    # disk full, whatever) must be refused before it reaches mflux, exactly
+    # like an incomplete WARM cache already is via `_verify_weights_complete`.
+    repo = "mflux-community/qwen-image-mflux-q6"
+    cache_root = tmp_path / "hf-cache"
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda repo_id, revision=None: _seed_pinned_download(
+            cache_root, repo_id, revision, omit_shard=True
+        ),
+    )
+
+    engine = ImageGenerationEngine(repo)
+    with pytest.raises(ImageRuntimeError, match="partially downloaded"):
+        engine._model_path_for_mflux()
+
+
 def test_model_path_for_mflux_falls_back_to_bare_repo_when_unpinned(
     monkeypatch,
 ) -> None:

--- a/tests/test_qwen_image_alias.py
+++ b/tests/test_qwen_image_alias.py
@@ -19,11 +19,30 @@ in the text encoder's RMSNorm with a shape mismatch
 (``[broadcast_shapes] Shapes (3584) and (1,50,672)``) — reproduced live
 against this project's pinned mflux before this alias was pointed
 elsewhere. ``mflux-community/qwen-image-mflux-q6`` (uploaded 2026-08-16,
-current at the time of pinning) keeps the text encoder full-precision
-(verified: zero ``scale``/``bias`` keys, correct ``[152064, 3584]`` embed
-shape) and was confirmed end-to-end: both a plain text-to-image prompt and
-a text-rendering prompt ("RAPID MLX" on a sign) produced correct images
-with this project's pinned mflux.
+commit ``c628fe4392d963557c3013c2709e6d3b67bca79d`` at the time of
+pinning — the alias tracks the mutable ``main`` ref, not this SHA;
+``aliases.json`` has no revision-pin field today, and adding one is a
+system-wide change out of scope here) keeps the text encoder
+full-precision (verified: zero ``scale``/``bias`` keys, correct
+``[152064, 3584]`` embed shape) and was confirmed end-to-end: both a
+plain text-to-image prompt and a text-rendering prompt ("RAPID MLX" on a
+sign) produced correct images with this project's pinned mflux.
+
+Provenance: the ``mflux-community`` HF account has published ~50 repos
+as a systematic multi-family, multi-bitwidth conversion pipeline (krea-2,
+z-image-turbo, flux2-klein-9b, each at q3-q8/bf16) — a pattern, not a
+one-off upload — though it carries no README/license file and is not a
+Hugging Face-verified org; this is a real supply-chain tradeoff against
+filipstrand (the mflux maintainer personally) that a future maintainer
+should weigh if a more authoritative source appears.
+
+Guarded going forward, not just for this one repo:
+``ImageGenerationEngine._verify_text_encoder_not_quantized`` is a
+structural preflight that reads ONLY the text encoder's safetensors
+header (no tensor data, no network beyond what is already cached) and
+refuses to build the model if ``embed_tokens`` is packed/quantized — so a
+FUTURE re-pin to a different repo with this same defect fails loudly
+before generation starts, not three prompts later.
 
 These tests guard the things a data-only alias can still get wrong:
 
@@ -35,12 +54,24 @@ These tests guard the things a data-only alias can still get wrong:
      load (which would also error against an already-quantized repo).
   3. The pinned repo is specifically NOT one with a quantized text
      encoder — see above. A future re-pin (e.g. chasing a smaller
-     download) must not silently reintroduce the corruption.
+     download) must not silently reintroduce the corruption, whether by
+     shape (structurally guarded now) or by name (guarded by the
+     regression pin below).
 """
 
 from __future__ import annotations
 
-from vllm_mlx.image.engine import _detect_family, _looks_like_prequantized
+import json
+import struct
+
+import pytest
+
+from vllm_mlx.image.engine import (
+    ImageGenerationEngine,
+    ImageRuntimeError,
+    _detect_family,
+    _looks_like_prequantized,
+)
 from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.runtime.resident_models import estimate_model_bytes
 
@@ -66,11 +97,13 @@ def test_qwen_image_alias_does_not_point_at_the_known_broken_repo() -> None:
 
 
 def test_qwen_image_alias_declares_a_memory_floor() -> None:
-    # Full-precision text encoder + 6-bit transformer measured ~40.2 GiB
-    # peak RSS during a real generation (`/usr/bin/time -l`, 512x512).
-    # The floor gates it off Macs that cannot hold that resident.
+    # Full-precision text encoder + 6-bit transformer measured ~55.7 GiB
+    # peak RSS during a real generation (`/usr/bin/time -l`) at 1024x1024 —
+    # the API/GUI default resolution, not the smaller size this was first
+    # measured at. The floor gates it off Macs that cannot hold that
+    # resident.
     profile = resolve_profile("qwen-image")
-    assert getattr(profile, "min_memory_gb", None) == 48
+    assert getattr(profile, "min_memory_gb", None) == 64
 
 
 def test_qwen_image_repo_is_detected_as_qwen_image_family() -> None:
@@ -88,4 +121,109 @@ def test_qwen_image_resident_estimate_is_not_the_bare_default() -> None:
     # fallback would charge the 4 GB default and mis-admit a ~29 GB model.
     # Both the alias and the pinned repo id must resolve to the real charge.
     for name in ("qwen-image", resolve_profile("qwen-image").hf_path):
-        assert estimate_model_bytes(name) == int(40.2 * _GIB)
+        assert estimate_model_bytes(name) == int(55.7 * _GIB)
+
+
+# MARK: - Structural guard against a quantized text encoder
+#
+# The regression these tests actually need to pin is not "this one repo name
+# is banned" (trivially defeated by a re-pin to a different broken repo) but
+# "a Qwen-Image checkpoint whose text encoder is packed/quantized is refused
+# BEFORE generation starts", using nothing but a synthetic safetensors header
+# — no network, no multi-gigabyte download, no real mflux model. See
+# ``ImageGenerationEngine._verify_text_encoder_not_quantized``.
+
+
+def _write_safetensors_header(path, header: dict) -> None:
+    """Write a syntactically valid ``.safetensors`` file carrying only
+    ``header`` — enough for header-only readers; the tensor data section is
+    empty because nothing under test reads past the header."""
+    payload = json.dumps(header).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(payload)) + payload)
+
+
+def _make_snapshot(
+    tmp_path, embed_header_entry: dict, *, extra_keys: dict | None = None
+):
+    snapshot = tmp_path / "snapshot"
+    text_encoder = snapshot / "text_encoder"
+    text_encoder.mkdir(parents=True)
+    shard_name = "0.safetensors"
+    (text_encoder / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"encoder.embed_tokens.weight": shard_name}})
+    )
+    header = {"encoder.embed_tokens.weight": embed_header_entry}
+    if extra_keys:
+        header.update(extra_keys)
+    _write_safetensors_header(text_encoder / shard_name, header)
+    return snapshot
+
+
+def _engine_for_family_check(monkeypatch, snapshot) -> ImageGenerationEngine:
+    # ``ImageGenerationEngine.__init__`` does real work (family detection,
+    # prequantized sniffing) that only needs a plausible qwen-image repo
+    # name — no engine method under test touches the network or mflux itself.
+    engine = ImageGenerationEngine("mflux-community/qwen-image-mflux-q6")
+    # ``_verify_text_encoder_not_quantized`` imports ``mflux_local_snapshot``
+    # from ``_download_gate`` inside the method body, so patching the
+    # source module's attribute is what the late-bound import picks up.
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot",
+        lambda _repo: str(snapshot),
+    )
+    return engine
+
+
+def test_full_precision_text_encoder_passes(tmp_path, monkeypatch) -> None:
+    snapshot = _make_snapshot(tmp_path, {"shape": [152064, 3584], "dtype": "F16"})
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    engine._verify_text_encoder_not_quantized()  # must not raise
+
+
+def test_packed_shape_is_refused(tmp_path, monkeypatch) -> None:
+    # The exact failure mode reproduced against filipstrand's repo: a packed
+    # last dimension instead of the real hidden size.
+    snapshot = _make_snapshot(tmp_path, {"shape": [152064, 672], "dtype": "U32"})
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
+        engine._verify_text_encoder_not_quantized()
+
+
+def test_scales_sibling_is_refused_even_with_a_plausible_shape(
+    tmp_path, monkeypatch
+) -> None:
+    # Belt-and-suspenders: a quantization scheme that happens to keep the
+    # embedding's own shape at [vocab, hidden] is still caught by the
+    # scales/biases siblings every quantized linear/embedding carries.
+    snapshot = _make_snapshot(
+        tmp_path,
+        {"shape": [152064, 3584], "dtype": "F16"},
+        extra_keys={
+            "encoder.embed_tokens.weight.scales": {
+                "shape": [152064, 56],
+                "dtype": "F16",
+            }
+        },
+    )
+    engine = _engine_for_family_check(monkeypatch, snapshot)
+    with pytest.raises(ImageRuntimeError, match="quantized text encoder"):
+        engine._verify_text_encoder_not_quantized()
+
+
+def test_non_qwen_family_is_not_checked(tmp_path, monkeypatch) -> None:
+    # The 3584 hidden-size expectation is Qwen2-specific; z-image/flux2-klein
+    # text encoders have entirely different architectures and must not be
+    # held to it.
+    engine = ImageGenerationEngine("filipstrand/Z-Image-Turbo-mflux-4bit")
+    assert engine.family != "qwen-image"
+    engine._verify_text_encoder_not_quantized()  # no-op, must not raise
+
+
+def test_missing_index_does_not_raise(tmp_path, monkeypatch) -> None:
+    # No index (or an unreadable one) is outside what this check can vouch
+    # for — ``_verify_weights_complete``'s completeness check is what must
+    # catch that; this guard degrades to a no-op rather than a false claim.
+    empty_snapshot = tmp_path / "empty"
+    empty_snapshot.mkdir()
+    engine = _engine_for_family_check(monkeypatch, empty_snapshot)
+    engine._verify_text_encoder_not_quantized()  # no-op, must not raise

--- a/tests/test_qwen_image_alias.py
+++ b/tests/test_qwen_image_alias.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract pins for the ``qwen-image`` image-gen alias.
+
+The mflux backend already understands the ``qwen-image`` family
+(``vllm_mlx/image/engine.py``); this alias is what makes
+``rapid-mlx serve qwen-image`` resolve to it without the caller having
+to type the raw Hugging Face path. These tests guard the two things a
+data-only alias can still get wrong:
+
+  1. It routes to the mflux image lane (``modality == "image-gen"``),
+     not the default text lane.
+  2. The pinned repo is a *pre-quantized* mflux checkpoint, so the
+     loader takes the ``model_path`` branch instead of pulling the
+     ~57 GB canonical ``Qwen/Qwen-Image`` weights and quantizing on
+     load (which would also error against an already-quantized repo).
+"""
+
+from __future__ import annotations
+
+from vllm_mlx.image.engine import _detect_family, _looks_like_prequantized
+from vllm_mlx.model_aliases import resolve_profile
+from vllm_mlx.runtime.resident_models import estimate_model_bytes
+
+_GIB = 1024**3
+
+
+def test_qwen_image_alias_routes_to_image_lane() -> None:
+    profile = resolve_profile("qwen-image")
+    assert profile is not None
+    assert profile.modality == "image-gen"
+    assert profile.hf_path == "filipstrand/Qwen-Image-mflux-6bit"
+
+
+def test_qwen_image_alias_declares_a_memory_floor() -> None:
+    # 6-bit Qwen-Image (~23 GB on disk) needs headroom to stay resident;
+    # the gate keeps it off Macs that cannot hold it.
+    profile = resolve_profile("qwen-image")
+    assert getattr(profile, "min_memory_gb", None) == 24
+
+
+def test_qwen_image_repo_is_detected_as_qwen_image_family() -> None:
+    hf_path = resolve_profile("qwen-image").hf_path
+    assert _detect_family(hf_path) == "qwen-image"
+
+
+def test_qwen_image_repo_is_prequantized_so_no_full_weight_pull() -> None:
+    hf_path = resolve_profile("qwen-image").hf_path
+    assert _looks_like_prequantized(hf_path) is True
+
+
+def test_qwen_image_resident_estimate_is_not_the_bare_default() -> None:
+    # The alias carries no digit params, so without a known-image entry the
+    # fallback would charge the 4 GB default and mis-admit a ~23 GB model.
+    # Both the alias and the pinned repo id must resolve to the real charge.
+    for name in ("qwen-image", resolve_profile("qwen-image").hf_path):
+        assert estimate_model_bytes(name) == int(18.0 * _GIB)

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -876,6 +876,20 @@ def split_model_local_snapshot(repo_id: str) -> str | None:
     return snap_dir if os.path.isdir(snap_dir) else None
 
 
+#: Repos whose weights must resolve to an exact, previously-verified commit,
+#: mirroring ``video/wan.py``'s ``WAN_REVISIONS``. Without this, an alias
+#: only ever resolves whatever ``refs/main`` currently points to (see
+#: ``_resolved_snapshot_sha``) — an upstream force-push or account
+#: compromise on the repo would silently change the weights a fresh pull
+#: (or a not-yet-cached machine) fetches next, with nothing here to notice.
+#: A repo absent from this map is unpinned and falls through to today's
+#: behavior; one present here is refused unless the resolved snapshot
+#: matches exactly (see the check in ``_mflux_snapshot_dir``).
+IMAGE_MODEL_REVISIONS: dict[str, str] = {
+    "mflux-community/qwen-image-mflux-q6": "c628fe4392d963557c3013c2709e6d3b67bca79d",
+}
+
+
 def _mflux_snapshot_dir(repo_id: str) -> tuple[str, str] | None:
     """``(repo_root, snapshot_dir)`` for a registered image-gen repo, or ``None``.
 
@@ -930,6 +944,13 @@ def _mflux_snapshot_dir(repo_id: str) -> tuple[str, str] | None:
         ):
             return None
         resolved_sha = candidates[0]
+    pinned_revision = IMAGE_MODEL_REVISIONS.get(repo_id)
+    if pinned_revision is not None and resolved_sha != pinned_revision:
+        # Whatever is cached does not match the verified-good commit — do
+        # not vouch for it. This includes a cache populated before this
+        # repo was pinned, so pinning a repo re-validates every existing
+        # install rather than only new downloads.
+        return None
     snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
     if not os.path.isdir(snap_dir):
         return None

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -916,6 +916,19 @@ def _mflux_snapshot_dir(repo_id: str) -> tuple[str, str] | None:
         HF_HUB_CACHE,
         f"models--{repo_id.replace('/', '--')}",
     )
+    pinned_revision = IMAGE_MODEL_REVISIONS.get(repo_id)
+    if pinned_revision is not None:
+        # A pinned repo's contract is "this exact commit, however it got
+        # cached" — go straight to snapshots/<pinned_revision> rather than
+        # through refs/main. snapshot_download(..., revision=<commit SHA>)
+        # (used for a cold pull of a pinned repo) caches the commit under
+        # its own snapshot directory WITHOUT necessarily moving refs/main
+        # — that ref only advances when a branch name is resolved — so
+        # resolving through it would never recognize a freshly pinned
+        # download and would re-download on every subsequent warm start.
+        snap_dir = os.path.join(repo_root, "snapshots", pinned_revision)
+        return (repo_root, snap_dir) if os.path.isdir(snap_dir) else None
+
     resolved_sha = _resolved_snapshot_sha(repo_root)
     if resolved_sha is None:
         # An interrupted first download can leave component indexes and
@@ -944,13 +957,6 @@ def _mflux_snapshot_dir(repo_id: str) -> tuple[str, str] | None:
         ):
             return None
         resolved_sha = candidates[0]
-    pinned_revision = IMAGE_MODEL_REVISIONS.get(repo_id)
-    if pinned_revision is not None and resolved_sha != pinned_revision:
-        # Whatever is cached does not match the verified-good commit — do
-        # not vouch for it. This includes a cache populated before this
-        # repo was pinned, so pinning a repo re-validates every existing
-        # install rather than only new downloads.
-        return None
     snap_dir = os.path.join(repo_root, "snapshots", resolved_sha)
     if not os.path.isdir(snap_dir):
         return None

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1681,7 +1681,7 @@
     "min_memory_gb": 16
   },
   "qwen-image": {
-    "hf_path": "filipstrand/Qwen-Image-mflux-6bit",
+    "hf_path": "mflux-community/qwen-image-mflux-q6",
     "modality": "image-gen",
     "tool_call_parser": null,
     "reasoning_parser": null,
@@ -1690,7 +1690,7 @@
     "supports_spec_decode": false,
     "supports_dflash": false,
     "suffix_decoding_tier": "unknown",
-    "min_memory_gb": 24
+    "min_memory_gb": 48
   },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1680,6 +1680,18 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 16
   },
+  "qwen-image": {
+    "hf_path": "filipstrand/Qwen-Image-mflux-6bit",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 24
+  },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",
     "tool_call_parser": null,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1690,7 +1690,7 @@
     "supports_spec_decode": false,
     "supports_dflash": false,
     "suffix_decoding_tier": "unknown",
-    "min_memory_gb": 48
+    "min_memory_gb": 64
   },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -320,9 +320,19 @@ class ImageGenerationEngine:
         from .._download_gate import mflux_missing_weights
 
         missing = mflux_missing_weights(self.model_name)
+        if missing is None:
+            # No verdict — not a registered image-gen alias, or nothing
+            # cached yet. An environment problem must not read as a broken
+            # model, and the structural text-encoder check below has no
+            # completeness guarantee to build on here either: `not missing`
+            # is True for BOTH `[]` and `None`, which used to let the
+            # text-encoder check run on a `None` verdict too — an
+            # indeterminate result treated as "go ahead and inspect it"
+            # instead of "no opinion".
+            return
         if not missing:
-            # ``[]`` verified complete, ``None`` no verdict — see that
-            # function: an environment problem must not read as a broken model.
+            # ``[]`` — verified complete. Only NOW does the structural
+            # text-encoder check have something to build on.
             self._verify_text_encoder_not_quantized()
             return
         raise ImageRuntimeError(
@@ -380,7 +390,22 @@ class ImageGenerationEngine:
         # ``scales``/``biases`` siblings can land in a DIFFERENT shard, which
         # would let a quantized checkpoint with a superficially plausible
         # primary-shard shape slip past a single-shard check.
-        if f"{weight_key}.scales" in weight_map or f"{weight_key}.biases" in weight_map:
+        #
+        # MLX's quantized-module convention names ``scales``/``biases`` as
+        # SIBLINGS of the base parameter's prefix — ``<module>.scales`` next
+        # to ``<module>.weight`` — not children of the weight key itself.
+        # Verified against the real filipstrand/Qwen-Image-mflux-6bit shard
+        # this check exists to catch: ``encoder.embed_tokens.weight``,
+        # ``encoder.embed_tokens.scales``, ``encoder.embed_tokens.biases`` —
+        # all three siblings under ``encoder.embed_tokens``, not nested under
+        # ``.weight``. An earlier version of this check looked for
+        # ``encoder.embed_tokens.weight.scales`` — a key that convention
+        # never produces — so it never actually matched real quantized
+        # metadata; it only worked by accident, via the shape check below,
+        # for the ONE packing width that happens to leave a mismatched last
+        # dimension.
+        prefix = weight_key.removesuffix(".weight")
+        if f"{prefix}.scales" in weight_map or f"{prefix}.biases" in weight_map:
             self._raise_quantized_text_encoder_error(weight_key, str(text_encoder_dir))
             return
         shard_path = self._resolve_shard_path(text_encoder_dir, weight_map[weight_key])

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -248,7 +248,16 @@ class ImageGenerationEngine:
             return self.model_name
         from huggingface_hub import snapshot_download
 
-        return snapshot_download(self.model_name, revision=pinned_revision)
+        downloaded = snapshot_download(self.model_name, revision=pinned_revision)
+        # A pinned cold pull bypasses ``_verify_weights_complete()``'s
+        # normal preflight — at the time it ran (in ``_ensure_loaded``,
+        # right before this method), there was nothing cached yet to
+        # inspect, so it no-opped. Run it again now that the pinned commit
+        # is actually on disk: an interrupted download or a checkpoint
+        # whose text encoder turns out to be quantized must not reach
+        # mflux either way, cold pull or not.
+        self._verify_weights_complete()
+        return downloaded
 
     def _build_model(self):
         """Instantiate the backing mflux model (import-lazy)."""

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -322,12 +322,133 @@ class ImageGenerationEngine:
         if not missing:
             # ``[]`` verified complete, ``None`` no verdict — see that
             # function: an environment problem must not read as a broken model.
+            self._verify_text_encoder_not_quantized()
             return
         raise ImageRuntimeError(
             f"Image model '{self.model_name}' is only partially downloaded, so "
             "generating with it would produce noise rather than an image. "
             f"Missing: {', '.join(missing)}. Re-run the download to finish it."
         )
+
+    # Hidden size mflux hardcodes for the Qwen2 text encoder backing both
+    # qwen-image and qwen-image-edit (``QwenEncoderLayer.__init__``'s
+    # ``hidden_size: int = 3584`` default) — not read from the checkpoint,
+    # so a repo whose weights disagree cannot be caught by shape-checking
+    # against anything the checkpoint itself declares.
+    _QWEN_TEXT_ENCODER_HIDDEN_SIZE = 3584
+
+    def _verify_text_encoder_not_quantized(self) -> None:
+        """Refuse a Qwen-Image checkpoint whose text encoder is quantized.
+
+        mflux's Qwen weight definition sets ``skip_quantization=True`` for
+        the text encoder ("quantization causes significant semantic
+        degradation") and never dequantizes on load. A checkpoint packaged
+        with a *quantized* text encoder anyway — ``embed_tokens.weight``
+        shape ``[vocab, hidden/pack_ratio]`` plus ``scales``/``biases``
+        siblings, instead of plain ``[vocab, hidden]`` — loads without error
+        and fails minutes later, deep in the transformer's RMSNorm, with a
+        shape-mismatch that gives no hint the text encoder was the cause.
+        Reproduced live against ``filipstrand/Qwen-Image-mflux-6bit`` before
+        this check existed; see ``tests/test_qwen_image_alias.py``.
+
+        Reads only the safetensors HEADER (a small JSON prefix — see
+        ``safetensors``' format spec) of the one shard holding
+        ``embed_tokens.weight``, never the tensor data, so this costs one
+        small file read regardless of checkpoint size.
+        """
+        if self.family not in {"qwen-image", "qwen-image-edit"}:
+            return
+        from .._download_gate import mflux_local_snapshot
+
+        snapshot = mflux_local_snapshot(self.model_name)
+        if snapshot is None:
+            return
+        shard_path = self._locate_embed_tokens_shard(snapshot)
+        if shard_path is None:
+            # No index, or no entry for this key: outside what this check can
+            # vouch for. ``_verify_weights_complete`` already required the
+            # index to exist and name every shard; this is reached only if a
+            # future component definition renames the key, which a shape
+            # check for the OLD name cannot meaningfully block.
+            return
+        header = self._read_safetensors_header(shard_path)
+        if header is None:
+            return
+        weight_key = "encoder.embed_tokens.weight"
+        if f"{weight_key}.scales" in header or f"{weight_key}.biases" in header:
+            self._raise_quantized_text_encoder_error(weight_key, shard_path)
+        entry = header.get(weight_key)
+        shape = entry.get("shape") if isinstance(entry, dict) else None
+        if (
+            isinstance(shape, list)
+            and shape
+            and shape[-1] != self._QWEN_TEXT_ENCODER_HIDDEN_SIZE
+        ):
+            self._raise_quantized_text_encoder_error(weight_key, shard_path)
+
+    def _raise_quantized_text_encoder_error(
+        self, weight_key: str, shard_path: str
+    ) -> None:
+        raise ImageRuntimeError(
+            f"Image model '{self.model_name}' packages a quantized text "
+            "encoder, which this mflux version cannot load correctly (it "
+            "never dequantizes the Qwen text encoder on load, and the "
+            "mismatch would otherwise surface as an unrelated shape error "
+            "deep in generation). Pick a checkpoint with a full-precision "
+            f"text encoder. (Found in {shard_path}: {weight_key!r} does not "
+            f"have the expected {self._QWEN_TEXT_ENCODER_HIDDEN_SIZE}-wide "
+            "last dimension, or carries quantization scale/bias tensors.)"
+        )
+
+    @staticmethod
+    def _locate_embed_tokens_shard(snapshot: str) -> str | None:
+        import json
+
+        index_path = Path(snapshot) / "text_encoder" / "model.safetensors.index.json"
+        try:
+            with open(index_path, encoding="utf-8") as fh:
+                index = json.load(fh)
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        weight_map = index.get("weight_map") if isinstance(index, dict) else None
+        if not isinstance(weight_map, dict):
+            return None
+        shard = weight_map.get("encoder.embed_tokens.weight")
+        if not isinstance(shard, str):
+            return None
+        shard_path = (Path(snapshot) / "text_encoder" / shard).resolve()
+        text_encoder_dir = (Path(snapshot) / "text_encoder").resolve()
+        if text_encoder_dir not in shard_path.parents:
+            # A shard name escaping its own directory (path traversal, an
+            # absolute path) cannot be trusted — same posture as the
+            # completeness check in ``_download_gate.py``.
+            return None
+        return str(shard_path) if shard_path.is_file() else None
+
+    @staticmethod
+    def _read_safetensors_header(path: str) -> dict | None:
+        """The JSON header of a ``.safetensors`` file, or ``None`` if unreadable.
+
+        Format: an 8-byte little-endian header length, then that many bytes
+        of JSON naming every tensor's dtype/shape/byte-offsets — never the
+        tensor data itself, which is why this is cheap for a multi-gigabyte
+        shard.
+        """
+        import json
+        import struct
+
+        try:
+            with open(path, "rb") as fh:
+                (header_len,) = struct.unpack("<Q", fh.read(8))
+                # A corrupt/truncated file could claim an enormous header
+                # length; refuse to read past the file's own size rather than
+                # let a malformed length exhaust memory.
+                if header_len <= 0 or header_len > Path(path).stat().st_size:
+                    return None
+                header = json.loads(fh.read(header_len))
+        except (OSError, json.JSONDecodeError, struct.error):
+            return None
+        return header if isinstance(header, dict) else None
 
     def _ensure_loaded(self, *, for_edit: bool | None = None):
         if for_edit is None:

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import gc
 import io
+import os
 import re
 import threading
 import time
@@ -363,28 +364,44 @@ class ImageGenerationEngine:
         snapshot = mflux_local_snapshot(self.model_name)
         if snapshot is None:
             return
-        shard_path = self._locate_embed_tokens_shard(snapshot)
-        if shard_path is None:
-            # No index, or no entry for this key: outside what this check can
-            # vouch for. ``_verify_weights_complete`` already required the
-            # index to exist and name every shard; this is reached only if a
-            # future component definition renames the key, which a shape
-            # check for the OLD name cannot meaningfully block.
-            return
-        header = self._read_safetensors_header(shard_path)
-        if header is None:
-            return
         weight_key = "encoder.embed_tokens.weight"
-        if f"{weight_key}.scales" in header or f"{weight_key}.biases" in header:
-            self._raise_quantized_text_encoder_error(weight_key, shard_path)
-        entry = header.get(weight_key)
+        text_encoder_dir = Path(snapshot) / "text_encoder"
+        weight_map = self._read_text_encoder_weight_map(text_encoder_dir)
+        if weight_map is None or weight_key not in weight_map:
+            # No index, unreadable, or no entry for this key: outside what
+            # this check can vouch for. ``_verify_weights_complete`` already
+            # required the index to exist and name every shard; a missing
+            # KEY (as opposed to a missing shard, handled below) is reached
+            # only if a future component definition renames it, which a
+            # check anchored to the OLD name cannot meaningfully block.
+            return
+        # Checked against the WHOLE index, not just the header of the shard
+        # holding ``embed_tokens.weight``: a quantized embedding's
+        # ``scales``/``biases`` siblings can land in a DIFFERENT shard, which
+        # would let a quantized checkpoint with a superficially plausible
+        # primary-shard shape slip past a single-shard check.
+        if f"{weight_key}.scales" in weight_map or f"{weight_key}.biases" in weight_map:
+            self._raise_quantized_text_encoder_error(weight_key, str(text_encoder_dir))
+            return
+        shard_path = self._resolve_shard_path(text_encoder_dir, weight_map[weight_key])
+        header = self._read_safetensors_header(shard_path) if shard_path else None
+        entry = header.get(weight_key) if header else None
         shape = entry.get("shape") if isinstance(entry, dict) else None
+        # Fail CLOSED, not open, once the index has named a shard for this
+        # key: the index is an explicit claim that the tensor lives there
+        # with some shape, so an unresolvable shard, an unreadable header, or
+        # a missing/malformed shape entry is itself suspicious — not a
+        # reason to silently let generation proceed.
         if (
-            isinstance(shape, list)
-            and shape
-            and shape[-1] != self._QWEN_TEXT_ENCODER_HIDDEN_SIZE
+            shard_path is None
+            or header is None
+            or not isinstance(shape, list)
+            or not shape
+            or shape[-1] != self._QWEN_TEXT_ENCODER_HIDDEN_SIZE
         ):
-            self._raise_quantized_text_encoder_error(weight_key, shard_path)
+            self._raise_quantized_text_encoder_error(
+                weight_key, shard_path or str(text_encoder_dir)
+            )
 
     def _raise_quantized_text_encoder_error(
         self, weight_key: str, shard_path: str
@@ -397,36 +414,52 @@ class ImageGenerationEngine:
             "deep in generation). Pick a checkpoint with a full-precision "
             f"text encoder. (Found in {shard_path}: {weight_key!r} does not "
             f"have the expected {self._QWEN_TEXT_ENCODER_HIDDEN_SIZE}-wide "
-            "last dimension, or carries quantization scale/bias tensors.)"
+            "last dimension, is missing/unreadable where the index says it "
+            "lives, or carries quantization scale/bias tensors.)"
         )
 
     @staticmethod
-    def _locate_embed_tokens_shard(snapshot: str) -> str | None:
+    def _read_text_encoder_weight_map(text_encoder_dir: Path) -> dict | None:
         import json
 
-        index_path = Path(snapshot) / "text_encoder" / "model.safetensors.index.json"
+        index_path = text_encoder_dir / "model.safetensors.index.json"
         try:
             with open(index_path, encoding="utf-8") as fh:
                 index = json.load(fh)
         except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             return None
         weight_map = index.get("weight_map") if isinstance(index, dict) else None
-        if not isinstance(weight_map, dict):
-            return None
-        shard = weight_map.get("encoder.embed_tokens.weight")
-        if not isinstance(shard, str):
-            return None
-        shard_path = (Path(snapshot) / "text_encoder" / shard).resolve()
-        text_encoder_dir = (Path(snapshot) / "text_encoder").resolve()
-        if text_encoder_dir not in shard_path.parents:
-            # A shard name escaping its own directory (path traversal, an
-            # absolute path) cannot be trusted — same posture as the
-            # completeness check in ``_download_gate.py``.
-            return None
-        return str(shard_path) if shard_path.is_file() else None
+        return weight_map if isinstance(weight_map, dict) else None
 
     @staticmethod
-    def _read_safetensors_header(path: str) -> dict | None:
+    def _resolve_shard_path(text_encoder_dir: Path, shard: object) -> str | None:
+        # String-only traversal guard — matching ``_download_gate.py``'s
+        # ``mflux_missing_weights`` — NOT ``.resolve()``-then-compare-parents:
+        # a HF hub cache's snapshot files are themselves symlinks into a
+        # sibling ``blobs/`` directory, so resolving them walks straight out
+        # of ``text_encoder_dir`` and made every real cached checkpoint fail
+        # this check (caught live: a false positive against a known-good,
+        # actually-cached repo — every ``blobs``-backed shard would trip the
+        # old parent-directory check identically, so this HF cache layout is
+        # unconditionally incompatible with resolve-and-compare here).
+        if (
+            not isinstance(shard, str)
+            or os.path.basename(shard) != shard
+            or shard in (".", "..")
+        ):
+            return None
+        shard_path = text_encoder_dir / shard
+        return str(shard_path) if shard_path.is_file() else None
+
+    # Real safetensors headers run from a few hundred bytes (this text
+    # encoder's own shards) to low tens of megabytes for the largest known
+    # checkpoints' component indices. A claimed length beyond this is a
+    # corrupt or hostile file, not a legitimately large model — reading it
+    # into memory to find out would defeat the point of a header-only check.
+    _SAFETENSORS_HEADER_MAX_BYTES = 64 * 1024 * 1024
+
+    @classmethod
+    def _read_safetensors_header(cls, path: str) -> dict | None:
         """The JSON header of a ``.safetensors`` file, or ``None`` if unreadable.
 
         Format: an 8-byte little-endian header length, then that many bytes
@@ -441,12 +474,15 @@ class ImageGenerationEngine:
             with open(path, "rb") as fh:
                 (header_len,) = struct.unpack("<Q", fh.read(8))
                 # A corrupt/truncated file could claim an enormous header
-                # length; refuse to read past the file's own size rather than
-                # let a malformed length exhaust memory.
-                if header_len <= 0 or header_len > Path(path).stat().st_size:
+                # length; cap it independent of the file's own (possibly
+                # multi-gigabyte) size rather than let a malformed length
+                # read gigabytes into memory before ``json.loads`` even runs.
+                if header_len <= 0 or header_len > cls._SAFETENSORS_HEADER_MAX_BYTES:
                     return None
-                header = json.loads(fh.read(header_len))
-        except (OSError, json.JSONDecodeError, struct.error):
+                if header_len > Path(path).stat().st_size:
+                    return None
+                header = json.loads(fh.read(header_len).decode("utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError, struct.error):
             return None
         return header if isinstance(header, dict) else None
 

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -387,6 +387,19 @@ class ImageGenerationEngine:
         header = self._read_safetensors_header(shard_path) if shard_path else None
         entry = header.get(weight_key) if header else None
         shape = entry.get("shape") if isinstance(entry, dict) else None
+        # A genuine embedding shape is rank-2: [vocab, hidden]. Requiring
+        # that (not just "the last element happens to equal 3584") rejects
+        # malformed entries like ``[3584]`` (rank-1), ``[0, 3584]``, or
+        # ``["x", 3584]`` that would otherwise slip past a bare
+        # ``shape[-1] == ...`` check despite being obvious nonsense.
+        shape_is_valid_rank2 = (
+            isinstance(shape, list)
+            and len(shape) == 2
+            and all(
+                isinstance(dim, int) and not isinstance(dim, bool) and dim > 0
+                for dim in shape
+            )
+        )
         # Fail CLOSED, not open, once the index has named a shard for this
         # key: the index is an explicit claim that the tensor lives there
         # with some shape, so an unresolvable shard, an unreadable header, or
@@ -395,8 +408,7 @@ class ImageGenerationEngine:
         if (
             shard_path is None
             or header is None
-            or not isinstance(shape, list)
-            or not shape
+            or not shape_is_valid_rank2
             or shape[-1] != self._QWEN_TEXT_ENCODER_HIDDEN_SIZE
         ):
             self._raise_quantized_text_encoder_error(
@@ -479,7 +491,12 @@ class ImageGenerationEngine:
                 # read gigabytes into memory before ``json.loads`` even runs.
                 if header_len <= 0 or header_len > cls._SAFETENSORS_HEADER_MAX_BYTES:
                     return None
-                if header_len > Path(path).stat().st_size:
+                # The 8-byte length prefix itself isn't part of what
+                # ``header_len`` counts, so the budget for the header bytes
+                # is the file size MINUS those 8 bytes — comparing against
+                # the raw file size let a file truncated by up to 8 bytes
+                # (e.g. only trailing padding lost) still "fit".
+                if header_len > Path(path).stat().st_size - 8:
                     return None
                 header = json.loads(fh.read(header_len).decode("utf-8"))
         except (OSError, json.JSONDecodeError, UnicodeDecodeError, struct.error):

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -231,13 +231,24 @@ class ImageGenerationEngine:
         start rather than failing fast. Resolving the cached snapshot ourselves
         and passing the directory keeps a warm start entirely local. Falls back
         to the repo id whenever the cache can't be vouched for, so a cold or
-        partial cache still pulls exactly as before.
+        partial cache still pulls exactly as before — unless the repo is
+        pinned (``IMAGE_MODEL_REVISIONS``), in which case we fetch it
+        ourselves at the exact verified commit rather than let mflux resolve
+        and download whatever ``main`` currently points to.
         """
         if not self._prequantized:
             return None
-        from .._download_gate import mflux_local_snapshot
+        from .._download_gate import IMAGE_MODEL_REVISIONS, mflux_local_snapshot
 
-        return mflux_local_snapshot(self.model_name) or self.model_name
+        snapshot = mflux_local_snapshot(self.model_name)
+        if snapshot is not None:
+            return snapshot
+        pinned_revision = IMAGE_MODEL_REVISIONS.get(self.model_name)
+        if pinned_revision is None:
+            return self.model_name
+        from huggingface_hub import snapshot_download
+
+        return snapshot_download(self.model_name, revision=pinned_revision)
 
     def _build_model(self):
         """Instantiate the backing mflux model (import-lazy)."""
@@ -377,14 +388,30 @@ class ImageGenerationEngine:
         weight_key = "encoder.embed_tokens.weight"
         text_encoder_dir = Path(snapshot) / "text_encoder"
         weight_map = self._read_text_encoder_weight_map(text_encoder_dir)
-        if weight_map is None or weight_key not in weight_map:
-            # No index, unreadable, or no entry for this key: outside what
-            # this check can vouch for. ``_verify_weights_complete`` already
-            # required the index to exist and name every shard; a missing
-            # KEY (as opposed to a missing shard, handled below) is reached
-            # only if a future component definition renames it, which a
-            # check anchored to the OLD name cannot meaningfully block.
+        if weight_map is None:
+            # No index, or unreadable: outside what this check can vouch
+            # for — ``_verify_weights_complete`` already required the index
+            # to exist and name every shard to reach this point, so this is
+            # an environment problem, not a signal about the checkpoint.
             return
+        if weight_key not in weight_map:
+            # The index is readable and complete but simply does not name
+            # this key. Every Qwen-Image / Qwen-Image-Edit checkpoint this
+            # check has ever seen uses it, so an absent key is more likely a
+            # differently packaged or renamed encoder than a legitimate
+            # repackaging — and this check exists specifically to catch
+            # checkpoints that would otherwise fail confusingly, minutes
+            # into generation. Refuse rather than fabricate an "OK" verdict
+            # for a layout it cannot actually vouch for.
+            raise ImageRuntimeError(
+                f"Image model '{self.model_name}' text encoder does not "
+                f"expose the expected weight key {weight_key!r} in its "
+                "safetensors index, so the text-encoder-not-quantized guard "
+                "has no way to vouch for it (unsupported layout, not "
+                "necessarily quantization). Refusing to load rather than "
+                "risk minutes of generation before an unrelated-looking "
+                "shape error."
+            )
         # Checked against the WHOLE index, not just the header of the shard
         # holding ``embed_tokens.weight``: a quantized embedding's
         # ``scales``/``biases`` siblings can land in a DIFFERENT shard, which

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -25,6 +25,7 @@
     "lmstudio-community/gpt-oss-20b-MLX-8bit": 22256510809,
     "lmstudio-community/gpt-oss-safeguard-20b-MLX-MXFP4": 11150438234,
     "lucasnewman/f5-tts-mlx": 4043696283,
+    "mflux-community/qwen-image-mflux-q6": 31013313085,
     "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx": 8844791792,
     "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit": 4619332904,
     "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit": 18443052369,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -228,8 +228,17 @@ def estimate_model_bytes(model_name: str) -> int:
         "qwen-image": 55.7,
     }
     for token, gib in known_image_gib.items():
-        if token in folded:
-            return int(gib * _GIB)
+        if token not in folded:
+            continue
+        if token == "qwen-image" and "qwen-image-edit" in folded:
+            # "qwen-image" is a substring of "qwen-image-edit" — this charge
+            # was measured against the txt2img family only (see the comment
+            # above), and the edit variant's extra image-conditioning input
+            # makes its real footprint unverified, not merely "the same
+            # number". Falls through to the generic param-count estimate
+            # below rather than asserting an unmeasured number.
+            continue
+        return int(gib * _GIB)
 
     params = [float(value) for value in _PARAM_RE.findall(folded)]
     if not params:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -216,6 +216,10 @@ def estimate_model_bytes(model_name: str) -> int:
     known_image_gib = {
         "flux2-klein-4b": 5.9,
         "z-image-turbo": 5.9,
+        # 6-bit Qwen-Image (20B) — ~23 GB on disk; the transformer +
+        # text-encoder + VAE stay resident. Without this the digit-free
+        # alias falls through to the 4 GB default and mis-admits.
+        "qwen-image": 18.0,
     }
     for token, gib in known_image_gib.items():
         if token in folded:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -217,14 +217,15 @@ def estimate_model_bytes(model_name: str) -> int:
         "flux2-klein-4b": 5.9,
         "z-image-turbo": 5.9,
         # 6-bit-transformer Qwen-Image (20B) — measured peak RSS during a
-        # real generation (mflux-community/qwen-image-mflux-q6, 512x512,
-        # `/usr/bin/time -l`): ~40.2 GiB. The text encoder in this repo is
-        # full precision (quantizing it "causes significant semantic
-        # degradation" per mflux's own weight definition), so it dominates
-        # the footprint over the quantized transformer. Without this entry
-        # the digit-free alias falls through to the 4 GB default and
-        # mis-admits.
-        "qwen-image": 40.2,
+        # real generation at 1024x1024 (mflux-community/qwen-image-mflux-q6,
+        # the API/GUI default resolution; `/usr/bin/time -l`): ~55.7 GiB.
+        # (512x512 measured lower, ~40.2 GiB — the API/GUI default is what
+        # this charge must cover.) The text encoder in this repo is full
+        # precision (quantizing it "causes significant semantic degradation"
+        # per mflux's own weight definition), so it dominates the footprint
+        # over the quantized transformer. Without this entry the digit-free
+        # alias falls through to the 4 GB default and mis-admits.
+        "qwen-image": 55.7,
     }
     for token, gib in known_image_gib.items():
         if token in folded:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -216,10 +216,15 @@ def estimate_model_bytes(model_name: str) -> int:
     known_image_gib = {
         "flux2-klein-4b": 5.9,
         "z-image-turbo": 5.9,
-        # 6-bit Qwen-Image (20B) — ~23 GB on disk; the transformer +
-        # text-encoder + VAE stay resident. Without this the digit-free
-        # alias falls through to the 4 GB default and mis-admits.
-        "qwen-image": 18.0,
+        # 6-bit-transformer Qwen-Image (20B) — measured peak RSS during a
+        # real generation (mflux-community/qwen-image-mflux-q6, 512x512,
+        # `/usr/bin/time -l`): ~40.2 GiB. The text encoder in this repo is
+        # full precision (quantizing it "causes significant semantic
+        # degradation" per mflux's own weight definition), so it dominates
+        # the footprint over the quantized transformer. Without this entry
+        # the digit-free alias falls through to the 4 GB default and
+        # mis-admits.
+        "qwen-image": 40.2,
     }
     for token, gib in known_image_gib.items():
         if token in folded:


### PR DESCRIPTION
## Why

Qwen-Image is the local leader for **text-in-image** generation — the one thing our current image lineup (FLUX.2 Klein, Z-Image, DiffusionGemma) is weakest at. The mflux backend **already understands the `qwen-image` family** (`vllm_mlx/image/engine.py` — `_detect_family`, per-family default steps, docstring), so the only thing missing was the alias that lets users type `rapid-mlx serve qwen-image` instead of the raw HF path.

Server-side only (no GUI wiring — Qwen-Image at 20B is intentionally not featured in the interactive desktop tab per the engine docstring).

## What

- **`qwen-image`** → `filipstrand/Qwen-Image-mflux-6bit` (modality `image-gen`, `min_memory_gb=24`).
  - `filipstrand` is the mflux maintainer — same provenance as the existing `z-image-turbo` alias.
  - Repo is pre-quantized (`_looks_like_prequantized` → True), so the loader uses the `model_path` branch instead of pulling the ~57 GB canonical `Qwen/Qwen-Image` weights and quantizing on load.
  - Verified complete mflux layout on HF: 8 transformer shards + text_encoder + vae + tokenizer, ~23 GB on disk.
- **`resident_models.estimate_model_bytes`**: add an 18 GiB known-image charge for `qwen-image`. The alias has no digit params, so the fallback estimator would otherwise charge the 4 GB default and mis-admit a ~23 GB model.
- **Contract tests** (`tests/test_qwen_image_alias.py`): routes to the image-gen lane, detected as the `qwen-image` family, treated as pre-quantized (no full weight pull), realistic residency charge.

## Follow-up (not in this PR)

`qwen-image-edit` (the "edit this image" story). No mflux-maintainer edit mirror exists yet; the only clean pre-quantized community candidate (`OsaurusAI/Qwen-Image-Edit-mflux-q4`, 27 GB) is unproven (0 downloads) — will validate on real hardware (Mac mini) or mirror our own before blessing it.

## Test notes

New contract tests pass locally (mlx-free venv). The full runtime test suite (`test_resident_models.py`, the server-loading half of `test_serve_image_gen_completeness.py`) needs the engine's heavy deps not installed on this box — those run in CI. Real image generation validated separately on Mac mini (32 GB).