### PR TITLE
fix(reasoning): add North (Cohere) reasoning parser — CoT leaked into content for North-Mini-Code

### DIFF
--- a/tests/test_cohere2_moe_vendored.py
+++ b/tests/test_cohere2_moe_vendored.py
@@ -93,15 +93,15 @@ def test_cache_layout_and_weight_key_cleanup_need_no_model_weights() -> None:
 
 
 def test_checkpoint_profile_defaults_and_conservative_capabilities() -> None:
-    # The North-native ``cohere`` tool/reasoning parsers ship in a separate
-    # shared-inference PR; until it lands the aliases run with default
-    # parsing (``None`` -> generic text path), which is sufficient to load
-    # and generate.
+    # The ``north`` reasoning parser landed in #2171 (the vendoring PR
+    # shipped these checkpoints with default parsing and this exact
+    # comment pointing at the follow-up). Tool calling remains
+    # conservative: no tool parser is declared for North yet.
     profile = detect_model_config("mlx-community/North-Mini-Code-1.0-bf16")
 
     assert profile is not None
     assert profile.tool_call_parser is None
-    assert profile.reasoning_parser is None
+    assert profile.reasoning_parser == "north"
     assert profile.is_hybrid is False
     assert profile.is_moe is True
     assert profile.supports_spec_decode is False
@@ -118,7 +118,7 @@ def test_public_4bit_alias_defaults_and_conservative_capabilities() -> None:
     assert profile is not None
     assert profile.hf_path == "mlx-community/North-Mini-Code-1.0-4bit"
     assert profile.tool_call_parser is None
-    assert profile.reasoning_parser is None
+    assert profile.reasoning_parser == "north"
     assert profile.is_hybrid is False
     assert profile.is_moe is True
     assert profile.supports_spec_decode is False

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -463,7 +463,6 @@ class TestStreaming:
         # JSON-mode streaming: bare JSON with no markers must stream on
         # the content lane, not vanish into reasoning — gated on the
         # explicit request signal (codex final-round #1).
-        parser.reset_state()
         parser.configure_request(json_mode=True)
         accumulated = ""
         rc, cc = [], []
@@ -477,6 +476,37 @@ class TestStreaming:
                 cc.append(msg.content)
         assert "".join(rc) == ""
         assert "".join(cc) == '{"answer": 4}'
+
+    def test_scalar_json_roots_route_to_content_in_json_mode(self, parser):
+        # JSON permits scalar roots — "ok", 42, true, null (codex
+        # final-round-2 #2).
+        for doc in ('"ok"', "42", "true", "null"):
+            parser.configure_request(json_mode=True)
+            reasoning, content = parser.extract_reasoning(doc)
+            assert reasoning is None, doc
+            assert content == doc
+
+    def test_streaming_scalar_json_routes_to_content(self, parser):
+        parser.configure_request(json_mode=True)
+        accumulated = ""
+        cc = []
+        for delta in ["tr", "ue"]:
+            prev = accumulated
+            accumulated += delta
+            msg = parser.extract_reasoning_streaming(prev, accumulated, delta)
+            if msg and msg.content:
+                cc.append(msg.content)
+        assert "".join(cc) == "true"
+
+    def test_configure_request_resets_machine_state(self, parser):
+        # The postprocessor reset path calls configure_request INSTEAD of
+        # reset_state — a reused parser must not carry the previous
+        # request's phase/buffer (codex final-round-2 #1).
+        parser.extract_reasoning_streaming("", END_THINK, END_THINK)
+        assert parser._sm_phase == "content"
+        parser.configure_request(json_mode=False)
+        assert parser._sm_phase == "thinking"
+        assert parser._sm_buf == ""
 
     def test_streaming_brace_thought_stays_reasoning_without_json_mode(self, parser):
         reasoning, content = _stream(parser, ['{"draft"', ": 1} hmm"])

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -503,3 +503,60 @@ class TestStreaming:
             ["cot", END_THINK, START_TEXT, "a <", " b", END_TEXT],
         )
         assert content == "a < b"
+
+
+class TestContentPhaseConsumesGenuineCloser:
+    """codex round-4 MAJOR on this PR: a reasoning-cap forced close
+    flips the machine to "content" while the model — which never saw
+    the forged closer — still emits its genuine ``<|END_THINKING|>``
+    later. Content phase stripped only TEXT wrappers, so the genuine
+    closer shipped as literal visible bytes (and leaked incrementally
+    when split across deltas). Content phase now consumes it as a
+    structural no-op. Revert ``_strip_content_phase_markers`` /
+    ``_CONTENT_MARKERS`` in the content branch to see these go red."""
+
+    def _force_flip(self, parser):
+        # The cap machinery's forced close: parser sees its own closer
+        # and flips to content phase with nothing else in the buffer.
+        msg = parser.extract_reasoning_streaming("", END_THINK, END_THINK)
+        assert parser._sm_phase == "content"
+        return msg
+
+    def test_whole_genuine_closer_after_forced_flip(self, parser):
+        self._force_flip(parser)
+        reasoning, content = _stream_from_phase(
+            parser, ["erate", END_THINK, START_TEXT, "4", END_TEXT]
+        )
+        assert content == "erate4", (reasoning, content)
+        assert "<|" not in content
+
+    def test_split_genuine_closer_after_forced_flip(self, parser):
+        self._force_flip(parser)
+        reasoning, content = _stream_from_phase(
+            parser, ["erate<|END_THI", "NKING|>", "<|START_TEXT|>4<|END_TEXT|>"]
+        )
+        assert content == "erate4", (reasoning, content)
+        assert "<|" not in content
+
+    def test_split_closer_pending_at_eof_flushes_literally(self, parser):
+        # Never-drop at EOF still wins over marker withholding: if the
+        # stream dies mid-marker the held bytes are model output.
+        self._force_flip(parser)
+        reasoning, content = _stream_from_phase(parser, ["answer tail<|END_THI"])
+        final = parser.finalize_streaming("")
+        flushed = (final.content or "") if final else ""
+        assert content + flushed == "answer tail<|END_THI", (content, flushed)
+
+
+def _stream_from_phase(parser, deltas):
+    accumulated = ""
+    results = []
+    for delta in deltas:
+        prev = accumulated
+        accumulated += delta
+        msg = parser.extract_reasoning_streaming(prev, accumulated, delta)
+        if msg:
+            results.append(msg)
+    reasoning = "".join(m.reasoning for m in results if m.reasoning)
+    content = "".join(m.content for m in results if m.content)
+    return reasoning, content

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -137,6 +137,95 @@ def _stream(parser, deltas):
     return reasoning, content
 
 
+class TestChatRouteStreaming:
+    """Route-level regression: the live 2026-08-20 dogfood repro streamed
+    the whole North output (CoT + literal markers) as ``delta.content``
+    because the casual-chat auto-disable resolved thinking to False and
+    the postprocessor bypassed the parser."""
+
+    def test_stream_splits_reasoning_and_strips_markers(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.config import reset_config
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.routes.chat import router as chat_router
+
+        class NorthPlainEngine:
+            preserve_native_tool_format = False
+            is_mllm = False
+            supports_guided_generation = False
+            tokenizer = None
+
+            def build_prompt(self, messages, tools=None, enable_thinking=None):
+                return "PROMPT"
+
+            async def stream_chat(self, messages, **kwargs):
+                deltas = [
+                    "Provide answer: 4.",
+                    END_THINK,
+                    START_TEXT,
+                    "4",
+                    END_TEXT,
+                ]
+                acc = ""
+                for i, d in enumerate(deltas):
+                    acc += d
+                    yield GenerationOutput(
+                        text=acc,
+                        new_text=d,
+                        prompt_tokens=4,
+                        completion_tokens=i + 1,
+                        finished=(i == len(deltas) - 1),
+                        finish_reason="stop" if i == len(deltas) - 1 else None,
+                    )
+
+        cfg = reset_config()
+        try:
+            cfg.engine = NorthPlainEngine()
+            cfg.model_name = "north-test"
+            cfg.model_registry = None
+            cfg.reasoning_parser = get_parser("north")()
+            cfg.reasoning_parser_name = "north"
+            cfg.tool_parser = None
+            cfg.no_thinking = False
+
+            app = FastAPI()
+            app.include_router(chat_router)
+            client = TestClient(app)
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "north-test",
+                    "messages": [{"role": "user", "content": "2+2?"}],
+                    "stream": True,
+                    "max_tokens": 100,
+                },
+            )
+            reasoning_parts, content_parts = [], []
+            for raw in resp.text.split("\n\n"):
+                for line in raw.splitlines():
+                    if not line.startswith("data: ") or line == "data: [DONE]":
+                        continue
+                    try:
+                        chunk = json.loads(line[len("data: ") :])
+                    except json.JSONDecodeError:
+                        continue
+                    for choice in chunk.get("choices", []):
+                        delta = choice.get("delta", {})
+                        if delta.get("reasoning_content"):
+                            reasoning_parts.append(delta["reasoning_content"])
+                        if delta.get("content"):
+                            content_parts.append(delta["content"])
+            reasoning = "".join(reasoning_parts)
+            content = "".join(content_parts)
+            assert reasoning == "Provide answer: 4."
+            assert content == "4"
+            assert "<|" not in content
+        finally:
+            reset_config()
+
+
 class TestStreaming:
     def test_streaming_simple_flow(self, parser):
         reasoning, content = _stream(
@@ -173,6 +262,15 @@ class TestStreaming:
             msg = parser.extract_reasoning_streaming(prev, accumulated, delta)
             if msg and msg.content:
                 assert "<|" not in msg.content
+
+    def test_sanitize_when_thinking_disabled_is_set(self, parser):
+        """North templates ignore ``enable_thinking`` and always pre-open
+        the thinking channel; the postprocessor's thinking-off bypass
+        (e.g. after the casual-chat auto-disable) must therefore keep the
+        parser engaged — this flag is the contract the streaming gate
+        checks. Live repro: with the flag absent, every streamed delta
+        (CoT + literal markers) shipped as ``delta.content``."""
+        assert parser.sanitize_when_thinking_disabled is True
 
     def test_streaming_lone_angle_in_answer_survives(self, parser):
         # A genuine "<" in the answer that never becomes a marker must be

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -45,6 +45,20 @@ class TestRegistry:
         assert cfg.tool_call_parser is None
 
 
+class TestPromptThinkingPredicateMixedTemplate:
+    def test_mixed_marker_template_uses_all_pairs(self):
+        # A template whose source mentions BOTH marker families but whose
+        # active branch renders only the North pair must still be
+        # detected (codex on #2171: first-present-pair inspection bug).
+        from vllm_mlx.service.helpers import _should_start_in_thinking
+
+        template = (
+            "{# legacy: <think></think> #}"
+            "{% if add_generation_prompt %}<|START_THINKING|>{% endif %}"
+        )
+        assert _should_start_in_thinking(template, None, unconditional=True) is True
+
+
 class TestPromptThinkingPredicate:
     def test_north_template_detected_as_prompt_thinking(self):
         from vllm_mlx.service.helpers import _should_start_in_thinking
@@ -100,15 +114,28 @@ class TestExtractReasoning:
         assert reasoning == "cot"
         assert content == "partial answer"
 
-    def test_bare_json_response_routes_to_content(self, parser):
+    def test_bare_json_response_routes_to_content_in_json_mode(self, parser):
         # JSON-mode contract: North's template instructs structured
-        # responses to emit bare JSON with no channel markers (codex r4).
+        # responses to emit bare JSON with no channel markers — gated on
+        # the EXPLICIT request signal, not inferred from the first
+        # character (codex final-round #1).
+        parser.configure_request(json_mode=True)
         reasoning, content = parser.extract_reasoning('{"answer": 4}')
         assert reasoning is None
         assert content == '{"answer": 4}'
         reasoning, content = parser.extract_reasoning("\n[1, 2, 3]")
         assert reasoning is None
         assert content == "\n[1, 2, 3]"
+
+    def test_brace_headed_thought_stays_reasoning_without_json_mode(self, parser):
+        # Privacy: a chain of thought that merely opens with a brace must
+        # NOT bypass the reasoning split when the request did not ask for
+        # JSON output (codex final-round #1).
+        reasoning, content = parser.extract_reasoning(
+            '{"draft": 1} — no wait, let me reconsider'
+        )
+        assert content is None
+        assert reasoning is not None and reasoning.startswith('{"draft"')
 
     def test_no_marker_leakage_in_either_channel(self, parser):
         out = f"think{END_THINK}{START_TEXT}answer{END_TEXT}"
@@ -434,13 +461,27 @@ class TestStreaming:
 
     def test_streaming_bare_json_routes_to_content(self, parser):
         # JSON-mode streaming: bare JSON with no markers must stream on
-        # the content lane, not vanish into reasoning (codex r4).
-        reasoning, content = _stream(
-            parser,
-            ['{"ans', 'wer": ', "4}"],
-        )
-        assert reasoning == ""
-        assert content == '{"answer": 4}'
+        # the content lane, not vanish into reasoning — gated on the
+        # explicit request signal (codex final-round #1).
+        parser.reset_state()
+        parser.configure_request(json_mode=True)
+        accumulated = ""
+        rc, cc = [], []
+        for delta in ['{"ans', 'wer": ', "4}"]:
+            prev = accumulated
+            accumulated += delta
+            msg = parser.extract_reasoning_streaming(prev, accumulated, delta)
+            if msg and msg.reasoning:
+                rc.append(msg.reasoning)
+            if msg and msg.content:
+                cc.append(msg.content)
+        assert "".join(rc) == ""
+        assert "".join(cc) == '{"answer": 4}'
+
+    def test_streaming_brace_thought_stays_reasoning_without_json_mode(self, parser):
+        reasoning, content = _stream(parser, ['{"draft"', ": 1} hmm"])
+        assert content == ""
+        assert reasoning.startswith('{"draft"')
 
     def test_streaming_split_end_thinking_marker(self, parser):
         # <|END_THINKING|> split across deltas must not leak marker bytes

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -263,6 +263,32 @@ class TestStreaming:
             if msg and msg.content:
                 assert "<|" not in msg.content
 
+    def test_streaming_split_end_thinking_marker(self, parser):
+        # <|END_THINKING|> split across deltas must not leak marker bytes
+        # into reasoning nor swallow the answer (codex r2 BLOCKING #1).
+        reasoning, content = _stream(
+            parser,
+            ["cot<", "|END_THINKING|>", START_TEXT, "answer", END_TEXT],
+        )
+        assert reasoning == "cot"
+        assert content == "answer"
+
+    def test_streaming_spill_before_start_text(self, parser):
+        # Channel spill before <|START_TEXT|> with no thinking closer:
+        # mirror of the non-streaming ("spill", "answer") split (codex r2
+        # BLOCKING #2).
+        reasoning, content = _stream(
+            parser,
+            ["spill", START_TEXT, "answer", END_TEXT],
+        )
+        assert reasoning == "spill"
+        assert content == "answer"
+
+    def test_implicit_reasoning_until_close_is_set(self, parser):
+        # North templates prime thinking unconditionally — same contract
+        # pair as DeepSeek-R1-Distill (codex r2 BLOCKING #3).
+        assert parser.implicit_reasoning_until_close is True
+
     def test_streaming_direct_answer_shape(self, parser):
         # No thinking block at all: <|START_TEXT|> arrives first (split
         # across deltas) — mirror of the non-streaming direct-answer

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -303,6 +303,87 @@ class TestChatRouteEofFlush:
         finally:
             reset_config()
 
+    def test_route_flushes_thinking_phase_tail_at_eof(self):
+        """Same never-drop contract, thinking phase (codex round-2 BLOCKING
+        on this PR): a stream that ends mid-marker while STILL inside the
+        thinking channel releases its withheld tail as a ``reasoning``
+        event from ``finalize()``. The route's finalize loop consumed only
+        ``tool_call`` and ``content`` events, so that tail vanished from
+        ``reasoning_content`` — delete the ``reasoning`` branch in the
+        finalize loop and this test goes red."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.config import reset_config
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.routes.chat import router as chat_router
+
+        class TruncatedThinkingEngine:
+            preserve_native_tool_format = False
+            is_mllm = False
+            supports_guided_generation = False
+            tokenizer = None
+
+            def build_prompt(self, messages, tools=None, enable_thinking=None):
+                return "PROMPT"
+
+            async def stream_chat(self, messages, **kwargs):
+                # Ends mid END_THINKING marker: still in thinking phase.
+                deltas = ["deliberating", " about it<|END_THI"]
+                acc = ""
+                for i, d in enumerate(deltas):
+                    acc += d
+                    yield GenerationOutput(
+                        text=acc,
+                        new_text=d,
+                        prompt_tokens=4,
+                        completion_tokens=i + 1,
+                        finished=(i == len(deltas) - 1),
+                        finish_reason="length" if i == len(deltas) - 1 else None,
+                    )
+
+        cfg = reset_config()
+        try:
+            cfg.engine = TruncatedThinkingEngine()
+            cfg.model_name = "north-test"
+            cfg.model_registry = None
+            cfg.reasoning_parser = get_parser("north")()
+            cfg.reasoning_parser_name = "north"
+            cfg.tool_parser = None
+            cfg.no_thinking = False
+
+            app = FastAPI()
+            app.include_router(chat_router)
+            client = TestClient(app)
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "north-test",
+                    "messages": [{"role": "user", "content": "2+2?"}],
+                    "stream": True,
+                    "max_tokens": 100,
+                },
+            )
+            reasoning_parts = []
+            for raw in resp.text.split("\n\n"):
+                for line in raw.splitlines():
+                    if not line.startswith("data: ") or line == "data: [DONE]":
+                        continue
+                    try:
+                        chunk = json.loads(line[len("data: ") :])
+                    except json.JSONDecodeError:
+                        continue
+                    for choice in chunk.get("choices", []):
+                        delta = choice.get("delta", {})
+                        if delta.get("reasoning_content"):
+                            reasoning_parts.append(delta["reasoning_content"])
+            reasoning = "".join(reasoning_parts)
+            assert reasoning.startswith("deliberating")
+            # The withheld mid-marker tail must reach reasoning_content.
+            assert "<|END_THI" in reasoning
+        finally:
+            reset_config()
+
 
 class TestStreaming:
     def test_streaming_simple_flow(self, parser):

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -100,6 +100,16 @@ class TestExtractReasoning:
         assert reasoning == "cot"
         assert content == "partial answer"
 
+    def test_bare_json_response_routes_to_content(self, parser):
+        # JSON-mode contract: North's template instructs structured
+        # responses to emit bare JSON with no channel markers (codex r4).
+        reasoning, content = parser.extract_reasoning('{"answer": 4}')
+        assert reasoning is None
+        assert content == '{"answer": 4}'
+        reasoning, content = parser.extract_reasoning("\n[1, 2, 3]")
+        assert reasoning is None
+        assert content == "\n[1, 2, 3]"
+
     def test_no_marker_leakage_in_either_channel(self, parser):
         out = f"think{END_THINK}{START_TEXT}answer{END_TEXT}"
         reasoning, content = parser.extract_reasoning(out)
@@ -421,6 +431,16 @@ class TestStreaming:
             msg = parser.extract_reasoning_streaming(prev, accumulated, delta)
             if msg and msg.content:
                 assert "<|" not in msg.content
+
+    def test_streaming_bare_json_routes_to_content(self, parser):
+        # JSON-mode streaming: bare JSON with no markers must stream on
+        # the content lane, not vanish into reasoning (codex r4).
+        reasoning, content = _stream(
+            parser,
+            ['{"ans', 'wer": ', "4}"],
+        )
+        assert reasoning == ""
+        assert content == '{"answer": 4}'
 
     def test_streaming_split_end_thinking_marker(self, parser):
         # <|END_THINKING|> split across deltas must not leak marker bytes

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -226,6 +226,84 @@ class TestChatRouteStreaming:
             reset_config()
 
 
+class TestChatRouteEofFlush:
+    def test_route_flushes_withheld_marker_tail_at_eof(self):
+        """Route-level never-drop contract (codex r3 BLOCKING): a stream
+        ending in a marker-like run must surface those bytes via the
+        StreamingPostProcessor EOF flush, not lose them."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.config import reset_config
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.routes.chat import router as chat_router
+
+        class TruncatedTailEngine:
+            preserve_native_tool_format = False
+            is_mllm = False
+            supports_guided_generation = False
+            tokenizer = None
+
+            def build_prompt(self, messages, tools=None, enable_thinking=None):
+                return "PROMPT"
+
+            async def stream_chat(self, messages, **kwargs):
+                deltas = ["cot", END_THINK, START_TEXT, "answer<|END_TE"]
+                acc = ""
+                for i, d in enumerate(deltas):
+                    acc += d
+                    yield GenerationOutput(
+                        text=acc,
+                        new_text=d,
+                        prompt_tokens=4,
+                        completion_tokens=i + 1,
+                        finished=(i == len(deltas) - 1),
+                        finish_reason="length" if i == len(deltas) - 1 else None,
+                    )
+
+        cfg = reset_config()
+        try:
+            cfg.engine = TruncatedTailEngine()
+            cfg.model_name = "north-test"
+            cfg.model_registry = None
+            cfg.reasoning_parser = get_parser("north")()
+            cfg.reasoning_parser_name = "north"
+            cfg.tool_parser = None
+            cfg.no_thinking = False
+
+            app = FastAPI()
+            app.include_router(chat_router)
+            client = TestClient(app)
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "north-test",
+                    "messages": [{"role": "user", "content": "2+2?"}],
+                    "stream": True,
+                    "max_tokens": 100,
+                },
+            )
+            content_parts = []
+            for raw in resp.text.split("\n\n"):
+                for line in raw.splitlines():
+                    if not line.startswith("data: ") or line == "data: [DONE]":
+                        continue
+                    try:
+                        chunk = json.loads(line[len("data: ") :])
+                    except json.JSONDecodeError:
+                        continue
+                    for choice in chunk.get("choices", []):
+                        delta = choice.get("delta", {})
+                        if delta.get("content"):
+                            content_parts.append(delta["content"])
+            content = "".join(content_parts)
+            assert content.startswith("answer")
+            # The withheld tail must be flushed, not dropped.
+            assert "<|END_TE" in content
+        finally:
+            reset_config()
+
+
 class TestStreaming:
     def test_streaming_simple_flow(self, parser):
         reasoning, content = _stream(

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Cohere North reasoning parser (North-Mini-Code).
+
+Regression (2026-08-20 release dogfood): serving
+``mlx-community/North-Mini-Code-1.0-4bit`` shipped the raw chain of
+thought and the literal ``<|END_THINKING|><|START_TEXT|>`` markers inside
+``message.content`` because no parser understood North's format.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.reasoning import get_parser
+from vllm_mlx.reasoning.north_parser import NorthReasoningParser
+
+END_THINK = "<|END_THINKING|>"
+START_TEXT = "<|START_TEXT|>"
+END_TEXT = "<|END_TEXT|>"
+
+
+@pytest.fixture
+def parser() -> NorthReasoningParser:
+    return NorthReasoningParser()
+
+
+class TestRegistry:
+    def test_north_is_registered(self):
+        assert get_parser("north") is NorthReasoningParser
+
+    def test_alias_profiles_wire_north(self):
+        aliases = json.loads(
+            (Path(__file__).parent.parent / "vllm_mlx" / "aliases.json").read_text()
+        )
+        for alias in ("north-mini-code-4bit", "north-mini-code-bf16"):
+            assert aliases[alias]["reasoning_parser"] == "north"
+
+    def test_auto_config_wires_north_for_raw_hf_paths(self):
+        from vllm_mlx.model_auto_config import detect_model_config
+
+        cfg = detect_model_config("mlx-community/North-Mini-Code-1.0-4bit")
+        assert cfg is not None
+        assert cfg.reasoning_parser == "north"
+        assert cfg.tool_call_parser is None
+
+
+class TestPromptThinkingPredicate:
+    def test_north_template_detected_as_prompt_thinking(self):
+        from vllm_mlx.service.helpers import _should_start_in_thinking
+
+        template = (
+            "{% if add_generation_prompt %}"
+            "<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|><|START_THINKING|>"
+            "{% endif %}"
+        )
+        assert _should_start_in_thinking(template, None) is True
+        # Explicitly disabled thinking still short-circuits to False.
+        assert _should_start_in_thinking(template, False) is False
+
+    def test_think_tag_templates_still_detected(self):
+        from vllm_mlx.service.helpers import _should_start_in_thinking
+
+        template = "{% if add_generation_prompt %}<think>\n{% endif %}"
+        assert _should_start_in_thinking(template, None) is True
+
+
+class TestExtractReasoning:
+    def test_implicit_think_shape(self, parser):
+        # The live dogfood shape: opener lives in the prompt, output is
+        # cot + END_THINKING + wrapped answer.
+        out = f"This is simple. Answer: 4.{END_THINK}{START_TEXT}4{END_TEXT}"
+        reasoning, content = parser.extract_reasoning(out)
+        assert reasoning == "This is simple. Answer: 4."
+        assert content == "4"
+
+    def test_explicit_both_markers(self, parser):
+        out = f"<|START_THINKING|>plan{END_THINK}{START_TEXT}done{END_TEXT}"
+        reasoning, content = parser.extract_reasoning(out)
+        assert reasoning == "plan"
+        assert content == "done"
+
+    def test_no_markers_routes_to_reasoning(self, parser):
+        # North templates end the prompt inside <|START_THINKING|>, so a
+        # marker-free output is a truncated thought trace.
+        reasoning, content = parser.extract_reasoning("half a thought")
+        assert reasoning == "half a thought"
+        assert content is None
+
+    def test_direct_answer_without_thinking_block(self, parser):
+        out = f"{START_TEXT}direct answer{END_TEXT}"
+        reasoning, content = parser.extract_reasoning(out)
+        assert reasoning is None
+        assert content == "direct answer"
+
+    def test_unterminated_text_wrapper(self, parser):
+        # Truncated mid-answer: END_TEXT never arrived.
+        out = f"cot{END_THINK}{START_TEXT}partial answer"
+        reasoning, content = parser.extract_reasoning(out)
+        assert reasoning == "cot"
+        assert content == "partial answer"
+
+    def test_no_marker_leakage_in_either_channel(self, parser):
+        out = f"think{END_THINK}{START_TEXT}answer{END_TEXT}"
+        reasoning, content = parser.extract_reasoning(out)
+        for channel in (reasoning, content):
+            assert channel is not None
+            assert "<|" not in channel
+
+
+class TestTruncationContract:
+    def test_open_in_think_before_end_marker(self, parser):
+        assert parser.is_open_in_think("some unfinished thought") is True
+
+    def test_not_open_after_end_marker(self, parser):
+        assert parser.is_open_in_think(f"thought{END_THINK}answer") is False
+
+    def test_not_open_in_direct_answer_shape(self, parser):
+        assert parser.is_open_in_think(f"{START_TEXT}answer") is False
+
+    def test_empty_is_not_open(self, parser):
+        assert parser.is_open_in_think("") is False
+
+
+def _stream(parser, deltas):
+    parser.reset_state()
+    accumulated = ""
+    results = []
+    for delta in deltas:
+        prev = accumulated
+        accumulated += delta
+        msg = parser.extract_reasoning_streaming(prev, accumulated, delta)
+        if msg:
+            results.append(msg)
+    reasoning = "".join(m.reasoning for m in results if m.reasoning)
+    content = "".join(m.content for m in results if m.content)
+    return reasoning, content
+
+
+class TestStreaming:
+    def test_streaming_simple_flow(self, parser):
+        reasoning, content = _stream(
+            parser,
+            ["think", "ing", END_THINK, START_TEXT, "ans", "wer", END_TEXT],
+        )
+        assert reasoning == "thinking"
+        assert content == "answer"
+
+    def test_streaming_text_marker_split_across_deltas(self, parser):
+        # START_TEXT arrives split over three deltas glued to answer bytes.
+        reasoning, content = _stream(
+            parser,
+            ["cot", END_THINK, "<|STA", "RT_TE", "XT|>an", "swer", END_TEXT],
+        )
+        assert reasoning == "cot"
+        assert content == "answer"
+
+    def test_streaming_end_text_split_with_glued_bytes(self, parser):
+        reasoning, content = _stream(
+            parser,
+            ["cot", END_THINK, START_TEXT, "answer<|END_", "TEXT|>"],
+        )
+        assert reasoning == "cot"
+        assert content == "answer"
+
+    def test_streaming_no_marker_bytes_leak(self, parser):
+        parser.reset_state()
+        deltas = ["cot", END_THINK, "<|STA", "RT_TE", "XT|>a", END_TEXT]
+        accumulated = ""
+        for delta in deltas:
+            prev = accumulated
+            accumulated += delta
+            msg = parser.extract_reasoning_streaming(prev, accumulated, delta)
+            if msg and msg.content:
+                assert "<|" not in msg.content
+
+    def test_streaming_lone_angle_in_answer_survives(self, parser):
+        # A genuine "<" in the answer that never becomes a marker must be
+        # flushed by the following delta, not swallowed.
+        reasoning, content = _stream(
+            parser,
+            ["cot", END_THINK, START_TEXT, "a <", " b", END_TEXT],
+        )
+        assert content == "a < b"

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -263,6 +263,44 @@ class TestStreaming:
             if msg and msg.content:
                 assert "<|" not in msg.content
 
+    def test_streaming_direct_answer_shape(self, parser):
+        # No thinking block at all: <|START_TEXT|> arrives first (split
+        # across deltas) — mirror of the non-streaming direct-answer
+        # branch (codex r1 BLOCKING #1).
+        reasoning, content = _stream(
+            parser,
+            ["<|STAR", "T_TEXT|>dir", "ect answer", END_TEXT],
+        )
+        assert reasoning == ""
+        assert content == "direct answer"
+
+    def test_streaming_direct_answer_with_leading_whitespace(self, parser):
+        reasoning, content = _stream(
+            parser,
+            ["\n ", START_TEXT, "ok", END_TEXT],
+        )
+        assert reasoning == ""
+        assert content == "ok"
+
+    def test_finalize_flushes_partial_marker_tail(self, parser):
+        # An answer that ends in a marker-like prefix is withheld by the
+        # streaming stripper; finalize must flush it, never drop it
+        # (codex r1 BLOCKING #2).
+        parser.reset_state()
+        accumulated = ""
+        outs = []
+        for delta in ["cot", END_THINK, START_TEXT, "answer<|END_TE"]:
+            prev = accumulated
+            accumulated += delta
+            msg = parser.extract_reasoning_streaming(prev, accumulated, delta)
+            if msg:
+                outs.append(msg)
+        content = "".join(m.content for m in outs if m.content)
+        assert content == "answer"
+        fin = parser.finalize_streaming(accumulated)
+        assert fin is not None
+        assert (fin.content or "").endswith("<|END_TE")
+
     def test_sanitize_when_thinking_disabled_is_set(self, parser):
         """North templates ignore ``enable_thinking`` and always pre-open
         the thinking channel; the postprocessor's thinking-off bypass

--- a/tests/test_north_reasoning_parser.py
+++ b/tests/test_north_reasoning_parser.py
@@ -538,6 +538,16 @@ class TestContentPhaseConsumesGenuineCloser:
     def _force_flip(self, parser):
         # The cap machinery's forced close: parser sees its own closer
         # and flips to content phase with nothing else in the buffer.
+        #
+        # These tests deliberately pin post-flip thought bytes
+        # ("erate") ARRIVING AS CONTENT. That is the reasoning-cap
+        # contract, not a leak: the cap (upstream vLLM #20859 backport)
+        # reroutes over-budget bytes to content precisely so no model
+        # output is ever silently dropped, and every think-tag parser
+        # behaves identically post-cap (probe-verified against qwen3 —
+        # same spill, same channel). A "discard until the genuine
+        # closer" state would silently destroy model bytes and diverge
+        # north from the whole parser family.
         msg = parser.extract_reasoning_streaming("", END_THINK, END_THINK)
         assert parser._sm_phase == "content"
         return msg

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1,12 +1,14 @@
 {
   "north-mini-code-4bit": {
     "hf_path": "mlx-community/North-Mini-Code-1.0-4bit",
+    "reasoning_parser": "north",
     "is_hybrid": false,
     "is_moe": true,
     "supports_spec_decode": false
   },
   "north-mini-code-bf16": {
     "hf_path": "mlx-community/North-Mini-Code-1.0-bf16",
+    "reasoning_parser": "north",
     "is_hybrid": false,
     "is_moe": true,
     "supports_spec_decode": false

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -357,6 +357,17 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             reasoning_parser=None,
         ),
     ),
+    # Cohere North family (North-Mini-Code) — <|START_THINKING|> /
+    # <|END_THINKING|> reasoning markers with <|START_TEXT|> content
+    # wrappers. No tool parser yet: North's <|START_ACTION|> tool format
+    # has no parser in the registry.
+    (
+        re.compile(r"north[-_]?mini", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser=None,
+            reasoning_parser="north",
+        ),
+    ),
     # MiniMax M2.5
     (
         re.compile(r"minimax", re.IGNORECASE),

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -93,6 +93,7 @@ def _register_builtin_parsers():
     from .hy3_parser import Hy3ReasoningParser
     from .minimax_parser import MiniMaxReasoningParser
     from .muse_parser import MuseReasoningParser
+    from .north_parser import NorthReasoningParser
     from .qwen3_parser import Qwen3ReasoningParser
     from .ui_tars_parser import UiTarsReasoningParser
 
@@ -122,6 +123,12 @@ def _register_builtin_parsers():
     # regex in ``model_auto_config`` and by the alias entries in
     # ``aliases.json``.
     register_parser("ui_tars", UiTarsReasoningParser)
+    # ``north`` — Cohere North family (North-Mini-Code):
+    # ``<|START_THINKING|>``/``<|END_THINKING|>`` implicit-think markers
+    # plus ``<|START_TEXT|>``/``<|END_TEXT|>`` content wrappers. Auto-wired
+    # by the ``north[-_]?mini`` regex in ``model_auto_config`` and by the
+    # ``north-mini-code-*`` alias entries in ``aliases.json``.
+    register_parser("north", NorthReasoningParser)
 
 
 # Register built-in parsers on module load

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -36,6 +36,18 @@ _TEXT_MARKER_RE = re.compile(r"<\|(?:START|END)_TEXT\|>")
 # ``<|END_THINKING|>`` later; in content phase that marker is a
 # structural no-op and must never ship as visible bytes (codex round-4
 # MAJOR on #2171).
+#
+# Two deliberate scope calls, per the reasoning-cap contract rather
+# than oversights:
+# * Post-flip thought bytes stay ON the content channel. The cap
+#   (upstream vLLM #20859 backport) reroutes over-budget bytes to
+#   content so nothing is silently dropped, and qwen3/deepseek spill
+#   identically post-cap — a discard-until-genuine-closer state would
+#   destroy model bytes and diverge north from the parser family.
+# * A literal ``<|END_THINKING|>`` the model intends as visible answer
+#   text is indistinguishable from the structural marker — the same
+#   documented limitation as the think-tag family's literal-tag caveat
+#   (it is a dedicated special token; models do not emit it as prose).
 _CONTENT_MARKER_RE = re.compile(r"<\|(?:(?:START|END)_TEXT|END_THINKING)\|>")
 _CONTENT_MARKERS = (_START_TEXT, _END_TEXT, _END_THINKING)
 

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -30,10 +30,22 @@ _END_TEXT = "<|END_TEXT|>"
 _TEXT_MARKERS = (_START_TEXT, _END_TEXT)
 _ALL_MARKERS = (_START_THINKING, _END_THINKING, _START_TEXT, _END_TEXT)
 _TEXT_MARKER_RE = re.compile(r"<\|(?:START|END)_TEXT\|>")
+# Content-phase strip: TEXT wrappers plus a genuine ``<|END_THINKING|>``.
+# After a reasoning-cap forced close flips the machine to "content", the
+# model (which never saw the forged closer) still emits its own
+# ``<|END_THINKING|>`` later; in content phase that marker is a
+# structural no-op and must never ship as visible bytes (codex round-4
+# MAJOR on #2171).
+_CONTENT_MARKER_RE = re.compile(r"<\|(?:(?:START|END)_TEXT|END_THINKING)\|>")
+_CONTENT_MARKERS = (_START_TEXT, _END_TEXT, _END_THINKING)
 
 
 def _strip_text_markers(text: str) -> str:
     return _TEXT_MARKER_RE.sub("", text)
+
+
+def _strip_content_phase_markers(text: str) -> str:
+    return _CONTENT_MARKER_RE.sub("", text)
 
 
 def _partial_marker_suffix_len(
@@ -212,10 +224,11 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
                 self._sm_buf = cleaned[len(emit) :]
                 push_reasoning(emit)
                 break
-            # content phase: strip complete TEXT markers, withhold a
-            # trailing partial-marker prefix.
-            stripped = _strip_text_markers(self._sm_buf)
-            held = _partial_marker_suffix_len(stripped)
+            # content phase: strip complete TEXT markers and any genuine
+            # ``<|END_THINKING|>`` arriving after a forced close, withhold
+            # a trailing partial-marker prefix.
+            stripped = _strip_content_phase_markers(self._sm_buf)
+            held = _partial_marker_suffix_len(stripped, _CONTENT_MARKERS)
             emit = stripped[: len(stripped) - held] if held else stripped
             self._sm_buf = stripped[len(emit) :]
             if emit:

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -56,6 +56,16 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
     (both full-output and streaming, with cross-delta marker buffering).
     """
 
+    # North chat templates do not consult ``enable_thinking`` — they
+    # unconditionally end the generation prompt inside
+    # ``<|START_THINKING|>``, so the model emits a thought trace even
+    # when the route resolved thinking to False (e.g. the casual-chat
+    # auto-disable). Keep the parser engaged in that case or the raw
+    # chain of thought and the literal channel markers stream into
+    # ``delta.content`` (2026-08-20 dogfood repro). Same contract as
+    # DeepSeek-V4 / DeepSeek-R1 / Muse.
+    sanitize_when_thinking_disabled = True
+
     @property
     def start_token(self) -> str:
         return "<|START_THINKING|>"

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Reasoning parser for the Cohere North family (North-Mini-Code).
+
+North chat templates pre-open the reasoning channel by ending the
+generation prompt with ``<|START_THINKING|>``. The model then emits::
+
+    ...chain of thought...<|END_THINKING|><|START_TEXT|>answer<|END_TEXT|>
+
+so the output contains the *closing* thinking marker but usually not the
+opening one (the implicit-think shape ``BaseThinkingReasoningParser``
+already supports), plus ``<|START_TEXT|>`` / ``<|END_TEXT|>`` wrappers
+around the user-visible answer that must be stripped from ``content``.
+
+Found via release dogfood (2026-08-20): without this parser the alias
+profile fell back to ``reasoning_parser=None`` and the raw chain of
+thought — policy deliberation included — shipped verbatim inside
+``message.content`` together with the literal channel markers.
+"""
+
+import re
+
+from .base import DeltaMessage
+from .think_parser import BaseThinkingReasoningParser
+
+_START_TEXT = "<|START_TEXT|>"
+_END_TEXT = "<|END_TEXT|>"
+_TEXT_MARKERS = (_START_TEXT, _END_TEXT)
+_TEXT_MARKER_RE = re.compile(r"<\|(?:START|END)_TEXT\|>")
+
+
+def _strip_text_markers(text: str) -> str:
+    return _TEXT_MARKER_RE.sub("", text)
+
+
+def _partial_marker_suffix_len(text: str) -> int:
+    """Length of the longest trailing run of ``text`` that is a proper
+    prefix of a TEXT marker — i.e. a marker possibly split across
+    streaming deltas that must be withheld until the next delta decides.
+    """
+    longest = max(len(m) for m in _TEXT_MARKERS) - 1
+    for n in range(min(len(text), longest), 0, -1):
+        suffix = text[-n:]
+        if any(marker.startswith(suffix) for marker in _TEXT_MARKERS):
+            return n
+    return 0
+
+
+class NorthReasoningParser(BaseThinkingReasoningParser):
+    """Parser for North's ``<|START_THINKING|>``/``<|END_THINKING|>``
+    reasoning markers with ``<|START_TEXT|>``/``<|END_TEXT|>`` content
+    wrappers.
+
+    Reuses the hardened think-tag state machine for the reasoning split
+    and layers the TEXT-wrapper stripping on top of the content channel
+    (both full-output and streaming, with cross-delta marker buffering).
+    """
+
+    @property
+    def start_token(self) -> str:
+        return "<|START_THINKING|>"
+
+    @property
+    def end_token(self) -> str:
+        return "<|END_THINKING|>"
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        # TEXT-marker bytes withheld from the last streamed content delta
+        # because they could be the head of a marker split across deltas.
+        self._content_marker_carry = ""
+
+    def reset_state(self):
+        super().reset_state()
+        self._content_marker_carry = ""
+
+    def is_open_in_think(self, accumulated_text: str) -> bool:
+        """North templates always pre-open the thinking channel, so a
+        truncated stream with no ``<|END_THINKING|>`` and no
+        ``<|START_TEXT|>`` is an unclosed thought, even though the opener
+        never appears in the output."""
+        if not accumulated_text:
+            return False
+        if self.end_token in accumulated_text:
+            return False
+        if _START_TEXT in accumulated_text:
+            return False
+        return True
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        enable_thinking: bool | None = None,
+    ) -> tuple[str | None, str | None]:
+        no_thinking_markers = (
+            self.start_token not in model_output and self.end_token not in model_output
+        )
+        if no_thinking_markers and _START_TEXT in model_output:
+            # Direct-answer shape: ``<|START_TEXT|>answer<|END_TEXT|>``
+            # with no thinking block (e.g. thinking disabled). Any prefix
+            # before the wrapper is stray channel spill — route it to
+            # reasoning rather than the user-visible answer.
+            before, _, after = model_output.partition(_START_TEXT)
+            reasoning = before.strip() or None
+            content = _strip_text_markers(after).strip() or None
+            return reasoning, content
+        if no_thinking_markers:
+            # No markers at all. The North chat template ends the prompt
+            # inside ``<|START_THINKING|>``, so marker-free output is a
+            # thought trace truncated before ``<|END_THINKING|>`` — the
+            # same routing the streaming path applies. ``content`` stays
+            # None so the truncated meta-cognition never ships as the
+            # user-visible answer.
+            return model_output.strip() or None, None
+        reasoning, content = super().extract_reasoning(model_output, enable_thinking)
+        if reasoning:
+            reasoning = _strip_text_markers(reasoning).strip() or None
+        if content:
+            content = _strip_text_markers(content).strip() or None
+        return reasoning, content
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        msg = super().extract_reasoning_streaming(
+            previous_text, current_text, delta_text
+        )
+        if msg is None or not msg.content:
+            return msg
+        merged = self._content_marker_carry + msg.content
+        self._content_marker_carry = ""
+        stripped = _strip_text_markers(merged)
+        held = _partial_marker_suffix_len(stripped)
+        if held:
+            self._content_marker_carry = stripped[-held:]
+            stripped = stripped[:-held]
+        if not stripped and not msg.reasoning:
+            return None
+        msg.content = stripped or None
+        return msg

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -160,6 +160,13 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
         (codex final-round #1).
         """
         del enable_thinking, prompt_thinking_active  # template ignores both
+        # ``configure_request`` marks the start of a NEW request. The
+        # postprocessor's reset path calls it INSTEAD of ``reset_state``
+        # (they are mutually exclusive there), so the per-request machine
+        # state must be cleared here or a reused parser would carry the
+        # previous request's phase/buffer into the next stream (codex
+        # final-round-2 #1).
+        self.reset_state()
         self._json_mode = bool(json_mode)
 
     def is_open_in_think(self, accumulated_text: str) -> bool:
@@ -195,12 +202,14 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
         if no_thinking_markers:
             stripped_output = model_output.strip()
             # North's chat template instructs JSON-mode/JSON-schema
-            # responses to emit BARE JSON with no channel markers — but
-            # ONLY when the request actually set a JSON ``response_format``
-            # (explicit signal via ``configure_request``): a thought trace
-            # that merely opens with a brace must not bypass the privacy
-            # split (codex final-round #1).
-            if self._json_mode and stripped_output.startswith(("{", "[")):
+            # responses to emit BARE JSON with no channel markers — under
+            # the EXPLICIT request signal (``configure_request``), a
+            # marker-free output IS the structured answer, whatever the
+            # JSON root type (object, array, string, number, boolean,
+            # null — codex final-round-2 #2). Without the signal, a
+            # thought trace that merely opens with a brace must not
+            # bypass the privacy split (codex final-round #1).
+            if self._json_mode:
                 return None, model_output
             # Otherwise: the template ends the prompt inside
             # ``<|START_THINKING|>``, so marker-free output is a thought
@@ -251,16 +260,18 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
 
         # Bare-JSON detection: only under an explicit request-level JSON
         # ``response_format`` (codex final-round #1) — North's template
-        # then instructs bare JSON with no channel markers. If the first
-        # non-whitespace byte is a JSON delimiter and nothing has been
-        # routed yet, the whole stream is the structured answer.
+        # then instructs bare JSON with NO channel markers, whatever the
+        # JSON root type (codex final-round-2 #2). Any head byte that is
+        # not marker-shaped (``<``) flips the stream to content; a
+        # ``<``-headed stream keeps the normal marker machinery so a
+        # model that thinks anyway still gets split.
         if (
             self._json_mode
             and self._sm_phase == "thinking"
             and not self._sm_reasoning_started
         ):
             head = self._sm_buf.lstrip()
-            if head and head[0] in "{[":
+            if head and not head.startswith("<"):
                 self._sm_phase = "content"
 
         while True:

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -132,12 +132,35 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
         # ``.strip()`` (the template's pre-opened channel often starts
         # with cosmetic whitespace).
         self._sm_reasoning_started = False
+        # Explicit request-level JSON mode (set via configure_request).
+        self._json_mode = False
 
     def reset_state(self):
         super().reset_state()
         self._sm_buf = ""
         self._sm_phase = "thinking"
         self._sm_reasoning_started = False
+        self._json_mode = False
+
+    def configure_request(
+        self,
+        *,
+        enable_thinking: bool | None = None,
+        prompt_thinking_active: bool = False,
+        json_mode: bool = False,
+    ) -> None:
+        """Per-request configuration from the postprocessor.
+
+        ``json_mode`` is the explicit ``response_format`` signal: North's
+        template instructs JSON-mode/JSON-schema responses to emit BARE
+        JSON with no channel markers, so only in that mode may a
+        marker-free ``{``/``[`` head be routed to content. Inferring it
+        from the first character alone would let a chain of thought that
+        happens to open with a literal brace bypass the privacy split
+        (codex final-round #1).
+        """
+        del enable_thinking, prompt_thinking_active  # template ignores both
+        self._json_mode = bool(json_mode)
 
     def is_open_in_think(self, accumulated_text: str) -> bool:
         """North templates always pre-open the thinking channel, so a
@@ -172,10 +195,12 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
         if no_thinking_markers:
             stripped_output = model_output.strip()
             # North's chat template instructs JSON-mode/JSON-schema
-            # responses to emit BARE JSON with no channel markers, so a
-            # marker-free output whose head is a JSON delimiter is the
-            # structured answer, not a thought trace (codex r4).
-            if stripped_output.startswith(("{", "[")):
+            # responses to emit BARE JSON with no channel markers — but
+            # ONLY when the request actually set a JSON ``response_format``
+            # (explicit signal via ``configure_request``): a thought trace
+            # that merely opens with a brace must not bypass the privacy
+            # split (codex final-round #1).
+            if self._json_mode and stripped_output.startswith(("{", "[")):
                 return None, model_output
             # Otherwise: the template ends the prompt inside
             # ``<|START_THINKING|>``, so marker-free output is a thought
@@ -224,12 +249,16 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
                 self._sm_reasoning_started = True
                 reasoning_parts.append(text)
 
-        # Bare-JSON detection (codex r4): North's template tells
-        # JSON-mode/JSON-schema responses to emit bare JSON with NO
-        # channel markers. If the first non-whitespace byte of the stream
-        # is a JSON delimiter and nothing has been routed yet, the whole
-        # stream is the structured answer — flip to content immediately.
-        if self._sm_phase == "thinking" and not self._sm_reasoning_started:
+        # Bare-JSON detection: only under an explicit request-level JSON
+        # ``response_format`` (codex final-round #1) — North's template
+        # then instructs bare JSON with no channel markers. If the first
+        # non-whitespace byte is a JSON delimiter and nothing has been
+        # routed yet, the whole stream is the structured answer.
+        if (
+            self._json_mode
+            and self._sm_phase == "thinking"
+            and not self._sm_reasoning_started
+        ):
             head = self._sm_buf.lstrip()
             if head and head[0] in "{[":
                 self._sm_phase = "content"

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -23,9 +23,12 @@ import re
 from .base import DeltaMessage
 from .think_parser import BaseThinkingReasoningParser
 
+_START_THINKING = "<|START_THINKING|>"
+_END_THINKING = "<|END_THINKING|>"
 _START_TEXT = "<|START_TEXT|>"
 _END_TEXT = "<|END_TEXT|>"
 _TEXT_MARKERS = (_START_TEXT, _END_TEXT)
+_ALL_MARKERS = (_START_THINKING, _END_THINKING, _START_TEXT, _END_TEXT)
 _TEXT_MARKER_RE = re.compile(r"<\|(?:START|END)_TEXT\|>")
 
 
@@ -33,15 +36,17 @@ def _strip_text_markers(text: str) -> str:
     return _TEXT_MARKER_RE.sub("", text)
 
 
-def _partial_marker_suffix_len(text: str) -> int:
+def _partial_marker_suffix_len(
+    text: str, markers: tuple[str, ...] = _TEXT_MARKERS
+) -> int:
     """Length of the longest trailing run of ``text`` that is a proper
-    prefix of a TEXT marker — i.e. a marker possibly split across
+    prefix of one of ``markers`` — i.e. a marker possibly split across
     streaming deltas that must be withheld until the next delta decides.
     """
-    longest = max(len(m) for m in _TEXT_MARKERS) - 1
+    longest = max(len(m) for m in markers) - 1
     for n in range(min(len(text), longest), 0, -1):
         suffix = text[-n:]
-        if any(marker.startswith(suffix) for marker in _TEXT_MARKERS):
+        if any(marker.startswith(suffix) for marker in markers):
             return n
     return 0
 
@@ -62,9 +67,17 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
     # when the route resolved thinking to False (e.g. the casual-chat
     # auto-disable). Keep the parser engaged in that case or the raw
     # chain of thought and the literal channel markers stream into
-    # ``delta.content`` (2026-08-20 dogfood repro). Same contract as
-    # DeepSeek-V4 / DeepSeek-R1 / Muse.
+    # ``delta.content`` (2026-08-20 dogfood repro). Same pair of flags
+    # as DeepSeek-R1-Distill, whose templates also prime thinking
+    # unconditionally: ``sanitize_when_thinking_disabled`` keeps the
+    # postprocessor from bypassing the parser, and
+    # ``implicit_reasoning_until_close`` tells
+    # ``_should_start_in_thinking``/rescue that generation starts inside
+    # the reasoning channel even when thinking resolved False (codex r2
+    # #3 — without it a marker-free truncated thought gets promoted back
+    # into user-visible content by terminal rescue).
     sanitize_when_thinking_disabled = True
+    implicit_reasoning_until_close = True
 
     @property
     def start_token(self) -> str:
@@ -76,20 +89,25 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
 
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
-        # TEXT-marker bytes withheld from the last streamed content delta
-        # because they could be the head of a marker split across deltas.
-        self._content_marker_carry = ""
-        # Streaming phase: "undecided" until the head of the stream shows
-        # whether this is a direct answer (``<|START_TEXT|>`` first — no
-        # thinking block) or the normal implicit-think shape; then
-        # "direct" (own content lane) or "thinking" (delegate to the
-        # think-tag state machine).
-        self._north_phase = "undecided"
+        # Self-contained streaming state machine (the base think-tag
+        # streamer does not withhold split ``<|END_THINKING|>`` bytes in
+        # implicit mode — codex r2 #1 — so North owns its streaming):
+        # ``_sm_buf`` holds bytes not yet classified; ``_sm_phase`` is
+        # "thinking" (initial — North templates pre-open the channel) or
+        # "content" (after ``<|END_THINKING|>`` or ``<|START_TEXT|>``).
+        self._sm_buf = ""
+        self._sm_phase = "thinking"
+        # Whether any non-whitespace reasoning byte has been emitted —
+        # the first emission is lstripped to mirror the non-streaming
+        # ``.strip()`` (the template's pre-opened channel often starts
+        # with cosmetic whitespace).
+        self._sm_reasoning_started = False
 
     def reset_state(self):
         super().reset_state()
-        self._content_marker_carry = ""
-        self._north_phase = "undecided"
+        self._sm_buf = ""
+        self._sm_phase = "thinking"
+        self._sm_reasoning_started = False
 
     def is_open_in_think(self, accumulated_text: str) -> bool:
         """North templates always pre-open the thinking channel, so a
@@ -136,80 +154,89 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
             content = _strip_text_markers(content).strip() or None
         return reasoning, content
 
-    def _emit_content_delta(self, text: str) -> DeltaMessage | None:
-        """Emit ``text`` on the content lane, stripping TEXT markers and
-        withholding a trailing partial-marker prefix until the next delta
-        (or the finalize flush) decides what it is."""
-        merged = self._content_marker_carry + text
-        self._content_marker_carry = ""
-        stripped = _strip_text_markers(merged)
-        held = _partial_marker_suffix_len(stripped)
-        if held:
-            self._content_marker_carry = stripped[-held:]
-            stripped = stripped[:-held]
-        if not stripped:
-            return None
-        return DeltaMessage(content=stripped)
-
     def extract_reasoning_streaming(
         self,
         previous_text: str,
         current_text: str,
         delta_text: str,
     ) -> DeltaMessage | None:
-        if self._north_phase == "direct":
-            return self._emit_content_delta(delta_text)
-        if self._north_phase == "undecided":
-            head = current_text.lstrip()
-            if not head or (
-                len(head) < len(_START_TEXT) and _START_TEXT.startswith(head)
-            ):
-                # Still ambiguous: everything so far could be the head of a
-                # direct-answer ``<|START_TEXT|>``. Withhold until decidable
-                # (bounded by the marker length plus leading whitespace).
-                return None
-            if head.startswith(_START_TEXT):
-                # Direct-answer shape: no thinking block — mirror the
-                # non-streaming branch and route the wrapped bytes to
-                # content (codex r1 BLOCKING #1).
-                self._north_phase = "direct"
-                return self._emit_content_delta(head[len(_START_TEXT) :])
-            # Normal implicit-think shape. Replay the (tiny, bounded)
-            # withheld head to the think-tag state machine as one delta so
-            # its own bookkeeping starts consistent.
-            self._north_phase = "thinking"
-            msg = super().extract_reasoning_streaming("", current_text, current_text)
-        else:
-            msg = super().extract_reasoning_streaming(
-                previous_text, current_text, delta_text
-            )
-        if msg is None or not msg.content:
-            return msg
-        content_msg = self._emit_content_delta(msg.content)
-        stripped = content_msg.content if content_msg is not None else None
-        if not stripped and not msg.reasoning:
+        """Self-contained streaming split.
+
+        The machine starts in the "thinking" phase (North templates
+        pre-open the channel in the prompt) and flips to "content" at the
+        FIRST structural transition — ``<|END_THINKING|>`` (normal shape)
+        or ``<|START_TEXT|>`` (direct-answer / channel-spill shape, codex
+        r2 #2). Bytes that could be the head of a marker split across
+        deltas are withheld in ``_sm_buf`` until decidable (bounded by
+        one marker length, codex r2 #1); ``finalize_streaming`` flushes
+        whatever remains so no model bytes are silently dropped.
+
+        Known limitation (same class as the think-tag parsers' literal-
+        tag caveat): a literal marker string INSIDE the chain of thought
+        is indistinguishable from the structural transition and flips
+        the phase early.
+        """
+        self._sm_buf += delta_text
+        reasoning_parts: list[str] = []
+        content_parts: list[str] = []
+
+        def push_reasoning(text: str) -> None:
+            if not self._sm_reasoning_started:
+                text = text.lstrip()
+            if text:
+                self._sm_reasoning_started = True
+                reasoning_parts.append(text)
+
+        while True:
+            if self._sm_phase == "thinking":
+                transitions = [
+                    (idx, marker)
+                    for marker in (_END_THINKING, _START_TEXT)
+                    if (idx := self._sm_buf.find(marker)) != -1
+                ]
+                if transitions:
+                    idx, marker = min(transitions)
+                    push_reasoning(self._sm_buf[:idx].replace(_START_THINKING, ""))
+                    self._sm_buf = self._sm_buf[idx + len(marker) :]
+                    self._sm_phase = "content"
+                    continue  # classify the remainder as content
+                cleaned = self._sm_buf.replace(_START_THINKING, "")
+                held = _partial_marker_suffix_len(cleaned, _ALL_MARKERS)
+                emit = cleaned[: len(cleaned) - held] if held else cleaned
+                self._sm_buf = cleaned[len(emit) :]
+                push_reasoning(emit)
+                break
+            # content phase: strip complete TEXT markers, withhold a
+            # trailing partial-marker prefix.
+            stripped = _strip_text_markers(self._sm_buf)
+            held = _partial_marker_suffix_len(stripped)
+            emit = stripped[: len(stripped) - held] if held else stripped
+            self._sm_buf = stripped[len(emit) :]
+            if emit:
+                content_parts.append(emit)
+            break
+        reasoning = "".join(reasoning_parts) or None
+        content = "".join(content_parts) or None
+        if reasoning is None and content is None:
             return None
-        msg.content = stripped
-        return msg
+        return DeltaMessage(reasoning=reasoning, content=content)
 
     def finalize_streaming(self, accumulated_text: str, **kwargs):
-        """Flush any withheld partial-marker bytes at end of stream.
+        """Flush withheld bytes at end of stream.
 
         A trailing run like ``<|END_TE`` is withheld by the streaming
-        stripper because it could be a marker split across deltas; when
+        machine because it could be a marker split across deltas; when
         the stream ends without completing the marker, those bytes are
-        model output and must not be silently dropped (codex r1 BLOCKING
-        #2; same never-drop contract as #569).
+        model output and must not be silently dropped (codex r1 #2; same
+        never-drop contract as #569). Phase decides the channel.
         """
-        try:
-            msg = super().finalize_streaming(accumulated_text, **kwargs)
-        except TypeError:
-            msg = super().finalize_streaming(accumulated_text)
-        carry = self._content_marker_carry
-        self._content_marker_carry = ""
+        del accumulated_text, kwargs  # the machine owns the full state
+        carry = self._sm_buf
+        self._sm_buf = ""
         if not carry:
-            return msg
-        if msg is None:
-            return DeltaMessage(content=carry)
-        msg.content = (msg.content or "") + carry
-        return msg
+            return None
+        if self._sm_phase == "content":
+            carry = _strip_text_markers(carry)
+            return DeltaMessage(content=carry) if carry else None
+        carry = carry.replace(_START_THINKING, "")
+        return DeltaMessage(reasoning=carry) if carry else None

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -158,13 +158,20 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
             content = _strip_text_markers(after).strip() or None
             return reasoning, content
         if no_thinking_markers:
-            # No markers at all. The North chat template ends the prompt
-            # inside ``<|START_THINKING|>``, so marker-free output is a
-            # thought trace truncated before ``<|END_THINKING|>`` — the
-            # same routing the streaming path applies. ``content`` stays
-            # None so the truncated meta-cognition never ships as the
+            stripped_output = model_output.strip()
+            # North's chat template instructs JSON-mode/JSON-schema
+            # responses to emit BARE JSON with no channel markers, so a
+            # marker-free output whose head is a JSON delimiter is the
+            # structured answer, not a thought trace (codex r4).
+            if stripped_output.startswith(("{", "[")):
+                return None, model_output
+            # Otherwise: the template ends the prompt inside
+            # ``<|START_THINKING|>``, so marker-free output is a thought
+            # trace truncated before ``<|END_THINKING|>`` — the same
+            # routing the streaming path applies. ``content`` stays None
+            # so the truncated meta-cognition never ships as the
             # user-visible answer.
-            return model_output.strip() or None, None
+            return stripped_output or None, None
         reasoning, content = super().extract_reasoning(model_output, enable_thinking)
         if reasoning:
             reasoning = _strip_text_markers(reasoning).strip() or None
@@ -204,6 +211,16 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
             if text:
                 self._sm_reasoning_started = True
                 reasoning_parts.append(text)
+
+        # Bare-JSON detection (codex r4): North's template tells
+        # JSON-mode/JSON-schema responses to emit bare JSON with NO
+        # channel markers. If the first non-whitespace byte of the stream
+        # is a JSON delimiter and nothing has been routed yet, the whole
+        # stream is the structured answer — flip to content immediately.
+        if self._sm_phase == "thinking" and not self._sm_reasoning_started:
+            head = self._sm_buf.lstrip()
+            if head and head[0] in "{[":
+                self._sm_phase = "content"
 
         while True:
             if self._sm_phase == "thinking":

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -79,10 +79,17 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
         # TEXT-marker bytes withheld from the last streamed content delta
         # because they could be the head of a marker split across deltas.
         self._content_marker_carry = ""
+        # Streaming phase: "undecided" until the head of the stream shows
+        # whether this is a direct answer (``<|START_TEXT|>`` first — no
+        # thinking block) or the normal implicit-think shape; then
+        # "direct" (own content lane) or "thinking" (delegate to the
+        # think-tag state machine).
+        self._north_phase = "undecided"
 
     def reset_state(self):
         super().reset_state()
         self._content_marker_carry = ""
+        self._north_phase = "undecided"
 
     def is_open_in_think(self, accumulated_text: str) -> bool:
         """North templates always pre-open the thinking channel, so a
@@ -129,25 +136,80 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
             content = _strip_text_markers(content).strip() or None
         return reasoning, content
 
-    def extract_reasoning_streaming(
-        self,
-        previous_text: str,
-        current_text: str,
-        delta_text: str,
-    ) -> DeltaMessage | None:
-        msg = super().extract_reasoning_streaming(
-            previous_text, current_text, delta_text
-        )
-        if msg is None or not msg.content:
-            return msg
-        merged = self._content_marker_carry + msg.content
+    def _emit_content_delta(self, text: str) -> DeltaMessage | None:
+        """Emit ``text`` on the content lane, stripping TEXT markers and
+        withholding a trailing partial-marker prefix until the next delta
+        (or the finalize flush) decides what it is."""
+        merged = self._content_marker_carry + text
         self._content_marker_carry = ""
         stripped = _strip_text_markers(merged)
         held = _partial_marker_suffix_len(stripped)
         if held:
             self._content_marker_carry = stripped[-held:]
             stripped = stripped[:-held]
+        if not stripped:
+            return None
+        return DeltaMessage(content=stripped)
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        if self._north_phase == "direct":
+            return self._emit_content_delta(delta_text)
+        if self._north_phase == "undecided":
+            head = current_text.lstrip()
+            if not head or (
+                len(head) < len(_START_TEXT) and _START_TEXT.startswith(head)
+            ):
+                # Still ambiguous: everything so far could be the head of a
+                # direct-answer ``<|START_TEXT|>``. Withhold until decidable
+                # (bounded by the marker length plus leading whitespace).
+                return None
+            if head.startswith(_START_TEXT):
+                # Direct-answer shape: no thinking block — mirror the
+                # non-streaming branch and route the wrapped bytes to
+                # content (codex r1 BLOCKING #1).
+                self._north_phase = "direct"
+                return self._emit_content_delta(head[len(_START_TEXT) :])
+            # Normal implicit-think shape. Replay the (tiny, bounded)
+            # withheld head to the think-tag state machine as one delta so
+            # its own bookkeeping starts consistent.
+            self._north_phase = "thinking"
+            msg = super().extract_reasoning_streaming("", current_text, current_text)
+        else:
+            msg = super().extract_reasoning_streaming(
+                previous_text, current_text, delta_text
+            )
+        if msg is None or not msg.content:
+            return msg
+        content_msg = self._emit_content_delta(msg.content)
+        stripped = content_msg.content if content_msg is not None else None
         if not stripped and not msg.reasoning:
             return None
-        msg.content = stripped or None
+        msg.content = stripped
+        return msg
+
+    def finalize_streaming(self, accumulated_text: str, **kwargs):
+        """Flush any withheld partial-marker bytes at end of stream.
+
+        A trailing run like ``<|END_TE`` is withheld by the streaming
+        stripper because it could be a marker split across deltas; when
+        the stream ends without completing the marker, those bytes are
+        model output and must not be silently dropped (codex r1 BLOCKING
+        #2; same never-drop contract as #569).
+        """
+        try:
+            msg = super().finalize_streaming(accumulated_text, **kwargs)
+        except TypeError:
+            msg = super().finalize_streaming(accumulated_text)
+        carry = self._content_marker_carry
+        self._content_marker_carry = ""
+        if not carry:
+            return msg
+        if msg is None:
+            return DeltaMessage(content=carry)
+        msg.content = (msg.content or "") + carry
         return msg

--- a/vllm_mlx/reasoning/north_parser.py
+++ b/vllm_mlx/reasoning/north_parser.py
@@ -78,6 +78,12 @@ class NorthReasoningParser(BaseThinkingReasoningParser):
     # into user-visible content by terminal rescue).
     sanitize_when_thinking_disabled = True
     implicit_reasoning_until_close = True
+    # Opt in to the StreamingPostProcessor EOF flush (the UI-TARS
+    # hold-back pattern): the machine withholds marker-like suffixes
+    # across deltas, so the route must call ``finalize_streaming`` at
+    # end of stream or a trailing ``<|END_TE``-style run is dropped
+    # (codex r3 BLOCKING).
+    stream_eof_flush = True
 
     @property
     def start_token(self) -> str:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -6726,6 +6726,7 @@ async def stream_chat_completion(
         # doesn't see a truncated reply (codex round-4 CRITICAL).
         fallback_tool_calls: list = []
         finalize_content_parts: list[str] = []
+        finalize_reasoning_parts: list[str] = []
         for event in processor.finalize():
             if event.type == "tool_call":
                 # r7-A R7-H1: normalize before append so terminal-merge
@@ -6736,7 +6737,23 @@ async def stream_chat_completion(
                 )
             elif event.type == "content" and event.content:
                 finalize_content_parts.append(event.content)
+            elif event.type == "reasoning" and event.reasoning:
+                # A stream_eof_flush parser (north) that ends while still
+                # in the thinking phase releases its withheld marker tail
+                # as a ``reasoning`` event. Content events get merged into
+                # the terminal chunk below, but nothing there carries a
+                # reasoning channel — so without this branch the tail is
+                # silently dropped from ``reasoning_content``, violating
+                # the same never-drop contract this finalize pass exists
+                # to uphold for content.
+                finalize_reasoning_parts.append(event.reasoning)
         finalize_content = "".join(finalize_content_parts)
+        if finalize_reasoning_parts:
+            if first_token_ts is None:
+                first_token_ts = time.perf_counter()
+            yield _fast_sse_chunk(
+                "".join(finalize_reasoning_parts), "reasoning_content"
+            )
 
         # #447 streaming-parity synthesis (2026-06-26). The non-stream
         # chat path at chat.py:~3147 / ~3215 falls back to

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -790,6 +790,17 @@ def _apply_reasoning_cap(
     return cleaned_text, truncated
 
 
+# Implicit-think marker pairs recognised by ``_should_start_in_thinking``.
+# Each entry is (opener, closer) as they appear in chat template source.
+# ``<think>`` covers the Qwen/DeepSeek/GLM think-tag families;
+# ``<|START_THINKING|>`` covers Cohere North (North-Mini-Code), whose
+# template ends the generation prompt inside the thinking channel.
+_IMPLICIT_THINK_MARKER_PAIRS = (
+    ("<think>", "</think>"),
+    ("<|START_THINKING|>", "<|END_THINKING|>"),
+)
+
+
 def _should_start_in_thinking(
     chat_template,
     enable_thinking: bool | None,
@@ -839,7 +850,11 @@ def _should_start_in_thinking(
     if enable_thinking is False and not unconditional:
         return False
     if unconditional:
-        if "<think>" not in chat_template:
+        marker_pair = next(
+            (pair for pair in _IMPLICIT_THINK_MARKER_PAIRS if pair[0] in chat_template),
+            None,
+        )
+        if marker_pair is None:
             return False
         # Use the same sandboxed Jinja compiler as Hugging Face tokenizers.
         # Rendering, unlike source scanning, honors assignments, macros,
@@ -880,10 +895,14 @@ def _should_start_in_thinking(
             return False
         # Priming means the rendered prompt ends *inside* a think block, not
         # merely that it contains a historical closed block.
-        if rendered.rfind("<think>") <= rendered.rfind("</think>"):
+        opener, closer = marker_pair
+        if rendered.rfind(opener) <= rendered.rfind(closer):
             return False
         return True
-    return "<think>" in chat_template and "add_generation_prompt" in chat_template
+    return (
+        any(opener in chat_template for opener, _ in _IMPLICIT_THINK_MARKER_PAIRS)
+        and "add_generation_prompt" in chat_template
+    )
 
 
 def _rescue_silent_drop_from_reasoning(

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -850,11 +850,14 @@ def _should_start_in_thinking(
     if enable_thinking is False and not unconditional:
         return False
     if unconditional:
-        marker_pair = next(
-            (pair for pair in _IMPLICIT_THINK_MARKER_PAIRS if pair[0] in chat_template),
-            None,
-        )
-        if marker_pair is None:
+        # Consider EVERY marker family present in the template source —
+        # a conditional template can contain both ``<think>`` and North
+        # markers, and inspecting only the first-present pair could pick
+        # the wrong family after rendering (codex on #2171).
+        present_pairs = [
+            pair for pair in _IMPLICIT_THINK_MARKER_PAIRS if pair[0] in chat_template
+        ]
+        if not present_pairs:
             return False
         # Use the same sandboxed Jinja compiler as Hugging Face tokenizers.
         # Rendering, unlike source scanning, honors assignments, macros,
@@ -895,10 +898,10 @@ def _should_start_in_thinking(
             return False
         # Priming means the rendered prompt ends *inside* a think block, not
         # merely that it contains a historical closed block.
-        opener, closer = marker_pair
-        if rendered.rfind(opener) <= rendered.rfind(closer):
-            return False
-        return True
+        return any(
+            rendered.rfind(opener) > rendered.rfind(closer)
+            for opener, closer in present_pairs
+        )
     return (
         any(opener in chat_template for opener, _ in _IMPLICIT_THINK_MARKER_PAIRS)
         and "add_generation_prompt" in chat_template

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -1746,10 +1746,25 @@ class StreamingPostProcessor:
         if self.reasoning_parser is None:
             # Standard / channel-routed path doesn't need the injection.
             return delta_text
-        # Prepend the marker so the parser sees ``</think>`` BEFORE the
-        # next body bytes. The caller flips ``_reasoning_close_injected``
-        # only after the parser call succeeds.
-        return "</think>" + delta_text
+        # Prepend the marker so the parser sees its close token BEFORE
+        # the next body bytes. The caller flips
+        # ``_reasoning_close_injected`` only after the parser call
+        # succeeds. Ask the parser for ITS closer (codex round-2 MAJOR
+        # on #2171): north transitions on ``<|END_THINKING|>``, not
+        # ``</think>`` — a hard-coded ``</think>`` is swallowed as
+        # reasoning bytes and the cap latch then reroutes the rest of
+        # the thought trace to visible content.
+        return self._reasoning_close_marker() + delta_text
+
+    def _reasoning_close_marker(self) -> str:
+        """The configured parser's thinking-close token, for cap-hit
+        forced-close injection. Falls back to ``</think>`` for parsers
+        that don't expose ``end_token`` (the think-tag family default).
+        """
+        marker = getattr(self.reasoning_parser, "end_token", None)
+        if isinstance(marker, str) and marker:
+            return marker
+        return "</think>"
 
     def _forced_tool_choice_name(self) -> str | None:
         """Return the forced ``tool_choice`` function name, if any.
@@ -3598,7 +3613,9 @@ class StreamingPostProcessor:
         ):
             self._reasoning_close_injected = True
             previous_text = self.accumulated_text
-            injected_delta = "</think>"
+            # Same parser-owned closer as the mid-stream site (codex
+            # round-2 MAJOR on #2171) — north needs <|END_THINKING|>.
+            injected_delta = self._reasoning_close_marker()
             # Codex round-5 BLOCKING #1: build the parser's view of
             # ``current`` LOCALLY rather than mutating
             # ``self.accumulated_text``. Downstream (routes/chat.py
@@ -3842,7 +3859,17 @@ class StreamingPostProcessor:
             and self.accumulated_text
             and (
                 type(self.reasoning_parser).__name__ == "UiTarsReasoningParser"
-                or getattr(self.reasoning_parser, "stream_eof_flush", False)
+                # Strict ``is True``: the opt-in must be the literal class
+                # attribute (north sets ``stream_eof_flush = True``). A
+                # truthiness check fires for ANY object whose attribute
+                # lookup fabricates values (MagicMock doubles in tests,
+                # __getattr__-based proxies) and then calls
+                # ``finalize_streaming`` on parsers with re-parse
+                # semantics — re-releasing bytes the forced-close
+                # extraction already emitted (the exact duplicate-flush
+                # hazard test_finalize_does_not_emit_close_marker_
+                # through_parser_twice pins).
+                or getattr(self.reasoning_parser, "stream_eof_flush", False) is True
             )
         ):
             try:

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -3128,7 +3128,10 @@ class StreamingPostProcessor:
                     # this represents the model output "up to the cap
                     # firing point" from the parser's POV.
                     flip_previous = previous_text + kept_reasoning
-                    flip_delta = "</think>"
+                    # Parser-owned closer, same as the other two
+                    # injection sites (codex round-3 on #2171): north
+                    # flips on <|END_THINKING|>, not </think>.
+                    flip_delta = self._reasoning_close_marker()
                     flip_current = flip_previous + flip_delta
                     try:
                         flip_msg = self.reasoning_parser.extract_reasoning_streaming(

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -3829,15 +3829,21 @@ class StreamingPostProcessor:
         # mid-token, or the model genuinely produced bare
         # ``"Thought"`` text), those bytes are otherwise silently
         # dropped at EOF. Mirror the ``tool_parser.flush_held_content``
-        # pattern below but scope it to the UI-TARS reasoning
-        # parser specifically — other reasoning parsers
-        # (``qwen3`` / ``deepseek_r1`` / ``gemma4``) have their own
+        # pattern below but scope it via the ``stream_eof_flush``
+        # opt-in attribute (UI-TARS by name for back-compat; the North
+        # parser opts in — its marker-withhold machinery has the same
+        # end-of-stream shape). Other reasoning parsers (``qwen3`` /
+        # ``deepseek_r1`` / ``gemma4``) have their own
         # ``finalize_streaming`` semantics tied to specific call
-        # sites that this generic hook would clash with.
+        # sites that this generic hook would clash with, and do NOT
+        # set the attribute.
         if (
             self.reasoning_parser is not None
             and self.accumulated_text
-            and type(self.reasoning_parser).__name__ == "UiTarsReasoningParser"
+            and (
+                type(self.reasoning_parser).__name__ == "UiTarsReasoningParser"
+                or getattr(self.reasoning_parser, "stream_eof_flush", False)
+            )
         ):
             try:
                 final_msg = self.reasoning_parser.finalize_streaming(

--- a/vllm_mlx/service/postprocessor.py
+++ b/vllm_mlx/service/postprocessor.py
@@ -365,6 +365,12 @@ class StreamingPostProcessor:
                             tools_requested=self.tools_requested,
                         )
                     )
+                if "json_mode" in configure_parameters:
+                    # Explicit response_format signal for parsers whose
+                    # template contracts change under JSON mode (North
+                    # emits bare JSON with no channel markers — codex
+                    # final-round #1 on #2171).
+                    configure_kwargs["json_mode"] = self.json_mode
                 _configure(**configure_kwargs)
             _set = getattr(self.reasoning_parser, "set_enable_thinking", None)
             if callable(_set):
@@ -2492,6 +2498,12 @@ class StreamingPostProcessor:
                             tools_requested=self.tools_requested,
                         )
                     )
+                if "json_mode" in configure_parameters:
+                    # Explicit response_format signal for parsers whose
+                    # template contracts change under JSON mode (North
+                    # emits bare JSON with no channel markers — codex
+                    # final-round #1 on #2171).
+                    configure_kwargs["json_mode"] = self.json_mode
                 _configure(**configure_kwargs)
             else:
                 self.reasoning_parser.reset_state()


### PR DESCRIPTION
## Why

Release dogfood (2026-08-20) caught a correctness/privacy bug on the newly vendored North-Mini-Code (#1223/#2150): serving `north-mini-code-4bit` shipped the model's **raw chain of thought — policy deliberation included — plus the literal channel markers** inside `message.content`:

```
content: 'The user asks: … We must follow policy …<|END_THINKING|><|START_TEXT|>4<|END_TEXT|>'
```

Root causes (two, layered):
1. No parser understands North's Cohere-style format — the template pre-opens `<|START_THINKING|>` in the generation prompt; output is `cot<|END_THINKING|><|START_TEXT|>answer<|END_TEXT|>`. The alias profile fell back to `reasoning_parser=None`.
2. Streaming additionally bypassed any parser: North templates ignore `enable_thinking`, but the casual-chat auto-disable resolves thinking to `False`, and the postprocessor's thinking-off bypass then routes every delta straight to `content` while the model thinks anyway.

## What

- New `NorthReasoningParser` (`reasoning_parser="north"`): subclasses the hardened `BaseThinkingReasoningParser` state machine (`<|START_THINKING|>`/`<|END_THINKING|>`), strips the `<|START_TEXT|>`/`<|END_TEXT|>` content wrappers in both full-output and streaming paths (cross-delta partial-marker buffering), routes marker-free truncated output to reasoning (template always pre-opens the channel), and overrides `is_open_in_think` for the implicit-opener truncation contract.
- `sanitize_when_thinking_disabled = True` — same contract as DeepSeek-V4/R1/Muse — keeps the parser engaged when the route resolved thinking off (fixes the streaming leak).
- Wiring: registry (`north`), `aliases.json` (`north-mini-code-4bit`/`-bf16`), `model_auto_config` regex (`north[-_]?mini`, raw HF paths), and `_should_start_in_thinking` marker-pair generalization (`<think>` + `<|START_THINKING|>`) so prompt-thinking detection works for all routes.
- No tool parser wired: North's `<|START_ACTION|>` format has no parser yet (noted in auto-config comment; follow-up).

## Tests

24 new tests in `tests/test_north_reasoning_parser.py`: full-output shapes (implicit/explicit/truncated/direct-answer/marker-leak), truncation contract, streaming (split markers across deltas, no marker bytes leak, lone `<` survives), registry/alias/auto-config wiring, `_should_start_in_thinking` for both marker families, and a **route-level SSE regression test** reproducing the live streaming leak through `/v1/chat/completions` with a mock engine.
Neighbor suites green: 450 passed (`test_reasoning_parser`, `test_chat_streaming_no_reasoning_alias`, `test_deepseek_v4_reasoning_parser`, `test_model_auto_config`).

Live E2E on the real checkpoint (Studio): non-stream `reasoning_content`/`content` split with zero markers; streaming `content='red, blue, yellow'`, CoT in `reasoning_content`, no marker bytes.

## Notes

AI-disclosure: authored by Claude (Fable 5) during self-driven release dogfooding, reviewed via codex + pr_validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QDdb5mYeBw8qqApuxX6F2