### PR TITLE
feat(models): support Qwen3-Next disk streaming

### DIFF
--- a/tests/test_disk_stream_cli_wiring.py
+++ b/tests/test_disk_stream_cli_wiring.py
@@ -40,7 +40,7 @@ Four things are pinned here, none of which need a model download:
    fixup the non-lazy path always runs — most importantly
    ``augment_eos_token_ids_from_generation_config``, whose own docstring
    names Qwen3/Qwen2.5 as the exact scenario it exists to fix, and
-   ``qwen2_moe`` is one of the two registered ``--disk-stream``
+   ``qwen2_moe`` is one of the registered ``--disk-stream``
    architectures. A fast, in-process test monkeypatches all five fixups
    to record whether/how they fire and asserts they do, without a
    checkpoint download.

--- a/tests/test_disk_stream_patch.py
+++ b/tests/test_disk_stream_patch.py
@@ -218,8 +218,13 @@ def test_streaming_forwards_use_each_projections_quantization_parameters():
     """Mixed-quantization checkpoints must not reuse gate settings."""
     from vllm_mlx.disk_stream_patch import _streaming_moe_forward
     from vllm_mlx.qwen2_moe_forward import qwen2_moe_streaming_forward
+    from vllm_mlx.qwen3_next_forward import qwen3_next_streaming_forward
 
-    for forward in (_streaming_moe_forward, qwen2_moe_streaming_forward):
+    for forward in (
+        _streaming_moe_forward,
+        qwen2_moe_streaming_forward,
+        qwen3_next_streaming_forward,
+    ):
         source = inspect.getsource(forward)
         for projection in ("gate_proj", "up_proj", "down_proj"):
             assert f"group_size={projection}.group_size" in source

--- a/tests/test_disk_stream_registry.py
+++ b/tests/test_disk_stream_registry.py
@@ -90,6 +90,30 @@ def test_qwen2_moe_streaming_forward_resolves_and_lfm2_moe_unaffected():
     assert lfm2_adapter.streaming_forward is _streaming_moe_forward
 
 
+def test_get_adapter_returns_qwen3_next_adapter():
+    """Qwen3-Coder-Next's published MLX checkpoint uses stacked tensors."""
+    adapter = get_adapter("qwen3_next")
+    assert adapter is not None
+    assert adapter.model_type == "qwen3_next"
+    assert adapter.num_experts == 512
+    assert adapter.tensor_template.layout == "stacked"
+    assert adapter.moe_block_attr == "mlp"
+
+    from mlx_lm.models.qwen3_next import Qwen3NextSparseMoeBlock
+    from vllm_mlx.qwen3_next_forward import qwen3_next_streaming_forward
+
+    assert adapter.moe_block_cls is Qwen3NextSparseMoeBlock
+    assert adapter.streaming_forward is qwen3_next_streaming_forward
+
+
+def test_qwen3_next_tensor_template_matches_published_mlx_checkpoint():
+    adapter = get_adapter("qwen3_next")
+    name = adapter.tensor_template.tensor_name(
+        layer_idx=2, proj="gate_proj", component="weight", expert_id=5
+    )
+    assert name == "model.layers.2.mlp.switch_mlp.gate_proj.weight"
+
+
 def test_direct_layout_tensor_name_requires_expert_id():
     """A ``"direct"``-layout template (qwen2_moe) must raise ``ValueError``
     when ``expert_id`` is omitted, rather than silently formatting

--- a/tests/test_disk_stream_registry.py
+++ b/tests/test_disk_stream_registry.py
@@ -100,6 +100,7 @@ def test_get_adapter_returns_qwen3_next_adapter():
     assert adapter.moe_block_attr == "mlp"
 
     from mlx_lm.models.qwen3_next import Qwen3NextSparseMoeBlock
+
     from vllm_mlx.qwen3_next_forward import qwen3_next_streaming_forward
 
     assert adapter.moe_block_cls is Qwen3NextSparseMoeBlock

--- a/tests/test_qwen3_next_forward.py
+++ b/tests/test_qwen3_next_forward.py
@@ -1,0 +1,48 @@
+"""Focused math test for Qwen3-Next's disk-streaming MoE forward."""
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.qwen3_next import Qwen3NextSparseMoeBlock
+
+from vllm_mlx.expert_cache import ExpertCache
+from vllm_mlx.qwen3_next_forward import qwen3_next_streaming_forward
+
+
+def test_qwen3_next_streaming_forward_matches_real_quantized_block():
+    """Selected-expert matmuls match mlx-lm's real QuantizedSwitchLinear."""
+    mx.random.seed(42)
+    args = SimpleNamespace(
+        hidden_size=64,
+        moe_intermediate_size=32,
+        shared_expert_intermediate_size=32,
+        norm_topk_prob=True,
+        num_experts=4,
+        num_experts_per_tok=2,
+    )
+    block = Qwen3NextSparseMoeBlock(args)
+    nn.quantize(block, group_size=32, bits=4)
+    block.eval()
+
+    def fetch_expert(_layer_idx: int, expert_id: int):
+        return {
+            projection: {
+                component: getattr(getattr(block.switch_mlp, projection), component)[
+                    expert_id
+                ]
+                for component in ("weight", "scales", "biases")
+            }
+            for projection in ("gate_proj", "up_proj", "down_proj")
+        }
+
+    cache = ExpertCache(fetch_fn=fetch_expert, budget_bytes=10_000_000)
+    x = mx.random.normal((2, 3, args.hidden_size)).astype(mx.float16)
+
+    expected = block(x)
+    actual = qwen3_next_streaming_forward(block, x, layer_idx=0, cache=cache)
+    mx.eval(expected, actual)
+
+    assert mx.allclose(actual, expected, rtol=1e-5, atol=1e-5).item()
+    assert cache.misses > 0

--- a/tests/test_qwen3_next_forward.py
+++ b/tests/test_qwen3_next_forward.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 
 import mlx.core as mx
 import mlx.nn as nn
-
 from mlx_lm.models.qwen3_next import Qwen3NextSparseMoeBlock
 
 from vllm_mlx.expert_cache import ExpertCache

--- a/vllm_mlx/qwen3_next_forward.py
+++ b/vllm_mlx/qwen3_next_forward.py
@@ -83,8 +83,7 @@ def qwen3_next_streaming_forward(
                     mode=down_proj.mode,
                 )
                 output = (
-                    output
-                    + down_output[0] * scores[batch_idx, position, selected_idx]
+                    output + down_output[0] * scores[batch_idx, position, selected_idx]
                 )
             rows_l.append(output)
         rows_b.append(mx.stack(rows_l, axis=0))

--- a/vllm_mlx/qwen3_next_forward.py
+++ b/vllm_mlx/qwen3_next_forward.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Disk-streaming forward for Qwen3-Next's shared+routed MoE block."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from vllm_mlx.expert_cache import ExpertCache
+
+
+def qwen3_next_streaming_forward(
+    block, x: mx.array, layer_idx: int, cache: ExpertCache
+) -> mx.array:
+    """Reproduce ``Qwen3NextSparseMoeBlock.__call__`` expert by expert.
+
+    Router and shared-expert weights remain resident. Only the selected
+    routed experts' quantized gate/up/down projections are fetched through
+    ``cache`` from the checkpoint's stacked ``switch_mlp`` tensors.
+    """
+    sharding_group = getattr(block, "sharding_group", None)
+    if sharding_group is not None:
+        from mlx.nn.layers.distributed import sum_gradients
+
+        x = sum_gradients(sharding_group)(x)
+
+    gates = block.gate(x)
+    gates = mx.softmax(gates, axis=-1, precise=True)
+
+    k = block.top_k
+    inds = mx.argpartition(gates, kth=-k, axis=-1)[..., -k:]
+    scores = mx.take_along_axis(gates, inds, axis=-1)
+    if block.norm_topk_prob:
+        scores = scores / scores.sum(axis=-1, keepdims=True)
+
+    gate_proj = block.switch_mlp.gate_proj
+    up_proj = block.switch_mlp.up_proj
+    down_proj = block.switch_mlp.down_proj
+
+    batch_size, sequence_length, hidden_size = x.shape
+    inds_list = inds.tolist()
+    rows_b = []
+    for batch_idx in range(batch_size):
+        rows_l = []
+        for position in range(sequence_length):
+            token_x = x[batch_idx, position][None, :]
+            output = mx.zeros((hidden_size,), dtype=x.dtype)
+            for selected_idx, expert_id in enumerate(inds_list[batch_idx][position]):
+                bundle = cache.get(layer_idx, expert_id)
+                gate = bundle["gate_proj"]
+                up = bundle["up_proj"]
+                down = bundle["down_proj"]
+
+                gate_output = mx.quantized_matmul(
+                    token_x,
+                    gate["weight"],
+                    scales=gate["scales"],
+                    biases=gate["biases"],
+                    transpose=True,
+                    group_size=gate_proj.group_size,
+                    bits=gate_proj.bits,
+                    mode=gate_proj.mode,
+                )
+                up_output = mx.quantized_matmul(
+                    token_x,
+                    up["weight"],
+                    scales=up["scales"],
+                    biases=up["biases"],
+                    transpose=True,
+                    group_size=up_proj.group_size,
+                    bits=up_proj.bits,
+                    mode=up_proj.mode,
+                )
+                hidden = nn.silu(gate_output) * up_output
+                down_output = mx.quantized_matmul(
+                    hidden,
+                    down["weight"],
+                    scales=down["scales"],
+                    biases=down["biases"],
+                    transpose=True,
+                    group_size=down_proj.group_size,
+                    bits=down_proj.bits,
+                    mode=down_proj.mode,
+                )
+                output = (
+                    output
+                    + down_output[0] * scores[batch_idx, position, selected_idx]
+                )
+            rows_l.append(output)
+        rows_b.append(mx.stack(rows_l, axis=0))
+    routed_output = mx.stack(rows_b, axis=0)
+
+    shared_output = block.shared_expert(x)
+    shared_output = mx.sigmoid(block.shared_expert_gate(x)) * shared_output
+    output = routed_output + shared_output
+    if sharding_group is not None:
+        output = mx.distributed.all_sum(output, group=sharding_group)
+    return output

--- a/vllm_mlx/registry.py
+++ b/vllm_mlx/registry.py
@@ -14,11 +14,12 @@ disk instead of holding them resident:
    where one routed expert's 9-tensor bundle (gate/up/down projections x
    weight/scales/biases) lives in that architecture's safetensors layout.
 
-LFM2.5 (``lfm2_moe``, ``"stacked"`` layout) and qwen2_moe
-(``qwen2_moe``, ``"direct"`` layout, shared+routed) are registered.
-Both ``model_type`` strings are confirmed against their respective
+LFM2.5 (``lfm2_moe``, ``"stacked"`` layout), qwen2_moe
+(``qwen2_moe``, ``"direct"`` layout, shared+routed), and Qwen3-Next
+(``qwen3_next``, ``"stacked"`` layout, shared+routed) are registered.
+All three ``model_type`` strings are confirmed against their respective
 downloaded checkpoints' ``config.json`` and against ``mlx_lm/models/``.
-Adding a third architecture is one more call to ``_register`` (plus,
+Adding another architecture is one more call to ``_register`` (plus,
 if its streaming math differs, one small new module for its
 streaming-forward function — see ``vllm_mlx/qwen2_moe_forward.py`` for
 the pattern) — no change to :func:`get_adapter` or its callers.
@@ -188,6 +189,29 @@ _register(
         moe_block_attr="feed_forward",
         streaming_forward_module="vllm_mlx.disk_stream_patch",
         streaming_forward_fn_name="_streaming_moe_forward",
+    )
+)
+
+# qwen3_next (e.g. mlx-community/Qwen3-Coder-Next-4bit) — shared+routed
+# MoE with 512 experts. The published MLX checkpoint stores the routed
+# experts as axis-0-stacked switch_mlp tensors (rather than the direct
+# per-expert names accepted by Model.sanitize()), so offset_reader can slice
+# one expert without materializing the 512-expert arrays. Its routing differs
+# subtly from qwen2_moe (negative-k argpartition plus optional top-k
+# renormalization), hence the architecture-specific forward module.
+_register(
+    StreamingAdapter(
+        model_type="qwen3_next",
+        moe_block_module="mlx_lm.models.qwen3_next",
+        moe_block_class_name="Qwen3NextSparseMoeBlock",
+        tensor_template=ExpertTensorTemplate(
+            layout="stacked",
+            name_template="model.layers.{layer}.mlp.switch_mlp.{proj}.{component}",
+        ),
+        num_experts=512,
+        moe_block_attr="mlp",
+        streaming_forward_module="vllm_mlx.qwen3_next_forward",
+        streaming_forward_fn_name="qwen3_next_streaming_forward",
     )
 )
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1172,7 +1172,7 @@ def load_model_with_fallback(
         # cut (see review-notes.md's blocking finding). Concretely:
         # `augment_eos_token_ids_from_generation_config`'s own docstring
         # names Qwen3/Qwen2.5 (151645/151643) as the exact scenario it
-        # exists to fix, and `qwen2_moe` is one of the two registered
+        # exists to fix, and `qwen2_moe` is one of the registered
         # --disk-stream architectures (vllm_mlx/registry.py) — without
         # this call a qwen2_moe checkpoint loaded with --disk-stream
         # would silently fail to stop at its chat-template terminator
@@ -1198,8 +1198,8 @@ def load_model_with_fallback(
         # chosen loader materializes weights eagerly or lazily. They are
         # also unreachable in practice for a --disk-stream load: neither
         # Gemma 4, nor any vendored architecture, nor Nemotron is a
-        # registered --disk-stream architecture (only `lfm2_moe` and
-        # `qwen2_moe` are, per vllm_mlx/registry.py), so none of these
+        # registered --disk-stream architecture (`lfm2_moe`, `qwen2_moe`,
+        # and `qwen3_next` are, per vllm_mlx/registry.py), so none of these
         # branches would ever fire for a checkpoint this code path is
         # actually used for.
         _post_load_ubc_evict(model_name)


### PR DESCRIPTION
Closes #2174.

## What changed
- register `qwen3_next` as a disk-streaming MoE architecture
- use the published MLX checkpoint's 512-expert stacked `switch_mlp` tensor layout
- add an architecture-specific streaming forward matching Qwen3-Next routing, top-k normalization, shared expert, distributed path, and per-projection quantization parameters
- add focused registry and real `mlx_lm` quantized-block equivalence tests

## Validation
- Mac Studio targeted tests: 212 passed
- Mac Mini (32 GB) downloaded the full 44.8 GB `mlx-community/Qwen3-Coder-Next-4bit` checkpoint
- real `rapid-mlx serve ... --disk-stream --disk-stream-cache-gb 1` loaded successfully, completed hybrid-model warmup, and served an OpenAI chat request
- exact response: `disk streaming works` (4 generated tokens)
- two Codex review rounds: no blocking issues
- exact-head PR validation: MERGE-SAFE; 18,258 passed; patch coverage 93.6%
- hosted CI: all required checks green
- server stopped cleanly and temporary 42 GB checkpoint removed after validation