### PR TITLE
fix(cli): fail open on HTTPException in version check — flaky network crashed upgrade

### DIFF
--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -166,6 +166,31 @@ def test_fetch_latest_fail_open_on_urlerror(monkeypatch):
     assert vc._fetch_latest() is None
 
 
+def test_fetch_latest_fail_open_on_incomplete_read(monkeypatch):
+    """Truncated chunked response (http.client.IncompleteRead, an
+    HTTPException — not an OSError) → None, never a crash. Regression:
+    ``rapid-mlx upgrade`` crashed with a raw traceback on a flaky
+    connection instead of failing open."""
+    import http.client
+
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.61")
+
+    class _TruncatedResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            raise http.client.IncompleteRead(b"partial")
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda req, timeout=None: _TruncatedResp()
+    )
+    assert vc._fetch_latest() is None
+
+
 def test_fetch_latest_fail_open_on_bad_json(monkeypatch):
     """Malformed worker response → None, no exception."""
     monkeypatch.setattr(vc, "_installed_version", lambda: "0.6.61")

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -38,6 +38,7 @@ Behaviour matrix:
 
 from __future__ import annotations
 
+import http.client
 import json
 import os
 import re
@@ -219,7 +220,17 @@ def _fetch_latest() -> str | None:
             if len(releases) < 100:
                 return ".".join(map(str, max(versions))) if versions else None
             page += 1
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+    except (
+        urllib.error.URLError,
+        TimeoutError,
+        json.JSONDecodeError,
+        OSError,
+        # http.client.HTTPException covers mid-body transport failures such
+        # as IncompleteRead (truncated chunked responses), which are NOT
+        # OSError subclasses — without it a flaky connection crashes the CLI
+        # instead of failing open (seen live: rapid-mlx upgrade --dry-run).
+        http.client.HTTPException,
+    ):
         return None
 
 


### PR DESCRIPTION
## Why

Release dogfood on mini hit a live crash: `rapid-mlx upgrade --dry-run` printed a raw `http.client` traceback (`_read_chunked` → `IncompleteRead`) when the update-check response was truncated mid-body. A second run succeeded — purely a flaky-transport window.

`_fetch_latest()` documents itself as fail-open ("any network / parse / sandbox error returns None silently"), and `upgrade_command`/`staleness_warning` both rely on the `None` contract. But its except clause catches only `URLError, TimeoutError, JSONDecodeError, OSError` — and `http.client.IncompleteRead` (raised by `resp.read()` on truncated chunked responses) is an `HTTPException`, **not** an `OSError` subclass. Any mid-body transport failure therefore escapes and crashes the CLI (and the same hole sits under the startup staleness banner path).

## What

Add `http.client.HTTPException` to the except tuple in `_fetch_latest()` — covers `IncompleteRead`, `BadStatusLine`, `RemoteDisconnected`-adjacent mid-body failures, restoring the documented fail-open contract. No behavior change on any success path.

## Tests

- New: `test_fetch_latest_fail_open_on_incomplete_read` — `resp.read()` raising `IncompleteRead` → `_fetch_latest()` returns `None`. **Red on main** (raises), green with the fix.
- Full `tests/test_version_check.py`: 65 passed.

## Notes

AI-disclosure: authored by Claude (Fable 5) during self-driven release dogfooding (crash observed live on mini), reviewed via codex + pr_validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QDdb5mYeBw8qqApuxX6F2