### PR TITLE
fix(mac): disarm dictation before app teardown

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -239,15 +239,28 @@ final class DictationController {
     }
 
     func disable() {
+        // Stop accepting global input before tearing down anything the input
+        // depends on. During app termination the server can spend several
+        // seconds in its graceful-shutdown window; leaving the event tap live
+        // for that window makes the hotkey appear to work even though no new
+        // transcription can possibly complete.
+        hotkey.stop()
         transcribeTask?.cancel()
         transcribeTask = nil
         prewarmTask?.cancel()
         prewarmTask = nil
         stopTicking()
-        hotkey.stop()
         recorder.shutdown()
         hud.hide()
         phase = .off
+    }
+
+    /// Tear down the process-wide dictation service without changing the
+    /// user's persisted Enabled preference. A normal relaunch should re-arm
+    /// dictation, but no global hotkey may survive into the app's synchronous
+    /// server/download shutdown window.
+    func shutdownForTermination() {
+        disable()
     }
 
     /// The system silently disables an event tap that misbehaves; re-arm when

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -280,6 +280,7 @@ struct RapidApp: App {
             fixtureState: updateBusyFixture ? .busy : nil
         )
         let downloadsInstance = DownloadManager(binaryPath: manager.binaryPath)
+        let dictationController = DictationController(server: manager)
         // #253: let ``ServerManager.start(alias:)`` await any in-flight
         // background pull for the same alias before spawning serve.
         manager.attachDownloads(downloadsInstance)
@@ -293,7 +294,7 @@ struct RapidApp: App {
         _chatViewModel = State(initialValue: chat)
         _imageGen = State(initialValue: ImageGenViewModel(server: manager))
         _audio = State(initialValue: AudioViewModel(server: manager))
-        _dictation = State(initialValue: DictationController(server: manager))
+        _dictation = State(initialValue: dictationController)
         _updater = State(initialValue: updateChecker)
         _sparkleUpdater = State(initialValue: sparkleUpdateController)
         _sampling = State(initialValue: samplingConfig)
@@ -308,6 +309,7 @@ struct RapidApp: App {
         AppDelegate.shared.updater = updateChecker
         AppDelegate.shared.sparkleUpdater = sparkleUpdateController
         AppDelegate.shared.chat = chat
+        AppDelegate.shared.dictation = dictationController
         AppDelegate.shared.appearance = appearanceConfig
     }
 
@@ -514,10 +516,10 @@ struct RapidApp: App {
     }
 }
 
-/// AppKit delegate whose only job is to tear down the embedded child
-/// before the process exits. SwiftUI's pure `App` lifecycle has no
-/// equivalent synchronous hook — `onDisappear` and scene phase changes
-/// fire on app activation transitions, not on terminate.
+/// AppKit delegate that tears down process-wide services and the embedded
+/// child before the process exits. SwiftUI's pure `App` lifecycle has no
+/// equivalent synchronous hook — `onDisappear` and scene phase changes fire
+/// on app activation transitions, not on terminate.
 ///
 /// ``@MainActor`` is required by Swift 6 strict concurrency — AppKit
 /// delegate callbacks all land on the main thread anyway, and the
@@ -537,6 +539,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// cancel the in-flight chat stream task before shutting the child
     /// down, and the menu-bar tray's "New Chat" can reach it.
     weak var chat: ChatViewModel?
+    /// Process-wide dictation owns a global CGEvent tap, microphone capture,
+    /// and asynchronous transcription work. It must be disarmed before the
+    /// server begins its synchronous quit grace, while keeping the persisted
+    /// Enabled preference intact for the next launch.
+    var dictation: DictationController?
     /// Persisted theme override. Re-applied from
     /// ``applicationDidFinishLaunching`` so the user's "Light" choice
     /// takes effect on the first window even when the host system is
@@ -918,7 +925,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// AppKit). Production code threads the live AppDelegate slots
     /// through; tests pass spy closures that record call order.
     ///
-    /// Codex r1 NIT: prior version had the 5 calls inlined in
+    /// Codex r1 NIT: prior version had the teardown calls inlined in
     /// `applicationWillTerminate`, with no test pinning the
     /// stop-first invariant against a future reorder.
     ///
@@ -943,15 +950,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// no grace period was shortened — the server's 5 s window is
     /// load-bearing for rapid-mlx's prefix-cache flush.
     static func runTerminationSequence(
+        stopDictation: () -> Void,
         stopStream: () -> Void,
         signalServer: () -> Void,
         signalDownloads: () -> Void,
         reapServer: () -> Void,
-        reapDownloads: () -> Void
+        reapDownloads: () -> Void,
+        flushConversations: () -> Void,
+        flushFolders: () -> Void
     ) {
-        // ORDER MATTERS — the audit P1 invariant is: stopStream BEFORE
-        // any teardown so the inflight URLSessionDataTask FIN reaches
-        // rapid-mlx before the child is SIGTERM'd.
+        // ORDER MATTERS — stop accepting process-global input before any
+        // dependency teardown. Otherwise the dictation hotkey remains live
+        // while the server is already leaving and presents a dead action.
+        stopDictation()
+        // The audit P1 invariant is: stopStream BEFORE any child teardown so
+        // the inflight URLSessionDataTask FIN reaches rapid-mlx before the
+        // child is SIGTERM'd.
         stopStream()
         // Signal phase — non-blocking. Both subsystems get their
         // SIGTERM before anyone waits, so the graces overlap.
@@ -968,8 +982,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // written in the same user actions (deleting a folder unfiles the
         // conversations in it), so flushing only one can leave the pair
         // disagreeing about where a row lives.
-        ConversationStore.flush()
-        ConversationFolderStore.flush()
+        flushConversations()
+        flushFolders()
     }
 
     /// The single clean-shutdown wiring, shared by ``applicationWillTerminate``
@@ -981,11 +995,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @MainActor
     static func runStandardTermination() {
         runTerminationSequence(
+            stopDictation: {
+                // Strong app-lifetime ownership makes this teardown
+                // independent of SwiftUI's scene/@State destruction order.
+                // Drop that ownership only after the event tap, recorder and
+                // in-flight work have all been stopped.
+                AppDelegate.shared.dictation?.shutdownForTermination()
+                AppDelegate.shared.dictation = nil
+            },
             stopStream: { AppDelegate.shared.chat?.stopAndPersist() },
             signalServer: { AppDelegate.shared.server?.beginShutdown() },
             signalDownloads: { AppDelegate.shared.downloads?.beginShutdown() },
             reapServer: { AppDelegate.shared.server?.shutdownSync() },
-            reapDownloads: { AppDelegate.shared.downloads?.finishShutdown() }
+            reapDownloads: { AppDelegate.shared.downloads?.finishShutdown() },
+            flushConversations: { ConversationStore.flush() },
+            flushFolders: { ConversationFolderStore.flush() }
         )
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/AppTerminationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AppTerminationTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import Rapid
+
+@Suite("App termination lifecycle")
+struct AppTerminationTests {
+    @Test("Dictation is disarmed before stream and child teardown")
+    @MainActor
+    func dictationStopsFirst() {
+        var events: [String] = []
+
+        AppDelegate.runTerminationSequence(
+            stopDictation: { events.append("dictation") },
+            stopStream: { events.append("stream") },
+            signalServer: { events.append("signal-server") },
+            signalDownloads: { events.append("signal-downloads") },
+            reapServer: { events.append("reap-server") },
+            reapDownloads: { events.append("reap-downloads") },
+            flushConversations: { events.append("flush-conversations") },
+            flushFolders: { events.append("flush-folders") }
+        )
+
+        #expect(events == [
+            "dictation",
+            "stream",
+            "signal-server",
+            "signal-downloads",
+            "reap-server",
+            "reap-downloads",
+            "flush-conversations",
+            "flush-folders",
+        ])
+    }
+}


### PR DESCRIPTION
## Why

Dictation owns a process-wide CGEvent tap. During the synchronous quit sequence, Rapid could begin shutting down the model server while that tap was still armed, leaving a short but user-visible window where the hotkey reacted even though no transcription could finish.

Closing the main window remains intentionally different from quitting: Rapid stays available from the menu bar and dictation should keep working. This change only affects actual process termination and re-onboarding restart.

## Change

- retain the app-owned DictationController in AppDelegate
- unregister the global hotkey before cancelling transcription/prewarm and releasing the recorder/HUD
- run dictation teardown before chat, server, and download teardown
- preserve the persisted Enabled preference so dictation re-arms on the next launch
- make conversation flushes injectable in the termination-order helper and pin the complete ordering in a unit test

## Validation

- Studio reproduction confirmed a true Quit ends the process; the misleading residual-hotkey state is the shutdown window/background-resident distinction, not a CGEvent tap surviving a dead process
- Studio: swift test --filter AppTerminationTests\|DictationTests (19 passed)
- local diff check clean; all runtime tests were kept off the user workstation