### PR TITLE
feat(spec-decode): separate capability from recommendation

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -60,7 +60,7 @@ The base text-only install is ~460 MB. Vision/audio/etc. ship as opt-in extras.
 | Extra | Install | Adds |
 |---|---|---|
 | `vision` | `pip install 'rapid-mlx[vision]'` | mlx-vlm + opencv + torch (~322 MB) for VLMs (Gemma 4, Qwen-VL, video) |
-| `dflash` | `pip install 'rapid-mlx[dflash]'` | mlx-vlm for DFlash speculative decoding on supported 8-bit aliases |
+| `dflash` | `pip install 'rapid-mlx[dflash]'` | mlx-vlm for DFlash speculative decoding; verified aliases get curated defaults, while explicit compatible target/drafter pairs may run experimentally |
 | `audio` | `pip install 'rapid-mlx[audio]'` | mlx-audio + spacy + scipy (~600 MB) for TTS / STT |
 | `embeddings` | `pip install 'rapid-mlx[embeddings]'` | mlx-embeddings (~50 MB) for `/v1/embeddings` |
 | `chat` | `pip install 'rapid-mlx[chat]'` | Gradio web UI (~150 MB) |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -149,7 +149,7 @@ mutually exclusive modes—still fail before generation.
 Generate the all-alias/all-method policy report with:
 
 ```bash
-python -m scripts.spec_capability_report
+python -m vllm_mlx.spec_decode.report
 ```
 
 #### MTP is not free — measure before you enable it

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -128,14 +128,29 @@ into the same config path.
 
 | Config | Description |
 |--------|-------------|
-| `{"method":"dflash"}` | Enable the DFlash single-user bridge on validated aliases. |
-| `{"method":"ddtree"}` | Enable experimental DDTree verification on validated aliases. |
+| `{"method":"dflash","model":"<drafter>"}` | Enable DFlash. Curated aliases may supply the drafter automatically; unknown/unverified targets require it explicitly. |
+| `{"method":"ddtree","model":"<drafter>","num_speculative_tokens":16,"tree_budget":24}` | Enable DDTree. Unknown/unverified targets require all structural inputs explicitly. |
 | `{"method":"dspark","num_speculative_tokens":5}` | Enable checkpoint-native DSpark for a local DeepSeek V4 Flash checkpoint. The token count must match the checkpoint's complete DSpark block. Greedy single-request decoding is accelerated; unsupported request shapes safely use baseline decoding. |
 | `{"method":"mtp"}` | Enable MTP speculative decoding for checkpoints accepted by the existing MTP eligibility gate. |
 | `{"method":"mtp","model":"<sidecar-head-repo>"}` | Attach a standalone MTP **sidecar head** (e.g. `mlx-community/Qwen3.6-27B-MTP-4bit`) to a full base checkpoint. The base must be MTP-eligible; the head repo goes in the `model` field — **not** in the `serve` positional. See [MTP sidecar heads are not standalone models](#mtp-sidecar-heads-are-not-standalone-models) below. Gemma 4 sidecar MTP remains disabled after its greedy-lossless A/B failed. |
 | `{"method":"mtp","num_speculative_tokens":3}` | Set the MTP max-K controller ceiling. |
 | `{"method":"mtp","disable_auto_k":true}` | Disable the MTP EV depth controller for fixed-K parity benches. |
 | `{"method":"suffix","num_speculative_tokens":8}` | Enable explicit SuffixDecoding for high-overlap workloads. |
+
+Rapid-MLX separates capability from recommendation. Registry flags identify
+combinations verified for correctness and performance; they control defaults,
+not operator permission. An explicit configuration may run an unverified or
+4-bit target after method-specific structural/runtime preflight, with an
+experimental warning. Such combinations remain default-off and may be slower
+or produce worse application-level output. True incompatibilities—missing or
+mismatched drafter metadata, unsupported verifiers, unavailable runtimes, and
+mutually exclusive modes—still fail before generation.
+
+Generate the all-alias/all-method policy report with:
+
+```bash
+python -m scripts.spec_capability_report
+```
 
 #### MTP is not free — measure before you enable it
 

--- a/scripts/spec_capability_report.py
+++ b/scripts/spec_capability_report.py
@@ -1,56 +1,11 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""Emit the all-alias/all-method speculative capability report as JSON."""
+"""Repository-compatible wrapper for the installed capability report."""
 
 from __future__ import annotations
 
-import json
-
-from vllm_mlx.model_aliases import list_profiles
-from vllm_mlx.spec_decode.capability import REGISTERED_METHODS, assess_method
-
-
-def _quantization(hf_path: str) -> str:
-    lowered = hf_path.lower()
-    for label in (
-        "nvfp4",
-        "mxfp4",
-        "int4",
-        "4bit",
-        "6bit",
-        "8bit",
-        "2bit",
-        "3bit",
-        "fp8",
-        "bfloat16",
-        "bf16",
-        "float16",
-        "fp16",
-    ):
-        if label in lowered:
-            return label
-    return "not-encoded-in-repo-name"
-
-
-def build_report() -> dict[str, dict]:
-    return {
-        alias: {
-            "model": {
-                "hf_path": profile.hf_path,
-                "checkpoint_format": "mlx",
-                "quantization": _quantization(profile.hf_path),
-                "modality": getattr(profile.modality, "value", profile.modality),
-                "is_hybrid": profile.is_hybrid,
-                "is_moe": profile.is_moe,
-            },
-            "methods": {
-                method: assess_method(profile, method).to_dict()
-                for method in REGISTERED_METHODS
-            },
-        }
-        for alias, profile in sorted(list_profiles().items())
-    }
+from vllm_mlx.spec_decode.report import main
 
 
 if __name__ == "__main__":
-    print(json.dumps(build_report(), indent=2, sort_keys=True))
+    main()

--- a/scripts/spec_capability_report.py
+++ b/scripts/spec_capability_report.py
@@ -10,11 +10,29 @@ from vllm_mlx.model_aliases import list_profiles
 from vllm_mlx.spec_decode.capability import REGISTERED_METHODS, assess_method
 
 
-def build_report() -> dict[str, dict[str, dict]]:
+def _quantization(hf_path: str) -> str:
+    lowered = hf_path.lower()
+    for label in ("nvfp4", "mxfp4", "4bit", "6bit", "8bit", "2bit", "3bit"):
+        if label in lowered:
+            return label
+    return "unknown"
+
+
+def build_report() -> dict[str, dict]:
     return {
         alias: {
-            method: assess_method(profile, method).to_dict()
-            for method in REGISTERED_METHODS
+            "model": {
+                "hf_path": profile.hf_path,
+                "checkpoint_format": "mlx",
+                "quantization": _quantization(profile.hf_path),
+                "modality": getattr(profile.modality, "value", profile.modality),
+                "is_hybrid": profile.is_hybrid,
+                "is_moe": profile.is_moe,
+            },
+            "methods": {
+                method: assess_method(profile, method).to_dict()
+                for method in REGISTERED_METHODS
+            },
         }
         for alias, profile in sorted(list_profiles().items())
     }

--- a/scripts/spec_capability_report.py
+++ b/scripts/spec_capability_report.py
@@ -15,11 +15,13 @@ def _quantization(hf_path: str) -> str:
     for label in (
         "nvfp4",
         "mxfp4",
+        "int4",
         "4bit",
         "6bit",
         "8bit",
         "2bit",
         "3bit",
+        "fp8",
         "bfloat16",
         "bf16",
         "float16",

--- a/scripts/spec_capability_report.py
+++ b/scripts/spec_capability_report.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Repository-compatible wrapper for the installed capability report."""
 
-from __future__ import annotations
-
 from vllm_mlx.spec_decode.report import main
 
 

--- a/scripts/spec_capability_report.py
+++ b/scripts/spec_capability_report.py
@@ -4,6 +4,5 @@
 
 from vllm_mlx.spec_decode.report import main
 
-
 if __name__ == "__main__":
     main()

--- a/scripts/spec_capability_report.py
+++ b/scripts/spec_capability_report.py
@@ -12,10 +12,22 @@ from vllm_mlx.spec_decode.capability import REGISTERED_METHODS, assess_method
 
 def _quantization(hf_path: str) -> str:
     lowered = hf_path.lower()
-    for label in ("nvfp4", "mxfp4", "4bit", "6bit", "8bit", "2bit", "3bit"):
+    for label in (
+        "nvfp4",
+        "mxfp4",
+        "4bit",
+        "6bit",
+        "8bit",
+        "2bit",
+        "3bit",
+        "bfloat16",
+        "bf16",
+        "float16",
+        "fp16",
+    ):
         if label in lowered:
             return label
-    return "unknown"
+    return "not-encoded-in-repo-name"
 
 
 def build_report() -> dict[str, dict]:

--- a/scripts/spec_capability_report.py
+++ b/scripts/spec_capability_report.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Emit the all-alias/all-method speculative capability report as JSON."""
+
+from __future__ import annotations
+
+import json
+
+from vllm_mlx.model_aliases import list_profiles
+from vllm_mlx.spec_decode.capability import REGISTERED_METHODS, assess_method
+
+
+def build_report() -> dict[str, dict[str, dict]]:
+    return {
+        alias: {
+            method: assess_method(profile, method).to_dict()
+            for method in REGISTERED_METHODS
+        }
+        for alias, profile in sorted(list_profiles().items())
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(build_report(), indent=2, sort_keys=True))

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -70,6 +70,8 @@ def test_explicit_4bit_main_model_is_experimental() -> None:
     assert r.reasons == ()
     assert r.recommendation == "experimental"
     assert "4-bit" in " ".join(r.warnings)
+    with pytest.raises(DDTreeUnavailable, match="explicit experimental opt-in"):
+        check(p, alias="qwen3.5-9b-4bit")
 
 
 def test_report_collects_all_failures() -> None:

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -158,6 +158,20 @@ def test_unverified_explicit_check_does_not_inherit_residual_metadata() -> None:
     assert "tree_budget" in message
 
 
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"drafter_model": "user/different"},
+        {"speculative_tokens": 8},
+        {"tree_budget": 12},
+    ],
+)
+def test_verified_target_with_any_override_is_experimental(overrides) -> None:
+    result = report(_good_profile(), explicit=True, **overrides)
+    assert result.recommendation == "experimental"
+    assert result.warnings
+
+
 def test_runtime_patches_rope_parameters_without_copying_weights(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -142,6 +142,22 @@ def test_explicit_non_positive_tree_values_are_rejected() -> None:
             )
 
 
+def test_unverified_explicit_check_does_not_inherit_residual_metadata() -> None:
+    profile = AliasProfile(
+        hf_path="user/unverified",
+        supports_ddtree=False,
+        ddtree_draft_model="registry/residual",
+        ddtree_speculative_tokens=16,
+        ddtree_tree_budget=24,
+    )
+    with pytest.raises(DDTreeUnavailable) as excinfo:
+        check(profile, explicit=True)
+    message = str(excinfo.value)
+    assert "drafter" in message
+    assert "num_speculative_tokens" in message
+    assert "tree_budget" in message
+
+
 def test_runtime_patches_rope_parameters_without_copying_weights(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -68,6 +68,7 @@ def test_explicit_4bit_main_model_is_experimental() -> None:
         tree_budget=24,
     )
     assert r.reasons == ()
+    assert r.recommendation == "experimental"
     assert "4-bit" in " ".join(r.warnings)
 
 

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -51,7 +51,7 @@ def test_check_rejects_moe_alias() -> None:
         check(p, alias="qwen3.6-35b-8bit")
 
 
-def test_check_rejects_4bit_main_model() -> None:
+def test_explicit_4bit_main_model_is_experimental() -> None:
     p = AliasProfile(
         hf_path="mlx-community/Qwen3.5-9B-4bit",
         supports_ddtree=True,
@@ -59,8 +59,16 @@ def test_check_rejects_4bit_main_model() -> None:
         ddtree_speculative_tokens=16,
         ddtree_tree_budget=24,
     )
-    with pytest.raises(DDTreeUnavailable, match="4-bit"):
-        check(p, alias="qwen3.5-9b-4bit")
+    r = check(
+        p,
+        alias="qwen3.5-9b-4bit",
+        explicit=True,
+        drafter_model=p.ddtree_draft_model,
+        speculative_tokens=16,
+        tree_budget=24,
+    )
+    assert r.reasons == ()
+    assert "4-bit" in " ".join(r.warnings)
 
 
 def test_report_collects_all_failures() -> None:
@@ -72,10 +80,10 @@ def test_report_collects_all_failures() -> None:
     r = report(bad, alias="qwen3.6-35b-4bit")
     joined = " ".join(r.reasons)
     assert "MoE" in joined
-    assert "4-bit" in joined
-    assert "ddtree_draft_model" in joined
-    assert "ddtree_speculative_tokens" in joined
-    assert "ddtree_tree_budget" in joined
+    assert "4-bit" in " ".join(r.warnings)
+    assert "drafter" in joined
+    assert "num_speculative_tokens" in joined
+    assert "tree_budget" in joined
 
 
 def test_qwen3_5_9b_8bit_alias_passes_check() -> None:
@@ -93,7 +101,20 @@ def test_qwen3_5_9b_4bit_alias_fails_with_4bit_reason() -> None:
     assert profile is not None
     with pytest.raises(DDTreeUnavailable) as excinfo:
         check(profile, alias="qwen3.5-9b-4bit")
-    assert "4-bit" in str(excinfo.value)
+    assert "not DDTree-enabled" in str(excinfo.value)
+
+
+def test_unknown_4bit_path_explicit_opt_in_is_allowed() -> None:
+    profile = AliasProfile(hf_path="user/Qwen3.5-9B-abliterated-4bit")
+    result = check(
+        profile,
+        explicit=True,
+        drafter_model="user/Qwen3.5-9B-abliterated-DFlash",
+        speculative_tokens=16,
+        tree_budget=24,
+    )
+    assert result.recommendation == "experimental"
+    assert result.reasons == ()
 
 
 def test_runtime_patches_rope_parameters_without_copying_weights(

--- a/tests/test_ddtree_eligibility.py
+++ b/tests/test_ddtree_eligibility.py
@@ -59,7 +59,7 @@ def test_explicit_4bit_main_model_is_experimental() -> None:
         ddtree_speculative_tokens=16,
         ddtree_tree_budget=24,
     )
-    r = check(
+    r = report(
         p,
         alias="qwen3.5-9b-4bit",
         explicit=True,
@@ -106,7 +106,7 @@ def test_qwen3_5_9b_4bit_alias_fails_with_4bit_reason() -> None:
 
 def test_unknown_4bit_path_explicit_opt_in_is_allowed() -> None:
     profile = AliasProfile(hf_path="user/Qwen3.5-9B-abliterated-4bit")
-    result = check(
+    result = report(
         profile,
         explicit=True,
         drafter_model="user/Qwen3.5-9B-abliterated-DFlash",
@@ -115,6 +115,31 @@ def test_unknown_4bit_path_explicit_opt_in_is_allowed() -> None:
     )
     assert result.recommendation == "experimental"
     assert result.reasons == ()
+
+
+def test_check_preserves_none_success_contract() -> None:
+    assert check(_good_profile(), alias="qwen3.5-9b-8bit") is None
+
+
+def test_explicit_non_positive_tree_values_are_rejected() -> None:
+    profile = _good_profile()
+    for value in (0, -1):
+        with pytest.raises(DDTreeUnavailable, match="num_speculative_tokens"):
+            check(
+                profile,
+                explicit=True,
+                drafter_model=profile.ddtree_draft_model,
+                speculative_tokens=value,
+                tree_budget=24,
+            )
+        with pytest.raises(DDTreeUnavailable, match="tree_budget"):
+            check(
+                profile,
+                explicit=True,
+                drafter_model=profile.ddtree_draft_model,
+                speculative_tokens=16,
+                tree_budget=value,
+            )
 
 
 def test_runtime_patches_rope_parameters_without_copying_weights(

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -115,6 +115,34 @@ def test_unknown_4bit_target_can_explicitly_opt_in(monkeypatch, capsys) -> None:
     assert "Experimental DDTree" in capsys.readouterr().out
 
 
+def test_unverified_ddtree_requires_all_fields_even_with_residual_profile(
+    monkeypatch,
+) -> None:
+    import pytest
+
+    from vllm_mlx.cli import (
+        _normalize_speculative_config_or_exit,
+        _preflight_ddtree_or_exit,
+    )
+    from vllm_mlx.model_aliases import AliasProfile
+
+    residual = AliasProfile(
+        hf_path="user/unverified",
+        supports_ddtree=False,
+        ddtree_draft_model="registry/residual",
+        ddtree_speculative_tokens=16,
+        ddtree_tree_budget=24,
+    )
+    monkeypatch.setattr("vllm_mlx.model_aliases.resolve_profile", lambda _: residual)
+    args = _ddtree_cli_args(
+        model="user/unverified",
+        speculative_config='{"method":"ddtree"}',
+    )
+    _normalize_speculative_config_or_exit(args)
+    with pytest.raises(SystemExit):
+        _preflight_ddtree_or_exit(args)
+
+
 def test_info_renders_ddtree_block_for_eligible_alias(capsys, monkeypatch) -> None:
     from vllm_mlx.cli import info_command
 

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -113,14 +113,14 @@ def test_info_renders_ddtree_block_for_eligible_alias(capsys, monkeypatch) -> No
     )
 
 
-def test_info_ddtree_marks_4bit_alias_ineligible(capsys) -> None:
+def test_info_ddtree_marks_4bit_alias_experimental(capsys) -> None:
     from vllm_mlx.cli import info_command
 
     args = type("Args", (), {"model": "qwen3.5-9b-4bit"})()
     info_command(args)
     captured = capsys.readouterr()
     assert "DDTree eligibility" in captured.out
-    assert "ineligible" in captured.out
+    assert "experimental" in captured.out
     assert "4-bit" in captured.out
 
 
@@ -152,16 +152,16 @@ def test_models_listing_renders_ddtree_column(capsys) -> None:
         None,
     )
     assert eligible_row is not None
-    assert ddtree_cell(eligible_row) == "✓", (
-        f"DDTree column should be ✓: {eligible_row!r}"
+    assert ddtree_cell(eligible_row) == "verified", (
+        f"DDTree column should be verified: {eligible_row!r}"
     )
     ineligible_row = next(
         (line for line in lines if line.strip().startswith("qwen3.5-9b-4bit ")),
         None,
     )
     assert ineligible_row is not None
-    assert ddtree_cell(ineligible_row) == "—", (
-        f"DDTree column should be —: {ineligible_row!r}"
+    assert ddtree_cell(ineligible_row) == "exp", (
+        f"DDTree column should be exp: {ineligible_row!r}"
     )
 
 

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -92,6 +92,29 @@ def test_speculative_config_ddtree_preflight_falls_back_to_alias_defaults(
     assert args._ddtree_tree_budget == 24
 
 
+def test_unknown_4bit_target_can_explicitly_opt_in(monkeypatch, capsys) -> None:
+    from vllm_mlx.cli import (
+        _normalize_speculative_config_or_exit,
+        _preflight_ddtree_or_exit,
+    )
+
+    monkeypatch.setattr(
+        "vllm_mlx.speculative.ddtree.eligibility.have_runtime", lambda: True
+    )
+    args = _ddtree_cli_args(
+        model="user/Qwen3.5-9B-abliterated-4bit",
+        speculative_config=(
+            '{"method":"ddtree","model":"user/matching-drafter",'
+            '"num_speculative_tokens":8,"tree_budget":12}'
+        ),
+    )
+    _normalize_speculative_config_or_exit(args)
+    _, profile = _preflight_ddtree_or_exit(args)
+    assert profile.hf_path == args.model
+    assert args._ddtree_drafter_repo == "user/matching-drafter"
+    assert "Experimental DDTree" in capsys.readouterr().out
+
+
 def test_info_renders_ddtree_block_for_eligible_alias(capsys, monkeypatch) -> None:
     from vllm_mlx.cli import info_command
 

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -46,7 +46,7 @@ def _good_profile() -> AliasProfile:
         ("mlx-community/Qwen3.6-35B-A3B-4bit-DWQ", True),
         ("user/Qwen3.5-9B-4-bit", True),
         ("user/Qwen3.5-9B_4bit", True),
-        ("user/Foo-4bit-attention", False),
+        ("user/model-4bit-instruct", True),
         # 8-bit + higher should NOT match
         ("mlx-community/Qwen3.5-27B-8bit", False),
         ("mlx-community/Qwen3.6-35B-A3B-8bit", False),

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -93,17 +93,20 @@ def test_check_rejects_moe_alias() -> None:
         check(p, alias="qwen3.6-35b-8bit")
 
 
-def test_check_rejects_4bit_main_model() -> None:
-    """4-bit main model → reject. Note: aliases marked
-    ``supports_dflash=True`` can't be 4-bit (alias-contract guard),
-    so this gate primarily defends against test-only profiles."""
+def test_explicit_4bit_main_model_is_experimental() -> None:
     p = AliasProfile(
         hf_path="mlx-community/Qwen3.5-27B-4bit",  # 4-bit!
         supports_dflash=True,
         dflash_draft_model="z-lab/Qwen3.5-27B-DFlash",
     )
-    with pytest.raises(DFlashUnavailable, match="4-bit"):
-        check(p, alias="qwen3.5-27b-4bit")
+    r = check(
+        p,
+        alias="qwen3.5-27b-4bit",
+        explicit=True,
+        drafter_model=p.dflash_draft_model,
+    )
+    assert r.reasons == ()
+    assert "4-bit" in " ".join(r.warnings)
 
 
 def test_check_message_lists_eligible_aliases() -> None:
@@ -137,7 +140,7 @@ def test_report_collects_all_failures() -> None:
     assert len(r.reasons) == 3, f"expected 3 reasons, got: {r.reasons}"
     joined = " ".join(r.reasons)
     assert "MoE" in joined
-    assert "4-bit" in joined
+    assert "4-bit" in " ".join(r.warnings)
     assert "not DFlash-enabled" in joined
 
 
@@ -183,6 +186,17 @@ def test_default_qwen3_5_27b_alias_fails_check_with_4bit_reason() -> None:
     with pytest.raises(DFlashUnavailable) as excinfo:
         check(profile, alias="qwen3.5-27b-4bit")
     msg = str(excinfo.value)
-    assert "4-bit" in msg, (
-        f"4-bit hint missing from DFlashUnavailable message; got:\n{msg}"
+    assert "not DFlash-enabled" in msg
+
+
+def test_unknown_4bit_path_explicit_opt_in_is_allowed() -> None:
+    profile = AliasProfile(hf_path="user/Qwen3.5-9B-abliterated-4bit")
+    result = check(
+        profile,
+        alias=None,
+        explicit=True,
+        drafter_model="user/Qwen3.5-9B-abliterated-DFlash",
     )
+    assert result.recommendation == "experimental"
+    assert result.reasons == ()
+    assert "performance-validated" in " ".join(result.warnings)

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -99,7 +99,7 @@ def test_explicit_4bit_main_model_is_experimental() -> None:
         supports_dflash=True,
         dflash_draft_model="z-lab/Qwen3.5-27B-DFlash",
     )
-    r = check(
+    r = report(
         p,
         alias="qwen3.5-27b-4bit",
         explicit=True,
@@ -191,7 +191,7 @@ def test_default_qwen3_5_27b_alias_fails_check_with_4bit_reason() -> None:
 
 def test_unknown_4bit_path_explicit_opt_in_is_allowed() -> None:
     profile = AliasProfile(hf_path="user/Qwen3.5-9B-abliterated-4bit")
-    result = check(
+    result = report(
         profile,
         alias=None,
         explicit=True,
@@ -200,3 +200,7 @@ def test_unknown_4bit_path_explicit_opt_in_is_allowed() -> None:
     assert result.recommendation == "experimental"
     assert result.reasons == ()
     assert "performance-validated" in " ".join(result.warnings)
+
+
+def test_check_preserves_none_success_contract() -> None:
+    assert check(_good_profile(), alias="qwen3.5-27b-8bit") is None

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -137,14 +137,15 @@ def test_report_collects_all_failures() -> None:
     bad = AliasProfile(
         hf_path="mlx-community/Qwen3.6-35B-A3B-4bit",  # 4-bit AND MoE
         is_moe=True,
-        # supports_dflash=False (default) → 3 reasons total
+        # supports_dflash=False (default)
     )
     r = report(bad, alias="qwen3.6-35b-4bit")
-    assert len(r.reasons) == 3, f"expected 3 reasons, got: {r.reasons}"
     joined = " ".join(r.reasons)
     assert "MoE" in joined
     assert "4-bit" in " ".join(r.warnings)
+    assert "explicit experimental opt-in" in joined
     assert "not DFlash-enabled" in joined
+    assert "drafter" in joined
 
 
 def test_report_no_alias_name_renders_cleanly() -> None:

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -108,6 +108,8 @@ def test_explicit_4bit_main_model_is_experimental() -> None:
     assert r.reasons == ()
     assert r.recommendation == "experimental"
     assert "4-bit" in " ".join(r.warnings)
+    with pytest.raises(DFlashUnavailable, match="explicit experimental opt-in"):
+        check(p, alias="qwen3.5-27b-4bit")
 
 
 def test_check_message_lists_eligible_aliases() -> None:

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -204,3 +204,13 @@ def test_unknown_4bit_path_explicit_opt_in_is_allowed() -> None:
 
 def test_check_preserves_none_success_contract() -> None:
     assert check(_good_profile(), alias="qwen3.5-27b-8bit") is None
+
+
+def test_unverified_explicit_check_does_not_inherit_residual_drafter() -> None:
+    profile = AliasProfile(
+        hf_path="user/unverified",
+        supports_dflash=False,
+        dflash_draft_model="registry/residual",
+    )
+    with pytest.raises(DFlashUnavailable, match="explicit drafter"):
+        check(profile, explicit=True, drafter_model=None)

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -214,3 +214,13 @@ def test_unverified_explicit_check_does_not_inherit_residual_drafter() -> None:
     )
     with pytest.raises(DFlashUnavailable, match="explicit drafter"):
         check(profile, explicit=True, drafter_model=None)
+
+
+def test_verified_target_with_overridden_drafter_is_experimental() -> None:
+    result = report(
+        _good_profile(),
+        explicit=True,
+        drafter_model="user/different-drafter",
+    )
+    assert result.recommendation == "experimental"
+    assert "performance-validated" in " ".join(result.warnings)

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -44,6 +44,8 @@ def _good_profile() -> AliasProfile:
         ("nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx", True),
         ("RedHatAI/Qwen3.6-35B-A3B-NVFP4", True),
         ("mlx-community/Qwen3.6-35B-A3B-4bit-DWQ", True),
+        ("user/Qwen3.5-9B-4-bit", True),
+        ("user/Qwen3.5-9B_4bit", True),
         # 8-bit + higher should NOT match
         ("mlx-community/Qwen3.5-27B-8bit", False),
         ("mlx-community/Qwen3.6-35B-A3B-8bit", False),

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -106,6 +106,7 @@ def test_explicit_4bit_main_model_is_experimental() -> None:
         drafter_model=p.dflash_draft_model,
     )
     assert r.reasons == ()
+    assert r.recommendation == "experimental"
     assert "4-bit" in " ".join(r.warnings)
 
 

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -46,6 +46,7 @@ def _good_profile() -> AliasProfile:
         ("mlx-community/Qwen3.6-35B-A3B-4bit-DWQ", True),
         ("user/Qwen3.5-9B-4-bit", True),
         ("user/Qwen3.5-9B_4bit", True),
+        ("user/Foo-4bit-attention", False),
         # 8-bit + higher should NOT match
         ("mlx-community/Qwen3.5-27B-8bit", False),
         ("mlx-community/Qwen3.6-35B-A3B-8bit", False),

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -158,6 +158,18 @@ def test_speculative_config_dflash_normalizes_to_legacy_server_flag() -> None:
     assert _resolve_dflash_drafter_repo(args, profile) == "z-lab/Qwen3.5-27B-DFlash"
 
 
+def test_unverified_dflash_profile_cannot_inherit_residual_drafter() -> None:
+    from vllm_mlx.cli import _resolve_dflash_drafter_repo
+
+    args = _dflash_cli_args()
+    args._speculative_config = SimpleNamespace(method="dflash", model=None)
+    profile = SimpleNamespace(
+        supports_dflash=False,
+        dflash_draft_model="registry/residual-drafter",
+    )
+    assert _resolve_dflash_drafter_repo(args, profile) is None
+
+
 def test_dflash_preflight_rejects_legacy_mtp_alias(capsys) -> None:
     from vllm_mlx.cli import _preflight_dflash_mutexes_or_exit
 

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -233,16 +233,16 @@ def test_info_dflash_block_skipped_for_unknown_alias(capsys) -> None:
     assert "DFlash eligibility" not in captured.out
 
 
-def test_info_dflash_marks_4bit_alias_ineligible(capsys) -> None:
+def test_info_dflash_marks_4bit_alias_experimental(capsys) -> None:
     """The default ``qwen3.5-27b-4bit`` alias points at the 4-bit variant and
-    must surface as ineligible with the right gate failing."""
+    must surface as explicit experimental opt-in."""
     from vllm_mlx.cli import info_command
 
     args = type("Args", (), {"model": "qwen3.5-27b-4bit"})()
     info_command(args)
     captured = capsys.readouterr()
     assert "DFlash eligibility" in captured.out
-    assert "ineligible" in captured.out
+    assert "experimental" in captured.out
 
 
 def test_info_dflash_start_with_uses_alias_not_hf_path(capsys, monkeypatch) -> None:
@@ -290,8 +290,8 @@ def test_info_dflash_start_with_uses_alias_not_hf_path(capsys, monkeypatch) -> N
 
 def test_models_listing_renders_dflash_column(capsys) -> None:
     """``rapid-mlx models`` must show a ``DFlash`` column so users can
-    scan eligibility at a glance. The known-good alias renders ✓; a
-    non-DFlash alias renders —."""
+    scan recommendation at a glance. The known-good alias renders verified;
+    an unverified alias renders exp."""
     from vllm_mlx.cli import models_command
 
     models_command(None)
@@ -307,7 +307,9 @@ def test_models_listing_renders_dflash_column(capsys) -> None:
         None,
     )
     assert eligible_row is not None, "qwen3.5-27b-8bit row missing"
-    assert "✓" in eligible_row, f"DFlash column should be ✓: {eligible_row!r}"
+    assert "verified" in eligible_row, (
+        f"DFlash column should be verified: {eligible_row!r}"
+    )
 
     # A non-DFlash alias renders — in the DFlash column.
     ineligible_row = next(
@@ -315,7 +317,7 @@ def test_models_listing_renders_dflash_column(capsys) -> None:
         None,
     )
     assert ineligible_row is not None, "qwen3.5-4b-4bit row missing"
-    assert "—" in ineligible_row, f"DFlash column should be —: {ineligible_row!r}"
+    assert "exp" in ineligible_row, f"DFlash column should be exp: {ineligible_row!r}"
 
 
 # =============================================================================

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -170,6 +170,24 @@ def test_unverified_dflash_profile_cannot_inherit_residual_drafter() -> None:
     assert _resolve_dflash_drafter_repo(args, profile) is None
 
 
+def test_programmatic_4bit_requires_explicit_experimental_opt_in(monkeypatch) -> None:
+    from vllm_mlx.speculative.dflash.eligibility import DFlashUnavailable
+    from vllm_mlx.speculative.dflash.server import run_dflash_server
+
+    monkeypatch.setattr("vllm_mlx.speculative.dflash.server.have_runtime", lambda: True)
+    with pytest.raises(DFlashUnavailable, match="experimental_opt_in=True"):
+        run_dflash_server(
+            main_model_repo="user/target-4bit",
+            drafter_repo="user/drafter",
+            host="127.0.0.1",
+            port=8000,
+            served_model_name="target",
+            default_max_tokens=32,
+            cors_origins=[],
+            uvicorn_log_level="error",
+        )
+
+
 def test_dflash_preflight_rejects_legacy_mtp_alias(capsys) -> None:
     from vllm_mlx.cli import _preflight_dflash_mutexes_or_exit
 

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -337,7 +337,9 @@ def test_models_listing_renders_dflash_column(capsys) -> None:
         None,
     )
     assert eligible_row is not None, "qwen3.5-27b-8bit row missing"
-    assert "verified" in eligible_row, (
+    # DFlash is third-to-last: DDTree and Preset follow it. Parse the exact
+    # cell so a marker in either neighboring column cannot mask a regression.
+    assert eligible_row.split()[-3] == "verified", (
         f"DFlash column should be verified: {eligible_row!r}"
     )
 
@@ -347,7 +349,9 @@ def test_models_listing_renders_dflash_column(capsys) -> None:
         None,
     )
     assert ineligible_row is not None, "qwen3.5-4b-4bit row missing"
-    assert "exp" in ineligible_row, f"DFlash column should be exp: {ineligible_row!r}"
+    assert ineligible_row.split()[-3] == "exp", (
+        f"DFlash column should be exp: {ineligible_row!r}"
+    )
 
 
 # =============================================================================

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -71,6 +71,18 @@ def test_incomplete_registry_flags_are_not_reported_verified():
         assert assessment.explicit_opt_in is True
 
 
+def test_quantized_curated_flags_remain_experimental():
+    for hf_path in ("user/target-4-bit", "user/target_4bit"):
+        profile = AliasProfile(
+            hf_path=hf_path,
+            supports_dflash=True,
+            dflash_draft_model="user/drafter",
+        )
+        assessment = assess_method(profile, "dflash")
+        assert assessment.recommendation == "experimental"
+        assert assessment.explicit_opt_in is True
+
+
 def test_quantization_recognizes_hyphenated_spellings():
     assert _quantization("user/model-4-bit") == "4bit"
     assert _quantization("user/model-8-bit") == "8bit"

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -40,6 +40,22 @@ def test_uncurated_non_hybrid_suffix_is_experimental():
     assert suffix.explicit_opt_in is True
 
 
+def test_verified_entries_do_not_require_experimental_opt_in():
+    profile = AliasProfile(
+        hf_path="user/verified-8bit",
+        supports_spec_decode=True,
+        suffix_decoding_tier="verified",
+        supports_dflash=True,
+        supports_ddtree=True,
+        mtp_draft_model="user/mtp-head",
+    )
+    for method in ("suffix", "dflash", "ddtree", "mtp"):
+        assessment = assess_method(profile, method)
+        assert assessment.recommendation == "verified"
+        assert assessment.explicit_opt_in is False
+
+
 def test_quantization_recognizes_hyphenated_spellings():
     assert _quantization("user/model-4-bit") == "4bit"
     assert _quantization("user/model-8-bit") == "8bit"
+    assert _quantization("user/paint4bitmaps") == "not-encoded-in-repo-name"

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -57,6 +57,7 @@ def test_verified_entries_do_not_require_experimental_opt_in():
         assessment = assess_method(profile, method)
         assert assessment.recommendation == "verified"
         assert assessment.explicit_opt_in is False
+        assert assessment.capable is True
 
 
 def test_incomplete_registry_flags_are_not_reported_verified():
@@ -87,3 +88,4 @@ def test_quantization_recognizes_hyphenated_spellings():
     assert _quantization("user/model-4-bit") == "4bit"
     assert _quantization("user/model-8-bit") == "8bit"
     assert _quantization("user/paint4bitmaps") == "not-encoded-in-repo-name"
+    assert _quantization("user/Foo-4bit-attention") == "not-encoded-in-repo-name"

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -1,0 +1,25 @@
+from scripts.spec_capability_report import build_report
+from vllm_mlx.model_aliases import AliasProfile, list_profiles
+from vllm_mlx.spec_decode.capability import REGISTERED_METHODS, assess_method
+
+
+def test_report_covers_every_alias_and_method():
+    report = build_report()
+    assert set(report) == set(list_profiles())
+    assert all(set(methods) == set(REGISTERED_METHODS) for methods in report.values())
+
+
+def test_4bit_is_recommendation_evidence_not_capability_ban():
+    profile = AliasProfile(hf_path="user/Qwen3.5-9B-abliterated-4bit")
+    for method in ("mtp", "dflash", "ddtree", "dspark"):
+        assessment = assess_method(profile, method)
+        assert assessment.recommendation == "experimental"
+        assert assessment.explicit_opt_in is True
+        assert assessment.capable is not False
+
+
+def test_true_verifier_incompatibility_remains_hard_failure():
+    hybrid = AliasProfile(hf_path="user/hybrid", is_hybrid=True)
+    suffix = assess_method(hybrid, "suffix")
+    assert suffix.capable is False
+    assert suffix.recommendation == "incompatible"

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -6,7 +6,14 @@ from vllm_mlx.spec_decode.capability import REGISTERED_METHODS, assess_method
 def test_report_covers_every_alias_and_method():
     report = build_report()
     assert set(report) == set(list_profiles())
-    assert all(set(methods) == set(REGISTERED_METHODS) for methods in report.values())
+    assert all(
+        set(entry["methods"]) == set(REGISTERED_METHODS) for entry in report.values()
+    )
+    assert all(
+        {"hf_path", "checkpoint_format", "quantization", "modality"}
+        <= set(entry["model"])
+        for entry in report.values()
+    )
 
 
 def test_4bit_is_recommendation_evidence_not_capability_ban():

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -79,10 +79,12 @@ def test_quantized_curated_flags_remain_experimental():
             hf_path=hf_path,
             supports_dflash=True,
             dflash_draft_model="user/drafter",
+            mtp_draft_model="user/mtp-head",
         )
-        assessment = assess_method(profile, "dflash")
-        assert assessment.recommendation == "experimental"
-        assert assessment.explicit_opt_in is True
+        for method in ("dflash", "mtp"):
+            assessment = assess_method(profile, method)
+            assert assessment.recommendation == "experimental"
+            assert assessment.explicit_opt_in is True
 
 
 def test_quantization_recognizes_hyphenated_spellings():

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -47,12 +47,28 @@ def test_verified_entries_do_not_require_experimental_opt_in():
         suffix_decoding_tier="verified",
         supports_dflash=True,
         supports_ddtree=True,
+        dflash_draft_model="user/dflash-drafter",
+        ddtree_draft_model="user/ddtree-drafter",
+        ddtree_speculative_tokens=16,
+        ddtree_tree_budget=24,
         mtp_draft_model="user/mtp-head",
     )
     for method in ("suffix", "dflash", "ddtree", "mtp"):
         assessment = assess_method(profile, method)
         assert assessment.recommendation == "verified"
         assert assessment.explicit_opt_in is False
+
+
+def test_incomplete_registry_flags_are_not_reported_verified():
+    profile = AliasProfile(
+        hf_path="user/incomplete-8bit",
+        supports_dflash=True,
+        supports_ddtree=True,
+    )
+    for method in ("dflash", "ddtree"):
+        assessment = assess_method(profile, method)
+        assert assessment.recommendation == "experimental"
+        assert assessment.explicit_opt_in is True
 
 
 def test_quantization_recognizes_hyphenated_spellings():

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -57,7 +57,8 @@ def test_verified_entries_do_not_require_experimental_opt_in():
         assessment = assess_method(profile, method)
         assert assessment.recommendation == "verified"
         assert assessment.explicit_opt_in is False
-        assert assessment.capable is True
+        if method != "mtp":
+            assert assessment.capable is True
 
 
 def test_incomplete_registry_flags_are_not_reported_verified():

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -91,4 +91,4 @@ def test_quantization_recognizes_hyphenated_spellings():
     assert _quantization("user/model-4-bit") == "4bit"
     assert _quantization("user/model-8-bit") == "8bit"
     assert _quantization("user/paint4bitmaps") == "not-encoded-in-repo-name"
-    assert _quantization("user/Foo-4bit-attention") == "not-encoded-in-repo-name"
+    assert _quantization("user/model-4bit-instruct") == "4bit"

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -32,6 +32,14 @@ def test_true_verifier_incompatibility_remains_hard_failure():
     assert suffix.recommendation == "incompatible"
 
 
+def test_uncurated_non_hybrid_suffix_is_experimental():
+    profile = AliasProfile(hf_path="user/custom-text-model")
+    suffix = assess_method(profile, "suffix")
+    assert suffix.capable is None
+    assert suffix.recommendation == "experimental"
+    assert suffix.explicit_opt_in is True
+
+
 def test_quantization_recognizes_hyphenated_spellings():
     assert _quantization("user/model-4-bit") == "4bit"
     assert _quantization("user/model-8-bit") == "8bit"

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -1,6 +1,6 @@
-from scripts.spec_capability_report import build_report
 from vllm_mlx.model_aliases import AliasProfile, list_profiles
 from vllm_mlx.spec_decode.capability import REGISTERED_METHODS, assess_method
+from vllm_mlx.spec_decode.report import _quantization, build_report
 
 
 def test_report_covers_every_alias_and_method():
@@ -30,3 +30,8 @@ def test_true_verifier_incompatibility_remains_hard_failure():
     suffix = assess_method(hybrid, "suffix")
     assert suffix.capable is False
     assert suffix.recommendation == "incompatible"
+
+
+def test_quantization_recognizes_hyphenated_spellings():
+    assert _quantization("user/model-4-bit") == "4bit"
+    assert _quantization("user/model-8-bit") == "8bit"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2323,13 +2323,18 @@ def _normalize_speculative_config_or_exit(args):
     _fill_suffix_defaults()
 
 
-def _resolve_dflash_drafter_repo(args, profile) -> str:
+def _resolve_dflash_drafter_repo(args, profile) -> str | None:
     """Return the effective DFlash drafter repo for normalized CLI args."""
 
     spec_config = getattr(args, "_speculative_config", None)
     if spec_config is not None and spec_config.method == "dflash" and spec_config.model:
         return spec_config.model
-    return profile.dflash_draft_model
+    # Only verified aliases may inherit a curated registry default. An
+    # experimental pair is enabled by the operator explicitly naming its
+    # drafter, never by stale/residual profile metadata.
+    if profile.supports_dflash:
+        return profile.dflash_draft_model
+    return None
 
 
 def _preflight_dflash_mutexes_or_exit(args) -> None:
@@ -2425,17 +2430,24 @@ def _preflight_ddtree_or_exit(args):
     profile = resolve_profile(alias_name)
     if profile is None:
         profile = ModelProfile(hf_path=args.model)
-    drafter = spec_config.model or profile.ddtree_draft_model
-    speculative_tokens = (
-        spec_config.num_speculative_tokens
-        if spec_config.num_speculative_tokens is not None
-        else profile.ddtree_speculative_tokens
-    )
-    tree_budget = (
-        spec_config.tree_budget
-        if spec_config.tree_budget is not None
-        else profile.ddtree_tree_budget
-    )
+    if profile.supports_ddtree:
+        drafter = spec_config.model or profile.ddtree_draft_model
+        speculative_tokens = (
+            spec_config.num_speculative_tokens
+            if spec_config.num_speculative_tokens is not None
+            else profile.ddtree_speculative_tokens
+        )
+        tree_budget = (
+            spec_config.tree_budget
+            if spec_config.tree_budget is not None
+            else profile.ddtree_tree_budget
+        )
+    else:
+        # Experimental profiles never inherit residual registry metadata:
+        # explicit opt-in means the operator supplies the whole pair.
+        drafter = spec_config.model
+        speculative_tokens = spec_config.num_speculative_tokens
+        tree_budget = spec_config.tree_budget
     try:
         assessment = ddtree_report(
             profile,
@@ -8290,6 +8302,7 @@ def _print_dflash_status(alias: str, profile) -> None:
     present) so a user who tried DFlash and got a vague error can see
     exactly which gate they're tripping.
     """
+    from vllm_mlx.spec_decode.capability import assess_method
     from vllm_mlx.speculative.dflash.eligibility import (
         _looks_like_4bit,
         have_runtime,
@@ -8332,8 +8345,9 @@ def _print_dflash_status(alias: str, profile) -> None:
         ),
     ]
 
-    capable = not profile.is_moe
-    verified = profile.supports_dflash
+    shared = assess_method(profile, "dflash")
+    capable = shared.recommendation != "incompatible"
+    verified = shared.recommendation == "verified"
     eligible = verified and have_runtime()
     if not capable:
         summary = "✗ incompatible"
@@ -8369,6 +8383,7 @@ def _print_dflash_status(alias: str, profile) -> None:
 
 def _print_ddtree_status(alias: str, profile) -> None:
     """Render DDTree status for ``rapid-mlx info <alias>``."""
+    from vllm_mlx.spec_decode.capability import assess_method
     from vllm_mlx.speculative.ddtree.eligibility import have_runtime
     from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
 
@@ -8429,8 +8444,9 @@ def _print_ddtree_status(alias: str, profile) -> None:
         ),
     ]
 
-    capable = not profile.is_moe
-    verified = profile.supports_ddtree
+    shared = assess_method(profile, "ddtree")
+    capable = shared.recommendation != "incompatible"
+    verified = shared.recommendation == "verified"
     eligible = verified and have_runtime()
     if not capable:
         summary = "✗ incompatible"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2413,7 +2413,13 @@ def _preflight_ddtree_or_exit(args):
     from .model_aliases import resolve_profile
     from .model_profile import ModelProfile
     from .speculative.ddtree import DDTreeUnavailable, check
-    from .speculative.ddtree.eligibility import have_runtime, runtime_probe_error
+    from .speculative.ddtree.eligibility import (
+        have_runtime,
+        runtime_probe_error,
+    )
+    from .speculative.ddtree.eligibility import (
+        report as ddtree_report,
+    )
 
     alias_name = getattr(args, "_original_alias", None) or args.model
     profile = resolve_profile(alias_name)
@@ -2421,11 +2427,25 @@ def _preflight_ddtree_or_exit(args):
         profile = ModelProfile(hf_path=args.model)
     drafter = spec_config.model or profile.ddtree_draft_model
     speculative_tokens = (
-        spec_config.num_speculative_tokens or profile.ddtree_speculative_tokens
+        spec_config.num_speculative_tokens
+        if spec_config.num_speculative_tokens is not None
+        else profile.ddtree_speculative_tokens
     )
-    tree_budget = spec_config.tree_budget or profile.ddtree_tree_budget
+    tree_budget = (
+        spec_config.tree_budget
+        if spec_config.tree_budget is not None
+        else profile.ddtree_tree_budget
+    )
     try:
-        assessment = check(
+        assessment = ddtree_report(
+            profile,
+            alias=alias_name,
+            explicit=True,
+            drafter_model=drafter,
+            speculative_tokens=speculative_tokens,
+            tree_budget=tree_budget,
+        )
+        check(
             profile,
             alias=alias_name,
             explicit=True,
@@ -3439,6 +3459,7 @@ def serve_command(args):
         from .model_aliases import resolve_profile
         from .model_profile import ModelProfile
         from .speculative.dflash import DFlashUnavailable, check
+        from .speculative.dflash.eligibility import report as dflash_report
 
         # ``have_runtime()`` validated at the top-of-function boot-guard
         # tier — see the 0.9.2 dogfood comment near the audio probe.
@@ -3448,7 +3469,13 @@ def serve_command(args):
             _profile = ModelProfile(hf_path=args.model)
         _drafter = _resolve_dflash_drafter_repo(args, _profile)
         try:
-            _assessment = check(
+            _assessment = dflash_report(
+                _profile,
+                alias=_alias_name,
+                explicit=True,
+                drafter_model=_drafter,
+            )
+            check(
                 _profile,
                 alias=_alias_name,
                 explicit=True,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3500,6 +3500,7 @@ def serve_command(args):
             print(f"\n  ⚠ Experimental DFlash: {_warning}.\n")
         args._dflash_profile = _profile
         args._dflash_drafter_repo = _drafter
+        args._dflash_experimental = _assessment.recommendation != "verified"
         # ``have_runtime()`` is already validated by the boot-guard tier
         # at the top of ``serve_command`` — see the 0.9.2 dogfood comment
         # there. We keep the import + the deeper DFlashUnavailable / alias
@@ -3668,6 +3669,7 @@ def serve_command(args):
                 args.tool_call_parser if args.enable_auto_tool_choice else None
             ),
             reasoning_parser_name=args.reasoning_parser,
+            experimental_opt_in=getattr(args, "_dflash_experimental", False),
         )
         return
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -8348,11 +8348,16 @@ def _print_dflash_status(alias: str, profile) -> None:
     shared = assess_method(profile, "dflash")
     capable = shared.recommendation != "incompatible"
     verified = shared.recommendation == "verified"
-    eligible = verified and have_runtime()
+    runtime_available = have_runtime()
+    eligible = verified and runtime_available
     if not capable:
         summary = "✗ incompatible"
-    elif verified:
+    elif verified and runtime_available:
         summary = "✓ recommended / verified"
+    elif verified:
+        summary = "⚠ verified pair; runtime unavailable"
+    elif not runtime_available:
+        summary = "⚠ experimental; runtime unavailable"
     else:
         summary = "⚠ experimental (explicit drafter required)"
 
@@ -8447,11 +8452,16 @@ def _print_ddtree_status(alias: str, profile) -> None:
     shared = assess_method(profile, "ddtree")
     capable = shared.recommendation != "incompatible"
     verified = shared.recommendation == "verified"
-    eligible = verified and have_runtime()
+    runtime_available = have_runtime()
+    eligible = verified and runtime_available
     if not capable:
         summary = "✗ incompatible"
-    elif verified:
+    elif verified and runtime_available:
         summary = "✓ recommended / verified"
+    elif verified:
+        summary = "⚠ verified pair; runtime unavailable"
+    elif not runtime_available:
+        summary = "⚠ experimental; runtime unavailable"
     else:
         summary = "⚠ experimental (explicit metadata required)"
     top = "┌" + "─" * (inner + 2) + "┐"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2411,24 +2411,33 @@ def _preflight_ddtree_or_exit(args):
         sys.exit(2)
 
     from .model_aliases import resolve_profile
+    from .model_profile import ModelProfile
     from .speculative.ddtree import DDTreeUnavailable, check
     from .speculative.ddtree.eligibility import have_runtime, runtime_probe_error
 
     alias_name = getattr(args, "_original_alias", None) or args.model
     profile = resolve_profile(alias_name)
     if profile is None:
-        print(
-            f"\n  Error: DDTree requires a known alias, got "
-            f"{alias_name!r}. DDTree eligibility is recorded per-alias "
-            f"in aliases.json; ad-hoc HuggingFace paths can't be "
-            f"validated. Try ``rapid-mlx info qwen3.5-9b-8bit``.\n"
-        )
-        sys.exit(1)
+        profile = ModelProfile(hf_path=args.model)
+    drafter = spec_config.model or profile.ddtree_draft_model
+    speculative_tokens = (
+        spec_config.num_speculative_tokens or profile.ddtree_speculative_tokens
+    )
+    tree_budget = spec_config.tree_budget or profile.ddtree_tree_budget
     try:
-        check(profile, alias=alias_name)
+        assessment = check(
+            profile,
+            alias=alias_name,
+            explicit=True,
+            drafter_model=drafter,
+            speculative_tokens=speculative_tokens,
+            tree_budget=tree_budget,
+        )
     except DDTreeUnavailable as e:
         print(f"\n  Error: {e}\n")
         sys.exit(1)
+    for warning in assessment.warnings:
+        print(f"\n  ⚠ Experimental DDTree: {warning}.\n")
     if not have_runtime():
         probe_error = runtime_probe_error()
         detail = f" Probe failure: {probe_error}." if probe_error else ""
@@ -2441,11 +2450,9 @@ def _preflight_ddtree_or_exit(args):
 
     args._ddtree_alias_name = alias_name
     args._ddtree_profile = profile
-    args._ddtree_drafter_repo = spec_config.model or profile.ddtree_draft_model
-    args._ddtree_speculative_tokens = (
-        spec_config.num_speculative_tokens or profile.ddtree_speculative_tokens
-    )
-    args._ddtree_tree_budget = spec_config.tree_budget or profile.ddtree_tree_budget
+    args._ddtree_drafter_repo = drafter
+    args._ddtree_speculative_tokens = speculative_tokens
+    args._ddtree_tree_budget = tree_budget
     return alias_name, profile
 
 
@@ -3430,6 +3437,7 @@ def serve_command(args):
     # aliases.json + checks the module spec); no model load yet.
     if args.enable_dflash:
         from .model_aliases import resolve_profile
+        from .model_profile import ModelProfile
         from .speculative.dflash import DFlashUnavailable, check
 
         # ``have_runtime()`` validated at the top-of-function boot-guard
@@ -3437,18 +3445,22 @@ def serve_command(args):
         _alias_name = getattr(args, "_original_alias", None) or args.model
         _profile = resolve_profile(_alias_name)
         if _profile is None:
-            print(
-                f"\n  Error: DFlash requires a known alias, got "
-                f"{_alias_name!r}. DFlash eligibility is recorded per-alias "
-                f"in aliases.json; ad-hoc HuggingFace paths can't be "
-                f"validated. Try ``rapid-mlx info qwen3.5-27b-8bit``.\n"
-            )
-            sys.exit(1)
+            _profile = ModelProfile(hf_path=args.model)
+        _drafter = _resolve_dflash_drafter_repo(args, _profile)
         try:
-            check(_profile, alias=_alias_name)
+            _assessment = check(
+                _profile,
+                alias=_alias_name,
+                explicit=True,
+                drafter_model=_drafter,
+            )
         except DFlashUnavailable as e:
             print(f"\n  Error: {e}\n")
             sys.exit(1)
+        for _warning in _assessment.warnings:
+            print(f"\n  ⚠ Experimental DFlash: {_warning}.\n")
+        args._dflash_profile = _profile
+        args._dflash_drafter_repo = _drafter
         # ``have_runtime()`` is already validated by the boot-guard tier
         # at the top of ``serve_command`` — see the 0.9.2 dogfood comment
         # there. We keep the import + the deeper DFlashUnavailable / alias
@@ -3588,17 +3600,17 @@ def serve_command(args):
         from .speculative.dflash.server import run_dflash_server
 
         _alias_name = getattr(args, "_original_alias", None) or args.model
-        _profile = resolve_profile(_alias_name)
-        assert _profile is not None and _profile.supports_dflash, (
-            f"DFlash profile invariant violated for {_alias_name!r}"
+        _profile = getattr(args, "_dflash_profile", None) or resolve_profile(
+            _alias_name
         )
 
         _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
         _check_memory_capacity(args.model)
         server._sync_config()
         run_dflash_server(
-            main_model_repo=_profile.hf_path,
-            drafter_repo=_resolve_dflash_drafter_repo(args, _profile),
+            main_model_repo=_profile.hf_path if _profile else args.model,
+            drafter_repo=getattr(args, "_dflash_drafter_repo", None)
+            or _resolve_dflash_drafter_repo(args, _profile),
             host=args.host,
             port=args.port,
             served_model_name=args.served_model_name or _alias_name,
@@ -4065,14 +4077,8 @@ def serve_command(args):
         _profile = getattr(args, "_ddtree_profile", None)
         if _alias_name is None or _profile is None:
             _alias_name, _profile = _preflight_ddtree_or_exit(args)
-        assert _profile is not None and _profile.supports_ddtree, (
-            f"DDTree profile invariant violated for {_alias_name!r}"
-        )
-        assert _profile.ddtree_draft_model is not None
-        assert _profile.ddtree_speculative_tokens is not None
-        assert _profile.ddtree_tree_budget is not None
         run_ddtree_server(
-            main_model_repo=_profile.hf_path,
+            main_model_repo=_profile.hf_path or args.model,
             drafter_repo=getattr(args, "_ddtree_drafter_repo", None)
             or _profile.ddtree_draft_model,
             speculative_tokens=getattr(args, "_ddtree_speculative_tokens", None)
@@ -5948,8 +5954,8 @@ def models_command(args):
         ("Reasoning", reasoning_width),
         ("Spec-Decode", 10),
         ("Suffix Tier", 11),
-        ("DFlash", 7),
-        ("DDTree", 7),
+        ("DFlash", 9),
+        ("DDTree", 9),
         ("Preset", 8),
     )
     width = sum(w for _, w in cols) + len(cols) - 1
@@ -5958,6 +5964,8 @@ def models_command(args):
     print(sep)
     print(header)
     print(sep)
+
+    from .spec_decode.capability import assess_method
 
     for alias in sorted(profiles.keys()):
         p = profiles[alias]
@@ -5978,13 +5986,22 @@ def models_command(args):
             preset = "Suffix" if p.supports_spec_decode else "—"
         if p.is_hybrid and not p.mtp_draft_model:
             preset = "—"
+
         # DFlash column — eligible aliases show ✓, everything else "—" so
         # the visual scan immediately surfaces what supports it. We don't
         # re-run the eligibility gate here (which would also check that
         # mlx-vlm 0.5.0+ is installed) — that's a runtime concern; the
         # registry column is pure declarative state.
-        dflash = "✓" if p.supports_dflash else "—"
-        ddtree = "✓" if p.supports_ddtree else "—"
+        def _tier_mark(profile, method: str) -> str:
+            assessment = assess_method(profile, method)
+            if assessment.recommendation == "verified":
+                return "verified"
+            if assessment.recommendation == "incompatible":
+                return "✗"
+            return "exp"
+
+        dflash = _tier_mark(p, "dflash")
+        ddtree = _tier_mark(p, "ddtree")
         size = format_size(p.hf_path)
         row = (
             f"  {alias:<{alias_width}} {size:<10} {tools:<{tools_width}} "
@@ -5994,6 +6011,7 @@ def models_command(args):
         print(row)
 
     print(sep)
+    print("  Spec tiers: verified = curated; exp = explicit opt-in; ✗ = incompatible")
 
     # R10-C1: audio alias section. Pre-R10 ``rapid-mlx models`` listed
     # zero audio aliases because they don't live in ``aliases.json``
@@ -8248,10 +8266,8 @@ def _print_dflash_status(alias: str, profile) -> None:
     from vllm_mlx.speculative.dflash.eligibility import (
         _looks_like_4bit,
         have_runtime,
-        report,
     )
 
-    r = report(profile, alias=alias)
     inner = 60
     sep = "─" * inner
 
@@ -8289,8 +8305,15 @@ def _print_dflash_status(alias: str, profile) -> None:
         ),
     ]
 
-    eligible = not r.reasons and have_runtime()
-    summary = "✓ eligible" if eligible else "✗ ineligible"
+    capable = not profile.is_moe
+    verified = profile.supports_dflash
+    eligible = verified and have_runtime()
+    if not capable:
+        summary = "✗ incompatible"
+    elif verified:
+        summary = "✓ recommended / verified"
+    else:
+        summary = "⚠ experimental (explicit drafter required)"
 
     top = "┌" + "─" * (inner + 2) + "┐"
     bot = "└" + "─" * (inner + 2) + "┘"
@@ -8307,14 +8330,21 @@ def _print_dflash_status(alias: str, profile) -> None:
             """--speculative-config '{"method":"dflash"}'"""
         )
         print()
+    elif capable:
+        print(
+            f"  Experimental opt-in: rapid-mlx serve {alias} "
+            "--speculative-config "
+            '\'{"method":"dflash","model":"<drafter>"}\''
+        )
+        print("  Performance and output quality are not Rapid-MLX recommendations.")
+        print()
 
 
 def _print_ddtree_status(alias: str, profile) -> None:
     """Render DDTree status for ``rapid-mlx info <alias>``."""
-    from vllm_mlx.speculative.ddtree.eligibility import have_runtime, report
+    from vllm_mlx.speculative.ddtree.eligibility import have_runtime
     from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
 
-    r = report(profile, alias=alias)
     inner = 60
     sep = "─" * inner
 
@@ -8372,8 +8402,15 @@ def _print_ddtree_status(alias: str, profile) -> None:
         ),
     ]
 
-    eligible = not r.reasons and have_runtime()
-    summary = "✓ eligible" if eligible else "✗ ineligible"
+    capable = not profile.is_moe
+    verified = profile.supports_ddtree
+    eligible = verified and have_runtime()
+    if not capable:
+        summary = "✗ incompatible"
+    elif verified:
+        summary = "✓ recommended / verified"
+    else:
+        summary = "⚠ experimental (explicit metadata required)"
     top = "┌" + "─" * (inner + 2) + "┐"
     bot = "└" + "─" * (inner + 2) + "┘"
     body = [top, _row(f"DDTree eligibility: {summary}"), _row(sep)]
@@ -8387,6 +8424,15 @@ def _print_ddtree_status(alias: str, profile) -> None:
             f"  Start with: rapid-mlx serve {alias} "
             """--speculative-config '{"method":"ddtree"}'"""
         )
+        print()
+    elif capable:
+        print(
+            f"  Experimental opt-in: rapid-mlx serve {alias} "
+            "--speculative-config "
+            '\'{"method":"ddtree","model":"<drafter>",'
+            '"num_speculative_tokens":16,"tree_budget":24}\''
+        )
+        print("  Performance and output quality are not Rapid-MLX recommendations.")
         print()
 
 

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -7,14 +7,24 @@ an operator-explicit target/drafter pair; runtime preflight owns compatibility.
 
 from __future__ import annotations
 
+import re
 from dataclasses import asdict, dataclass
 
 from vllm_mlx.model_profile import ModelProfile
 
 
+def looks_like_4bit(hf_path: str) -> bool:
+    """Detect delimiter-bounded 4-bit quantization tags in repo names."""
+    return bool(
+        re.search(
+            r"(?<![a-z0-9])(?:4[-_]?bit|mxfp4|nvfp4)(?![a-z0-9])",
+            hf_path.lower(),
+        )
+    )
+
+
 def _is_experimental_quantization(profile: ModelProfile) -> bool:
-    lowered = profile.hf_path.lower()
-    return "-4bit" in lowered or "mxfp4" in lowered or "nvfp4" in lowered
+    return looks_like_4bit(profile.hf_path)
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -110,7 +110,9 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
             warnings=("requires drafter, speculative-token, and tree-budget metadata",),
         )
     if method == "mtp":
-        verified = bool(profile.mtp_draft_model)
+        verified = bool(profile.mtp_draft_model) and not _is_experimental_quantization(
+            profile
+        )
         return SpecCapability(
             method,
             None,

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capability and recommendation tiers for speculative decoding.
+
+Registry flags are recommendation evidence. They are not permission checks for
+an operator-explicit target/drafter pair; runtime preflight owns compatibility.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from vllm_mlx.model_profile import ModelProfile
+
+
+@dataclass(frozen=True)
+class SpecCapability:
+    method: str
+    capable: bool | None
+    recommendation: str
+    explicit_opt_in: bool
+    reasons: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
+    """Statically assess one alias; runtime-only facts remain unknown."""
+    if profile.modality != "text":
+        return SpecCapability(
+            method, False, "incompatible", False, ("non-text serving lane",)
+        )
+    if method == "suffix":
+        if profile.is_hybrid or not profile.supports_spec_decode:
+            return SpecCapability(
+                method,
+                False,
+                "incompatible",
+                False,
+                ("target verifier does not support lossless rollback",),
+            )
+        tier = profile.suffix_decoding_tier
+        recommendation = "verified" if tier == "verified" else "experimental"
+        return SpecCapability(method, True, recommendation, True)
+    if method == "dflash":
+        if profile.is_moe:
+            return SpecCapability(
+                method, False, "incompatible", False, ("MoE verifier unsupported",)
+            )
+        return SpecCapability(
+            method,
+            None,
+            "verified" if profile.supports_dflash else "experimental",
+            True,
+            warnings=("requires a structurally compatible drafter",),
+        )
+    if method == "ddtree":
+        if profile.is_moe:
+            return SpecCapability(
+                method, False, "incompatible", False, ("MoE tree verifier unsupported",)
+            )
+        return SpecCapability(
+            method,
+            None,
+            "verified" if profile.supports_ddtree else "experimental",
+            True,
+            warnings=("requires drafter, speculative-token, and tree-budget metadata",),
+        )
+    if method == "mtp":
+        return SpecCapability(
+            method,
+            None,
+            "verified" if profile.mtp_draft_model else "experimental",
+            True,
+            warnings=("runtime validates architecture and sidecar metadata",),
+        )
+    if method == "dspark":
+        return SpecCapability(
+            method,
+            None,
+            "experimental",
+            True,
+            warnings=("runtime validates embedded DSpark metadata",),
+        )
+    raise ValueError(f"unknown speculative method: {method}")
+
+
+REGISTERED_METHODS = ("suffix", "mtp", "dflash", "ddtree", "dspark")

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -17,10 +17,7 @@ def looks_like_4bit(hf_path: str) -> bool:
     """Detect delimiter-bounded 4-bit quantization tags in repo names."""
     return bool(
         re.search(
-            r"(?<![a-z0-9])(?:"
-            r"4[-_]?bit(?=$|[-_](?:mlx|dwq)(?:$|[-_]))|"
-            r"(?:mxfp4|nvfp4)(?![a-z0-9])"
-            r")",
+            r"(?<![a-z0-9])(?:4[-_]?bit|mxfp4|nvfp4)(?![a-z0-9])",
             hf_path.lower(),
         )
     )

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -32,7 +32,7 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
             method, False, "incompatible", False, ("non-text serving lane",)
         )
     if method == "suffix":
-        if profile.is_hybrid or not profile.supports_spec_decode:
+        if profile.is_hybrid:
             return SpecCapability(
                 method,
                 False,
@@ -41,8 +41,16 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
                 ("target verifier does not support lossless rollback",),
             )
         tier = profile.suffix_decoding_tier
-        recommendation = "verified" if tier == "verified" else "experimental"
-        return SpecCapability(method, True, recommendation, True)
+        verified = profile.supports_spec_decode and tier == "verified"
+        return SpecCapability(
+            method,
+            True if verified else None,
+            "verified" if verified else "experimental",
+            True,
+            warnings=()
+            if verified
+            else ("runtime validates lossless rollback support",),
+        )
     if method == "dflash":
         if profile.is_moe:
             return SpecCapability(

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -12,6 +12,11 @@ from dataclasses import asdict, dataclass
 from vllm_mlx.model_profile import ModelProfile
 
 
+def _is_experimental_quantization(profile: ModelProfile) -> bool:
+    lowered = profile.hf_path.lower()
+    return "-4bit" in lowered or "mxfp4" in lowered or "nvfp4" in lowered
+
+
 @dataclass(frozen=True)
 class SpecCapability:
     method: str
@@ -56,7 +61,11 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
             return SpecCapability(
                 method, False, "incompatible", False, ("MoE verifier unsupported",)
             )
-        verified = profile.supports_dflash
+        verified = (
+            profile.supports_dflash
+            and bool(profile.dflash_draft_model)
+            and not _is_experimental_quantization(profile)
+        )
         return SpecCapability(
             method,
             None,
@@ -69,7 +78,17 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
             return SpecCapability(
                 method, False, "incompatible", False, ("MoE tree verifier unsupported",)
             )
-        verified = profile.supports_ddtree
+        verified = (
+            profile.supports_ddtree
+            and bool(profile.ddtree_draft_model)
+            and isinstance(profile.ddtree_speculative_tokens, int)
+            and not isinstance(profile.ddtree_speculative_tokens, bool)
+            and profile.ddtree_speculative_tokens > 0
+            and isinstance(profile.ddtree_tree_budget, int)
+            and not isinstance(profile.ddtree_tree_budget, bool)
+            and profile.ddtree_tree_budget > 0
+            and not _is_experimental_quantization(profile)
+        )
         return SpecCapability(
             method,
             None,

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -46,7 +46,7 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
             method,
             True if verified else None,
             "verified" if verified else "experimental",
-            True,
+            not verified,
             warnings=()
             if verified
             else ("runtime validates lossless rollback support",),
@@ -56,11 +56,12 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
             return SpecCapability(
                 method, False, "incompatible", False, ("MoE verifier unsupported",)
             )
+        verified = profile.supports_dflash
         return SpecCapability(
             method,
             None,
-            "verified" if profile.supports_dflash else "experimental",
-            True,
+            "verified" if verified else "experimental",
+            not verified,
             warnings=("requires a structurally compatible drafter",),
         )
     if method == "ddtree":
@@ -68,19 +69,21 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
             return SpecCapability(
                 method, False, "incompatible", False, ("MoE tree verifier unsupported",)
             )
+        verified = profile.supports_ddtree
         return SpecCapability(
             method,
             None,
-            "verified" if profile.supports_ddtree else "experimental",
-            True,
+            "verified" if verified else "experimental",
+            not verified,
             warnings=("requires drafter, speculative-token, and tree-budget metadata",),
         )
     if method == "mtp":
+        verified = bool(profile.mtp_draft_model)
         return SpecCapability(
             method,
             None,
-            "verified" if profile.mtp_draft_model else "experimental",
-            True,
+            "verified" if verified else "experimental",
+            not verified,
             warnings=("runtime validates architecture and sidecar metadata",),
         )
     if method == "dspark":

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -17,7 +17,10 @@ def looks_like_4bit(hf_path: str) -> bool:
     """Detect delimiter-bounded 4-bit quantization tags in repo names."""
     return bool(
         re.search(
-            r"(?<![a-z0-9])(?:4[-_]?bit|mxfp4|nvfp4)(?![a-z0-9])",
+            r"(?<![a-z0-9])(?:"
+            r"4[-_]?bit(?=$|[-_](?:mlx|dwq)(?:$|[-_]))|"
+            r"(?:mxfp4|nvfp4)(?![a-z0-9])"
+            r")",
             hf_path.lower(),
         )
     )
@@ -78,7 +81,7 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
         )
         return SpecCapability(
             method,
-            None,
+            True if verified else None,
             "verified" if verified else "experimental",
             not verified,
             warnings=("requires a structurally compatible drafter",),
@@ -101,7 +104,7 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
         )
         return SpecCapability(
             method,
-            None,
+            True if verified else None,
             "verified" if verified else "experimental",
             not verified,
             warnings=("requires drafter, speculative-token, and tree-budget metadata",),

--- a/vllm_mlx/spec_decode/report.py
+++ b/vllm_mlx/spec_decode/report.py
@@ -16,7 +16,7 @@ def _quantization(hf_path: str) -> str:
         ("nvfp4", r"nvfp4"),
         ("mxfp4", r"mxfp4"),
         ("int4", r"int4"),
-        ("4bit", r"4[-_]?bit"),
+        ("4bit", r"4[-_]?bit(?=$|[-_](?:mlx|dwq)(?:$|[-_]))"),
         ("6bit", r"6[-_]?bit"),
         ("8bit", r"8[-_]?bit"),
         ("2bit", r"2[-_]?bit"),

--- a/vllm_mlx/spec_decode/report.py
+++ b/vllm_mlx/spec_decode/report.py
@@ -16,7 +16,7 @@ def _quantization(hf_path: str) -> str:
         ("nvfp4", r"nvfp4"),
         ("mxfp4", r"mxfp4"),
         ("int4", r"int4"),
-        ("4bit", r"4[-_]?bit(?=$|[-_](?:mlx|dwq)(?:$|[-_]))"),
+        ("4bit", r"4[-_]?bit"),
         ("6bit", r"6[-_]?bit"),
         ("8bit", r"8[-_]?bit"),
         ("2bit", r"2[-_]?bit"),

--- a/vllm_mlx/spec_decode/report.py
+++ b/vllm_mlx/spec_decode/report.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Emit the all-alias/all-method speculative capability report as JSON."""
+
+from __future__ import annotations
+
+import json
+
+from vllm_mlx.model_aliases import list_profiles
+from vllm_mlx.spec_decode.capability import REGISTERED_METHODS, assess_method
+
+
+def _quantization(hf_path: str) -> str:
+    lowered = hf_path.lower().replace("-", "").replace("_", "")
+    for label in (
+        "nvfp4",
+        "mxfp4",
+        "int4",
+        "4bit",
+        "6bit",
+        "8bit",
+        "2bit",
+        "3bit",
+        "fp8",
+        "bfloat16",
+        "bf16",
+        "float16",
+        "fp16",
+    ):
+        if label in lowered:
+            return label
+    return "not-encoded-in-repo-name"
+
+
+def build_report() -> dict[str, dict]:
+    return {
+        alias: {
+            "model": {
+                "hf_path": profile.hf_path,
+                "checkpoint_format": "mlx",
+                "quantization": _quantization(profile.hf_path),
+                "modality": getattr(profile.modality, "value", profile.modality),
+                "is_hybrid": profile.is_hybrid,
+                "is_moe": profile.is_moe,
+            },
+            "methods": {
+                method: assess_method(profile, method).to_dict()
+                for method in REGISTERED_METHODS
+            },
+        }
+        for alias, profile in sorted(list_profiles().items())
+    }
+
+
+def main() -> None:
+    print(json.dumps(build_report(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_mlx/spec_decode/report.py
+++ b/vllm_mlx/spec_decode/report.py
@@ -4,29 +4,30 @@
 from __future__ import annotations
 
 import json
+import re
 
 from vllm_mlx.model_aliases import list_profiles
 from vllm_mlx.spec_decode.capability import REGISTERED_METHODS, assess_method
 
 
 def _quantization(hf_path: str) -> str:
-    lowered = hf_path.lower().replace("-", "").replace("_", "")
-    for label in (
-        "nvfp4",
-        "mxfp4",
-        "int4",
-        "4bit",
-        "6bit",
-        "8bit",
-        "2bit",
-        "3bit",
-        "fp8",
-        "bfloat16",
-        "bf16",
-        "float16",
-        "fp16",
+    lowered = hf_path.lower()
+    for label, pattern in (
+        ("nvfp4", r"nvfp4"),
+        ("mxfp4", r"mxfp4"),
+        ("int4", r"int4"),
+        ("4bit", r"4[-_]?bit"),
+        ("6bit", r"6[-_]?bit"),
+        ("8bit", r"8[-_]?bit"),
+        ("2bit", r"2[-_]?bit"),
+        ("3bit", r"3[-_]?bit"),
+        ("fp8", r"fp8"),
+        ("bfloat16", r"bfloat16"),
+        ("bf16", r"bf16"),
+        ("float16", r"float16"),
+        ("fp16", r"fp16"),
     ):
-        if label in lowered:
+        if re.search(rf"(?<![a-z0-9])(?:{pattern})(?![a-z0-9])", lowered):
             return label
     return "not-encoded-in-repo-name"
 

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -101,6 +101,9 @@ def report(
     curated_pair = (
         not is_4bit
         and profile.supports_ddtree
+        and has_drafter
+        and has_speculative_tokens
+        and has_tree_budget
         and (drafter_model is None or drafter_model == profile.ddtree_draft_model)
         and effective_tokens == profile.ddtree_speculative_tokens
         and effective_budget == profile.ddtree_tree_budget

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -64,6 +64,8 @@ def report(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
             "DDTree on this quantization is not performance-validated"
         )
+        if not explicit:
+            reasons.append("4-bit DDTree requires explicit experimental opt-in")
     experimental_explicit = explicit and not profile.supports_ddtree
     has_drafter = (
         bool(drafter_model)

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -32,12 +32,23 @@ class EligibilityReport:
     has_drafter: bool
     has_speculative_tokens: bool
     has_tree_budget: bool
+    recommendation: str
+    warnings: tuple[str, ...]
     reasons: tuple[str, ...]
 
 
-def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport:
+def report(
+    profile: AliasProfile,
+    alias: str | None = None,
+    *,
+    explicit: bool = False,
+    drafter_model: str | None = None,
+    speculative_tokens: int | None = None,
+    tree_budget: int | None = None,
+) -> EligibilityReport:
     reasons: list[str] = []
-    if not profile.supports_ddtree:
+    warnings: list[str] = []
+    if not profile.supports_ddtree and not explicit:
         reasons.append(
             "alias is not DDTree-enabled (set supports_ddtree=true only after "
             "benching this exact target/drafter pair)"
@@ -49,19 +60,26 @@ def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport
         )
     is_4bit = _looks_like_4bit(profile.hf_path)
     if is_4bit:
-        reasons.append(
+        warnings.append(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
-            "DDTree on 4-bit is not validated yet"
+            "DDTree on this quantization is not performance-validated"
         )
-    has_drafter = bool(profile.ddtree_draft_model)
-    if profile.supports_ddtree and not has_drafter:
-        reasons.append("supports_ddtree is set but ddtree_draft_model is empty")
-    has_speculative_tokens = profile.ddtree_speculative_tokens is not None
-    if profile.supports_ddtree and not has_speculative_tokens:
-        reasons.append("supports_ddtree is set but ddtree_speculative_tokens is empty")
-    has_tree_budget = profile.ddtree_tree_budget is not None
-    if profile.supports_ddtree and not has_tree_budget:
-        reasons.append("supports_ddtree is set but ddtree_tree_budget is empty")
+    has_drafter = bool(drafter_model or profile.ddtree_draft_model)
+    if not has_drafter:
+        reasons.append("DDTree requires an explicit drafter model")
+    has_speculative_tokens = (
+        speculative_tokens or profile.ddtree_speculative_tokens
+    ) is not None
+    if not has_speculative_tokens:
+        reasons.append("DDTree requires num_speculative_tokens")
+    has_tree_budget = (tree_budget or profile.ddtree_tree_budget) is not None
+    if not has_tree_budget:
+        reasons.append("DDTree requires tree_budget")
+    if explicit and not profile.supports_ddtree:
+        warnings.append(
+            "this target/drafter pair is experimental and has not been "
+            "performance-validated by Rapid-MLX; it may be slower"
+        )
     return EligibilityReport(
         alias=alias,
         supports_ddtree=profile.supports_ddtree,
@@ -70,6 +88,8 @@ def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport
         has_drafter=has_drafter,
         has_speculative_tokens=has_speculative_tokens,
         has_tree_budget=has_tree_budget,
+        recommendation=("verified" if profile.supports_ddtree else "experimental"),
+        warnings=tuple(warnings),
         reasons=tuple(reasons),
     )
 
@@ -82,10 +102,25 @@ def eligible_aliases() -> list[str]:
     )
 
 
-def check(profile: AliasProfile, alias: str | None = None) -> None:
-    r = report(profile, alias=alias)
+def check(
+    profile: AliasProfile,
+    alias: str | None = None,
+    *,
+    explicit: bool = False,
+    drafter_model: str | None = None,
+    speculative_tokens: int | None = None,
+    tree_budget: int | None = None,
+) -> EligibilityReport:
+    r = report(
+        profile,
+        alias=alias,
+        explicit=explicit,
+        drafter_model=drafter_model,
+        speculative_tokens=speculative_tokens,
+        tree_budget=tree_budget,
+    )
     if not r.reasons:
-        return
+        return r
     header = f"DDTree unavailable for {alias!r}" if alias else "DDTree unavailable"
     bullet = "\n  - ".join(r.reasons)
     eligible = eligible_aliases()

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -97,7 +97,8 @@ def report(
     if not has_tree_budget:
         reasons.append("DDTree requires tree_budget")
     curated_pair = (
-        profile.supports_ddtree
+        not is_4bit
+        and profile.supports_ddtree
         and (drafter_model is None or drafter_model == profile.ddtree_draft_model)
         and effective_tokens == profile.ddtree_speculative_tokens
         and effective_budget == profile.ddtree_tree_budget

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -64,12 +64,17 @@ def report(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
             "DDTree on this quantization is not performance-validated"
         )
-    has_drafter = bool(drafter_model or profile.ddtree_draft_model)
+    experimental_explicit = explicit and not profile.supports_ddtree
+    has_drafter = (
+        bool(drafter_model)
+        if experimental_explicit
+        else bool(drafter_model or profile.ddtree_draft_model)
+    )
     if not has_drafter:
         reasons.append("DDTree requires an explicit drafter model")
     effective_tokens = (
         speculative_tokens
-        if speculative_tokens is not None
+        if experimental_explicit or speculative_tokens is not None
         else profile.ddtree_speculative_tokens
     )
     has_speculative_tokens = (
@@ -80,7 +85,9 @@ def report(
     if not has_speculative_tokens:
         reasons.append("DDTree requires num_speculative_tokens")
     effective_budget = (
-        tree_budget if tree_budget is not None else profile.ddtree_tree_budget
+        tree_budget
+        if experimental_explicit or tree_budget is not None
+        else profile.ddtree_tree_budget
     )
     has_tree_budget = (
         isinstance(effective_budget, int)

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -67,12 +67,26 @@ def report(
     has_drafter = bool(drafter_model or profile.ddtree_draft_model)
     if not has_drafter:
         reasons.append("DDTree requires an explicit drafter model")
+    effective_tokens = (
+        speculative_tokens
+        if speculative_tokens is not None
+        else profile.ddtree_speculative_tokens
+    )
     has_speculative_tokens = (
-        speculative_tokens or profile.ddtree_speculative_tokens
-    ) is not None
+        isinstance(effective_tokens, int)
+        and not isinstance(effective_tokens, bool)
+        and effective_tokens > 0
+    )
     if not has_speculative_tokens:
         reasons.append("DDTree requires num_speculative_tokens")
-    has_tree_budget = (tree_budget or profile.ddtree_tree_budget) is not None
+    effective_budget = (
+        tree_budget if tree_budget is not None else profile.ddtree_tree_budget
+    )
+    has_tree_budget = (
+        isinstance(effective_budget, int)
+        and not isinstance(effective_budget, bool)
+        and effective_budget > 0
+    )
     if not has_tree_budget:
         reasons.append("DDTree requires tree_budget")
     if explicit and not profile.supports_ddtree:
@@ -88,7 +102,11 @@ def report(
         has_drafter=has_drafter,
         has_speculative_tokens=has_speculative_tokens,
         has_tree_budget=has_tree_budget,
-        recommendation=("verified" if profile.supports_ddtree else "experimental"),
+        recommendation=(
+            "incompatible"
+            if profile.is_moe
+            else ("verified" if profile.supports_ddtree else "experimental")
+        ),
         warnings=tuple(warnings),
         reasons=tuple(reasons),
     )
@@ -110,7 +128,7 @@ def check(
     drafter_model: str | None = None,
     speculative_tokens: int | None = None,
     tree_budget: int | None = None,
-) -> EligibilityReport:
+) -> None:
     r = report(
         profile,
         alias=alias,
@@ -120,7 +138,7 @@ def check(
         tree_budget=tree_budget,
     )
     if not r.reasons:
-        return r
+        return
     header = f"DDTree unavailable for {alias!r}" if alias else "DDTree unavailable"
     bullet = "\n  - ".join(r.reasons)
     eligible = eligible_aliases()

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -96,7 +96,13 @@ def report(
     )
     if not has_tree_budget:
         reasons.append("DDTree requires tree_budget")
-    if explicit and not profile.supports_ddtree:
+    curated_pair = (
+        profile.supports_ddtree
+        and (drafter_model is None or drafter_model == profile.ddtree_draft_model)
+        and effective_tokens == profile.ddtree_speculative_tokens
+        and effective_budget == profile.ddtree_tree_budget
+    )
+    if explicit and not curated_pair:
         warnings.append(
             "this target/drafter pair is experimental and has not been "
             "performance-validated by Rapid-MLX; it may be slower"
@@ -112,7 +118,7 @@ def report(
         recommendation=(
             "incompatible"
             if profile.is_moe
-            else ("verified" if profile.supports_ddtree else "experimental")
+            else ("verified" if curated_pair else "experimental")
         ),
         warnings=tuple(warnings),
         reasons=tuple(reasons),

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -112,7 +112,11 @@ def report(
         is_moe=profile.is_moe,
         is_4bit=is_4bit,
         has_drafter=has_drafter,
-        recommendation=("verified" if profile.supports_dflash else "experimental"),
+        recommendation=(
+            "incompatible"
+            if profile.is_moe
+            else ("verified" if profile.supports_dflash else "experimental")
+        ),
         warnings=tuple(warnings),
         reasons=tuple(reasons),
     )
@@ -144,12 +148,12 @@ def check(
     *,
     explicit: bool = False,
     drafter_model: str | None = None,
-) -> EligibilityReport:
+) -> None:
     """Raise ``DFlashUnavailable`` with an actionable message if any
     eligibility gate fails. Returns ``None`` on success."""
     r = report(profile, alias=alias, explicit=explicit, drafter_model=drafter_model)
     if not r.reasons:
-        return r
+        return
     header = f"DFlash unavailable for {alias!r}" if alias else "DFlash unavailable"
     bullet = "\n  - ".join(r.reasons)
     eligible = eligible_aliases()

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -42,6 +42,8 @@ class EligibilityReport:
     is_moe: bool
     is_4bit: bool
     has_drafter: bool
+    recommendation: str
+    warnings: tuple[str, ...]
     reasons: tuple[str, ...]  # all failing-gate reasons (empty if eligible)
 
 
@@ -64,12 +66,19 @@ def _looks_like_4bit(hf_path: str) -> bool:
     return False
 
 
-def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport:
+def report(
+    profile: AliasProfile,
+    alias: str | None = None,
+    *,
+    explicit: bool = False,
+    drafter_model: str | None = None,
+) -> EligibilityReport:
     """Compute the eligibility report without raising. Used by ``info``
     to render gate status — ``check`` is the raise-on-failure variant.
     """
     reasons: list[str] = []
-    if not profile.supports_dflash:
+    warnings: list[str] = []
+    if not profile.supports_dflash and not explicit:
         reasons.append(
             "alias is not DFlash-enabled (set supports_dflash=true in "
             "aliases.json after benching to validate ≥1.3× speedup)"
@@ -82,21 +91,29 @@ def report(profile: AliasProfile, alias: str | None = None) -> EligibilityReport
         )
     is_4bit = _looks_like_4bit(profile.hf_path)
     if is_4bit:
-        reasons.append(
+        warnings.append(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
-            "DFlash regresses on 4-bit (use an 8-bit or higher variant)"
+            "this pair has not been performance-validated and may be slower"
         )
-    has_drafter = bool(profile.dflash_draft_model)
-    if profile.supports_dflash and not has_drafter:
+    has_drafter = bool(drafter_model or profile.dflash_draft_model)
+    if not has_drafter:
         # Should be caught at JSON-load time by _coerce, but defend
         # against direct AliasProfile construction in tests/code.
-        reasons.append("supports_dflash is set but dflash_draft_model is empty")
+        reasons.append("DFlash requires an explicit drafter model")
+    if explicit and not profile.supports_dflash:
+        warnings.append(
+            "this target/drafter pair is experimental and has not been "
+            "performance-validated by Rapid-MLX; it may provide no speedup "
+            "or may be slower than autoregressive decoding"
+        )
     return EligibilityReport(
         alias=alias,
         supports_dflash=profile.supports_dflash,
         is_moe=profile.is_moe,
         is_4bit=is_4bit,
         has_drafter=has_drafter,
+        recommendation=("verified" if profile.supports_dflash else "experimental"),
+        warnings=tuple(warnings),
         reasons=tuple(reasons),
     )
 
@@ -121,12 +138,18 @@ def eligible_aliases() -> list[str]:
         return []
 
 
-def check(profile: AliasProfile, alias: str | None = None) -> None:
+def check(
+    profile: AliasProfile,
+    alias: str | None = None,
+    *,
+    explicit: bool = False,
+    drafter_model: str | None = None,
+) -> EligibilityReport:
     """Raise ``DFlashUnavailable`` with an actionable message if any
     eligibility gate fails. Returns ``None`` on success."""
-    r = report(profile, alias=alias)
+    r = report(profile, alias=alias, explicit=explicit, drafter_model=drafter_model)
     if not r.reasons:
-        return
+        return r
     header = f"DFlash unavailable for {alias!r}" if alias else "DFlash unavailable"
     bullet = "\n  - ".join(r.reasons)
     eligible = eligible_aliases()

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -95,6 +95,8 @@ def report(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
             "this pair has not been performance-validated and may be slower"
         )
+        if not explicit:
+            reasons.append("4-bit DFlash requires explicit experimental opt-in")
     curated_pair = not is_4bit and profile.supports_dflash and (
         drafter_model is None or drafter_model == profile.dflash_draft_model
     )

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -95,7 +95,10 @@ def report(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
             "this pair has not been performance-validated and may be slower"
         )
-    has_drafter = bool(drafter_model or profile.dflash_draft_model)
+    if explicit and not profile.supports_dflash:
+        has_drafter = bool(drafter_model)
+    else:
+        has_drafter = bool(drafter_model or profile.dflash_draft_model)
     if not has_drafter:
         # Should be caught at JSON-load time by _coerce, but defend
         # against direct AliasProfile construction in tests/code.

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -95,7 +95,7 @@ def report(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
             "this pair has not been performance-validated and may be slower"
         )
-    curated_pair = profile.supports_dflash and (
+    curated_pair = not is_4bit and profile.supports_dflash and (
         drafter_model is None or drafter_model == profile.dflash_draft_model
     )
     if explicit and not profile.supports_dflash:

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -95,6 +95,9 @@ def report(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
             "this pair has not been performance-validated and may be slower"
         )
+    curated_pair = profile.supports_dflash and (
+        drafter_model is None or drafter_model == profile.dflash_draft_model
+    )
     if explicit and not profile.supports_dflash:
         has_drafter = bool(drafter_model)
     else:
@@ -103,7 +106,7 @@ def report(
         # Should be caught at JSON-load time by _coerce, but defend
         # against direct AliasProfile construction in tests/code.
         reasons.append("DFlash requires an explicit drafter model")
-    if explicit and not profile.supports_dflash:
+    if explicit and not curated_pair:
         warnings.append(
             "this target/drafter pair is experimental and has not been "
             "performance-validated by Rapid-MLX; it may provide no speedup "
@@ -118,7 +121,7 @@ def report(
         recommendation=(
             "incompatible"
             if profile.is_moe
-            else ("verified" if profile.supports_dflash else "experimental")
+            else ("verified" if curated_pair else "experimental")
         ),
         warnings=tuple(warnings),
         reasons=tuple(reasons),

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from vllm_mlx.model_aliases import AliasProfile
+from vllm_mlx.spec_decode.capability import looks_like_4bit
 
 
 class DFlashUnavailable(RuntimeError):  # noqa: N818 — domain-specific error name
@@ -54,16 +55,7 @@ def _looks_like_4bit(hf_path: str) -> bool:
     suffixes/segments. Mirrors the contract test's detection so a CLI
     error and a unit-test guard share one rule.
     """
-    lowered = hf_path.lower()
-    # Anchor the 4-bit infix on a leading hyphen so a model name like
-    # "Foo-4bit-attention" (where "4bit-" is part of the architecture
-    # tag rather than the quant suffix) doesn't get falsely flagged.
-    # "-4bit" handles both the trailing form and any mid-name segment.
-    if "-4bit" in lowered:
-        return True
-    if "mxfp4" in lowered or "nvfp4" in lowered:
-        return True
-    return False
+    return looks_like_4bit(hf_path)
 
 
 def report(

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -97,9 +97,6 @@ def report(
         )
         if not explicit:
             reasons.append("4-bit DFlash requires explicit experimental opt-in")
-    curated_pair = not is_4bit and profile.supports_dflash and (
-        drafter_model is None or drafter_model == profile.dflash_draft_model
-    )
     if explicit and not profile.supports_dflash:
         has_drafter = bool(drafter_model)
     else:
@@ -108,6 +105,12 @@ def report(
         # Should be caught at JSON-load time by _coerce, but defend
         # against direct AliasProfile construction in tests/code.
         reasons.append("DFlash requires an explicit drafter model")
+    curated_pair = (
+        not is_4bit
+        and profile.supports_dflash
+        and has_drafter
+        and (drafter_model is None or drafter_model == profile.dflash_draft_model)
+    )
     if explicit and not curated_pair:
         warnings.append(
             "this target/drafter pair is experimental and has not been "

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -2074,6 +2074,7 @@ def run_dflash_server(
     cors_policy: Any | None = None,
     tool_call_parser: str | None = "hermes",
     reasoning_parser_name: str | None = "qwen3",
+    experimental_opt_in: bool = False,
 ) -> None:
     """Load the model + DFlash drafter via mlx-vlm and start uvicorn.
 
@@ -2103,8 +2104,19 @@ def run_dflash_server(
             "for optional extras."
         )
 
-    from .eligibility import DFlashUnavailable
+    from .eligibility import DFlashUnavailable, _looks_like_4bit
 
+    if _looks_like_4bit(main_model_repo):
+        if not experimental_opt_in:
+            raise DFlashUnavailable(
+                "4-bit DFlash is unverified. Programmatic callers must pass "
+                "experimental_opt_in=True after accepting that it may provide "
+                "no speedup or may be slower than autoregressive decoding."
+            )
+        logger.warning(
+            "Experimental DFlash: this 4-bit target/drafter pair has not "
+            "been performance-validated by Rapid-MLX and may be slower"
+        )
     if not drafter_repo:
         raise DFlashUnavailable(
             "DFlash requires a non-empty drafter_repo — pass the DFlash "

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -2103,21 +2103,8 @@ def run_dflash_server(
             "for optional extras."
         )
 
-    # Belt-and-suspenders eligibility re-check for programmatic callers
-    # (the CLI's serve_command already gates on the alias upstream, but
-    # we don't want to depend on it being the only entrypoint).
-    from .eligibility import (
-        DFlashUnavailable,
-        _looks_like_4bit,  # noqa: PLC2701 — internal helper
-    )
+    from .eligibility import DFlashUnavailable
 
-    if _looks_like_4bit(main_model_repo):
-        raise DFlashUnavailable(
-            f"DFlash cannot run on a 4-bit quantized model "
-            f"(main_model_repo={main_model_repo!r}); upstream PoC measured "
-            "regression to 0.63-0.96× on Qwen3.5-4B-MLX-4bit. Use the "
-            "8-bit variant."
-        )
     if not drafter_repo:
         raise DFlashUnavailable(
             "DFlash requires a non-empty drafter_repo — pass the DFlash "


### PR DESCRIPTION
## What does this PR do?

Fixes #2176 by separating speculative-decoding runtime capability from Rapid-MLX's curated recommendation/default policy.

- Explicit DFlash/DDTree configs may use unknown HF targets and 4-bit targets when the operator supplies the required drafter/metadata.
- Unverified combinations remain default-off and emit an actionable experimental/performance warning.
- Curated alias flags remain recommendation evidence (`verified`), not execution permission.
- MoE verifier gaps, missing drafter/tree metadata, unavailable runtimes, and method mutexes remain hard startup failures.
- Removes the duplicate DFlash server-side 4-bit policy ban so CLI and programmatic entrypoints no longer disagree.
- `rapid-mlx info` and `rapid-mlx models` distinguish verified, experimental opt-in, and incompatible states.
- Adds an automated report covering every registry alias across suffix, MTP, DFlash, DDTree, and DSpark, including model/quantization metadata.
- Documents the capability-vs-recommendation policy and explicit opt-in syntax.

## User-visible policy

Defaults stay conservative. Rapid-MLX only auto-supplies curated presets for verified aliases. An explicit user configuration is permission to attempt an experimental pair; runtime/model loading still validates actual structural compatibility before generation.

## Validation

- Mac mini: 218 passed, 1 skipped across DFlash/DDTree eligibility and integration, speculative config parsing, and the all-model capability report.
- `ruff check` and `ruff format --check` pass on changed Python files.
- Generated report covers 187 aliases × 5 methods = 935 assessments.

## Checklist

- [x] Tests pass on Mac mini
- [x] Lint and formatting pass
- [x] 4-bit explicit opt-in covered
- [x] Unknown HF-path explicit opt-in covered
- [x] Verified defaults remain covered
- [x] Known incompatibility remains a hard failure
- [x] Documentation updated
- [x] Self-validated implementation and diff before PR creation
