### PR TITLE
fix(mac): allow clean quit before telemetry consent

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -124,6 +124,11 @@ struct ContentView: View {
                 .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
+        .overlay {
+            if telemetryConsentPending {
+                firstRunConsentOverlay
+            }
+        }
         .onChange(of: server.state) { _, newState in
             // #223: clear the download-prompt CTA the moment the server
             // moves out of ``.idle``.
@@ -212,9 +217,6 @@ struct ContentView: View {
         } message: { warning in
             Text(warning.message)
         }
-        .sheet(isPresented: firstRunSheetPresented) {
-            firstRunSheet
-        }
         .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
             quickstartDismissedThisSession = false
         }
@@ -227,7 +229,7 @@ struct ContentView: View {
         // so "may the model run this" is a decision that belongs on screen.
         .modifier(MCPToolApprovalDialog(store: mcpApproval))
         // #1589: keyed on the consent decision rather than fire-once, so
-        // the launch auto-start that stood down for the modal sheet gets
+        // the launch auto-start that stood down for the consent gate gets
         // its turn the moment the user answers it. The value only ever
         // moves true → false (once per install), so this is a single
         // re-run, and the first pass returns at the gate without an
@@ -894,22 +896,18 @@ struct ContentView: View {
 
     // MARK: - First-run telemetry consent
 
-    private var firstRunSheetPresented: Binding<Bool> {
-        Binding(
-            get: { telemetryConsentPending },
-            set: { presented in
-                // Swallow external dismiss attempts while undecided.
-                _ = presented
-            }
-        )
-    }
-
     @ViewBuilder
-    private var firstRunSheet: some View {
-        if telemetryConsentPending {
+    private var firstRunConsentOverlay: some View {
+        ZStack {
+            RapidTheme.surfaceCanvas.opacity(0.92)
+                .contentShape(Rectangle())
+
             TelemetryConsentView(onDecision: decideTelemetry)
-                .interactiveDismissDisabled()
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+                .shadow(color: .black.opacity(0.16), radius: 24, y: 8)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityAddTraits(.isModal)
     }
 
     private func decideTelemetry(_ enabled: Bool) {

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -84,7 +84,9 @@ struct ContentView: View {
         // model comes up on first send (implicit lifecycle). Search belongs
         // to the sidebar column beside macOS's native collapse control.
         Group {
-            if quickstartVisible {
+            if telemetryConsentPending {
+                firstRunConsentGate
+            } else if quickstartVisible {
                 // Setup owns the window (Paper 05.1.A). See ``onboardingShell``.
                 onboardingShell
             } else {
@@ -122,11 +124,6 @@ struct ContentView: View {
                 }
                 .padding(20)
                 .transition(.move(edge: .trailing).combined(with: .opacity))
-            }
-        }
-        .overlay {
-            if telemetryConsentPending {
-                firstRunConsentOverlay
             }
         }
         .onChange(of: server.state) { _, newState in
@@ -897,16 +894,12 @@ struct ContentView: View {
     // MARK: - First-run telemetry consent
 
     @ViewBuilder
-    private var firstRunConsentOverlay: some View {
-        ZStack {
-            RapidTheme.surfaceCanvas.opacity(0.92)
-                .contentShape(Rectangle())
-
-            TelemetryConsentView(onDecision: decideTelemetry)
-                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
-                .shadow(color: .black.opacity(0.16), radius: 24, y: 8)
-        }
+    private var firstRunConsentGate: some View {
+        TelemetryConsentView(onDecision: decideTelemetry)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.16), radius: 24, y: 8)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(RapidTheme.surfaceCanvas)
         .accessibilityAddTraits(.isModal)
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 /// First-run disclosure for the shared desktop + embedded-engine
-/// telemetry pipeline. The user must make an explicit choice; closing
-/// the sheet without an answer is disabled by the presenter.
+/// telemetry pipeline. The full-window presenter blocks the workspace
+/// until the user makes an explicit choice without creating an AppKit
+/// modal sheet that would also block normal application termination.
 struct TelemetryConsentView: View {
     let onDecision: (Bool) -> Void
 

--- a/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TelemetryConsentView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// modal sheet that would also block normal application termination.
 struct TelemetryConsentView: View {
     let onDecision: (Bool) -> Void
+    @FocusState private var primaryActionFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -56,11 +57,13 @@ struct TelemetryConsentView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
+                .focused($primaryActionFocused)
                 .accessibilityIdentifier("TelemetryConsent.Share")
             }
         }
         .padding(24)
         .frame(width: 500)
+        .onAppear { primaryActionFocused = true }
     }
 
     private func disclosureRow(icon: String, text: String) -> some View {

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.consent.txt
@@ -1,15 +1,14 @@
 # rapid-mac AX structural baseline v1
-AXSheet
-  AXGroup subrole=AXHostingView
-    AXImage id="chart.bar.xaxis" desc="chart.bar.xaxis" enabled=true
-    AXStaticText value=text enabled=true
-    AXStaticText value=text enabled=true
-    AXImage id="desktopcomputer" desc="Computer" enabled=true
-    AXStaticText value=text enabled=true
-    AXImage id="gauge.with.dots.needle.<percent>" desc="gauge.with.dots.needle.<percent>" enabled=true
-    AXStaticText value=text enabled=true
-    AXImage id="hand.raised.fill" desc="Block" enabled=true
-    AXStaticText value=text enabled=true
-    AXStaticText value=text enabled=true
-    AXButton id="TelemetryConsent.DontShare" desc="Don't share" enabled=true
-    AXButton id="TelemetryConsent.Share" desc="Share anonymous data" enabled=true
+AXGroup subrole=AXHostingView
+  AXStaticText value=text enabled=true
+  AXStaticText value=text enabled=true
+  AXStaticText value=text enabled=true
+  AXStaticText value=text enabled=true
+  AXStaticText value=text enabled=true
+  AXStaticText value=text enabled=true
+  AXButton id="TelemetryConsent.DontShare" desc="Don't share" enabled=true
+  AXButton id="TelemetryConsent.Share" desc="Share anonymous data" enabled=true
+  AXImage id="chart.bar.xaxis" desc="chart.bar.xaxis" enabled=true
+  AXImage id="desktopcomputer" desc="Computer" enabled=true
+  AXImage id="gauge.with.dots.needle.<percent>" desc="gauge.with.dots.needle.<percent>" enabled=true
+  AXImage id="hand.raised.fill" desc="Block" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
@@ -218,14 +218,13 @@ struct LaunchOnboardingOrderingTests {
         #expect(decision == .skip(reason: .retiredStarter))
     }
 
-    // MARK: - Consent sheet
+    // MARK: - Consent gate
 
-    /// Nothing loads behind the modal first-run consent sheet. The sheet
-    /// is `interactiveDismissDisabled` and swallows external dismisses, so
-    /// the user cannot reach anything a warm model would serve — while an
-    /// 8.4 GB serve was being committed before they had answered the first
-    /// question the app asks.
-    @Test("Nothing auto-starts while the first-run consent sheet is still unanswered")
+    /// Nothing loads behind the full-window first-run consent gate. The
+    /// overlay owns hit testing, so the user cannot reach anything a warm
+    /// model would serve. Previously an 8.4 GB serve could be committed
+    /// before they had answered the first question the app asks.
+    @Test("Nothing auto-starts while the first-run consent gate is still unanswered")
     func consentPendingBlocksAutoStart() {
         let decision = launchDecision(
             lastServedAlias: "qwen3.5-4b-4bit",
@@ -234,6 +233,22 @@ struct LaunchOnboardingOrderingTests {
             consentPending: true
         )
         #expect(decision == .skip(reason: .firstRunDecisionPending))
+    }
+
+    @Test("Consent blocks the workspace without an AppKit modal sheet")
+    func consentUsesNonModalOverlay() throws {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Rapid/UI/ContentView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+
+        #expect(source.contains("iftelemetryConsentPending{firstRunConsentOverlay}"))
+        #expect(!source.contains(".sheet(isPresented:firstRunSheetPresented)"))
+        #expect(!source.contains(".interactiveDismissDisabled()"))
     }
 
     /// Once answered, the same user's model comes up — the deferral is a

--- a/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
@@ -249,8 +249,13 @@ struct LaunchOnboardingOrderingTests {
         let presenterEnd = try #require(
             rawSource.range(of: "private func decideTelemetry", range: presenterStart.upperBound..<rawSource.endIndex))
         let presenter = rawSource[presenterStart.lowerBound..<presenterEnd.lowerBound]
+        let bodyStart = try #require(rawSource.range(of: "var body: some View"))
+        let bodyEnd = try #require(
+            rawSource.range(of: "/// First-run setup", range: bodyStart.upperBound..<rawSource.endIndex))
+        let body = rawSource[bodyStart.lowerBound..<bodyEnd.lowerBound]
 
         #expect(source.contains("iftelemetryConsentPending{firstRunConsentGate}"))
+        #expect(!body.contains(".sheet"))
         #expect(!presenter.contains(".sheet"))
         #expect(!presenter.contains("interactiveDismissDisabled"))
     }

--- a/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LaunchOnboardingOrderingTests.swift
@@ -242,13 +242,17 @@ struct LaunchOnboardingOrderingTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Sources/Rapid/UI/ContentView.swift")
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
-            .replacingOccurrences(of: " ", with: "")
-            .replacingOccurrences(of: "\n", with: "")
+        let rawSource = try String(contentsOf: sourceURL, encoding: .utf8)
+        let source = rawSource.filter { !$0.isWhitespace }
+        let presenterStart = try #require(
+            rawSource.range(of: "private var firstRunConsentGate"))
+        let presenterEnd = try #require(
+            rawSource.range(of: "private func decideTelemetry", range: presenterStart.upperBound..<rawSource.endIndex))
+        let presenter = rawSource[presenterStart.lowerBound..<presenterEnd.lowerBound]
 
-        #expect(source.contains("iftelemetryConsentPending{firstRunConsentOverlay}"))
-        #expect(!source.contains(".sheet(isPresented:firstRunSheetPresented)"))
-        #expect(!source.contains(".interactiveDismissDisabled()"))
+        #expect(source.contains("iftelemetryConsentPending{firstRunConsentGate}"))
+        #expect(!presenter.contains(".sheet"))
+        #expect(!presenter.contains("interactiveDismissDisabled"))
     }
 
     /// Once answered, the same user's model comes up — the deferral is a

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1161,10 +1161,23 @@ flow_fresh_install() {
     see_main "$OUT/consent-visible.json"
     jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' "$OUT/consent-visible.json" >/dev/null \
         || die "fresh install did not show telemetry consent"
-    role_subtree_only "$OUT/consent-visible.json" AXSheet "$OUT/consent-sheet.json"
-    baseline fresh-install.consent "$OUT/consent-sheet.json"
+    # Consent owns the window as a full-window gate. It deliberately must not
+    # be an AppKit sheet: sheets prevent a fresh-install user from quitting
+    # normally before making a telemetry choice.
+    if jq -e '.data.ui_elements[]? | select(.role == "AXSheet")' \
+        "$OUT/consent-visible.json" >/dev/null; then
+        die "fresh-install consent regressed to a quit-blocking AXSheet"
+    fi
+    for hidden in Sidebar.NewChat Sidebar.Launch rapid.chat.compose; do
+        if jq -e --arg id "$hidden" '.data.ui_elements[]? | select(.identifier == $id)' \
+            "$OUT/consent-visible.json" >/dev/null; then
+            die "telemetry consent mounted production control $hidden behind the gate"
+        fi
+    done
+    role_subtree_only "$OUT/consent-visible.json" AXGroup "$OUT/consent-gate.json"
+    baseline fresh-install.consent "$OUT/consent-gate.json"
     # #1560: merely launching a fresh install must not inspect model caches
-    # behind the consent sheet. Give both SwiftUI catalog tasks time to run;
+    # behind the consent gate. Give both SwiftUI catalog tasks time to run;
     # the fake sidecar records every non-serve command before it exits.
     sleep 0.75
     if [[ -s "$OUT/fake-events.jsonl" ]] && jq -e \


### PR DESCRIPTION
## Why

Fresh-install telemetry consent was presented as an AppKit modal sheet. macOS blocked normal application termination while that sheet was unanswered, so Quit was canceled and forced termination left an `unclean_shutdown` crash marker.

## What changed

- present the mandatory consent gate as a full-window, hit-testing overlay instead of an AppKit modal sheet
- preserve explicit consent and the launch auto-start gate
- add a source-wiring regression test preventing the modal presentation from returning

## Validation

- [x] Reproduced old build: `NSRunningApplication.terminate()` leaves the process alive and logs `App termination blocked by modal sheet`
- [x] Isolated fresh-install fixed build exits normally through the same API
- [x] Fixed build clears its crash marker during `applicationWillTerminate`
- [x] `swift test --filter LaunchOnboardingOrderingTests` (15 passed)
- [x] `bash scripts/smoke.sh`
- [x] `SKIP_SIDECAR=1 bash scripts/build.sh`
- [x] No production preferences, sessions, or installed app modified
- [x] No model download; tests used the shared read-mostly cache only