### PR TITLE
feat(models): add Ternary Bonsai 8B alias

### DIFF
--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -840,6 +840,20 @@ def test_bonsai_ternary_alias_wiring() -> None:
     )
     assert p.supports_spec_decode is False
 
+    # Discussion #1060 specifically requested the packed 8B checkpoint.
+    # Its Qwen3 chat template emits Hermes JSON tool envelopes and explicit
+    # <think> wrappers, so unlike the non-thinking 1.7B variant it uses the
+    # qwen3 reasoning parser.
+    alias_8b = "bonsai-8b-2bit"
+    assert alias_8b in raw, f"{alias_8b} missing from aliases.json"
+    p8 = list_profiles()[alias_8b]
+    assert p8.hf_path == "prism-ml/Ternary-Bonsai-8B-mlx-2bit"
+    assert p8.tool_call_parser == "hermes"
+    assert p8.reasoning_parser == "qwen3"
+    assert p8.is_hybrid is False
+    assert raw[alias_8b].get("is_hybrid_explicit") is True
+    assert p8.supports_spec_decode is False
+
     # The three FP16 ``bonsai-*-unpacked`` aliases are gone, and no alias
     # may resurrect an ``-unpacked`` repo (they lose all compression).
     assert not any(k.startswith("bonsai-") and k.endswith("-unpacked") for k in raw), (

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 import pytest
 
+from vllm_mlx import model_sizes
 from vllm_mlx.model_aliases import (
     POPULAR_ALIASES,
     VALID_PFLASH_TIERS,
@@ -853,6 +854,10 @@ def test_bonsai_ternary_alias_wiring() -> None:
     assert p8.is_hybrid is False
     assert raw[alias_8b].get("is_hybrid_explicit") is True
     assert p8.supports_spec_decode is False
+    assert model_sizes.size_bytes(p8.hf_path) == 2_315_084_354, (
+        f"{alias_8b}: download footprint drifted from the Hugging Face "
+        "repository metadata verified on 2026-08-20"
+    )
 
     # The three FP16 ``bonsai-*-unpacked`` aliases are gone, and no alias
     # may resurrect an ``-unpacked`` repo (they lose all compression).

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1384,6 +1384,14 @@
     "is_hybrid_explicit": true,
     "supports_spec_decode": false
   },
+  "bonsai-8b-2bit": {
+    "hf_path": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "supports_spec_decode": false
+  },
   "bonsai-27b-2bit": {
     "hf_path": "prism-ml/Ternary-Bonsai-27B-mlx-2bit",
     "is_text_only": true,

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -197,6 +197,7 @@
     "pipenetwork/Holo-3.1-35B-A3B-MLX-4bit": 23490832707,
     "pipenetwork/Holo-3.1-35B-A3B-MLX-8bit": 40810031931,
     "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit": 495525300,
+    "prism-ml/Ternary-Bonsai-8B-mlx-2bit": 2315084354,
     "prism-ml/Ternary-Bonsai-27B-mlx-2bit": 8521052337,
     "rapid-mlx/Ling-3.0-tiny-MLX-4bit": 4459772529,
     "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX": 16320413916,


### PR DESCRIPTION
## Summary

- add `bonsai-8b-2bit` for `prism-ml/Ternary-Bonsai-8B-mlx-2bit`
- configure the Hermes tool parser and Qwen3 reasoning parser from the checkpoint chat-template contract
- record the Hugging Face repository storage size and pin the alias contract in tests

This directly addresses Discussion #1060. It uses the original packed MLX 2-bit checkpoint and does not claim a separate Rapid-MLX addition-only BitNet kernel.

## Verification

- `uv run ruff check tests/test_aliases_contract.py`
- `uv run pytest tests/test_aliases_contract.py tests/test_model_profiles_ssot.py tests/test_model_sizes.py -q` — 2884 passed

Closes discussion follow-up: https://github.com/raullenchai/Rapid-MLX/discussions/1060