### PR TITLE
fix(mac): dedupe duplicate TextKit2 link segments under the macOS 26 SDK

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextRenderer.swift
@@ -170,7 +170,15 @@ final class MarkdownTextRenderer {
             textLayoutManager.enumerateTextSegments(
                 in: textRange, type: .standard, options: []
             ) { _, frame, _, _ in
-                regions.append((url, frame))
+                // TextKit2 under the macOS 26 SDK reports the segment of a
+                // range that ends at the document's tail twice, with
+                // identical frames. Two rects for one segment means two
+                // cursor tracking areas for the same pixels, and it breaks
+                // the one-rect-per-rendered-line contract linkRects()
+                // promises its callers.
+                if regions.last?.url != url || regions.last?.rect != frame {
+                    regions.append((url, frame))
+                }
                 return true
             }
         }


### PR DESCRIPTION
## Why

Dogfooding the full rapid-mac suite for the next release surfaced a deterministic failure on main: `MarkdownLinkPerformanceTests` "Adjacent links keep their own hit targets" gets **3 rects for 2 adjacent links**.

Root cause is not any recent markdown PR: the failure reproduces identically at c8d19552 — the very commit that introduced the test (bisect control). The macOS 26 SDK / Xcode 26.6 toolchain changed TextKit2 behavior: `enumerateTextSegments` now reports the segment of a range ending at the document's tail **twice**, with identical frames. Storage attributes are clean (two distinct `.link` runs); the duplication is purely in segment enumeration.

Beyond the red test, each duplicate rect registers a duplicate cursor tracking area over the same pixels, and `linkRects()` breaks its one-rect-per-rendered-line contract to callers.

## What

`MarkdownTextRenderer.linkRegions()` skips a segment whose `(url, frame)` equals the pair just appended. Wrapped links are unaffected — consecutive segments of a wrapped link differ in frame, so the dedupe never collapses them.

## Testing

- `adjacentLinksDoNotMerge` red on untouched main → green with this fix (red/green established by the bisect itself).
- `wrappedLinkSegmentsRemainClickable` still passes: one rect per rendered line for wrapped links, each hit-testable.
- Full rapid-mac suite: 2666 tests, only the 4 known load-induced timing flakes under a concurrent pytest run (HFCacheByteMonitor polling, download-stagger elapsed-time); all pass in isolated rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)