### PR TITLE
feat(video): add LTX-2.5 MLX support

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -64,7 +64,7 @@ The base text-only install is ~460 MB. Vision/audio/etc. ship as opt-in extras.
 | `audio` | `pip install 'rapid-mlx[audio]'` | mlx-audio + spacy + scipy (~600 MB) for TTS / STT |
 | `embeddings` | `pip install 'rapid-mlx[embeddings]'` | mlx-embeddings (~50 MB) for `/v1/embeddings` |
 | `chat` | `pip install 'rapid-mlx[chat]'` | Gradio web UI (~150 MB) |
-| `video` | `pip install 'rapid-mlx[video]'` | mlx-video + imageio for video generation (LTX-2.3 T2V/I2V with audio); requires Python 3.11+ |
+| `video` | `pip install 'rapid-mlx[video]'` | mlx-video + imageio for LTX-2.3/Wan; LTX-2.5 additionally uses a pinned source runtime documented in the video guide; requires Python 3.11+ |
 | `image` | `pip install 'rapid-mlx[image]'` | mflux for text-to-image / image edit (FLUX.1-schnell, Qwen-Image); requires Python 3.11+ |
 | `mtp` | `pip install 'rapid-mlx[mtp]'` | pillow for MTP speculative decoding (Gemma 4 assistant drafters) |
 | `guided` | `pip install 'rapid-mlx[guided]'` | Legacy no-op kept for compatibility — llguidance ships in the core install (it replaced outlines in 0.10) |

--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -1,6 +1,6 @@
 # Video generation
 
-Rapid-MLX exposes LTX-2.3, CogVideoX-Fun and Wan through the asynchronous
+Rapid-MLX exposes LTX-2.3, LTX-2.5, CogVideoX-Fun and Wan through the asynchronous
 OpenAI-compatible Videos API.
 
 Video generation requires Python 3.11 or newer because the upstream
@@ -16,8 +16,8 @@ text and audio features continue to support Python 3.10.
 - `frames` overrides the frame count derived from `seconds`. LTX requires
   `8n+1` with a minimum of 9; Wan and CogVideoX-Fun require `4n+1` with a
   minimum of 5.
-- `guidance_scale` (1–30) and `negative_prompt` are passed to the served
-  backend's classifier-free guidance implementation.
+- `guidance_scale` (1–30) and `negative_prompt` are passed to backends with
+  classifier-free guidance. LTX-2.5's distilled pipeline rejects both.
 - `conditioning_strength` (0–1) controls how closely LTX image-to-video follows
   `input_reference`; it is rejected without a reference image and is not
   currently supported by Wan or CogVideoX-Fun.
@@ -111,6 +111,43 @@ curl http://localhost:8000/v1/videos \
 
 LTX honours the `fps`, `frames` and `conditioning_strength` controls described
 above; `frames` must satisfy LTX's own frame-count rule.
+
+## LTX-2.5
+
+LTX-2.5 uses a new Gemma 4 text encoder and is served through the standalone
+`ltx-2-mlx` research runtime. That runtime is not published on PyPI yet, so it
+must be installed from its audited source commit. The registered Q8 checkpoint
+is a 67.7 GB download and uses the low-RAM distilled path by default.
+The weights are distributed under the LTX-2.x Community License rather than
+an open-source license; review the checkpoint's `LICENSE.md` before use,
+especially its commercial-use and generated-content disclosure terms.
+
+```bash
+git clone --branch ltx25 https://github.com/MrMoferFRAN/ltx-2-mlx.git
+git -C ltx-2-mlx checkout 57952288076766abe27dda3a774b2c24f7346977
+uv sync --project ltx-2-mlx
+brew install ffmpeg
+
+RAPID_MLX_LTX25_RUNTIME="$PWD/ltx-2-mlx/.venv/bin/ltx-2-mlx" \
+  rapid-mlx serve ltx-2.5-mlx-q8
+```
+
+Create a job with the same API. LTX-2.5 generates synchronized audio and Rapid
+preserves that audio track:
+
+```bash
+curl http://localhost:8000/v1/videos \
+  -F model=ltx-2.5-mlx-q8 \
+  -F 'prompt=A red fox trots across fresh snow at golden hour' \
+  -F frames=97 \
+  -F fps=24 \
+  -F size=704x480
+```
+
+Text-to-video and image-to-video are supported. Frame counts must be `8n+1`;
+dimensions are rounded up to the runtime's required 32-pixel boundary and
+cropped back to the requested OpenAI size when necessary. The distilled path
+does not expose `guidance_scale` or `negative_prompt`.
 
 ## CogVideoX-Fun
 

--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -133,10 +133,12 @@ RAPID_MLX_LTX25_RUNTIME="$PWD/ltx-2-mlx/.venv/bin/ltx-2-mlx" \
 ```
 
 Rapid uses the executable only to locate and verify the source checkout: it
-must be the expected workspace entry point, with a clean tree, tracked lockfile,
-and the exact HEAD above. Generation runs through `uv --isolated --frozen`, so
-the mutable checkout `.venv` is never trusted or executed. Generations have a
-two-hour safety deadline; set
+must be the expected workspace entry point, with a tracked lockfile and the
+exact HEAD above. For every generation, Rapid materializes only the tracked
+files from that exact commit into a fresh temporary tree, then runs
+`uv --isolated --frozen`; checkout modifications, untracked files and the
+mutable checkout `.venv` are never executed. Generations have a two-hour safety
+deadline; set
 `RAPID_MLX_LTX25_TIMEOUT_SEC` to a larger value (minimum 60) for unusually
 large jobs.
 

--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -132,8 +132,9 @@ RAPID_MLX_LTX25_RUNTIME="$PWD/ltx-2-mlx/.venv/bin/ltx-2-mlx" \
   rapid-mlx serve ltx-2.5-mlx-q8
 ```
 
-Rapid verifies that this executable belongs to the exact commit above before
-starting. Generations have a two-hour safety deadline; set
+Rapid verifies that this executable is the expected workspace entry point, the
+checkout is clean, its lockfile is tracked, and HEAD is the exact commit above
+before starting. Generations have a two-hour safety deadline; set
 `RAPID_MLX_LTX25_TIMEOUT_SEC` to a larger value (minimum 60) for unusually
 large jobs.
 

--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -132,6 +132,11 @@ RAPID_MLX_LTX25_RUNTIME="$PWD/ltx-2-mlx/.venv/bin/ltx-2-mlx" \
   rapid-mlx serve ltx-2.5-mlx-q8
 ```
 
+Rapid verifies that this executable belongs to the exact commit above before
+starting. Generations have a two-hour safety deadline; set
+`RAPID_MLX_LTX25_TIMEOUT_SEC` to a larger value (minimum 60) for unusually
+large jobs.
+
 Create a job with the same API. LTX-2.5 generates synchronized audio and Rapid
 preserves that audio track:
 

--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -135,10 +135,11 @@ RAPID_MLX_LTX25_RUNTIME="$PWD/ltx-2-mlx/.venv/bin/ltx-2-mlx" \
 Rapid uses the executable only to locate and verify the source checkout: it
 must be the expected workspace entry point, with a tracked lockfile and the
 exact HEAD above. For every generation, Rapid materializes only the tracked
-files from that exact commit into a fresh temporary tree, then runs
-`uv --isolated --frozen`; checkout modifications, untracked files and the
-mutable checkout `.venv` are never executed. Generations have a two-hour safety
-deadline; set
+files from that exact commit into a process-private temporary tree and runs
+`uv sync --frozen` during startup preflight. Generations reuse that provisioned
+environment, so checkout modifications, untracked files and the mutable
+checkout `.venv` are never executed or rebuilt per request. Generations have a
+two-hour safety deadline; set
 `RAPID_MLX_LTX25_TIMEOUT_SEC` to a larger value (minimum 60) for unusually
 large jobs.
 

--- a/docs/guides/video-generation.md
+++ b/docs/guides/video-generation.md
@@ -132,9 +132,11 @@ RAPID_MLX_LTX25_RUNTIME="$PWD/ltx-2-mlx/.venv/bin/ltx-2-mlx" \
   rapid-mlx serve ltx-2.5-mlx-q8
 ```
 
-Rapid verifies that this executable is the expected workspace entry point, the
-checkout is clean, its lockfile is tracked, and HEAD is the exact commit above
-before starting. Generations have a two-hour safety deadline; set
+Rapid uses the executable only to locate and verify the source checkout: it
+must be the expected workspace entry point, with a clean tree, tracked lockfile,
+and the exact HEAD above. Generation runs through `uv --isolated --frozen`, so
+the mutable checkout `.venv` is never trusted or executed. Generations have a
+two-hour safety deadline; set
 `RAPID_MLX_LTX25_TIMEOUT_SEC` to a larger value (minimum 60) for unusually
 large jobs.
 

--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -384,7 +384,8 @@ def test_serve_dispatches_video_preflight(monkeypatch: pytest.MonkeyPatch) -> No
     class PreflightReachedError(RuntimeError):
         pass
 
-    def stop_at_preflight() -> None:
+    def stop_at_preflight(model_name: str) -> None:
+        assert model_name == "ltx-2.3-mlx-q4"
         raise PreflightReachedError
 
     monkeypatch.setattr(video_lane, "require_video_runtime_or_exit", stop_at_preflight)

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -44,6 +44,24 @@ def test_ltx25_capabilities_match_distilled_controls() -> None:
     }
 
 
+def test_ltx25_direct_engine_rejects_conditioning_without_image() -> None:
+    engine = VideoEngine.__new__(VideoEngine)
+    engine._ltx25_engine = object()
+
+    with pytest.raises(VideoRuntimeError, match="requires an input image"):
+        engine.generate(
+            prompt="fox",
+            output_path=Path("unused.mp4"),
+            width=704,
+            height=480,
+            num_frames=97,
+            fps=24,
+            seed=7,
+            image=None,
+            conditioning_strength=0.5,
+        )
+
+
 def test_ltx25_runtime_preflight_fails_before_download(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -1,0 +1,234 @@
+"""LTX-2.5 external MLX runtime integration tests."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from vllm_mlx.model_aliases import resolve_profile
+from vllm_mlx.runtime import video_lane
+from vllm_mlx.runtime.video_lane import VideoEngine, VideoRuntimeError
+from vllm_mlx.video import ltx25
+
+
+def test_ltx25_alias_routes_to_video_lane() -> None:
+    profile = resolve_profile("ltx-2.5-mlx-q8")
+    assert profile is not None
+    assert profile.hf_path == "MrMofer/ltx-2.5-mlx-q8"
+    assert profile.modality == "video-gen"
+    assert profile.min_memory_gb == 24
+
+
+def test_ltx25_capabilities_match_distilled_controls() -> None:
+    from vllm_mlx.routes.video import _video_capabilities
+
+    capabilities = _video_capabilities(
+        SimpleNamespace(model_name="MrMofer/ltx-2.5-mlx-q8", video_family="ltx-2.5")
+    )
+    assert capabilities["family"] == "ltx-2.5"
+    assert capabilities["limits"]["size"]["width"]["multiple_of"] == 32
+    assert capabilities["limits"]["workload"]["dimension_rounding"] == "ceil_to_32"
+    assert capabilities["controls"]["guidance_scale"] is None
+    assert capabilities["controls"]["negative_prompt"] is False
+    assert capabilities["controls"]["conditioning_strength"] == {
+        "minimum": 0.0,
+        "maximum": 1.0,
+    }
+
+
+def test_ltx25_runtime_preflight_fails_before_download(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: None)
+    monkeypatch.setattr(
+        video_lane, "_resolve_ffmpeg", lambda: "/opt/homebrew/bin/ffmpeg"
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        video_lane.require_video_runtime_or_exit("MrMofer/ltx-2.5-mlx-q8")
+
+    error = capsys.readouterr().err
+    assert ltx25.LTX25_RUNTIME_COMMIT in error
+    assert "video generation guide" in error
+
+
+def test_ltx25_runtime_override_must_be_executable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = tmp_path / "ltx-2-mlx"
+    runtime.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("RAPID_MLX_LTX25_RUNTIME", str(runtime))
+    monkeypatch.setattr(
+        ltx25.shutil,
+        "which",
+        lambda _: pytest.fail(
+            "an invalid explicit override must not fall back to PATH"
+        ),
+    )
+
+    assert ltx25.resolve_ltx25_runtime() is None
+
+    runtime.chmod(0o755)
+    assert ltx25.resolve_ltx25_runtime() == str(runtime)
+
+
+def test_serve_routes_ltx25_model_to_specific_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx import cli
+
+    class PreflightReachedError(RuntimeError):
+        pass
+
+    def stop_at_preflight(model_name: str) -> None:
+        assert model_name == "ltx-2.5-mlx-q8"
+        raise PreflightReachedError
+
+    monkeypatch.setattr(video_lane, "require_video_runtime_or_exit", stop_at_preflight)
+    args = SimpleNamespace(model="ltx-2.5-mlx-q8", max_tokens=None, watchdog_ppid=None)
+    with pytest.raises(PreflightReachedError):
+        cli.serve_command(args)
+
+
+def test_ltx25_engine_invokes_pinned_runtime_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "result.mp4"
+    image = tmp_path / "reference.png"
+    image.write_bytes(b"png")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: "/trusted/ltx-2-mlx")
+
+    def run(command: list[str], **kwargs) -> None:
+        calls.append(command)
+        output.write_bytes(b"mp4-with-audio")
+
+    monkeypatch.setattr(ltx25.subprocess, "run", run)
+    ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8").generate(
+        prompt="a fox",
+        output_path=output,
+        width=704,
+        height=480,
+        num_frames=97,
+        fps=24,
+        seed=7,
+        image=image,
+        conditioning_strength=0.6,
+    )
+
+    command = calls[0]
+    assert command[0] == "/trusted/ltx-2-mlx"
+    assert command[1:3] == ["generate", "--model"]
+    assert "--distilled" in command
+    assert "--low-ram" in command
+    assert command[command.index("--image") + 1 :] == [str(image), "0", "0.6"]
+    assert output.read_bytes() == b"mp4-with-audio"
+
+
+def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: "/trusted/ltx-2-mlx")
+
+    def fail(*args, **kwargs) -> None:
+        raise subprocess.CalledProcessError(1, ["ltx-2-mlx"], stderr="secret")
+
+    monkeypatch.setattr(ltx25.subprocess, "run", fail)
+    engine = ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8")
+    with pytest.raises(ltx25.LTX25BackendError) as exc:
+        engine.generate(
+            prompt="a fox",
+            output_path=tmp_path / "result.mp4",
+            width=704,
+            height=480,
+            num_frames=97,
+            fps=24,
+            seed=7,
+            image=None,
+        )
+    assert "secret" not in str(exc.value)
+
+
+def test_video_engine_selects_ltx25_and_preserves_generated_audio(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = {}
+
+    def generate(self, **kwargs) -> None:
+        captured.update(kwargs)
+        kwargs["output_path"].write_bytes(b"mp4-with-audio")
+
+    monkeypatch.setattr(ltx25.LTX25VideoEngine, "generate", generate)
+    monkeypatch.setattr(
+        VideoEngine,
+        "_crop_generated_output",
+        lambda *args, **kwargs: captured.update(crop=kwargs),
+    )
+    engine = VideoEngine("MrMofer/ltx-2.5-mlx-q8")
+    output = tmp_path / "result.mp4"
+    engine.generate(
+        prompt="a fox",
+        output_path=output,
+        width=704,
+        height=512,
+        num_frames=97,
+        fps=24,
+        seed=7,
+        image=None,
+    )
+
+    assert engine.video_family == "ltx-2.5"
+    assert output.read_bytes() == b"mp4-with-audio"
+    assert captured["crop"]["family"] == "LTX-2.5"
+
+
+def test_ltx25_distilled_rejects_cfg_controls() -> None:
+    engine = VideoEngine("MrMofer/ltx-2.5-mlx-q8")
+    with pytest.raises(VideoRuntimeError, match="does not support"):
+        engine.generate(
+            prompt="a fox",
+            output_path=Path("result.mp4"),
+            width=704,
+            height=480,
+            num_frames=97,
+            fps=24,
+            seed=7,
+            image=None,
+            guidance_scale=4.0,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "unsupported",
+    [{"guidance_scale": 4.0}, {"negative_prompt": "blurry"}],
+)
+async def test_ltx25_route_rejects_unsupported_cfg_before_queueing(
+    monkeypatch: pytest.MonkeyPatch, unsupported: dict[str, object]
+) -> None:
+    from vllm_mlx.routes import video
+
+    engine = SimpleNamespace(
+        model_name="MrMofer/ltx-2.5-mlx-q8", video_family="ltx-2.5"
+    )
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+    monkeypatch.setattr(video, "_accepting_jobs", True)
+    before = set(video._jobs)
+
+    with pytest.raises(HTTPException, match="does not support") as exc:
+        await video.create_video(
+            prompt="a fox",
+            model="ltx-2.5-mlx-q8",
+            seconds="1",
+            size="704x512",
+            seed=7,
+            input_reference=None,
+            **unsupported,
+        )
+
+    assert exc.value.status_code == 400
+    assert set(video._jobs) == before

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -100,11 +101,18 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     output = tmp_path / "result.mp4"
     image = tmp_path / "reference.png"
     image.write_bytes(b"png")
-    calls: list[list[str]] = []
-    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: "/trusted/ltx-2-mlx")
+    calls: list[tuple[list[str], dict]] = []
+    runtime = tmp_path / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir()
+    runtime.write_text("#!/bin/sh\n")
+    runtime.chmod(0o755)
+    runtime_python = runtime.with_name("python")
+    runtime_python.write_text("#!/bin/sh\n")
+    runtime_python.chmod(0o755)
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
 
     def run(command: list[str], **kwargs) -> None:
-        calls.append(command)
+        calls.append((command, kwargs))
         output.write_bytes(b"mp4-with-audio")
 
     monkeypatch.setattr(ltx25.subprocess, "run", run)
@@ -120,19 +128,28 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
         conditioning_strength=0.6,
     )
 
-    command = calls[0]
-    assert command[0] == "/trusted/ltx-2-mlx"
-    assert command[1:3] == ["generate", "--model"]
+    command, run_kwargs = calls[0]
+    assert command[0] == str(runtime_python)
+    assert command[1] == "-c"
+    assert command[3:5] == ["generate", "--model"]
     assert "--distilled" in command
     assert "--low-ram" in command
+    assert "a fox" not in command
     assert command[command.index("--image") + 1 :] == [str(image), "0", "0.6"]
+    assert run_kwargs == {"check": True, "input": "a fox", "text": True}
     assert output.read_bytes() == b"mp4-with-audio"
 
 
 def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: "/trusted/ltx-2-mlx")
+    runtime = tmp_path / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir()
+    runtime.write_text("#!/bin/sh\n")
+    runtime.chmod(0o755)
+    runtime.with_name("python").write_text("#!/bin/sh\n")
+    runtime.with_name("python").chmod(0o755)
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
 
     def fail(*args, **kwargs) -> None:
         raise subprocess.CalledProcessError(1, ["ltx-2-mlx"], stderr="secret")
@@ -184,6 +201,66 @@ def test_video_engine_selects_ltx25_and_preserves_generated_audio(
     assert engine.video_family == "ltx-2.5"
     assert output.read_bytes() == b"mp4-with-audio"
     assert captured["crop"]["family"] == "LTX-2.5"
+
+
+def test_ltx25_real_crop_preserves_audio_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ffmpeg = video_lane._resolve_ffmpeg()
+    ffprobe = shutil.which("ffprobe")
+    if ffmpeg is None or ffprobe is None:
+        pytest.skip("ffmpeg and ffprobe are required for the real media assertion")
+    output = tmp_path / "with-audio.mp4"
+    subprocess.run(
+        [
+            ffmpeg,
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:s=64x64:d=0.2",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=1000:duration=0.2",
+            "-c:v",
+            "libx264",
+            "-c:a",
+            "aac",
+            "-shortest",
+            str(output),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    VideoEngine._crop_generated_output(
+        output_path=output,
+        width=64,
+        height=64,
+        output_width=32,
+        output_height=32,
+        family="LTX-2.5",
+    )
+    streams = subprocess.run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert streams.stdout.strip() == "audio"
 
 
 def test_ltx25_distilled_rejects_cfg_controls() -> None:

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -64,6 +64,9 @@ def test_ltx25_runtime_override_must_be_executable(
     runtime.write_text("#!/bin/sh\n")
     monkeypatch.setenv("RAPID_MLX_LTX25_RUNTIME", str(runtime))
     monkeypatch.setattr(
+        ltx25, "_runtime_revision", lambda _: ltx25.LTX25_RUNTIME_COMMIT
+    )
+    monkeypatch.setattr(
         ltx25.shutil,
         "which",
         lambda _: pytest.fail(
@@ -75,6 +78,19 @@ def test_ltx25_runtime_override_must_be_executable(
 
     runtime.chmod(0o755)
     assert ltx25.resolve_ltx25_runtime() == str(runtime)
+
+
+def test_ltx25_runtime_rejects_unpinned_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = tmp_path / ".venv" / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text("#!/bin/sh\n")
+    runtime.chmod(0o755)
+    monkeypatch.setenv("RAPID_MLX_LTX25_RUNTIME", str(runtime))
+    monkeypatch.setattr(ltx25, "_runtime_revision", lambda _: "wrong-revision")
+
+    assert ltx25.resolve_ltx25_runtime() is None
 
 
 def test_serve_routes_ltx25_model_to_specific_preflight(
@@ -102,6 +118,7 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     image = tmp_path / "reference.png"
     image.write_bytes(b"png")
     calls: list[tuple[list[str], dict]] = []
+    communicates: list[tuple[str, int]] = []
     runtime = tmp_path / "bin" / "ltx-2-mlx"
     runtime.parent.mkdir()
     runtime.write_text("#!/bin/sh\n")
@@ -111,11 +128,17 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     runtime_python.chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
 
-    def run(command: list[str], **kwargs) -> None:
-        calls.append((command, kwargs))
-        output.write_bytes(b"mp4-with-audio")
+    class Process:
+        returncode = 0
 
-    monkeypatch.setattr(ltx25.subprocess, "run", run)
+        def __init__(self, command: list[str], **kwargs) -> None:
+            calls.append((command, kwargs))
+
+        def communicate(self, *, input: str, timeout: int) -> None:
+            communicates.append((input, timeout))
+            output.write_bytes(b"mp4-with-audio")
+
+    monkeypatch.setattr(ltx25.subprocess, "Popen", Process)
     ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8").generate(
         prompt="a fox",
         output_path=output,
@@ -136,7 +159,8 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     assert "--low-ram" in command
     assert "a fox" not in command
     assert command[command.index("--image") + 1 :] == [str(image), "0", "0.6"]
-    assert run_kwargs == {"check": True, "input": "a fox", "text": True}
+    assert run_kwargs == {"stdin": subprocess.PIPE, "text": True}
+    assert communicates == [("a fox", 7200)]
     assert output.read_bytes() == b"mp4-with-audio"
 
 
@@ -151,10 +175,16 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
     runtime.with_name("python").chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
 
-    def fail(*args, **kwargs) -> None:
-        raise subprocess.CalledProcessError(1, ["ltx-2-mlx"], stderr="secret")
+    class Process:
+        returncode = 1
 
-    monkeypatch.setattr(ltx25.subprocess, "run", fail)
+        def __init__(self, command: list[str], **kwargs) -> None:
+            pass
+
+        def communicate(self, *, input: str, timeout: int) -> None:
+            pass
+
+    monkeypatch.setattr(ltx25.subprocess, "Popen", Process)
     engine = ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8")
     with pytest.raises(ltx25.LTX25BackendError) as exc:
         engine.generate(
@@ -168,6 +198,52 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
             image=None,
         )
     assert "secret" not in str(exc.value)
+
+
+def test_ltx25_timeout_terminates_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = tmp_path / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir()
+    runtime.write_text("#!/bin/sh\n")
+    runtime.chmod(0o755)
+    runtime.with_name("python").write_text("#!/bin/sh\n")
+    runtime.with_name("python").chmod(0o755)
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
+    terminated = []
+
+    class Process:
+        returncode = None
+
+        def __init__(self, command: list[str], **kwargs) -> None:
+            pass
+
+        def communicate(self, *, input: str, timeout: int) -> None:
+            raise subprocess.TimeoutExpired("ltx-2-mlx", timeout)
+
+    process = Process([], stdin=subprocess.PIPE, text=True)
+    monkeypatch.setattr(ltx25.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(
+        ltx25.LTX25VideoEngine,
+        "_terminate_process",
+        staticmethod(lambda candidate: terminated.append(candidate)),
+    )
+    engine = ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8")
+
+    with pytest.raises(ltx25.LTX25BackendError, match="time limit"):
+        engine.generate(
+            prompt="a fox",
+            output_path=tmp_path / "result.mp4",
+            width=704,
+            height=480,
+            num_frames=97,
+            fps=24,
+            seed=7,
+            image=None,
+        )
+
+    assert terminated == [process]
+    assert engine._process is None
 
 
 def test_video_engine_selects_ltx25_and_preserves_generated_audio(

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -142,14 +142,15 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     image.write_bytes(b"png")
     calls: list[tuple[list[str], dict]] = []
     communicates: list[tuple[str, int]] = []
-    runtime = tmp_path / "bin" / "ltx-2-mlx"
-    runtime.parent.mkdir()
+    runtime = tmp_path / ".venv" / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir(parents=True)
     runtime.write_text("#!/bin/sh\n")
     runtime.chmod(0o755)
     runtime_python = runtime.with_name("python")
     runtime_python.write_text("#!/bin/sh\n")
     runtime_python.chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
+    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
 
     class Process:
         returncode = 0
@@ -176,9 +177,17 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     )
 
     command, run_kwargs = calls[0]
-    assert command[0] == str(runtime_python)
-    assert command[1] == "-c"
-    assert command[3:5] == ["generate", "--model"]
+    assert command[:7] == [
+        "/trusted/uv",
+        "run",
+        "--isolated",
+        "--frozen",
+        "--project",
+        str(tmp_path),
+        "python",
+    ]
+    assert command[7] == "-c"
+    assert command[9:11] == ["generate", "--model"]
     assert "--distilled" in command
     assert "--low-ram" in command
     assert "a fox" not in command
@@ -188,6 +197,7 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "text": True,
+        "start_new_session": True,
     }
     assert communicates == [("a fox", 7200)]
     assert output.read_bytes() == b"mp4-with-audio"
@@ -196,13 +206,14 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
 def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    runtime = tmp_path / "bin" / "ltx-2-mlx"
-    runtime.parent.mkdir()
+    runtime = tmp_path / ".venv" / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir(parents=True)
     runtime.write_text("#!/bin/sh\n")
     runtime.chmod(0o755)
     runtime.with_name("python").write_text("#!/bin/sh\n")
     runtime.with_name("python").chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
+    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
 
     class Process:
         returncode = 1
@@ -227,7 +238,8 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
             image=None,
         )
     assert str(exc.value) == (
-        "LTX-2.5 generation failed; check the server logs for runtime details."
+        "LTX-2.5 runtime exited with code 1; runtime output is not retained "
+        "because it may contain request data."
     )
     assert "private-output-sentinel" not in str(exc.value)
     assert "private-error-sentinel" not in str(exc.value)
@@ -236,13 +248,14 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
 def test_ltx25_timeout_terminates_process(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    runtime = tmp_path / "bin" / "ltx-2-mlx"
-    runtime.parent.mkdir()
+    runtime = tmp_path / ".venv" / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir(parents=True)
     runtime.write_text("#!/bin/sh\n")
     runtime.chmod(0o755)
     runtime.with_name("python").write_text("#!/bin/sh\n")
     runtime.with_name("python").chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
+    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
     terminated = []
 
     class Process:
@@ -282,13 +295,14 @@ def test_ltx25_timeout_terminates_process(
 def test_ltx25_invalid_timeout_does_not_spawn(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    runtime = tmp_path / "bin" / "ltx-2-mlx"
-    runtime.parent.mkdir()
+    runtime = tmp_path / ".venv" / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir(parents=True)
     runtime.write_text("#!/bin/sh\n")
     runtime.chmod(0o755)
     runtime.with_name("python").write_text("#!/bin/sh\n")
     runtime.with_name("python").chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
+    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
     monkeypatch.setenv("RAPID_MLX_LTX25_TIMEOUT_SEC", "invalid")
     monkeypatch.setattr(
         ltx25.subprocess,

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -24,6 +24,7 @@ def test_ltx25_alias_routes_to_video_lane() -> None:
     assert profile.hf_path == "MrMofer/ltx-2.5-mlx-q8"
     assert profile.modality == "video-gen"
     assert profile.min_memory_gb == 24
+    assert ltx25.is_ltx25_model("org/my-ltx25-experiment") is False
 
 
 def test_ltx25_capabilities_match_distilled_controls() -> None:

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -94,7 +94,7 @@ def test_ltx25_runtime_rejects_unpinned_checkout(
     assert ltx25.resolve_ltx25_runtime() is None
 
 
-def test_ltx25_materialization_excludes_untracked_files(
+def test_ltx25_materialization_ignores_checkout_and_replace_refs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -128,6 +128,31 @@ def test_ltx25_materialization_excludes_untracked_files(
     ).stdout.strip()
     subprocess.run(
         ["git", "-C", str(repository), "update-ref", "HEAD", commit], check=True
+    )
+    tracked.write_text("raise RuntimeError('replaced')\n")
+    subprocess.run(["git", "-C", str(repository), "add", "tracked.py"], check=True)
+    replacement_tree = subprocess.run(
+        ["git", "-C", str(repository), "write-tree"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    replacement_commit = subprocess.run(
+        ["git", "-C", str(repository), "commit-tree", replacement_tree, "-m", "evil"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(repository), "replace", commit, replacement_commit],
+        check=True,
     )
     (repository / "untracked.py").write_text("raise RuntimeError('unsafe')\n")
     destination = tmp_path / "snapshot"

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -93,27 +94,50 @@ def test_ltx25_runtime_rejects_unpinned_checkout(
     assert ltx25.resolve_ltx25_runtime() is None
 
 
-def test_ltx25_runtime_rejects_dirty_checkout(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_ltx25_materialization_excludes_untracked_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repository = tmp_path / "runtime"
-    runtime = repository / ".venv" / "bin" / "ltx-2-mlx"
-    runtime.parent.mkdir(parents=True)
-    runtime.write_text("#!/bin/sh\n")
-    runtime.chmod(0o755)
-    (repository / ".git").mkdir()
+    repository.mkdir()
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    tracked = repository / "tracked.py"
+    tracked.write_text("safe = True\n")
+    (repository / "uv.lock").write_text("version = 1\n")
+    subprocess.run(
+        ["git", "-C", str(repository), "add", "tracked.py", "uv.lock"], check=True
+    )
+    tree = subprocess.run(
+        ["git", "-C", str(repository), "write-tree"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    commit = subprocess.run(
+        ["git", "-C", str(repository), "commit-tree", tree, "-m", "fixture"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(repository), "update-ref", "HEAD", commit], check=True
+    )
+    (repository / "untracked.py").write_text("raise RuntimeError('unsafe')\n")
+    destination = tmp_path / "snapshot"
+    destination.mkdir()
 
-    def git(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
-        if "rev-parse" in command:
-            stdout = ltx25.LTX25_RUNTIME_COMMIT + "\n"
-        elif "status" in command:
-            stdout = " M packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py\n"
-        else:
-            raise AssertionError(command)
-        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+    monkeypatch.setattr(ltx25, "LTX25_RUNTIME_COMMIT", commit)
+    ltx25._materialize_runtime(repository, destination)
 
-    monkeypatch.setattr(ltx25.subprocess, "run", git)
-    assert ltx25._runtime_revision(str(runtime)) is None
+    assert (destination / "tracked.py").read_text() == "safe = True\n"
+    assert not (destination / "untracked.py").exists()
 
 
 def test_serve_routes_ltx25_model_to_specific_preflight(
@@ -151,6 +175,7 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     runtime_python.chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
     monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
+    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
 
     class Process:
         returncode = 0
@@ -177,16 +202,15 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     )
 
     command, run_kwargs = calls[0]
-    assert command[:7] == [
+    assert command[:5] == [
         "/trusted/uv",
         "run",
         "--isolated",
         "--frozen",
         "--project",
-        str(tmp_path),
-        "python",
     ]
-    assert command[7] == "-c"
+    assert Path(command[5]).name.startswith("rapidmlx-ltx25-runtime-")
+    assert command[6:8] == ["python", "-c"]
     assert command[9:11] == ["generate", "--model"]
     assert "--distilled" in command
     assert "--low-ram" in command
@@ -194,8 +218,8 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     assert command[command.index("--image") + 1 :] == [str(image), "0", "0.6"]
     assert run_kwargs == {
         "stdin": subprocess.PIPE,
-        "stdout": subprocess.PIPE,
-        "stderr": subprocess.PIPE,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
         "text": True,
         "start_new_session": True,
     }
@@ -214,6 +238,7 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
     runtime.with_name("python").chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
     monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
+    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
 
     class Process:
         returncode = 1
@@ -256,6 +281,7 @@ def test_ltx25_timeout_terminates_process(
     runtime.with_name("python").chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
     monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
+    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
     terminated = []
 
     class Process:

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -275,6 +276,12 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
             return "private-output-sentinel", "private-error-sentinel"
 
     monkeypatch.setattr(ltx25.subprocess, "Popen", Process)
+    terminated = []
+    monkeypatch.setattr(
+        ltx25.LTX25VideoEngine,
+        "_terminate_process",
+        staticmethod(lambda candidate: terminated.append(candidate)),
+    )
     engine = ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8")
     with pytest.raises(ltx25.LTX25BackendError) as exc:
         engine.generate(
@@ -293,6 +300,7 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
     )
     assert "private-output-sentinel" not in str(exc.value)
     assert "private-error-sentinel" not in str(exc.value)
+    assert len(terminated) == 1
 
 
 def test_ltx25_timeout_terminates_process(
@@ -341,6 +349,27 @@ def test_ltx25_timeout_terminates_process(
 
     assert terminated == [process]
     assert engine._process is None
+
+
+def test_ltx25_termination_kills_group_after_leader_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signals = []
+
+    class Process:
+        pid = 123
+
+        def poll(self) -> int:
+            return 1
+
+        def wait(self, *, timeout: int) -> None:
+            pytest.fail("an exited group leader must not be waited on again")
+
+    monkeypatch.setattr(ltx25.os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+
+    ltx25.LTX25VideoEngine._terminate_process(Process())  # type: ignore[arg-type]
+
+    assert signals == [(123, signal.SIGTERM), (123, signal.SIGKILL)]
 
 
 def test_ltx25_unexpected_communication_error_terminates_process(

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -453,7 +453,7 @@ def test_ltx25_timeout_terminates_process(
     assert engine._process is None
 
 
-def test_ltx25_termination_kills_group_after_leader_exits(
+def test_ltx25_termination_does_not_reuse_exited_leader_pgid(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     signals = []
@@ -471,7 +471,34 @@ def test_ltx25_termination_kills_group_after_leader_exits(
 
     ltx25.LTX25VideoEngine._terminate_process(Process())  # type: ignore[arg-type]
 
+    assert signals == [(123, signal.SIGTERM)]
+
+
+def test_ltx25_termination_escalates_while_leader_is_unreaped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signals = []
+
+    class Process:
+        pid = 123
+        waits = 0
+
+        def poll(self) -> None:
+            return None
+
+        def wait(self, *, timeout: int) -> int:
+            self.waits += 1
+            if self.waits == 1:
+                raise subprocess.TimeoutExpired("ltx", timeout)
+            return -signal.SIGKILL
+
+    process = Process()
+    monkeypatch.setattr(ltx25.os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+
+    ltx25.LTX25VideoEngine._terminate_process(process)  # type: ignore[arg-type]
+
     assert signals == [(123, signal.SIGTERM), (123, signal.SIGKILL)]
+    assert process.waits == 2
 
 
 def test_ltx25_unexpected_communication_error_terminates_process(

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -50,6 +50,7 @@ def test_ltx25_runtime_preflight_fails_before_download(
     monkeypatch.setattr(
         video_lane, "_resolve_ffmpeg", lambda: "/opt/homebrew/bin/ffmpeg"
     )
+    monkeypatch.setattr(video_lane.shutil, "which", lambda name: "/usr/bin/uv")
 
     with pytest.raises(SystemExit, match="2"):
         video_lane.require_video_runtime_or_exit("MrMofer/ltx-2.5-mlx-q8")
@@ -57,6 +58,19 @@ def test_ltx25_runtime_preflight_fails_before_download(
     error = capsys.readouterr().err
     assert ltx25.LTX25_RUNTIME_COMMIT in error
     assert "video generation guide" in error
+
+
+def test_ltx25_runtime_preflight_requires_uv(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: "/runtime/ltx-2-mlx")
+    monkeypatch.setattr(video_lane, "_resolve_ffmpeg", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(video_lane.shutil, "which", lambda name: None)
+
+    with pytest.raises(SystemExit, match="2"):
+        video_lane.require_video_runtime_or_exit("MrMofer/ltx-2.5-mlx-q8")
+
+    assert "uv (`brew install uv`)" in capsys.readouterr().err
 
 
 def test_ltx25_runtime_override_must_be_executable(
@@ -164,6 +178,16 @@ def test_ltx25_materialization_ignores_checkout_and_replace_refs(
 
     assert (destination / "tracked.py").read_text() == "safe = True\n"
     assert not (destination / "untracked.py").exists()
+
+
+def test_ltx25_materialization_wraps_malformed_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    malformed = subprocess.CompletedProcess([], 0, stdout=b"not a tar", stderr=b"")
+    monkeypatch.setattr(ltx25.subprocess, "run", lambda *args, **kwargs: malformed)
+
+    with pytest.raises(ltx25.LTX25BackendError, match="could not be materialized"):
+        ltx25._materialize_runtime(tmp_path, tmp_path / "snapshot")
 
 
 def test_serve_routes_ltx25_model_to_specific_preflight(

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -207,11 +207,13 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
         returncode = 0
 
         def __init__(self, command: list[str], **kwargs) -> None:
+            self.command = command
             calls.append((command, kwargs))
 
         def communicate(self, *, input: str, timeout: int) -> tuple[str, str]:
             communicates.append((input, timeout))
-            output.write_bytes(b"mp4-with-audio")
+            generated = Path(self.command[self.command.index("--output") + 1])
+            generated.write_bytes(b"mp4-with-audio")
             return "", ""
 
     monkeypatch.setattr(ltx25.subprocess, "Popen", Process)
@@ -238,6 +240,10 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     assert Path(command[5]).name.startswith("rapidmlx-ltx25-runtime-")
     assert command[6:8] == ["python", "-c"]
     assert command[9:11] == ["generate", "--model"]
+    generated = Path(command[command.index("--output") + 1])
+    assert generated != output
+    assert generated.parent == output.parent
+    assert output.read_bytes() == b"mp4-with-audio"
     assert "--distilled" in command
     assert "--low-ram" in command
     assert "a fox" not in command
@@ -300,6 +306,53 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
     )
     assert "private-output-sentinel" not in str(exc.value)
     assert "private-error-sentinel" not in str(exc.value)
+    assert len(terminated) == 1
+
+
+def test_ltx25_zero_exit_cannot_reuse_stale_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "result.mp4"
+    output.write_bytes(b"stale-video")
+    runtime = tmp_path / ".venv" / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text("#!/bin/sh\n")
+    runtime.chmod(0o755)
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
+    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
+    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
+
+    class Process:
+        returncode = 0
+
+        def __init__(self, command: list[str], **kwargs) -> None:
+            pass
+
+        def communicate(self, *, input: str, timeout: int) -> tuple[str, str]:
+            return "", ""
+
+    monkeypatch.setattr(ltx25.subprocess, "Popen", Process)
+    terminated = []
+    monkeypatch.setattr(
+        ltx25.LTX25VideoEngine,
+        "_terminate_process",
+        staticmethod(lambda candidate: terminated.append(candidate)),
+    )
+
+    with pytest.raises(ltx25.LTX25BackendError, match="without an MP4 output"):
+        ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8").generate(
+            prompt="a fox",
+            output_path=output,
+            width=704,
+            height=480,
+            num_frames=97,
+            fps=24,
+            seed=7,
+            image=None,
+        )
+
+    assert output.read_bytes() == b"stale-video"
+    assert list(tmp_path.glob(".result.mp4.*.tmp.mp4")) == []
     assert len(terminated) == 1
 
 

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -318,6 +318,52 @@ def test_ltx25_timeout_terminates_process(
     assert engine._process is None
 
 
+def test_ltx25_unexpected_communication_error_terminates_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = tmp_path / ".venv" / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text("#!/bin/sh\n")
+    runtime.chmod(0o755)
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
+    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
+    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
+    terminated = []
+
+    class Process:
+        returncode = None
+
+        def communicate(self, *, input: str, timeout: int) -> None:
+            raise UnicodeEncodeError("utf-8", "bad surrogate \ud800", 14, 15, "invalid")
+
+        def poll(self) -> None:
+            return None
+
+    process = Process()
+    monkeypatch.setattr(ltx25.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(
+        ltx25.LTX25VideoEngine,
+        "_terminate_process",
+        staticmethod(lambda candidate: terminated.append(candidate)),
+    )
+    engine = ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8")
+
+    with pytest.raises(ltx25.LTX25BackendError, match="isolated runtime"):
+        engine.generate(
+            prompt="bad surrogate \ud800",
+            output_path=tmp_path / "result.mp4",
+            width=704,
+            height=480,
+            num_frames=97,
+            fps=24,
+            seed=7,
+            image=None,
+        )
+
+    assert terminated == [process]
+    assert engine._process is None
+
+
 def test_ltx25_invalid_timeout_does_not_spawn(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -93,6 +93,29 @@ def test_ltx25_runtime_rejects_unpinned_checkout(
     assert ltx25.resolve_ltx25_runtime() is None
 
 
+def test_ltx25_runtime_rejects_dirty_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = tmp_path / "runtime"
+    runtime = repository / ".venv" / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text("#!/bin/sh\n")
+    runtime.chmod(0o755)
+    (repository / ".git").mkdir()
+
+    def git(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        if "rev-parse" in command:
+            stdout = ltx25.LTX25_RUNTIME_COMMIT + "\n"
+        elif "status" in command:
+            stdout = " M packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py\n"
+        else:
+            raise AssertionError(command)
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(ltx25.subprocess, "run", git)
+    assert ltx25._runtime_revision(str(runtime)) is None
+
+
 def test_serve_routes_ltx25_model_to_specific_preflight(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -134,9 +157,10 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
         def __init__(self, command: list[str], **kwargs) -> None:
             calls.append((command, kwargs))
 
-        def communicate(self, *, input: str, timeout: int) -> None:
+        def communicate(self, *, input: str, timeout: int) -> tuple[str, str]:
             communicates.append((input, timeout))
             output.write_bytes(b"mp4-with-audio")
+            return "", ""
 
     monkeypatch.setattr(ltx25.subprocess, "Popen", Process)
     ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8").generate(
@@ -159,7 +183,12 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     assert "--low-ram" in command
     assert "a fox" not in command
     assert command[command.index("--image") + 1 :] == [str(image), "0", "0.6"]
-    assert run_kwargs == {"stdin": subprocess.PIPE, "text": True}
+    assert run_kwargs == {
+        "stdin": subprocess.PIPE,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+    }
     assert communicates == [("a fox", 7200)]
     assert output.read_bytes() == b"mp4-with-audio"
 
@@ -181,8 +210,8 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
         def __init__(self, command: list[str], **kwargs) -> None:
             pass
 
-        def communicate(self, *, input: str, timeout: int) -> None:
-            pass
+        def communicate(self, *, input: str, timeout: int) -> tuple[str, str]:
+            return "private-output-sentinel", "private-error-sentinel"
 
     monkeypatch.setattr(ltx25.subprocess, "Popen", Process)
     engine = ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8")
@@ -197,7 +226,11 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
             seed=7,
             image=None,
         )
-    assert "secret" not in str(exc.value)
+    assert str(exc.value) == (
+        "LTX-2.5 generation failed; check the server logs for runtime details."
+    )
+    assert "private-output-sentinel" not in str(exc.value)
+    assert "private-error-sentinel" not in str(exc.value)
 
 
 def test_ltx25_timeout_terminates_process(
@@ -244,6 +277,36 @@ def test_ltx25_timeout_terminates_process(
 
     assert terminated == [process]
     assert engine._process is None
+
+
+def test_ltx25_invalid_timeout_does_not_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = tmp_path / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir()
+    runtime.write_text("#!/bin/sh\n")
+    runtime.chmod(0o755)
+    runtime.with_name("python").write_text("#!/bin/sh\n")
+    runtime.with_name("python").chmod(0o755)
+    monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
+    monkeypatch.setenv("RAPID_MLX_LTX25_TIMEOUT_SEC", "invalid")
+    monkeypatch.setattr(
+        ltx25.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("invalid config must fail before spawn"),
+    )
+
+    with pytest.raises(ltx25.LTX25BackendError, match="integer"):
+        ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8").generate(
+            prompt="a fox",
+            output_path=tmp_path / "result.mp4",
+            width=704,
+            height=480,
+            num_frames=97,
+            fps=24,
+            seed=7,
+            image=None,
+        )
 
 
 def test_video_engine_selects_ltx25_and_preserves_generated_audio(

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -190,6 +190,35 @@ def test_ltx25_materialization_wraps_malformed_archive(
         ltx25._materialize_runtime(tmp_path, tmp_path / "snapshot")
 
 
+def test_ltx25_runtime_is_provisioned_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = tmp_path / "checkout" / ".venv" / "bin" / "ltx-2-mlx"
+    runtime.parent.mkdir(parents=True)
+    calls = []
+    monkeypatch.setattr(ltx25, "_RUNTIME_CACHE", None)
+    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
+    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
+
+    def provision(command: list[str], **kwargs) -> subprocess.CompletedProcess:
+        calls.append((command, kwargs))
+        workspace = Path(command[command.index("--project") + 1])
+        interpreter = workspace / ".venv/bin/python"
+        interpreter.parent.mkdir(parents=True)
+        interpreter.write_text("#!/bin/sh\n")
+        interpreter.chmod(0o755)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(ltx25.subprocess, "run", provision)
+
+    first = ltx25.prepare_ltx25_runtime(str(runtime))
+    second = ltx25.prepare_ltx25_runtime(str(runtime))
+
+    assert first == second
+    assert len(calls) == 1
+    assert calls[0][0][:3] == ["/trusted/uv", "sync", "--frozen"]
+
+
 def test_serve_routes_ltx25_model_to_specific_preflight(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -224,8 +253,8 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     runtime_python.write_text("#!/bin/sh\n")
     runtime_python.chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
-    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
-    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
+    runtime_cache = tmp_path / "runtime-cache"
+    monkeypatch.setattr(ltx25, "prepare_ltx25_runtime", lambda _: runtime_cache)
 
     class Process:
         returncode = 0
@@ -254,16 +283,9 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     )
 
     command, run_kwargs = calls[0]
-    assert command[:5] == [
-        "/trusted/uv",
-        "run",
-        "--isolated",
-        "--frozen",
-        "--project",
-    ]
-    assert Path(command[5]).name.startswith("rapidmlx-ltx25-runtime-")
-    assert command[6:8] == ["python", "-c"]
-    assert command[9:11] == ["generate", "--model"]
+    assert command[:2] == [str(runtime_cache / ".venv/bin/python"), "-c"]
+    assert command[2] == ltx25._STDIN_PROMPT_RUNNER
+    assert command[3:5] == ["generate", "--model"]
     generated = Path(command[command.index("--output") + 1])
     assert generated != output
     assert generated.parent == output.parent
@@ -293,8 +315,9 @@ def test_ltx25_engine_reports_subprocess_failure_without_leaking_details(
     runtime.with_name("python").write_text("#!/bin/sh\n")
     runtime.with_name("python").chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
-    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
-    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
+    monkeypatch.setattr(
+        ltx25, "prepare_ltx25_runtime", lambda _: tmp_path / "runtime-cache"
+    )
 
     class Process:
         returncode = 1
@@ -343,8 +366,9 @@ def test_ltx25_zero_exit_cannot_reuse_stale_output(
     runtime.write_text("#!/bin/sh\n")
     runtime.chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
-    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
-    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
+    monkeypatch.setattr(
+        ltx25, "prepare_ltx25_runtime", lambda _: tmp_path / "runtime-cache"
+    )
 
     class Process:
         returncode = 0
@@ -390,8 +414,9 @@ def test_ltx25_timeout_terminates_process(
     runtime.with_name("python").write_text("#!/bin/sh\n")
     runtime.with_name("python").chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
-    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
-    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
+    monkeypatch.setattr(
+        ltx25, "prepare_ltx25_runtime", lambda _: tmp_path / "runtime-cache"
+    )
     terminated = []
 
     class Process:
@@ -457,8 +482,9 @@ def test_ltx25_unexpected_communication_error_terminates_process(
     runtime.write_text("#!/bin/sh\n")
     runtime.chmod(0o755)
     monkeypatch.setattr(ltx25, "resolve_ltx25_runtime", lambda: str(runtime))
-    monkeypatch.setattr(ltx25.shutil, "which", lambda _: "/trusted/uv")
-    monkeypatch.setattr(ltx25, "_materialize_runtime", lambda *args: None)
+    monkeypatch.setattr(
+        ltx25, "prepare_ltx25_runtime", lambda _: tmp_path / "runtime-cache"
+    )
     terminated = []
 
     class Process:

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -219,6 +219,40 @@ def test_ltx25_runtime_is_provisioned_once(
     assert calls[0][0][:3] == ["/trusted/uv", "sync", "--frozen"]
 
 
+def test_ltx25_generation_uses_cache_without_rechecking_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        ltx25, "_prepared_ltx25_runtime", lambda: tmp_path / "runtime-cache"
+    )
+    monkeypatch.setattr(
+        ltx25,
+        "resolve_ltx25_runtime",
+        lambda: pytest.fail("a prepared runtime must not recheck the checkout"),
+    )
+
+    class Process:
+        returncode = 0
+
+        def __init__(self, command: list[str], **kwargs) -> None:
+            self.command = command
+
+        def communicate(self, *, input: str, timeout: int) -> None:
+            Path(self.command[self.command.index("--output") + 1]).write_bytes(b"mp4")
+
+    monkeypatch.setattr(ltx25.subprocess, "Popen", Process)
+    ltx25.LTX25VideoEngine("MrMofer/ltx-2.5-mlx-q8").generate(
+        prompt="fox",
+        output_path=tmp_path / "result.mp4",
+        width=704,
+        height=480,
+        num_frames=97,
+        fps=24,
+        seed=7,
+        image=None,
+    )
+
+
 def test_serve_routes_ltx25_model_to_specific_preflight(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -288,7 +288,7 @@ def test_ltx25_engine_invokes_pinned_runtime_contract(
     assert command[3:5] == ["generate", "--model"]
     generated = Path(command[command.index("--output") + 1])
     assert generated != output
-    assert generated.parent == output.parent
+    assert generated.parent.parent == output.parent
     assert output.read_bytes() == b"mp4-with-audio"
     assert "--distilled" in command
     assert "--low-ram" in command
@@ -400,7 +400,7 @@ def test_ltx25_zero_exit_cannot_reuse_stale_output(
         )
 
     assert output.read_bytes() == b"stale-video"
-    assert list(tmp_path.glob(".result.mp4.*.tmp.mp4")) == []
+    assert list(tmp_path.glob(".result.mp4.*")) == []
     assert len(terminated) == 1
 
 
@@ -471,7 +471,7 @@ def test_ltx25_termination_does_not_reuse_exited_leader_pgid(
 
     ltx25.LTX25VideoEngine._terminate_process(Process())  # type: ignore[arg-type]
 
-    assert signals == [(123, signal.SIGTERM)]
+    assert signals == []
 
 
 def test_ltx25_termination_escalates_while_leader_is_unreaped(

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -490,6 +490,10 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         "RAPID_MLX_WAN_LORA",
         "RAPID_MLX_WAN_LORA_HIGH",
         "RAPID_MLX_WAN_LORA_LOW",
+        # LTX-2.5 runtime executable selected only after aliases.json has
+        # routed the request to the audited LTX-2.5 video lane. It changes
+        # dependency location, not model/parser/tier routing.
+        "RAPID_MLX_LTX25_RUNTIME",
     }
 )
 

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -494,6 +494,9 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # routed the request to the audited LTX-2.5 video lane. It changes
         # dependency location, not model/parser/tier routing.
         "RAPID_MLX_LTX25_RUNTIME",
+        # Hard deadline for an already-selected LTX-2.5 generation process;
+        # affects lifecycle only, never model/parser/tier routing.
+        "RAPID_MLX_LTX25_TIMEOUT_SEC",
     }
 )
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1656,6 +1656,18 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 24
   },
+  "ltx-2.5-mlx-q8": {
+    "hf_path": "MrMofer/ltx-2.5-mlx-q8",
+    "modality": "video-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 24
+  },
   "flux2-klein-4b": {
     "hf_path": "Runpod/FLUX.2-klein-4B-mflux-4bit",
     "modality": "image-gen",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2756,12 +2756,8 @@ def serve_command(args):
         from .runtime.video_lane import require_video_runtime_or_exit
         from .video.wan import is_wan_model
 
-        model_folded = args.model.casefold()
         _is_wan_video = is_wan_model(args.model)
-        if "cogvideox" in model_folded or _is_wan_video:
-            require_video_runtime_or_exit(args.model)
-        else:
-            require_video_runtime_or_exit()
+        require_video_runtime_or_exit(args.model)
 
     # F-H08-INCOMPLETE: the ``[embeddings]`` extra-required guard MUST
     # fire first thing in ``serve_command`` — before

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2756,6 +2756,8 @@ def serve_command(args):
         from .runtime.video_lane import require_video_runtime_or_exit
         from .video.wan import is_wan_model
 
+        # Used by the generic model-prefetch guard later in this function;
+        # Wan owns its own revision-pinned download path.
         _is_wan_video = is_wan_model(args.model)
         require_video_runtime_or_exit(args.model)
 

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -191,6 +191,7 @@
     "mlx-community/whisper-tiny-mlx": 74418802,
     "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx": 64915343903,
     "notapalindrome/ltx23-mlx-av-q4": 22815502995,
+    "MrMofer/ltx-2.5-mlx-q8": 67695751883,
     "openbmb/MiniCPM5-1B-MLX": 617961816,
     "pipenetwork/GLM-5.2-REAP50-MLX-4bit": 214380689191,
     "pipenetwork/Holo-3.1-35B-A3B-MLX-4bit": 23490832707,

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -325,7 +325,7 @@ def _video_engine():
     return engine
 
 
-def _parse_size(value: str) -> tuple[int, int]:
+def _parse_size(value: str, *, multiple: int = 64) -> tuple[int, int]:
     try:
         width, height = (int(part) for part in value.lower().split("x", 1))
     except (TypeError, ValueError) as exc:
@@ -333,7 +333,7 @@ def _parse_size(value: str) -> tuple[int, int]:
             status_code=400, detail="size must be WIDTHxHEIGHT"
         ) from exc
     openai_sizes = {(1280, 720), (720, 1280)}
-    is_model_aligned = width % 64 == 0 and height % 64 == 0
+    is_model_aligned = width % multiple == 0 and height % multiple == 0
     if not (
         256 <= width <= 1920
         and 256 <= height <= 1920
@@ -342,7 +342,7 @@ def _parse_size(value: str) -> tuple[int, int]:
         raise HTTPException(
             status_code=400,
             detail=(
-                "video width/height must be 256..1920 and divisible by 64, "
+                f"video width/height must be 256..1920 and divisible by {multiple}, "
                 "or use 1280x720 / 720x1280"
             ),
         )
@@ -392,6 +392,16 @@ def _video_capabilities(engine) -> dict:
         }
         seconds = {"minimum": 1, "maximum": 20, "default": 4}
         frames = {"minimum": 5, "maximum": 1201, "step": 4, "offset": 1}
+    elif family == "ltx-2.5":
+        modes = ["text-to-video", "image-to-video"]
+        size = {
+            "type": "range",
+            "width": {"minimum": 256, "maximum": 1920, "multiple_of": 32},
+            "height": {"minimum": 256, "maximum": 1920, "multiple_of": 32},
+            "also_supported": ["1280x720", "720x1280"],
+        }
+        seconds = {"minimum": 1, "maximum": 20, "default": 4}
+        frames = {"minimum": 9, "maximum": 1201, "step": 8, "offset": 1}
     else:
         modes = ["text-to-video", "image-to-video"]
         size = {
@@ -423,7 +433,9 @@ def _video_capabilities(engine) -> dict:
                 "metric": "pixel_frames",
                 "maximum": _MAX_PIXEL_FRAMES,
                 "dimension_rounding": (
-                    "none" if family == "cogvideox-fun" else "ceil_to_64"
+                    "none"
+                    if family == "cogvideox-fun"
+                    else ("ceil_to_32" if family == "ltx-2.5" else "ceil_to_64")
                 ),
             },
             "input_reference": {
@@ -433,11 +445,15 @@ def _video_capabilities(engine) -> dict:
             },
         },
         "controls": {
-            "guidance_scale": {"minimum": 1.0, "maximum": 30.0},
-            "conditioning_strength": (
-                {"minimum": 0.0, "maximum": 1.0} if family == "ltx-2.3" else None
+            "guidance_scale": (
+                None if family == "ltx-2.5" else {"minimum": 1.0, "maximum": 30.0}
             ),
-            "negative_prompt": True,
+            "conditioning_strength": (
+                {"minimum": 0.0, "maximum": 1.0}
+                if family in {"ltx-2.3", "ltx-2.5"}
+                else None
+            ),
+            "negative_prompt": family != "ltx-2.5",
         },
     }
 
@@ -486,8 +502,13 @@ async def _run_job(
     output = _jobs_root / job.id / "output.mp4"
     generation_gate = _generation_gate_for_current_loop()
     is_cogvideox = getattr(engine, "video_family", "") == "cogvideox-fun"
-    generation_width = width if is_cogvideox else ((width + 63) // 64) * 64
-    generation_height = height if is_cogvideox else ((height + 63) // 64) * 64
+    alignment = 32 if getattr(engine, "video_family", "") == "ltx-2.5" else 64
+    generation_width = (
+        width if is_cogvideox else ((width + alignment - 1) // alignment) * alignment
+    )
+    generation_height = (
+        height if is_cogvideox else ((height + alignment - 1) // alignment) * alignment
+    )
 
     async def generate_under_gate() -> bool:
         nonlocal started
@@ -586,6 +607,7 @@ async def create_video(
     engine = _video_engine()
     is_cogvideox = getattr(engine, "video_family", "") == "cogvideox-fun"
     is_wan = getattr(engine, "video_family", "") == "wan"
+    is_ltx25 = getattr(engine, "video_family", "") == "ltx-2.5"
     with _jobs_lock:
         if not _accepting_jobs:
             raise HTTPException(status_code=503, detail="video server is shutting down")
@@ -596,7 +618,7 @@ async def create_video(
     profile = resolve_profile(model)
     if profile is not None and profile.hf_path == engine.model_name:
         allowed_models.add(model)
-    if not (is_cogvideox or is_wan):
+    if not (is_cogvideox or is_wan or is_ltx25):
         allowed_models.add("ltx-2.3-mlx-q4")
     if model not in allowed_models:
         raise HTTPException(
@@ -631,7 +653,7 @@ async def create_video(
             )
         width, height = 672, 384
     else:
-        width, height = _parse_size(size)
+        width, height = _parse_size(size, multiple=32 if is_ltx25 else 64)
     native_fps = 5 if is_cogvideox else getattr(engine, "native_fps", 24)
     request_fps = native_fps if fps is None else fps
     if not 1 <= request_fps <= 60:
@@ -667,9 +689,18 @@ async def create_video(
                 detail="conditioning_strength requires input_reference",
             )
     if negative_prompt is not None:
-        negative_prompt = negative_prompt.strip()
-    generation_width = ((width + 63) // 64) * 64
-    generation_height = ((height + 63) // 64) * 64
+        negative_prompt = negative_prompt.strip() or None
+    if is_ltx25 and (negative_prompt or guidance_scale is not None):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "LTX-2.5 distilled generation does not support negative_prompt "
+                "or guidance_scale"
+            ),
+        )
+    alignment = 32 if is_ltx25 else 64
+    generation_width = ((width + alignment - 1) // alignment) * alignment
+    generation_height = ((height + alignment - 1) // alignment) * alignment
     if frames is not None:
         request_frames = frames
     elif is_cogvideox:
@@ -705,7 +736,9 @@ async def create_video(
     workload_height = height if is_cogvideox else generation_height
     if workload_width * workload_height * request_frames > _MAX_PIXEL_FRAMES:
         family = (
-            "CogVideoX-Fun" if is_cogvideox else ("Wan" if is_wan else "LTX-2.3 Q4")
+            "CogVideoX-Fun"
+            if is_cogvideox
+            else ("Wan" if is_wan else ("LTX-2.5 Q8" if is_ltx25 else "LTX-2.3 Q4"))
         )
         raise HTTPException(
             status_code=400,
@@ -765,7 +798,7 @@ async def create_video(
 
         job = _VideoJob(
             id=job_id,
-            model=model if (is_cogvideox or is_wan) else "ltx-2.3-mlx-q4",
+            model=model if (is_cogvideox or is_wan or is_ltx25) else "ltx-2.3-mlx-q4",
             prompt=prompt,
             seconds=str(seconds_int),
             size=f"{width}x{height}",

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MLX-native LTX-2.3, CogVideoX-Fun and Wan video-generation lane."""
+"""MLX-native LTX, CogVideoX-Fun and Wan video-generation lane."""
 
 from __future__ import annotations
 
@@ -85,6 +85,12 @@ def _is_wan_name(model_name: str | None) -> bool:
     return is_wan_model(model_name)
 
 
+def _is_ltx25_name(model_name: str | None) -> bool:
+    from ..video.ltx25 import is_ltx25_model
+
+    return is_ltx25_model(model_name)
+
+
 def require_video_runtime_or_exit(model_name: str | None = None) -> None:
     """Fail before model download when the optional video stack is absent."""
     if sys.version_info < (3, 11):
@@ -98,7 +104,15 @@ def require_video_runtime_or_exit(model_name: str | None = None) -> None:
         raise SystemExit(2)
 
     missing = []
-    if _is_cogvideox_name(model_name):
+    if _is_ltx25_name(model_name):
+        from ..video.ltx25 import LTX25_RUNTIME_COMMIT, resolve_ltx25_runtime
+
+        if resolve_ltx25_runtime() is None:
+            missing.append(
+                "the pinned LTX-2.5 runtime "
+                f"(commit {LTX25_RUNTIME_COMMIT}; see the video generation guide)"
+            )
+    elif _is_cogvideox_name(model_name):
         cogvideox_modules = {
             "videox_fun_mlx": "the bundled VideoX-Fun-mlx runtime",
             "mlx_arsenal": "mlx-arsenal",
@@ -131,7 +145,7 @@ def require_video_runtime_or_exit(model_name: str | None = None) -> None:
 
 
 class VideoEngine:
-    """Thin adapter over ``mlx-video-with-audio``'s LTX-2.3 pipeline.
+    """Adapter over the supported MLX video runtimes.
 
     The upstream function owns model loading and generation. Rapid-MLX owns
     request validation, job lifecycle, concurrency and the OpenAI-compatible
@@ -158,10 +172,15 @@ class VideoEngine:
         self.video_family = (
             "cogvideox-fun"
             if _is_cogvideox_name(model_name)
-            else ("wan" if _is_wan_name(model_name) else "ltx-2.3")
+            else (
+                "wan"
+                if _is_wan_name(model_name)
+                else ("ltx-2.5" if _is_ltx25_name(model_name) else "ltx-2.3")
+            )
         )
         self._cog_engine = None
         self._wan_engine = None
+        self._ltx25_engine = None
         if self.video_family == "cogvideox-fun":
             from ..video.engine import VideoGenerationEngine
 
@@ -170,6 +189,10 @@ class VideoEngine:
             from ..video.wan import WanVideoEngine
 
             self._wan_engine = WanVideoEngine(model_name)
+        elif self.video_family == "ltx-2.5":
+            from ..video.ltx25 import LTX25VideoEngine
+
+            self._ltx25_engine = LTX25VideoEngine(model_name)
         # Shared across engine instances and app lifespans. A bounded shutdown
         # may detach an old daemon worker; an in-process restart must not run a
         # second Metal graph concurrently with that still-draining worker.
@@ -192,6 +215,38 @@ class VideoEngine:
         output_width: int | None = None,
         output_height: int | None = None,
     ) -> None:
+        if getattr(self, "_ltx25_engine", None) is not None:
+            from ..video.ltx25 import LTX25BackendError
+
+            if negative_prompt is not None or guidance_scale is not None:
+                raise VideoRuntimeError(
+                    "LTX-2.5 distilled generation does not support negative_prompt "
+                    "or guidance_scale."
+                )
+            try:
+                with self._generation_lock:
+                    self._ltx25_engine.generate(
+                        prompt=prompt,
+                        output_path=output_path,
+                        width=width,
+                        height=height,
+                        num_frames=num_frames,
+                        fps=fps,
+                        seed=seed,
+                        image=image,
+                        conditioning_strength=conditioning_strength,
+                    )
+            except LTX25BackendError as exc:
+                raise VideoRuntimeError(str(exc)) from exc
+            self._crop_generated_output(
+                output_path=output_path,
+                width=width,
+                height=height,
+                output_width=output_width,
+                output_height=output_height,
+                family="LTX-2.5",
+            )
+            return
         if self._wan_engine is not None:
             from ..video.wan import WanBackendError
 

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -112,6 +112,8 @@ def require_video_runtime_or_exit(model_name: str | None = None) -> None:
                 "the pinned LTX-2.5 runtime "
                 f"(commit {LTX25_RUNTIME_COMMIT}; see the video generation guide)"
             )
+        if shutil.which("uv") is None:
+            missing.append("uv (`brew install uv`)")
     elif _is_cogvideox_name(model_name):
         cogvideox_modules = {
             "videox_fun_mlx": "the bundled VideoX-Fun-mlx runtime",

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -463,5 +463,7 @@ class VideoEngine:
         """Video weights load lazily; startup must not trigger a 40+ GB pull."""
 
     async def stop(self) -> None:
+        if getattr(self, "_ltx25_engine", None) is not None:
+            self._ltx25_engine.stop()
         if self._cog_engine is not None:
             await self._cog_engine.close()

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -236,6 +236,10 @@ class VideoEngine:
                     "LTX-2.5 distilled generation does not support negative_prompt "
                     "or guidance_scale."
                 )
+            if image is None and conditioning_strength is not None:
+                raise VideoRuntimeError(
+                    "LTX-2.5 conditioning_strength requires an input image."
+                )
             try:
                 with self._generation_lock:
                     self._ltx25_engine.generate(

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -464,6 +464,8 @@ class VideoEngine:
 
     async def stop(self) -> None:
         if getattr(self, "_ltx25_engine", None) is not None:
-            self._ltx25_engine.stop()
+            import asyncio
+
+            await asyncio.to_thread(self._ltx25_engine.stop)
         if self._cog_engine is not None:
             await self._cog_engine.close()

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -105,15 +105,26 @@ def require_video_runtime_or_exit(model_name: str | None = None) -> None:
 
     missing = []
     if _is_ltx25_name(model_name):
-        from ..video.ltx25 import LTX25_RUNTIME_COMMIT, resolve_ltx25_runtime
+        from ..video.ltx25 import (
+            LTX25_RUNTIME_COMMIT,
+            LTX25BackendError,
+            prepare_ltx25_runtime,
+            resolve_ltx25_runtime,
+        )
 
-        if resolve_ltx25_runtime() is None:
+        runtime = resolve_ltx25_runtime()
+        if runtime is None:
             missing.append(
                 "the pinned LTX-2.5 runtime "
                 f"(commit {LTX25_RUNTIME_COMMIT}; see the video generation guide)"
             )
         if shutil.which("uv") is None:
             missing.append("uv (`brew install uv`)")
+        elif runtime is not None:
+            try:
+                prepare_ltx25_runtime(runtime)
+            except LTX25BackendError:
+                missing.append("a provisioned pinned LTX-2.5 runtime")
     elif _is_cogvideox_name(model_name):
         cogvideox_modules = {
             "videox_fun_mlx": "the bundled VideoX-Fun-mlx runtime",

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -214,6 +214,14 @@ class LTX25VideoEngine:
         try:
             snapshot_path = Path(snapshot.name)
             _materialize_runtime(repository, snapshot_path)
+            descriptor, staged_name = tempfile.mkstemp(
+                prefix=f".{output_path.name}.",
+                suffix=".tmp.mp4",
+                dir=output_path.parent,
+            )
+            os.close(descriptor)
+            staged_output = Path(staged_name)
+            staged_output.unlink()
         except Exception:
             snapshot.cleanup()
             raise
@@ -245,7 +253,7 @@ class LTX25VideoEngine:
             "--seed",
             str(seed),
             "--output",
-            str(output_path),
+            str(staged_output),
         ]
         if image is not None:
             command.extend(
@@ -278,11 +286,15 @@ class LTX25VideoEngine:
                 self._process = process
             process.communicate(input=prompt, timeout=timeout)
             if process.returncode:
-                self._terminate_process(process)
                 raise LTX25BackendError(
                     f"LTX-2.5 runtime exited with code {process.returncode}; "
                     "runtime output is not retained because it may contain request data."
                 )
+            if not staged_output.is_file() or staged_output.stat().st_size == 0:
+                raise LTX25BackendError(
+                    "LTX-2.5 generation completed without an MP4 output."
+                )
+            os.replace(staged_output, output_path)
         except subprocess.TimeoutExpired as exc:
             if process is not None:
                 self._terminate_process(process)
@@ -290,6 +302,8 @@ class LTX25VideoEngine:
                 "LTX-2.5 generation exceeded its configured time limit."
             ) from exc
         except LTX25BackendError:
+            if process is not None:
+                self._terminate_process(process)
             raise
         except BaseException as exc:
             if process is not None:
@@ -303,8 +317,5 @@ class LTX25VideoEngine:
             with self._process_lock:
                 if self._process is process:
                     self._process = None
+            staged_output.unlink(missing_ok=True)
             snapshot.cleanup()
-        if not output_path.is_file() or output_path.stat().st_size == 0:
-            raise LTX25BackendError(
-                "LTX-2.5 generation completed without an MP4 output."
-            )

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adapter for the standalone LTX-2.5 MLX runtime."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+LTX25_RUNTIME_COMMIT = "57952288076766abe27dda3a774b2c24f7346977"
+LTX25_RUNTIME_REPOSITORY = "https://github.com/MrMoferFRAN/ltx-2-mlx.git"
+
+
+def is_ltx25_model(model_name: str | None) -> bool:
+    """Return whether a model identifier explicitly selects LTX-2.5."""
+    if not model_name:
+        return False
+    normalized = model_name.casefold().replace("_", "-")
+    return "ltx-2.5" in normalized or "ltx25" in normalized
+
+
+def resolve_ltx25_runtime() -> str | None:
+    """Resolve the separately installed, pinned LTX-2.5 CLI."""
+    override = os.environ.get("RAPID_MLX_LTX25_RUNTIME", "").strip()
+    if override:
+        candidate = Path(override).expanduser()
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate.absolute())
+        return None
+    executable = shutil.which("ltx-2-mlx")
+    return str(Path(executable).absolute()) if executable else None
+
+
+class LTX25BackendError(RuntimeError):
+    """Safe, public-facing error from the LTX-2.5 backend."""
+
+
+class LTX25VideoEngine:
+    """Run LTX-2.5 through its native MLX command-line runtime."""
+
+    native_fps = 24
+
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+
+    def generate(
+        self,
+        *,
+        prompt: str,
+        output_path: Path,
+        width: int,
+        height: int,
+        num_frames: int,
+        fps: int,
+        seed: int,
+        image: Path | None,
+        conditioning_strength: float | None = None,
+    ) -> None:
+        executable = resolve_ltx25_runtime()
+        if executable is None:
+            raise LTX25BackendError(
+                "LTX-2.5 support requires the pinned ltx-2-mlx runtime. "
+                "See the LTX-2.5 setup in the video generation guide."
+            )
+
+        command = [
+            executable,
+            "generate",
+            "--model",
+            self.model_name,
+            "--distilled",
+            "--low-ram",
+            "--quiet",
+            "--prompt",
+            prompt,
+            "--height",
+            str(height),
+            "--width",
+            str(width),
+            "--frames",
+            str(num_frames),
+            "--frame-rate",
+            str(fps),
+            "--seed",
+            str(seed),
+            "--output",
+            str(output_path),
+        ]
+        if image is not None:
+            command.extend(
+                [
+                    "--image",
+                    str(image),
+                    "0",
+                    str(
+                        1.0 if conditioning_strength is None else conditioning_strength
+                    ),
+                ]
+            )
+        try:
+            subprocess.run(command, check=True)
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise LTX25BackendError(
+                "LTX-2.5 generation failed; check the server logs for runtime details."
+            ) from exc
+        if not output_path.is_file() or output_path.stat().st_size == 0:
+            raise LTX25BackendError(
+                "LTX-2.5 generation completed without an MP4 output."
+            )

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -212,16 +212,12 @@ class LTX25VideoEngine:
     @staticmethod
     def _terminate_process(process: subprocess.Popen[str]) -> None:
         leader_running = process.poll() is None
+        if not leader_running:
+            return
         try:
             os.killpg(process.pid, signal.SIGTERM)
         except ProcessLookupError:
-            if leader_running:
-                process.wait(timeout=_TERMINATE_GRACE_SECONDS)
-            return
-        # Once a reaped leader's PID is reusable, signaling its old PGID again
-        # could target an unrelated group. TERM is therefore the final signal
-        # for an already-exited leader and any surviving descendants.
-        if not leader_running:
+            process.wait(timeout=_TERMINATE_GRACE_SECONDS)
             return
         try:
             process.wait(timeout=_TERMINATE_GRACE_SECONDS)
@@ -270,14 +266,11 @@ class LTX25VideoEngine:
         timeout = _generation_timeout_seconds()
         workspace = prepare_ltx25_runtime(executable)
         try:
-            descriptor, staged_name = tempfile.mkstemp(
+            staging = tempfile.TemporaryDirectory(
                 prefix=f".{output_path.name}.",
-                suffix=".tmp.mp4",
                 dir=output_path.parent,
             )
-            os.close(descriptor)
-            staged_output = Path(staged_name)
-            staged_output.unlink()
+            staged_output = Path(staging.name) / "output.mp4"
         except OSError as exc:
             raise LTX25BackendError(
                 "LTX-2.5 generation could not create its temporary output."
@@ -368,4 +361,4 @@ class LTX25VideoEngine:
             with self._process_lock:
                 if self._process is process:
                     self._process = None
-            staged_output.unlink(missing_ok=True)
+            staging.cleanup()

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -211,30 +211,34 @@ class LTX25VideoEngine:
 
     @staticmethod
     def _terminate_process(process: subprocess.Popen[str]) -> None:
+        leader_running = process.poll() is None
         try:
             os.killpg(process.pid, signal.SIGTERM)
         except ProcessLookupError:
-            if process.poll() is None:
+            if leader_running:
                 process.wait(timeout=_TERMINATE_GRACE_SECONDS)
             return
-        if process.poll() is None:
-            try:
-                process.wait(timeout=_TERMINATE_GRACE_SECONDS)
-            except subprocess.TimeoutExpired:
-                pass
-        # The group leader can exit before ffmpeg or worker descendants. Kill
-        # the process group even after the leader has been reaped.
+        # Once a reaped leader's PID is reusable, signaling its old PGID again
+        # could target an unrelated group. TERM is therefore the final signal
+        # for an already-exited leader and any surviving descendants.
+        if not leader_running:
+            return
         try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        if process.poll() is None:
+            process.wait(timeout=_TERMINATE_GRACE_SECONDS)
+            return
+        except subprocess.TimeoutExpired:
+            # The unreaped leader still owns this PID/PGID, so reuse is
+            # impossible and escalation is safe.
             try:
-                process.wait(timeout=_TERMINATE_GRACE_SECONDS)
-            except subprocess.TimeoutExpired as exc:
-                raise LTX25BackendError(
-                    "The LTX-2.5 runtime process group could not be reaped."
-                ) from exc
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        try:
+            process.wait(timeout=_TERMINATE_GRACE_SECONDS)
+        except subprocess.TimeoutExpired as exc:
+            raise LTX25BackendError(
+                "The LTX-2.5 runtime process group could not be reaped."
+            ) from exc
 
     def stop(self) -> None:
         """Stop an active external generation during bounded shutdown."""

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -17,6 +17,8 @@ LTX25_RUNTIME_COMMIT = "57952288076766abe27dda3a774b2c24f7346977"
 LTX25_RUNTIME_REPOSITORY = "https://github.com/MrMoferFRAN/ltx-2-mlx.git"
 _DEFAULT_TIMEOUT_SECONDS = 7200
 _TERMINATE_GRACE_SECONDS = 10
+_RUNTIME_CACHE_LOCK = threading.Lock()
+_RUNTIME_CACHE: tempfile.TemporaryDirectory[str] | None = None
 _STDIN_PROMPT_RUNNER = """\
 import sys
 from ltx_pipelines_mlx.cli import main
@@ -124,6 +126,59 @@ def _materialize_runtime(repository: Path, destination: Path) -> None:
         ) from exc
 
 
+def prepare_ltx25_runtime(executable: str) -> Path:
+    """Provision the pinned runtime once into a process-private workspace."""
+    global _RUNTIME_CACHE
+
+    uv = shutil.which("uv")
+    if uv is None:
+        raise LTX25BackendError(
+            "LTX-2.5 support requires uv to build its pinned runtime."
+        )
+    with _RUNTIME_CACHE_LOCK:
+        if _RUNTIME_CACHE is not None:
+            return Path(_RUNTIME_CACHE.name)
+        cache: tempfile.TemporaryDirectory[str] | None = None
+        try:
+            cache = tempfile.TemporaryDirectory(prefix="rapidmlx-ltx25-runtime-")
+            workspace = Path(cache.name)
+            _materialize_runtime(Path(executable).parents[2], workspace)
+            subprocess.run(
+                [
+                    str(Path(uv).absolute()),
+                    "sync",
+                    "--frozen",
+                    "--project",
+                    str(workspace),
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=1800,
+            )
+            interpreter = workspace / ".venv" / "bin" / "python"
+            if not interpreter.is_file() or not os.access(interpreter, os.X_OK):
+                raise LTX25BackendError(
+                    "The pinned LTX-2.5 runtime did not create its Python environment."
+                )
+        except LTX25BackendError:
+            if cache is not None:
+                cache.cleanup()
+            raise
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ) as exc:
+            if cache is not None:
+                cache.cleanup()
+            raise LTX25BackendError(
+                "The pinned LTX-2.5 runtime could not be provisioned."
+            ) from exc
+        _RUNTIME_CACHE = cache
+        return workspace
+
+
 def _generation_timeout_seconds() -> int:
     raw = os.environ.get("RAPID_MLX_LTX25_TIMEOUT_SEC", "").strip()
     if not raw:
@@ -208,17 +263,9 @@ class LTX25VideoEngine:
                 "LTX-2.5 support requires the pinned ltx-2-mlx runtime. "
                 "See the LTX-2.5 setup in the video generation guide."
             )
-        repository = Path(executable).parents[2]
-        uv = shutil.which("uv")
-        if uv is None:
-            raise LTX25BackendError(
-                "LTX-2.5 support requires uv to build its pinned isolated runtime."
-            )
         timeout = _generation_timeout_seconds()
-        snapshot = tempfile.TemporaryDirectory(prefix="rapidmlx-ltx25-runtime-")
+        workspace = prepare_ltx25_runtime(executable)
         try:
-            snapshot_path = Path(snapshot.name)
-            _materialize_runtime(repository, snapshot_path)
             descriptor, staged_name = tempfile.mkstemp(
                 prefix=f".{output_path.name}.",
                 suffix=".tmp.mp4",
@@ -227,18 +274,13 @@ class LTX25VideoEngine:
             os.close(descriptor)
             staged_output = Path(staged_name)
             staged_output.unlink()
-        except Exception:
-            snapshot.cleanup()
-            raise
+        except OSError as exc:
+            raise LTX25BackendError(
+                "LTX-2.5 generation could not create its temporary output."
+            ) from exc
 
         command = [
-            str(Path(uv).absolute()),
-            "run",
-            "--isolated",
-            "--frozen",
-            "--project",
-            str(snapshot_path),
-            "python",
+            str(workspace / ".venv" / "bin" / "python"),
             "-c",
             _STDIN_PROMPT_RUNNER,
             "generate",
@@ -323,4 +365,3 @@ class LTX25VideoEngine:
                 if self._process is process:
                     self._process = None
             staged_output.unlink(missing_ok=True)
-            snapshot.cleanup()

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -113,7 +113,12 @@ def _materialize_runtime(repository: Path, destination: Path) -> None:
                         "The pinned LTX-2.5 source archive contains an unsafe entry."
                     )
             source.extractall(destination, members=members)
-    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+    except (
+        OSError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        tarfile.TarError,
+    ) as exc:
         raise LTX25BackendError(
             "The pinned LTX-2.5 source snapshot could not be materialized."
         ) from exc

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -10,6 +10,13 @@ from pathlib import Path
 
 LTX25_RUNTIME_COMMIT = "57952288076766abe27dda3a774b2c24f7346977"
 LTX25_RUNTIME_REPOSITORY = "https://github.com/MrMoferFRAN/ltx-2-mlx.git"
+_STDIN_PROMPT_RUNNER = """\
+import sys
+from ltx_pipelines_mlx.cli import main
+
+sys.argv = ["ltx-2-mlx", *sys.argv[1:], "--prompt", sys.stdin.read()]
+main()
+"""
 
 
 def is_ltx25_model(model_name: str | None) -> bool:
@@ -63,17 +70,23 @@ class LTX25VideoEngine:
                 "LTX-2.5 support requires the pinned ltx-2-mlx runtime. "
                 "See the LTX-2.5 setup in the video generation guide."
             )
+        runtime_python = Path(executable).with_name("python")
+        if not runtime_python.is_file() or not os.access(runtime_python, os.X_OK):
+            raise LTX25BackendError(
+                "The LTX-2.5 runtime does not have its isolated Python executable. "
+                "Reinstall it using the video generation guide."
+            )
 
         command = [
-            executable,
+            str(runtime_python),
+            "-c",
+            _STDIN_PROMPT_RUNNER,
             "generate",
             "--model",
             self.model_name,
             "--distilled",
             "--low-ram",
             "--quiet",
-            "--prompt",
-            prompt,
             "--height",
             str(height),
             "--width",
@@ -99,7 +112,9 @@ class LTX25VideoEngine:
                 ]
             )
         try:
-            subprocess.run(command, check=True)
+            # Prompts may contain private user data. Keep them out of argv and
+            # local process listings by feeding the isolated runtime over stdin.
+            subprocess.run(command, check=True, input=prompt, text=True)
         except (OSError, subprocess.CalledProcessError) as exc:
             raise LTX25BackendError(
                 "LTX-2.5 generation failed; check the server logs for runtime details."

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import subprocess
 import threading
 from pathlib import Path
@@ -112,21 +113,29 @@ class LTX25VideoEngine:
         self.model_name = model_name
         self._process_lock = threading.Lock()
         self._process: subprocess.Popen[str] | None = None
+        self._stopping = False
 
     @staticmethod
     def _terminate_process(process: subprocess.Popen[str]) -> None:
         if process.poll() is not None:
             return
-        process.terminate()
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
         try:
             process.wait(timeout=_TERMINATE_GRACE_SECONDS)
         except subprocess.TimeoutExpired:
-            process.kill()
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                return
             process.wait(timeout=_TERMINATE_GRACE_SECONDS)
 
     def stop(self) -> None:
         """Stop an active external generation during bounded shutdown."""
         with self._process_lock:
+            self._stopping = True
             process = self._process
         if process is not None:
             self._terminate_process(process)
@@ -150,16 +159,22 @@ class LTX25VideoEngine:
                 "LTX-2.5 support requires the pinned ltx-2-mlx runtime. "
                 "See the LTX-2.5 setup in the video generation guide."
             )
-        runtime_python = Path(executable).with_name("python")
-        if not runtime_python.is_file() or not os.access(runtime_python, os.X_OK):
+        repository = Path(executable).parents[2]
+        uv = shutil.which("uv")
+        if uv is None:
             raise LTX25BackendError(
-                "The LTX-2.5 runtime does not have its isolated Python executable. "
-                "Reinstall it using the video generation guide."
+                "LTX-2.5 support requires uv to build its pinned isolated runtime."
             )
         timeout = _generation_timeout_seconds()
 
         command = [
-            str(runtime_python),
+            str(Path(uv).absolute()),
+            "run",
+            "--isolated",
+            "--frozen",
+            "--project",
+            str(repository),
+            "python",
             "-c",
             _STDIN_PROMPT_RUNNER,
             "generate",
@@ -196,29 +211,37 @@ class LTX25VideoEngine:
         try:
             # Prompts may contain private user data. Keep them out of argv and
             # local process listings by feeding the isolated runtime over stdin.
-            process = subprocess.Popen(
-                command,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
             with self._process_lock:
+                if self._stopping:
+                    raise LTX25BackendError(
+                        "LTX-2.5 generation cannot start while the server is stopping."
+                    )
+                process = subprocess.Popen(
+                    command,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    start_new_session=True,
+                )
                 self._process = process
             # Captured output is deliberately discarded: upstream diagnostics
             # are not a safe public/logging channel for request data.
             process.communicate(input=prompt, timeout=timeout)
             if process.returncode:
-                raise subprocess.CalledProcessError(process.returncode, command)
+                raise LTX25BackendError(
+                    f"LTX-2.5 runtime exited with code {process.returncode}; "
+                    "runtime output is not retained because it may contain request data."
+                )
         except subprocess.TimeoutExpired as exc:
             if process is not None:
                 self._terminate_process(process)
             raise LTX25BackendError(
                 "LTX-2.5 generation exceeded its configured time limit."
             ) from exc
-        except (OSError, subprocess.CalledProcessError) as exc:
+        except OSError as exc:
             raise LTX25BackendError(
-                "LTX-2.5 generation failed; check the server logs for runtime details."
+                "LTX-2.5 generation could not start its isolated runtime."
             ) from exc
         finally:
             with self._process_lock:

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -19,12 +19,36 @@ _DEFAULT_TIMEOUT_SECONDS = 7200
 _TERMINATE_GRACE_SECONDS = 10
 _RUNTIME_CACHE_LOCK = threading.Lock()
 _RUNTIME_CACHE: tempfile.TemporaryDirectory[str] | None = None
-_STDIN_PROMPT_RUNNER = """\
+_INNER_PROMPT_RUNNER = """\
+import signal
 import sys
 from ltx_pipelines_mlx.cli import main
 
+signal.signal(signal.SIGTERM, signal.SIG_DFL)
 sys.argv = ["ltx-2-mlx", *sys.argv[1:], "--prompt", sys.stdin.read()]
 main()
+"""
+_STDIN_PROMPT_RUNNER = f"""\
+import os
+import signal
+import subprocess
+import sys
+
+prompt = sys.stdin.read()
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+child = subprocess.Popen(
+    [sys.executable, "-c", {_INNER_PROMPT_RUNNER!r}, *sys.argv[1:]],
+    stdin=subprocess.PIPE,
+    text=True,
+)
+try:
+    child.communicate(input=prompt)
+finally:
+    try:
+        os.killpg(os.getpgrp(), signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+raise SystemExit(child.returncode)
 """
 
 
@@ -33,7 +57,7 @@ def is_ltx25_model(model_name: str | None) -> bool:
     if not model_name:
         return False
     normalized = model_name.casefold().replace("_", "-")
-    return "ltx-2.5" in normalized or "ltx25" in normalized
+    return normalized.rsplit("/", 1)[-1] == "ltx-2.5-mlx-q8"
 
 
 def resolve_ltx25_runtime() -> str | None:
@@ -218,6 +242,8 @@ class LTX25VideoEngine:
     def _terminate_process(process: subprocess.Popen[str]) -> None:
         leader_running = process.poll() is None
         if not leader_running:
+            # The runner is a group supervisor: before it exits it signals the
+            # still-owned process group, so no stale PGID needs to be reused.
             return
         try:
             os.killpg(process.pid, signal.SIGTERM)

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -151,19 +151,24 @@ class LTX25VideoEngine:
 
     @staticmethod
     def _terminate_process(process: subprocess.Popen[str]) -> None:
-        if process.poll() is not None:
-            return
         try:
             os.killpg(process.pid, signal.SIGTERM)
         except ProcessLookupError:
+            if process.poll() is None:
+                process.wait(timeout=_TERMINATE_GRACE_SECONDS)
             return
-        try:
-            process.wait(timeout=_TERMINATE_GRACE_SECONDS)
-        except subprocess.TimeoutExpired:
+        if process.poll() is None:
             try:
-                os.killpg(process.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                return
+                process.wait(timeout=_TERMINATE_GRACE_SECONDS)
+            except subprocess.TimeoutExpired:
+                pass
+        # The group leader can exit before ffmpeg or worker descendants. Kill
+        # the process group even after the leader has been reaped.
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        if process.poll() is None:
             try:
                 process.wait(timeout=_TERMINATE_GRACE_SECONDS)
             except subprocess.TimeoutExpired as exc:
@@ -273,6 +278,7 @@ class LTX25VideoEngine:
                 self._process = process
             process.communicate(input=prompt, timeout=timeout)
             if process.returncode:
+                self._terminate_process(process)
                 raise LTX25BackendError(
                     f"LTX-2.5 runtime exited with code {process.returncode}; "
                     "runtime output is not retained because it may contain request data."
@@ -286,7 +292,7 @@ class LTX25VideoEngine:
         except LTX25BackendError:
             raise
         except BaseException as exc:
-            if process is not None and process.poll() is None:
+            if process is not None:
                 self._terminate_process(process)
             if isinstance(exc, (KeyboardInterrupt, SystemExit)):
                 raise

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -281,9 +281,15 @@ class LTX25VideoEngine:
             raise LTX25BackendError(
                 "LTX-2.5 generation exceeded its configured time limit."
             ) from exc
-        except OSError as exc:
+        except LTX25BackendError:
+            raise
+        except BaseException as exc:
+            if process is not None and process.poll() is None:
+                self._terminate_process(process)
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
             raise LTX25BackendError(
-                "LTX-2.5 generation could not start its isolated runtime."
+                "LTX-2.5 generation failed while running its isolated runtime."
             ) from exc
         finally:
             with self._process_lock:

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -51,7 +51,7 @@ def resolve_ltx25_runtime() -> str | None:
 
 
 def _runtime_revision(executable: str) -> str | None:
-    """Read the immutable git identity of the documented workspace install."""
+    """Verify the documented workspace install is pinned and unmodified."""
     path = Path(executable)
     try:
         repository = path.parents[2]
@@ -59,14 +59,26 @@ def _runtime_revision(executable: str) -> str | None:
         return None
     if not (repository / ".git").exists():
         return None
+    if path.absolute() != (repository / ".venv" / "bin" / "ltx-2-mlx").absolute():
+        return None
     try:
-        result = subprocess.run(
-            ["git", "-C", str(repository), "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
+
+        def git(*arguments: str) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                ["git", "-C", str(repository), *arguments],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+        result = git("rev-parse", "HEAD")
+        # The runtime packages are editable workspace installs, so verifying
+        # every tracked source and lockfile is clean verifies the code Python
+        # imports. Reject a missing/untracked lockfile as an incomplete clone.
+        if git("status", "--porcelain=v1", "--untracked-files=no").stdout.strip():
+            return None
+        git("ls-files", "--error-unmatch", "uv.lock")
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
     return result.stdout.strip()
@@ -83,9 +95,7 @@ def _generation_timeout_seconds() -> int:
             "The LTX-2.5 timeout must be an integer number of seconds."
         ) from exc
     if value < 60:
-        raise LTX25BackendError(
-            "The LTX-2.5 timeout must be at least 60 seconds."
-        )
+        raise LTX25BackendError("The LTX-2.5 timeout must be at least 60 seconds.")
     return value
 
 
@@ -146,6 +156,7 @@ class LTX25VideoEngine:
                 "The LTX-2.5 runtime does not have its isolated Python executable. "
                 "Reinstall it using the video generation guide."
             )
+        timeout = _generation_timeout_seconds()
 
         command = [
             str(runtime_python),
@@ -185,10 +196,18 @@ class LTX25VideoEngine:
         try:
             # Prompts may contain private user data. Keep them out of argv and
             # local process listings by feeding the isolated runtime over stdin.
-            process = subprocess.Popen(command, stdin=subprocess.PIPE, text=True)
+            process = subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
             with self._process_lock:
                 self._process = process
-            process.communicate(input=prompt, timeout=_generation_timeout_seconds())
+            # Captured output is deliberately discarded: upstream diagnostics
+            # are not a safe public/logging channel for request data.
+            process.communicate(input=prompt, timeout=timeout)
             if process.returncode:
                 raise subprocess.CalledProcessError(process.returncode, command)
         except subprocess.TimeoutExpired as exc:

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -6,10 +6,13 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 
 LTX25_RUNTIME_COMMIT = "57952288076766abe27dda3a774b2c24f7346977"
 LTX25_RUNTIME_REPOSITORY = "https://github.com/MrMoferFRAN/ltx-2-mlx.git"
+_DEFAULT_TIMEOUT_SECONDS = 7200
+_TERMINATE_GRACE_SECONDS = 10
 _STDIN_PROMPT_RUNNER = """\
 import sys
 from ltx_pipelines_mlx.cli import main
@@ -28,15 +31,62 @@ def is_ltx25_model(model_name: str | None) -> bool:
 
 
 def resolve_ltx25_runtime() -> str | None:
-    """Resolve the separately installed, pinned LTX-2.5 CLI."""
+    """Resolve the CLI only when its checkout is at the audited revision."""
     override = os.environ.get("RAPID_MLX_LTX25_RUNTIME", "").strip()
     if override:
         candidate = Path(override).expanduser()
         if candidate.is_file() and os.access(candidate, os.X_OK):
-            return str(candidate.absolute())
+            absolute = str(candidate.absolute())
+            return (
+                absolute
+                if _runtime_revision(absolute) == LTX25_RUNTIME_COMMIT
+                else None
+            )
         return None
     executable = shutil.which("ltx-2-mlx")
-    return str(Path(executable).absolute()) if executable else None
+    if executable is None:
+        return None
+    absolute = str(Path(executable).absolute())
+    return absolute if _runtime_revision(absolute) == LTX25_RUNTIME_COMMIT else None
+
+
+def _runtime_revision(executable: str) -> str | None:
+    """Read the immutable git identity of the documented workspace install."""
+    path = Path(executable)
+    try:
+        repository = path.parents[2]
+    except IndexError:
+        return None
+    if not (repository / ".git").exists():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repository), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+    return result.stdout.strip()
+
+
+def _generation_timeout_seconds() -> int:
+    raw = os.environ.get("RAPID_MLX_LTX25_TIMEOUT_SEC", "").strip()
+    if not raw:
+        return _DEFAULT_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise LTX25BackendError(
+            "The LTX-2.5 timeout must be an integer number of seconds."
+        ) from exc
+    if value < 60:
+        raise LTX25BackendError(
+            "The LTX-2.5 timeout must be at least 60 seconds."
+        )
+    return value
 
 
 class LTX25BackendError(RuntimeError):
@@ -50,6 +100,26 @@ class LTX25VideoEngine:
 
     def __init__(self, model_name: str) -> None:
         self.model_name = model_name
+        self._process_lock = threading.Lock()
+        self._process: subprocess.Popen[str] | None = None
+
+    @staticmethod
+    def _terminate_process(process: subprocess.Popen[str]) -> None:
+        if process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=_TERMINATE_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=_TERMINATE_GRACE_SECONDS)
+
+    def stop(self) -> None:
+        """Stop an active external generation during bounded shutdown."""
+        with self._process_lock:
+            process = self._process
+        if process is not None:
+            self._terminate_process(process)
 
     def generate(
         self,
@@ -111,14 +181,30 @@ class LTX25VideoEngine:
                     ),
                 ]
             )
+        process: subprocess.Popen[str] | None = None
         try:
             # Prompts may contain private user data. Keep them out of argv and
             # local process listings by feeding the isolated runtime over stdin.
-            subprocess.run(command, check=True, input=prompt, text=True)
+            process = subprocess.Popen(command, stdin=subprocess.PIPE, text=True)
+            with self._process_lock:
+                self._process = process
+            process.communicate(input=prompt, timeout=_generation_timeout_seconds())
+            if process.returncode:
+                raise subprocess.CalledProcessError(process.returncode, command)
+        except subprocess.TimeoutExpired as exc:
+            if process is not None:
+                self._terminate_process(process)
+            raise LTX25BackendError(
+                "LTX-2.5 generation exceeded its configured time limit."
+            ) from exc
         except (OSError, subprocess.CalledProcessError) as exc:
             raise LTX25BackendError(
                 "LTX-2.5 generation failed; check the server logs for runtime details."
             ) from exc
+        finally:
+            with self._process_lock:
+                if self._process is process:
+                    self._process = None
         if not output_path.is_file() or output_path.stat().st_size == 0:
             raise LTX25BackendError(
                 "LTX-2.5 generation completed without an MP4 output."

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -130,14 +130,14 @@ def prepare_ltx25_runtime(executable: str) -> Path:
     """Provision the pinned runtime once into a process-private workspace."""
     global _RUNTIME_CACHE
 
-    uv = shutil.which("uv")
-    if uv is None:
-        raise LTX25BackendError(
-            "LTX-2.5 support requires uv to build its pinned runtime."
-        )
     with _RUNTIME_CACHE_LOCK:
         if _RUNTIME_CACHE is not None:
             return Path(_RUNTIME_CACHE.name)
+        uv = shutil.which("uv")
+        if uv is None:
+            raise LTX25BackendError(
+                "LTX-2.5 support requires uv to build its pinned runtime."
+            )
         cache: tempfile.TemporaryDirectory[str] | None = None
         try:
             cache = tempfile.TemporaryDirectory(prefix="rapidmlx-ltx25-runtime-")
@@ -177,6 +177,11 @@ def prepare_ltx25_runtime(executable: str) -> Path:
             ) from exc
         _RUNTIME_CACHE = cache
         return workspace
+
+
+def _prepared_ltx25_runtime() -> Path | None:
+    with _RUNTIME_CACHE_LOCK:
+        return Path(_RUNTIME_CACHE.name) if _RUNTIME_CACHE is not None else None
 
 
 def _generation_timeout_seconds() -> int:
@@ -257,14 +262,16 @@ class LTX25VideoEngine:
         image: Path | None,
         conditioning_strength: float | None = None,
     ) -> None:
-        executable = resolve_ltx25_runtime()
-        if executable is None:
-            raise LTX25BackendError(
-                "LTX-2.5 support requires the pinned ltx-2-mlx runtime. "
-                "See the LTX-2.5 setup in the video generation guide."
-            )
         timeout = _generation_timeout_seconds()
-        workspace = prepare_ltx25_runtime(executable)
+        workspace = _prepared_ltx25_runtime()
+        if workspace is None:
+            executable = resolve_ltx25_runtime()
+            if executable is None:
+                raise LTX25BackendError(
+                    "LTX-2.5 support requires the pinned ltx-2-mlx runtime. "
+                    "See the LTX-2.5 setup in the video generation guide."
+                )
+            workspace = prepare_ltx25_runtime(executable)
         try:
             staging = tempfile.TemporaryDirectory(
                 prefix=f".{output_path.name}.",

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import io
 import os
 import shutil
 import signal
 import subprocess
+import tarfile
+import tempfile
 import threading
 from pathlib import Path
 
@@ -52,7 +55,7 @@ def resolve_ltx25_runtime() -> str | None:
 
 
 def _runtime_revision(executable: str) -> str | None:
-    """Verify the documented workspace install is pinned and unmodified."""
+    """Verify the documented workspace points at the pinned Git revision."""
     path = Path(executable)
     try:
         repository = path.parents[2]
@@ -74,15 +77,44 @@ def _runtime_revision(executable: str) -> str | None:
             )
 
         result = git("rev-parse", "HEAD")
-        # The runtime packages are editable workspace installs, so verifying
-        # every tracked source and lockfile is clean verifies the code Python
-        # imports. Reject a missing/untracked lockfile as an incomplete clone.
-        if git("status", "--porcelain=v1", "--untracked-files=no").stdout.strip():
-            return None
         git("ls-files", "--error-unmatch", "uv.lock")
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
     return result.stdout.strip()
+
+
+def _materialize_runtime(repository: Path, destination: Path) -> None:
+    """Extract only tracked files from the audited commit into a fresh tree."""
+    try:
+        archive = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repository),
+                "archive",
+                "--format=tar",
+                LTX25_RUNTIME_COMMIT,
+            ],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        ).stdout
+        root = destination.resolve()
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as source:
+            members = source.getmembers()
+            for member in members:
+                target = (destination / member.name).resolve()
+                if not target.is_relative_to(root) or not (
+                    member.isfile() or member.isdir()
+                ):
+                    raise LTX25BackendError(
+                        "The pinned LTX-2.5 source archive contains an unsafe entry."
+                    )
+            source.extractall(destination, members=members)
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise LTX25BackendError(
+            "The pinned LTX-2.5 source snapshot could not be materialized."
+        ) from exc
 
 
 def _generation_timeout_seconds() -> int:
@@ -130,7 +162,12 @@ class LTX25VideoEngine:
                 os.killpg(process.pid, signal.SIGKILL)
             except ProcessLookupError:
                 return
-            process.wait(timeout=_TERMINATE_GRACE_SECONDS)
+            try:
+                process.wait(timeout=_TERMINATE_GRACE_SECONDS)
+            except subprocess.TimeoutExpired as exc:
+                raise LTX25BackendError(
+                    "The LTX-2.5 runtime process group could not be reaped."
+                ) from exc
 
     def stop(self) -> None:
         """Stop an active external generation during bounded shutdown."""
@@ -166,6 +203,13 @@ class LTX25VideoEngine:
                 "LTX-2.5 support requires uv to build its pinned isolated runtime."
             )
         timeout = _generation_timeout_seconds()
+        snapshot = tempfile.TemporaryDirectory(prefix="rapidmlx-ltx25-runtime-")
+        try:
+            snapshot_path = Path(snapshot.name)
+            _materialize_runtime(repository, snapshot_path)
+        except Exception:
+            snapshot.cleanup()
+            raise
 
         command = [
             str(Path(uv).absolute()),
@@ -173,7 +217,7 @@ class LTX25VideoEngine:
             "--isolated",
             "--frozen",
             "--project",
-            str(repository),
+            str(snapshot_path),
             "python",
             "-c",
             _STDIN_PROMPT_RUNNER,
@@ -219,14 +263,12 @@ class LTX25VideoEngine:
                 process = subprocess.Popen(
                     command,
                     stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
                     text=True,
                     start_new_session=True,
                 )
                 self._process = process
-            # Captured output is deliberately discarded: upstream diagnostics
-            # are not a safe public/logging channel for request data.
             process.communicate(input=prompt, timeout=timeout)
             if process.returncode:
                 raise LTX25BackendError(
@@ -247,6 +289,7 @@ class LTX25VideoEngine:
             with self._process_lock:
                 if self._process is process:
                     self._process = None
+            snapshot.cleanup()
         if not output_path.is_file() or output_path.stat().st_size == 0:
             raise LTX25BackendError(
                 "LTX-2.5 generation completed without an MP4 output."

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -74,6 +74,7 @@ def _runtime_revision(executable: str) -> str | None:
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env={**os.environ, "GIT_NO_REPLACE_OBJECTS": "1"},
             )
 
         result = git("rev-parse", "HEAD")
@@ -98,6 +99,7 @@ def _materialize_runtime(repository: Path, destination: Path) -> None:
             check=True,
             capture_output=True,
             timeout=30,
+            env={**os.environ, "GIT_NO_REPLACE_OBJECTS": "1"},
         ).stdout
         root = destination.resolve()
         with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as source:


### PR DESCRIPTION
## Summary
- register the 67.7 GB `ltx-2.5-mlx-q8` video alias and route it to a dedicated MLX adapter
- integrate the pinned `MrMoferFRAN/ltx-2-mlx` LTX-2.5 runtime through a safe argv-only subprocess boundary
- support T2V/I2V, 32-pixel alignment, low-RAM distilled generation, and preserve synchronized audio
- expose accurate capabilities and reject unsupported distilled CFG controls before queueing
- document the verified source install and LTX-2.x Community License considerations

## Validation
- isolated source-runtime install at commit `57952288076766abe27dda3a774b2c24f7346977`; CLI starts successfully
- targeted video/routing suite: 92 passed
- full unit suite: 17,969 passed, 243 skipped, 45 deselected, 6 xfailed, 1 xpassed
- three review passes; fixes included model-specific startup preflight, accurate CFG capability declarations, 32-pixel LTX-2.5 alignment, and compatibility with partially constructed video engines

## Scope note
A real 67.7 GB checkpoint render was not run in this workspace. The external runtime installation and CLI contract were exercised; generation is hermetically tested at the subprocess boundary.

🤖 AI-assisted: implementation and review by Codex.