### PR TITLE
feat(mtp): expose tested experimental MTP presets

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -61,7 +61,9 @@ struct SpeculativeDecodingPreset: Codable, Sendable, Hashable {
     let model: String?
     let tokens: Int?
 
-    var displayName: String { method == .mtp ? "MTP" : "Suffix decoding" }
+    var displayName: String {
+        method == .mtp ? "Experimental MTP" : "Suffix decoding"
+    }
 }
 
 /// One model in the rapid-mlx catalog. The picker UI groups cached vs.

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsPerformancePanel.swift
@@ -265,7 +265,9 @@ struct SettingsPerformancePanel: View {
                 tradeOffLine(
                     preset == nil
                         ? "This alias does not declare a verified speculative-decoding preset."
-                        : "Off by default. It can improve generation speed on some Macs, but may be slower on others; accepted output remains token-exact.",
+                        : preset?.method == .mtp
+                            ? "Experimental and off by default. It may improve generation speed, but can be slower on some Macs. Enabling downloads an additional draft model and requires a restart; accepted output remains token-exact."
+                            : "Off by default. It can improve generation speed on some Macs, but may be slower on others; accepted output remains token-exact.",
                     warns: false
                 )
             }

--- a/apps/rapid-mac/Tests/RapidTests/ModelPerfConfigTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelPerfConfigTests.swift
@@ -44,6 +44,16 @@ struct ModelPerfConfigTests {
         #expect(store.launchFlags(forAlias: "qwen3.8-27b-mixed-3.5bpw").isEmpty)
     }
 
+    @Test("MTP presets are visibly experimental")
+    func mtpPresetIsExperimental() {
+        let preset = SpeculativeDecodingPreset(
+            method: .mtp,
+            model: "mlx-community/Qwen3.5-9B-MTP-4bit",
+            tokens: 2
+        )
+        #expect(preset.displayName == "Experimental MTP")
+    }
+
     @Test("Setting a knob then clearing it removes the row rather than pinning the default")
     func clearingAnOverrideRemovesTheRow() {
         let store = makeStore()

--- a/tests/test_mtp_alias_declared_sidecar_1998.py
+++ b/tests/test_mtp_alias_declared_sidecar_1998.py
@@ -27,7 +27,27 @@ import pytest
 # real aliases (not fixtures) is deliberate — the bug was precisely that the
 # registry and the serve path disagreed, so the test has to read the registry.
 ALIAS_WITH_MTP = "qwen3.8-27b-mixed-3.5bpw"
-ALIAS_WITHOUT_MTP = "qwen3.6-35b-8bit"
+ALIAS_WITHOUT_MTP = "qwen3.5-27b-4bit"
+
+# Popular aliases with a published, architecture-matched sidecar and a
+# production-registered MTP injector.  This is intentionally curated rather
+# than inferred from the model name: adding an alias here is a product promise
+# that the GUI toggle can reach a real sidecar and boot path.
+EXPERIMENTAL_MTP_ALIASES = {
+    "qwen3.5-4b-4bit": "mlx-community/Qwen3.5-4B-MTP-4bit",
+    "qwen3.5-4b-6bit": "mlx-community/Qwen3.5-4B-MTP-4bit",
+    "qwen3.5-4b-8bit": "mlx-community/Qwen3.5-4B-MTP-4bit",
+    "qwen3.5-9b-4bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "qwen3.5-9b-6bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "qwen3.5-9b-8bit": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "qwen3.6-27b-4bit": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "qwen3.6-27b-6bit": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "qwen3.6-27b-8bit": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "qwen3.6-35b-4bit": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "qwen3.6-35b-6bit": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "qwen3.6-35b-8bit": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "hy3-preview-4bit": "mlx-community/Hy3-preview-MTP-4bit",
+}
 
 
 def _args(**overrides):
@@ -77,6 +97,18 @@ def test_registry_precondition_the_alias_still_declares_mtp():
     other = resolve_profile(ALIAS_WITHOUT_MTP)
     assert other is not None
     assert not other.mtp_draft_model
+
+
+@pytest.mark.parametrize(
+    ("alias", "sidecar"), sorted(EXPERIMENTAL_MTP_ALIASES.items())
+)
+def test_popular_experimental_mtp_aliases_declare_a_real_preset(alias, sidecar):
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile(alias)
+    assert profile is not None
+    assert profile.mtp_draft_model == sidecar
+    assert profile.mtp_speculative_tokens > 0
 
 
 # ------------------------------------------------------------------ the fix

--- a/tests/test_mtp_alias_declared_sidecar_1998.py
+++ b/tests/test_mtp_alias_declared_sidecar_1998.py
@@ -104,9 +104,7 @@ def test_registry_precondition_the_alias_still_declares_mtp():
     assert not other.mtp_draft_model
 
 
-@pytest.mark.parametrize(
-    ("alias", "sidecar"), sorted(EXPERIMENTAL_MTP_ALIASES.items())
-)
+@pytest.mark.parametrize(("alias", "sidecar"), sorted(EXPERIMENTAL_MTP_ALIASES.items()))
 def test_popular_experimental_mtp_aliases_declare_a_real_preset(alias, sidecar):
     from vllm_mlx.model_aliases import resolve_profile
 

--- a/tests/test_mtp_alias_declared_sidecar_1998.py
+++ b/tests/test_mtp_alias_declared_sidecar_1998.py
@@ -43,10 +43,15 @@ EXPERIMENTAL_MTP_ALIASES = {
     "qwen3.6-27b-4bit": "mlx-community/Qwen3.6-27B-MTP-4bit",
     "qwen3.6-27b-6bit": "mlx-community/Qwen3.6-27B-MTP-4bit",
     "qwen3.6-27b-8bit": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "qwen3.6-27b-ud": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "qwen3.6-27b": "mlx-community/Qwen3.6-27B-MTP-4bit",
     "qwen3.6-35b-4bit": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
     "qwen3.6-35b-6bit": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
     "qwen3.6-35b-8bit": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
-    "hy3-preview-4bit": "mlx-community/Hy3-preview-MTP-4bit",
+    "qwen3.6-35b-ud": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "qwen3.6-35b": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "qwen3.8-27b-4bit": "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX",
+    "qwen3.8-27b-mixed-3.5bpw": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",
 }
 
 

--- a/tests/test_mtp_self_contained_repo.py
+++ b/tests/test_mtp_self_contained_repo.py
@@ -1,6 +1,20 @@
 from pathlib import Path
 
-from vllm_mlx.spec_decode.mtp.qwen3_5_inject import _find_mtp_weights_file
+import json
+
+from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+    _find_mtp_weights_file,
+    _load_mtplx_runtime_contract,
+)
+
+
+def test_finds_mtplx_root_sidecar_before_target_shards(tmp_path: Path):
+    sidecar = tmp_path / "mtp.safetensors"
+    target = tmp_path / "model.safetensors"
+    sidecar.touch()
+    target.touch()
+
+    assert _find_mtp_weights_file(tmp_path) == sidecar
 
 
 def test_finds_nested_mtp_sidecar_in_self_contained_repo(tmp_path: Path):
@@ -29,3 +43,39 @@ def test_nested_sidecar_wins_over_target_root_weights(tmp_path: Path):
     sidecar.touch()
 
     assert _find_mtp_weights_file(tmp_path) == sidecar
+
+
+def test_reads_closed_mtplx_runtime_contract(tmp_path: Path):
+    weights = tmp_path / "mtp.safetensors"
+    weights.touch()
+    (tmp_path / "mtplx_runtime.json").write_text(
+        json.dumps(
+            {
+                "mtp_contract": {
+                    "base_hidden_variant": "post_norm",
+                    "hidden_variant": "post_norm",
+                    "concat_order": "embedding_hidden",
+                    "mtp_position_mode": "local",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert _load_mtplx_runtime_contract(weights) == {
+        "base_hidden_variant": "post_norm",
+        "hidden_variant": "post_norm",
+        "concat_order": "embedding_hidden",
+        "mtp_position_mode": "local",
+    }
+
+
+def test_rejects_unknown_mtplx_contract_values(tmp_path: Path):
+    weights = tmp_path / "mtp.safetensors"
+    weights.touch()
+    (tmp_path / "mtplx_runtime.json").write_text(
+        json.dumps({"mtp_contract": {"base_hidden_variant": "mystery"}}),
+        encoding="utf-8",
+    )
+
+    assert _load_mtplx_runtime_contract(weights) == {}

--- a/tests/test_mtp_self_contained_repo.py
+++ b/tests/test_mtp_self_contained_repo.py
@@ -1,6 +1,5 @@
-from pathlib import Path
-
 import json
+from pathlib import Path
 
 from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
     _find_mtp_weights_file,

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2586,7 +2586,9 @@ def test_generator_rolls_back_verify_round_on_early_materialization_abort(
     def _boom_on_verify_sync(*_args, **_kwargs):
         nonlocal eval_calls
         eval_calls += 1
-        if eval_calls >= 2:
+        # Draft chaining stays lazy now, so the first materialization after
+        # resuming the generator is the batched target-verify boundary.
+        if eval_calls >= 1:
             raise RuntimeError("sentinel materialization abort")
 
     monkeypatch.setattr(generator_mod.mx, "eval", _boom_on_verify_sync)

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1246,8 +1246,6 @@
     "is_hybrid": false,
     "is_moe": true,
     "supports_spec_decode": true,
-    "mtp_draft_model": "mlx-community/Hy3-preview-MTP-4bit",
-    "mtp_speculative_tokens": 1,
     "min_memory_gb": 192
   },
   "muse-glimmer-30b-4bit": {

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -19,6 +19,8 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.5-4B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "pflash_tier": "verified"
   },
   "qwen3.5-4b-8bit": {
@@ -29,6 +31,8 @@
     "is_hybrid_explicit": true,
     "is_moe": false,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.5-4B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "pflash_tier": "verified"
   },
   "qwen3.5-4b-6bit": {
@@ -38,7 +42,9 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "is_moe": false,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.5-4B-MTP-4bit",
+    "mtp_speculative_tokens": 2
   },
   "qwen3.5-9b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-9B-4bit",
@@ -47,6 +53,8 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "pflash_tier": "verified",
     "turboquant_tier": "k8v4_verified"
   },
@@ -58,6 +66,8 @@
     "is_hybrid_explicit": true,
     "is_moe": false,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "supports_dflash": false,
     "supports_ddtree": true,
     "ddtree_draft_model": "z-lab/Qwen3.5-9B-DFlash",
@@ -73,7 +83,9 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "is_moe": false,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.5-9B-MTP-4bit",
+    "mtp_speculative_tokens": 2
   },
   "qwen3.5-27b-4bit": {
     "hf_path": "mlx-community/Qwen3.5-27B-4bit",
@@ -230,6 +242,8 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "pflash_tier": "verified"
   },
   "qwen3.6-27b-8bit": {
@@ -239,6 +253,8 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "supports_dflash": false,
     "pflash_tier": "verified"
   },
@@ -249,7 +265,9 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "is_moe": false,
-    "supports_spec_decode": false
+    "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "mtp_speculative_tokens": 2
   },
   "qwen3.6-27b-ud": {
     "hf_path": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -258,6 +276,8 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "pflash_tier": "verified"
   },
   "qwen3.6-35b-4bit": {
@@ -266,6 +286,8 @@
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "is_moe": true,
     "pflash_tier": "verified",
     "turboquant_tier": "k8v4_verified"
@@ -276,6 +298,8 @@
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "is_moe": true,
     "pflash_tier": "verified",
     "turboquant_tier": "k8v4_verified"
@@ -286,6 +310,8 @@
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "is_moe": true,
     "pflash_tier": "verified",
     "turboquant_tier": "k8v4_verified"
@@ -296,6 +322,8 @@
     "reasoning_parser": "qwen3",
     "is_hybrid": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "is_moe": true,
     "pflash_tier": "verified"
   },
@@ -350,6 +378,8 @@
     "is_hybrid": false,
     "is_hybrid_explicit": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-27B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "pflash_tier": "verified"
   },
   "qwen3.6-35b": {
@@ -359,6 +389,8 @@
     "is_hybrid": true,
     "is_moe": true,
     "supports_spec_decode": false,
+    "mtp_draft_model": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
+    "mtp_speculative_tokens": 2,
     "pflash_tier": "verified"
   },
   "qwen3.6-27b-mtp-4bit": {
@@ -1214,6 +1246,8 @@
     "is_hybrid": false,
     "is_moe": true,
     "supports_spec_decode": true,
+    "mtp_draft_model": "mlx-community/Hy3-preview-MTP-4bit",
+    "mtp_speculative_tokens": 1,
     "min_memory_gb": 192
   },
   "muse-glimmer-30b-4bit": {

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -618,10 +618,11 @@ def mtp_generate_step(
                 cache_commit=cur_commit,
                 want_hidden=_mtp_supports_hidden and K >= 2,
             )
-            # Materialize before chaining — the next iteration needs
-            # ``prev_tok.item()`` inside ``_step_mtp`` (via reshape,
-            # not .item(), but the MLX graph needs the value pinned).
-            mx.eval(d_tok)
+            # Keep the draft chain on-device.  ``prev_tok`` is consumed as an
+            # MLX array by the next head call; forcing ``mx.eval`` here adds
+            # one CPU/GPU synchronization per depth and defeats the purpose
+            # of batched verification.  The final verify round evaluates the
+            # complete draft graph once.
             draft_toks.append(d_tok)
             draft_lps.append(d_lp)
             draft_accept_lps.append(d_alp)
@@ -633,7 +634,6 @@ def mtp_generate_step(
             # ``hidden_last`` constant on injects that don't expose
             # ``return_hidden`` (Qwen 3.5 today).
             if d_hidden is not None:
-                mx.eval(d_hidden)
                 cur_hidden = d_hidden
             cur_commit = None
         return draft_toks, draft_lps, draft_accept_lps, xtc_draws

--- a/vllm_mlx/spec_decode/mtp/head.py
+++ b/vllm_mlx/spec_decode/mtp/head.py
@@ -147,11 +147,13 @@ def build_mtp_module(
             next_token_ids: mx.array,
             embed_tokens: nn.Embedding,
             cache: Any | None = None,
+            concat_order: str = "embedding_hidden",
         ) -> mx.array:
             embeds = embed_tokens(next_token_ids)  # (B, N, H)
             e = self.pre_fc_norm_embedding(embeds)
             h = self.pre_fc_norm_hidden(hidden_states)
-            fused = self.fc(mx.concatenate([e, h], axis=-1))  # (B, N, H)
+            parts = [e, h] if concat_order == "embedding_hidden" else [h, e]
+            fused = self.fc(mx.concatenate(parts, axis=-1))  # (B, N, H)
 
             if cache is None:
                 cache = [None] * len(self.layers)

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -335,6 +335,10 @@ def _find_mtp_weights_file(sidecar_dir: Path) -> Path | None:
     Qwen3-Next convention used by ``add_mtp_weights.py``). Try both.
     """
     candidates = (
+        # MTPLX packages the target trunk and its native head together.
+        # ``mlx_lm`` ignores this non-model shard while loading the trunk;
+        # the MTP injector consumes it explicitly.
+        sidecar_dir / "mtp.safetensors",
         sidecar_dir / "model-mtp.safetensors",
         sidecar_dir / "mtp" / "model.safetensors",
         sidecar_dir / "model.safetensors",
@@ -343,6 +347,51 @@ def _find_mtp_weights_file(sidecar_dir: Path) -> Path | None:
         if c.exists():
             return c
     return None
+
+
+def _load_mtplx_runtime_contract(weights_file: Path) -> dict[str, Any]:
+    """Return the colocated MTPLX MTP contract, or an empty mapping.
+
+    Ordinary mlx-community sidecars have no runtime manifest and retain the
+    upstream mlx-lm PR #990 contract (pre-norm hidden, cache-relative MTP
+    positions).  MTPLX combined artifacts carry ``mtplx_runtime.json`` next
+    to ``mtp.safetensors``; silently treating their post-norm head as the
+    PR #990 variant produces plausible but low-acceptance drafts.  Read only
+    the closed contract fields we implement and fail closed on malformed
+    metadata.
+    """
+
+    import json
+
+    manifest = weights_file.parent / "mtplx_runtime.json"
+    if not manifest.is_file():
+        return {}
+    try:
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        logger.warning("[mtp.inject] could not read %s: %s", manifest, exc)
+        return {}
+    contract = payload.get("mtp_contract")
+    if not isinstance(contract, dict):
+        return {}
+    base_hidden = contract.get("base_hidden_variant", "pre_norm")
+    hidden = contract.get("hidden_variant", base_hidden)
+    concat = contract.get("concat_order", "embedding_hidden")
+    position = contract.get("mtp_position_mode", "cache")
+    if base_hidden not in {"pre_norm", "post_norm"}:
+        return {}
+    if hidden not in {"pre_norm", "post_norm"}:
+        return {}
+    if concat not in {"embedding_hidden", "hidden_embedding"}:
+        return {}
+    if position not in {"cache", "local", "absolute"}:
+        return {}
+    return {
+        "base_hidden_variant": base_hidden,
+        "hidden_variant": hidden,
+        "concat_order": concat,
+        "mtp_position_mode": position,
+    }
 
 
 def inject_mtp_support(
@@ -478,6 +527,12 @@ def inject_mtp_support(
                 mtp_sidecar,
             )
             return False
+
+    runtime_contract = (
+        _load_mtplx_runtime_contract(weights_file) if weights_file is not None else {}
+    )
+    base_hidden_variant = runtime_contract.get("base_hidden_variant", "pre_norm")
+    mtp_concat_order = runtime_contract.get("concat_order", "embedding_hidden")
 
     # --- Step 3: Match the MTP module's quantization to the SIDECAR ---
     # The packed weight/scales shapes of a ``QuantizedLinear`` are a
@@ -889,7 +944,8 @@ def inject_mtp_support(
                 out = self.lm_head(normed)
 
             if return_hidden:
-                return out, hidden_states
+                hidden = normed if base_hidden_variant == "post_norm" else hidden_states
+                return out, hidden
             return out
 
         def mtp_forward(
@@ -905,6 +961,7 @@ def inject_mtp_support(
                 next_token_ids,
                 self.model.embed_tokens,
                 mtp_cache,
+                concat_order=mtp_concat_order,
             )
             if self.args.tie_word_embeddings:
                 logits = self.model.embed_tokens.as_linear(mtp_out)
@@ -923,6 +980,7 @@ def inject_mtp_support(
                 next_token_ids,
                 self.model.embed_tokens,
                 mtp_cache,
+                concat_order=mtp_concat_order,
             )
             token = quantized_argmax(self.lm_head, mtp_out)
             if token is None:


### PR DESCRIPTION
## Summary
- honor MTPLX runtime contracts for Qwen native MTP artifacts
- expose opt-in `Experimental MTP` toggles for 18 real-weight-smoked Qwen aliases
- keep MTP off by default and warn that it may be slower and requires a restart/download
- keep HY3 and Gemma 4 out of the GUI roster until they can be validated end-to-end

## Real-weight validation
Mac Studio MTP-enabled generation passed for:
- Qwen 3.5 4B: 4/6/8-bit
- Qwen 3.5 9B: 4/6/8-bit
- Qwen 3.6 27B: 4/6/8-bit and UD
- Qwen 3.6 35B-A3B: 4/6/8-bit and UD
- both existing Qwen 3.8 27B aliases

Canonical Qwen 3.6 aliases share the exact tested 4-bit HF paths.

## Tests
- Studio: 2,967 registry/CLI/MTP tests passed
- Studio: 25 Swift ModelPerfConfig tests passed
- Mini: 103 registry/CLI/MTP tests passed
- Qwen real-weight smoke logs retained under `/tmp/mtp-smoke-*.json` on Studio

## Defaults
No alias enables MTP automatically. Performance is deliberately not a landing gate for this experimental, user-controlled toggle.