### PR TITLE
test(mac): refresh AX golden baselines

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.speech.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.speech.txt
@@ -35,12 +35,6 @@ AXApplication title="Rapid-MLX"
               AXStaticText value=text enabled=true
               AXButton id="Readiness.Action" desc="Download" enabled=true
             AXButton id="Audio.Speech.Generate" desc="Generate Speech" enabled=false
-            AXScrollBar value=number enabled=true
-              AXValueIndicator value=number
-              AXButton subrole=AXIncrementArrow
-              AXButton subrole=AXDecrementArrow
-              AXButton subrole=AXIncrementPage
-              AXButton subrole=AXDecrementPage
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -27,16 +27,19 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
@@ -54,10 +57,12 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXScrollArea
               AXOutline desc="Markdown table" enabled=true
@@ -95,26 +100,31 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXScrollBar value=number enabled=true
               AXValueIndicator value=number
               AXButton subrole=AXIncrementArrow

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
@@ -27,16 +27,19 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
@@ -54,10 +57,12 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXScrollArea
               AXOutline desc="Markdown table" enabled=true
@@ -95,26 +100,31 @@ AXApplication title="Rapid-MLX"
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy message" help="Copy message" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Edit.<uuid>" desc="Edit message" help="Edit message" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXDisclosureTriangle id="ChatView.Message.ReasoningDisclosure.<uuid>" desc="Reasoning" value=bool:false enabled=true
             AXStaticText value=text enabled=true
             AXStaticText value=text enabled=true
             AXButton id="ChatView.Message.Copy.<uuid>" desc="Copy response" help="Copy response" enabled=true
             AXButton id="ChatView.Message.SelectText.<uuid>" desc="Select text" help="Select text" enabled=true
             AXButton id="ChatView.Message.Retry.<uuid>" desc="Retry response" enabled=true
+            AXButton id="ChatView.Message.Delete.<uuid>" desc="Delete message" help="Delete message" enabled=true
             AXScrollBar value=number enabled=true
               AXValueIndicator value=number
               AXButton subrole=AXIncrementArrow

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
@@ -5,6 +5,12 @@ AXApplication title="Rapid-MLX"
       AXTextField id="ConversationSearch.Field" value=text enabled=true
       AXButton id="ConversationSearch.Clear" desc="Clear search" help="Clear search" enabled=true
       AXButton id="ConversationSearch.Close" desc="Close" help="Close — Esc" enabled=true
+      AXUnknown id="ConversationSearch.Panel" enabled=true
+      AXScrollArea
+        AXOpaqueProviderGroup subrole=AXOpaqueProviderList enabled=true
+          AXButton id="ConversationSearch.NewChat" desc="New chat" enabled=true
+          AXHeading desc="<relative-day>" enabled=true
+          AXButton id="ConversationSearch.Result.<uuid>" desc="golden restore marker" enabled=true
       AXSplitGroup id="main, SidebarNavigationSplitView"
         AXGroup subrole=AXHostingView
           AXButton id="Sidebar.NewChat" desc="New Chat" enabled=true
@@ -34,12 +40,6 @@ AXApplication title="Rapid-MLX"
           AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
           AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true
           AXButton id="ChatView.SendOrStopButton" desc="Send message" enabled=false
-      AXUnknown id="ConversationSearch.Panel" enabled=true
-      AXScrollArea
-        AXOpaqueProviderGroup subrole=AXOpaqueProviderList enabled=true
-          AXButton id="ConversationSearch.NewChat" desc="New chat" enabled=true
-          AXHeading desc="<relative-day>" enabled=true
-          AXButton id="ConversationSearch.Result.<uuid>" desc="golden restore marker" enabled=true
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true
       AXUnknown desc="Server status" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXScrollArea id="Settings.Performance.Panel"

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXScrollArea id="Settings.Performance.Panel"

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Custom Instructions, Set preferences for how the assistant responds in every conversation." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Custom Instructions, Set preferences for how the assistant responds in every conversation." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Model Management, Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Model Management, Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Model Management, Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXScrollArea id="Settings.Performance.Panel"

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Model Management, Manage the on-disk model cache. Download what you need in the background; delete what you don't to reclaim space." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Rapid-MLX, Self-update for Rapid-MLX. New releases bundle the latest models, performance improvements, and bug fixes." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
@@ -68,9 +68,6 @@ AXApplication title="Rapid-MLX"
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.app" desc="App" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
-              AXButton id="Settings.Category.developer" desc="Developer" enabled=true
           AXColumn id="ListColumn"
       AXScrollArea
         AXHeading desc="Rapid-MLX, Self-update for Rapid-MLX. New releases bundle the latest models, performance improvements, and bug fixes." enabled=true


### PR DESCRIPTION
## Summary

Refresh 15 stale Rapid Mac AX golden snapshots against the current shipping UI.

The drift covers:
- per-message Delete actions in deep chat transcripts
- Conversation Search AX child ordering
- the production Settings category list, where Developer is hidden
- the current Speech readiness scroll-area shape

No product code changes.

## Validation

- Mac Mini dogfood on `main`: all 28 named GUI golden flows passed their behavior assertions
- 21/28 passed committed baselines directly
- the remaining 7 passed end to end with refreshed baselines in an isolated copy
- `92 passed`: GUI golden CI coverage, preflight, walk completeness, control behavior, and AX identifier contracts
- `git diff --check`

The Mac Mini lacked Screen Recording permission, so the screenshot-only `gui-ax-smoke.sh` preflight was not available; Accessibility-driven flows were fully available and the session was unlocked.
