### PR TITLE
feat(mac): add GitHub star onboarding prompts

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/ReonboardingReset.swift
@@ -158,6 +158,9 @@ enum ReonboardingReset {
 
         if scope.contains(.onboarding) {
             quickstart.resetForReonboarding()
+            defaults.removeObject(
+                forKey: GitHubCommunity.didShowOnboardingPromptKey
+            )
             // The wizard is gated on this alias as well as on its own flags,
             // and `stop()` only clears it when there was a child to stop —
             // so an idle app would otherwise restart straight past Quickstart.

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -521,30 +521,33 @@ struct ChatView: View {
     }
 
     private var heroBlock: some View {
-        EmptyState(
-            title: "Ask anything",
-            message: emptyStateSubtitle,
-            hint: downloadHint,
-            // No disc. The plate was framing an illustration that already
-            // has its own silhouette, and — being amber-tinted — it was
-            // spending a second amber moment on a surface whose whole
-            // budget is one (that one is the send disc).
-            //
-            // 116 is deliberately ≥ 64: ``CheetahLogo`` switches to the
-            // 440×390 master above that threshold, so the artwork is
-            // downsampled from a large source (crisp at @2x) rather than
-            // upscaled from the 56×50 crop. ``scaledToFit`` inside the
-            // square frame preserves the asset's own aspect ratio, which
-            // is why the mark renders ~116×103 rather than square.
-            markDiameter: 116,
-            marksOnBackplate: false,
-            // The chat surface at rest has nothing else in it. A 20pt
-            // line alone in 1440pt of canvas reads as a caption that lost
-            // its picture; at 34/40 the greeting is the object it should
-            // be.
-            titleEmphasis: .display,
-            mark: { CheetahLogo(size: 116) }
-        )
+        VStack(spacing: RapidTheme.Space.lg) {
+            EmptyState(
+                title: "Ask anything",
+                message: emptyStateSubtitle,
+                hint: downloadHint,
+                // No disc. The plate was framing an illustration that already
+                // has its own silhouette, and — being amber-tinted — it was
+                // spending a second amber moment on a surface whose whole
+                // budget is one (that one is the send disc).
+                //
+                // 116 is deliberately ≥ 64: ``CheetahLogo`` switches to the
+                // 440×390 master above that threshold, so the artwork is
+                // downsampled from a large source (crisp at @2x) rather than
+                // upscaled from the 56×50 crop. ``scaledToFit`` inside the
+                // square frame preserves the asset's own aspect ratio, which
+                // is why the mark renders ~116×103 rather than square.
+                markDiameter: 116,
+                marksOnBackplate: false,
+                // The chat surface at rest has nothing else in it. A 20pt
+                // line alone in 1440pt of canvas reads as a caption that lost
+                // its picture; at 34/40 the greeting is the object it should
+                // be.
+                titleEmphasis: .display,
+                mark: { CheetahLogo(size: 116) }
+            )
+            GitHubStarButton()
+        }
     }
 
     /// The line under "Ask anything", and the quieter hint below it.

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -770,14 +770,16 @@ struct ContentView: View {
         section = .chat
         VoiceOverAnnouncer.announce("Setup complete. Opening your first chat.")
         composerFocusRequest &+= 1
-        if !didShowOnboardingCompletePrompt {
-            didShowOnboardingCompletePrompt = true
-            withAnimation(RapidMotion.resolve(
-                RapidMotion.standard,
-                reduceMotion: reduceMotion
-            )) {
-                showOnboardingCompletePrompt = true
-            }
+        let prompt = GitHubStarPromptCompletion.completingOnboarding(
+            hasShown: didShowOnboardingCompletePrompt
+        )
+        didShowOnboardingCompletePrompt = prompt.hasShown
+        guard prompt.shouldPresent else { return }
+        withAnimation(RapidMotion.resolve(
+            RapidMotion.standard,
+            reduceMotion: reduceMotion
+        )) {
+            showOnboardingCompletePrompt = true
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -50,6 +50,9 @@ struct ContentView: View {
     /// by the onboarding completion transaction so the user lands in their
     /// first chat with the caret already in the message field.
     @State private var composerFocusRequest: Int = 0
+    @State private var showOnboardingCompletePrompt = false
+    @AppStorage(GitHubCommunity.didShowOnboardingPromptKey)
+    private var didShowOnboardingCompletePrompt = false
     @Environment(SettingsRouter.self) private var settingsRouter
     /// #223: launch-time auto-start "needs download" state — the empty
     /// state names the pending pull when non-nil.
@@ -105,6 +108,20 @@ struct ContentView: View {
         .overlay {
             if showConversationSearch {
                 conversationSearchOverlay
+            }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            if showOnboardingCompletePrompt {
+                OnboardingCompletePrompt {
+                    withAnimation(RapidMotion.resolve(
+                        RapidMotion.standard,
+                        reduceMotion: reduceMotion
+                    )) {
+                        showOnboardingCompletePrompt = false
+                    }
+                }
+                .padding(20)
+                .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
         .onChange(of: server.state) { _, newState in
@@ -753,6 +770,15 @@ struct ContentView: View {
         section = .chat
         VoiceOverAnnouncer.announce("Setup complete. Opening your first chat.")
         composerFocusRequest &+= 1
+        if !didShowOnboardingCompletePrompt {
+            didShowOnboardingCompletePrompt = true
+            withAnimation(RapidMotion.resolve(
+                RapidMotion.standard,
+                reduceMotion: reduceMotion
+            )) {
+                showOnboardingCompletePrompt = true
+            }
+        }
     }
 
     /// True when the Quickstart card should render in place of the chat

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+enum GitHubCommunity {
+    static let repositoryURL = URL(string: "https://github.com/raullenchai/Rapid-MLX")!
+    static let didShowOnboardingPromptKey = "Rapid.didShowOnboardingGitHubStarPrompt"
+}
+
+struct GitHubStarButton: View {
+    var onOpen: () -> Void = {}
+    var accessibilityIdentifier = "GitHub.Star.EmptyState"
+
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        Button {
+            onOpen()
+            openURL(GitHubCommunity.repositoryURL)
+        } label: {
+            Label("Star on GitHub", systemImage: "star")
+                .font(.system(size: 12, weight: .medium))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(RapidTheme.brandPrimaryDeep)
+        .background(
+            Capsule(style: .continuous)
+                .fill(RapidTheme.brandPrimaryTint)
+        )
+        .overlay(
+            Capsule(style: .continuous)
+                .stroke(RapidTheme.brandPrimary.opacity(0.55), lineWidth: 1)
+        )
+        .contentShape(Capsule(style: .continuous))
+        .accessibilityIdentifier(accessibilityIdentifier)
+        .accessibilityHint("Opens the Rapid-MLX repository in your browser")
+    }
+}
+
+struct OnboardingCompletePrompt: View {
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(.green)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Onboarding complete")
+                        .font(.system(size: 14, weight: .semibold))
+                    Text("You’re ready to chat locally with Rapid-MLX.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 8)
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Dismiss onboarding completion")
+                .accessibilityIdentifier("OnboardingComplete.Close")
+            }
+
+            HStack(spacing: 8) {
+                GitHubStarButton(
+                    onOpen: onDismiss,
+                    accessibilityIdentifier: "OnboardingComplete.Star"
+                )
+                Spacer(minLength: 0)
+                Button("Later", action: onDismiss)
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .accessibilityIdentifier("OnboardingComplete.Later")
+            }
+        }
+        .padding(16)
+        .frame(width: 342)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(.primary.opacity(0.1), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.16), radius: 18, y: 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("OnboardingComplete.Prompt")
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -5,6 +5,15 @@ enum GitHubCommunity {
     static let didShowOnboardingPromptKey = "Rapid.didShowOnboardingGitHubStarPrompt"
 }
 
+struct GitHubStarPromptCompletion: Equatable {
+    let hasShown: Bool
+    let shouldPresent: Bool
+
+    static func completingOnboarding(hasShown: Bool) -> Self {
+        Self(hasShown: true, shouldPresent: !hasShown)
+    }
+}
+
 struct GitHubStarButton: View {
     var onOpen: () -> Void = {}
     var accessibilityIdentifier = "GitHub.Star.EmptyState"

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("GitHub star onboarding prompt")
+struct GitHubStarPromptTests {
+    private static func source(_ name: String) throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: root.appendingPathComponent("Sources/Rapid/UI/\(name)"),
+            encoding: .utf8
+        )
+    }
+
+    @Test("Repository link targets the canonical Rapid-MLX project")
+    func canonicalRepositoryURL() {
+        #expect(GitHubCommunity.repositoryURL.absoluteString ==
+                "https://github.com/raullenchai/Rapid-MLX")
+    }
+
+    @Test("First-run prompt owns a stable persistence key")
+    func stablePromptPersistenceKey() {
+        #expect(GitHubCommunity.didShowOnboardingPromptKey ==
+                "Rapid.didShowOnboardingGitHubStarPrompt")
+    }
+
+    @Test("Star entry is mounted in Chat and the completion overlay")
+    func productionWiring() throws {
+        let chat = try Self.source("ChatView.swift")
+        let content = try Self.source("ContentView.swift")
+
+        #expect(chat.contains("GitHubStarButton()"))
+        #expect(content.contains("OnboardingCompletePrompt"))
+        #expect(content.contains("if !didShowOnboardingCompletePrompt"))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
@@ -27,6 +27,23 @@ struct GitHubStarPromptTests {
                 "Rapid.didShowOnboardingGitHubStarPrompt")
     }
 
+    @Test("Completion prompt presents once and records that presentation")
+    func oneShotCompletionTransition() {
+        let first = GitHubStarPromptCompletion.completingOnboarding(hasShown: false)
+        #expect(first == GitHubStarPromptCompletion(
+            hasShown: true,
+            shouldPresent: true
+        ))
+
+        let repeated = GitHubStarPromptCompletion.completingOnboarding(
+            hasShown: first.hasShown
+        )
+        #expect(repeated == GitHubStarPromptCompletion(
+            hasShown: true,
+            shouldPresent: false
+        ))
+    }
+
     @Test("Star entry is mounted in Chat and the completion overlay")
     func productionWiring() throws {
         let chat = try Self.source("ChatView.swift")
@@ -34,6 +51,6 @@ struct GitHubStarPromptTests {
 
         #expect(chat.contains("GitHubStarButton()"))
         #expect(content.contains("OnboardingCompletePrompt"))
-        #expect(content.contains("if !didShowOnboardingCompletePrompt"))
+        #expect(content.contains("GitHubStarPromptCompletion.completingOnboarding"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
@@ -498,8 +498,6 @@ struct OnboardingCompletionBehaviorTests {
             hear that setup finished never learns their action worked.
             """
         )
-        #expect(body.contains("showOnboardingCompletePrompt=true"),
-                "first onboarding completion must present its completion prompt")
         // The parent half must be gated on the coordinator's verdict so a
         // repeated activation cannot re-run the transition.
         let view = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingCompletionBehaviorTests.swift
@@ -488,7 +488,7 @@ struct OnboardingCompletionBehaviorTests {
         // the transaction, in that order.
         let handoff = "privatefuncfinishOnboardingHandoff(){section=.chat" +
             #"VoiceOverAnnouncer.announce("Setupcomplete.Openingyourfirstchat.")"# +
-            "composerFocusRequest&+=1}"
+            "composerFocusRequest&+=1"
         #expect(
             body.contains(handoff),
             """
@@ -498,6 +498,8 @@ struct OnboardingCompletionBehaviorTests {
             hear that setup finished never learns their action worked.
             """
         )
+        #expect(body.contains("showOnboardingCompletePrompt=true"),
+                "first onboarding completion must present its completion prompt")
         // The parent half must be gated on the coordinator's verdict so a
         // repeated activation cannot re-run the transition.
         let view = try Self.strippedSource("Sources/Rapid/UI/QuickstartView.swift")

--- a/apps/rapid-mac/Tests/RapidTests/ReonboardingResetTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReonboardingResetTests.swift
@@ -173,6 +173,7 @@ struct ReonboardingResetTests {
         defer { TestDefaultsScope.cleanup(suiteNames: [suite]) }
         let defaults = UserDefaults(suiteName: suite)!
         defaults.set("qwen3.5-9b-4bit", forKey: "rapid.serve.lastAlias")
+        defaults.set(true, forKey: GitHubCommunity.didShowOnboardingPromptKey)
 
         ReonboardingReset.eraseState(
             scope: .onboarding,
@@ -184,6 +185,9 @@ struct ReonboardingResetTests {
         )
 
         #expect(defaults.object(forKey: "rapid.serve.lastAlias") == nil)
+        #expect(defaults.object(
+            forKey: GitHubCommunity.didShowOnboardingPromptKey
+        ) == nil)
     }
 
     // MARK: - Relaunch


### PR DESCRIPTION
## Why

Give first-time users a clear completion moment and make the project community link discoverable from the default Chat surface.

## What changed

- show a one-time bottom-trailing onboarding completion card with Star, Later, and close actions
- add a persistent, lightweight Star on GitHub CTA beneath the Chat empty-state hero
- persist the one-time prompt and preserve re-onboarding behavior
- add accessibility identifiers, hints, and Reduce Motion-aware transitions

## Validation

- `swift test --filter "GitHubStarPromptTests|OnboardingCompletionBehaviorTests"` (33 passed)
- `swift test` compiled and ran 2,663 tests; 4 unrelated timing/concurrency tests failed, while all changed-area tests passed

## Visual reference

Interaction and hierarchy were informed by the supplied Orca screenshots; styling uses Rapid’s existing theme and cheetah-centered Chat empty state.