### PR TITLE
fix(markdown): draw the SVG preview the right way up

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownCodeBlockView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownCodeBlockView.swift
@@ -232,20 +232,17 @@ final class MarkdownCodeBlockView: NSView {
     /// press away.
     @discardableResult
     private func drawPreview(contentWidth: CGFloat) -> Bool {
-        guard isShowingPreview, let previewImage,
-              let context = NSGraphicsContext.current?.cgContext else { return false }
+        guard isShowingPreview, let previewImage else { return false }
         let size = SVGPreview.drawSize(for: previewImage.size, inWidth: contentWidth)
         guard size.width > 0, size.height > 0 else { return false }
         let origin = CGPoint(
             x: options.codeInsets.leading,
             y: headerHeight + options.codeInsets.top
         )
-        // NSImage compensates for the flipped view. Mirror the destination
-        // coordinate space around this rect first so the image's document-top
-        // still lands at the view's visual top (pinned by the bitmap test).
-        context.saveGState()
-        context.translateBy(x: 0, y: 2 * origin.y + size.height)
-        context.scaleBy(x: 1, y: -1)
+        // `respectFlipped: true` is the whole of it. This view is `isFlipped`,
+        // and the short `draw(in:)` overload does not compensate — it paints
+        // the image bottom-up into a top-down coordinate space. Nothing else
+        // is needed, and mirroring the destination as well flips it back.
         previewImage.draw(
             in: CGRect(origin: origin, size: size),
             from: .zero,
@@ -254,7 +251,6 @@ final class MarkdownCodeBlockView: NSView {
             respectFlipped: true,
             hints: nil
         )
-        context.restoreGState()
         return true
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/SVGPreviewTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SVGPreviewTests.swift
@@ -473,9 +473,36 @@ struct PreviewOrientationTests {
             firstRow { $0.blueComponent > 0.7 && $0.redComponent < 0.3 },
             "no blue band found — the preview did not draw"
         )
-        // Bitmap rows count from the bottom even though the source view is
-        // flipped, so the visually higher red band has the larger row index.
-        #expect(red > blue, "the preview is upside down: blue (bottom of the document) drew above red")
+        // `NSBitmapImageRep` numbers rows from the top: row 0 is the visual
+        // top of the card, whatever the source view's `isFlipped` says. So an
+        // upright picture puts red — the document's top band — at the smaller
+        // row index. `rowOrderIsTopDown` below pins this, because believing
+        // the opposite is exactly how the preview shipped upside down.
+        #expect(red < blue, "the preview is upside down: blue (bottom of the document) drew above red")
+    }
+
+    /// Which end of an `NSBitmapImageRep` is the top.
+    ///
+    /// The orientation test above is only as good as its idea of row order,
+    /// and a wrong idea there is invisible: it makes the assertion demand the
+    /// bug. That happened — the row order was asserted from memory as
+    /// bottom-up, the expectation was inverted to match, and two rounds of
+    /// "fixes" then chased the inverted test by adding a second flip. So the
+    /// premise gets measured against a picture drawn with no flipping at all.
+    @Test("Bitmap rows are numbered from the top")
+    func rowOrderIsTopDown() throws {
+        let image = try #require(NSImage(data: Data(banded.utf8)))
+        let canvas = NSImage(size: CGSize(width: 100, height: 100))
+        canvas.lockFocus()
+        image.draw(in: CGRect(x: 0, y: 0, width: 100, height: 100))
+        canvas.unlockFocus()
+        let tiff = try #require(canvas.tiffRepresentation)
+        let rep = try #require(NSBitmapImageRep(data: tiff))
+
+        let top = try #require(rep.colorAt(x: 50, y: 0))
+        let bottom = try #require(rep.colorAt(x: 50, y: rep.pixelsHigh - 1))
+        #expect(top.redComponent > 0.7, "row 0 is not the document's red top band")
+        #expect(bottom.blueComponent > 0.7, "the last row is not the document's blue bottom band")
     }
 }
 


### PR DESCRIPTION
The SVG preview on `main` renders upside down. Any document that is not
vertically symmetric — a logo above its caption, a chart with a legend, a
flowchart — comes out inverted.

## What happens

`drawPreview` mirrors the destination coordinate space *and* passes
`respectFlipped: true`. NSImage already compensates for the flipped view, so
the hand-written mirror flips it a second time.

## How it got there

The manual mirror was added to satisfy a test whose expectation had been
inverted one commit earlier.

- `af7f4482` changed the expectation from `red < blue` to `red > blue`, on
  the stated grounds that "bitmap rows count from the bottom". They do not:
  `NSBitmapImageRep.colorAt(x:y:)` numbers rows from the top. The inverted
  expectation therefore requires an upside-down picture.
- `e1b4adcb` then supplied one, by adding the mirror.

Both are green, because in each case the test and the implementation moved
together. This is not a gap in the test's coverage — the test executes the
drawing code and samples its pixels. It is a wrong premise about the
framework, which made a correct-looking assertion demand the defect.

## Evidence

Rendering a real document through the drawing path and comparing it against
a reference render, rather than reading the code:

| | result |
|---|---|
| reference (no flipped view, no mirror) | circle above the caption |
| `main`'s drawing path | caption above an inverted circle |

## The change

1. Drop the manual mirror. `respectFlipped: true` is the whole of it.
2. Restore the expectation to `red < blue`.
3. Add `rowOrderIsTopDown`, which measures the row order against a picture
   drawn with no flipping at all.

(3) is the part worth keeping. The orientation test is only as good as its
idea of which end of the bitmap is the top, and being wrong there is
invisible — it does not weaken the assertion, it reverses it. Pinning the
premise separately is what stops the same inversion happening again.

## Verification

- Full suite on this branch: 2672 tests, no failures other than a
  pre-existing DNS test that needs network.
- Mutation check: reintroducing the mirror fails
  `The preview is drawn the right way up` with `(red → 188) < (blue → 88)`.

Independent of any other work in flight — it touches only `drawPreview` and
the orientation tests.