### PR TITLE
fix(mac): surface dictation cold model loading [skip-version-bump]

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -47,6 +47,9 @@ final class DictationController {
     /// one slow" without a log dive.
     private(set) var lastLatencyDetail: String?
     private(set) var elapsed: TimeInterval = 0
+    /// The model is installed but not yet hot. This is user-visible readiness:
+    /// “on disk” alone is not enough to promise an immediate first dictation.
+    private(set) var isPreparingModel = false
     /// Set when the TCC row says Accessibility is granted but this process
     /// still cannot install an event tap — i.e. the grant landed after launch.
     private(set) var accessibilityNeedsRelaunch = false
@@ -305,6 +308,7 @@ final class DictationController {
         beginRecordingRequestID = nil
         prewarmTask?.cancel()
         prewarmTask = nil
+        isPreparingModel = false
         stopTicking()
         recorder.shutdown()
         hud.hide()
@@ -423,6 +427,7 @@ final class DictationController {
             return
         }
         var created: Task<Void, Never>!
+        isPreparingModel = true
         created = Task { [weak self] in
             await self?.performPrewarm()
             // Only the flight that still OWNS the slot may clear it. A
@@ -430,6 +435,7 @@ final class DictationController {
             // task a later enable started, or single-flight breaks.
             if let self, self.prewarmTask == created {
                 self.prewarmTask = nil
+                self.isPreparingModel = false
             }
         }
         prewarmTask = created
@@ -546,12 +552,37 @@ final class DictationController {
             return
         }
         let requestedAlias = modelAlias
-        // A probe still in flight would sit in front of this dictation in the
-        // engine's serial STT lane. Abandon it — if it already reached the
-        // sidecar, the weight load it triggered continues server-side and
-        // benefits the transcription that follows either way.
-        prewarmTask?.cancel()
-        prewarmTask = nil
+        // If enable-time prewarm is still running, or an LLM/VLM displaced the
+        // audio sidecar since then, pay that cold load before opening the mic.
+        // Cancelling a probe after it reached the sidecar cannot remove it from
+        // the engine's serial STT lane; the real transcription would simply
+        // queue behind it while the HUD misleadingly said “Transcribing…”.
+        if Self.shouldPrepareModelForRecording(
+            prewarmInFlight: prewarmTask != nil,
+            servingAlias: server.servingAlias,
+            requestedAlias: requestedAlias
+        ) {
+            hud.show(.loadingModel)
+            await prewarmModel()
+            guard !Task.isCancelled,
+                  beginRecordingRequestID == requestID,
+                  isEnabled,
+                  phase == .idle,
+                  modelAlias == requestedAlias
+            else {
+                hud.hide()
+                return
+            }
+            guard server.servingAlias == requestedAlias else {
+                lastError = "\(requestedAlias) couldn't start. There may not be enough memory to load it."
+                hud.update(.failed(message: "Couldn't start the model"))
+                Task {
+                    try? await Task.sleep(nanoseconds: 1_600_000_000)
+                    if phase == .idle { hud.hide() }
+                }
+                return
+            }
+        }
         // Model Management changes the cache out of process from this
         // controller. Re-read disk facts on every hotkey press; trusting the
         // enable-time snapshot here could pass a stale repo to ``serve`` and
@@ -587,6 +618,17 @@ final class DictationController {
         phase = .starting
         hud.show(.starting)
         startTicking()
+    }
+
+    /// A same-alias sidecar plus a completed enable-time probe is the only hot
+    /// path. Any in-flight probe or process swap must finish before capture so
+    /// its latency cannot be attributed to transcription after the user talks.
+    nonisolated static func shouldPrepareModelForRecording(
+        prewarmInFlight: Bool,
+        servingAlias: String?,
+        requestedAlias: String
+    ) -> Bool {
+        prewarmInFlight || servingAlias != requestedAlias
     }
 
     /// Fresh cache truth used at the recording boundary. Internal so the

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -81,6 +81,7 @@ final class DictationController {
             // leaves the Enable switch stuck until something else refreshes.
             refreshReadiness()
             if isEnabled {
+                cancelActiveSessionForModelChange()
                 hotkey.stop()
                 phase = .preparingModel
             }
@@ -119,6 +120,7 @@ final class DictationController {
     private let testingReadiness: Readiness?
     private let testingPrewarm: (@MainActor () async -> Bool)?
     private let testingHotkeyStart: (@MainActor () -> Bool)?
+    private let testingRecorderCancel: (@MainActor () -> Void)?
 
     private var tickTimer: Timer?
     private var recordingStart: Date?
@@ -161,6 +163,7 @@ final class DictationController {
         testingReadiness: Readiness? = nil,
         testingPrewarm: (@MainActor () async -> Bool)? = nil,
         testingHotkeyStart: (@MainActor () -> Bool)? = nil,
+        testingRecorderCancel: (@MainActor () -> Void)? = nil,
         audioCatalogLoader: @escaping @MainActor (URL) async -> [ModelEntry]? = {
             await ModelCatalog.audioEntriesIfAvailable(binary: $0)
         }
@@ -173,6 +176,7 @@ final class DictationController {
         self.testingReadiness = testingReadiness
         self.testingPrewarm = testingPrewarm
         self.testingHotkeyStart = testingHotkeyStart
+        self.testingRecorderCancel = testingRecorderCancel
 
         let defaults = UserDefaults.standard
         self.isEnabled = testingEnabled ?? defaults.bool(forKey: Keys.enabled)
@@ -344,6 +348,27 @@ final class DictationController {
         recorder.shutdown()
         hud.hide()
         phase = .off
+    }
+
+    /// A model change cannot safely preserve an in-flight utterance: after
+    /// the swap it would be submitted to a different model. Tear the active
+    /// session down before entering preparation so the microphone cannot be
+    /// stranded behind a phase that ignores the stop hotkey.
+    private func cancelActiveSessionForModelChange() {
+        beginRecordingTask?.cancel()
+        beginRecordingTask = nil
+        beginRecordingRequestID = nil
+        if phase == .starting || phase == .recording {
+            if let testingRecorderCancel {
+                testingRecorderCancel()
+            } else {
+                recorder.cancelCapture()
+            }
+        }
+        stopTicking()
+        recordingStart = nil
+        capturingApp = nil
+        hud.hide()
     }
 
     /// Tear down the process-wide dictation service without changing the
@@ -553,6 +578,10 @@ final class DictationController {
     func modelDownloadDidFinish() async {
         await refreshModelCacheState()
         if isEnabled {
+            // DownloadManager retains its completed job. A recreated view can
+            // replay that completion, but a hot same-alias session must keep
+            // its working hotkey instead of needlessly disarming and probing.
+            guard phase != .idle || server.servingAlias != modelAlias else { return }
             await enable(replacingCurrentPrewarm: true)
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -121,12 +121,14 @@ final class DictationController {
     private let testingPrewarm: (@MainActor () async -> Bool)?
     private let testingHotkeyStart: (@MainActor () -> Bool)?
     private let testingRecorderCancel: (@MainActor () -> Void)?
+    private let testingTranscribeCancel: (@MainActor () -> Void)?
 
     private var tickTimer: Timer?
     private var recordingStart: Date?
     private var capturingApp: String?
     private var level: Float = 0
     private var transcribeTask: Task<Void, Never>?
+    private var transcribeRequestID: UUID?
     /// The on-disk revalidation between a hotkey tap and capture. Keeping the
     /// task cancellable means turning dictation off while the catalog CLI is
     /// running cannot let its stale continuation start the microphone later.
@@ -164,6 +166,7 @@ final class DictationController {
         testingPrewarm: (@MainActor () async -> Bool)? = nil,
         testingHotkeyStart: (@MainActor () -> Bool)? = nil,
         testingRecorderCancel: (@MainActor () -> Void)? = nil,
+        testingTranscribeCancel: (@MainActor () -> Void)? = nil,
         audioCatalogLoader: @escaping @MainActor (URL) async -> [ModelEntry]? = {
             await ModelCatalog.audioEntriesIfAvailable(binary: $0)
         }
@@ -177,6 +180,7 @@ final class DictationController {
         self.testingPrewarm = testingPrewarm
         self.testingHotkeyStart = testingHotkeyStart
         self.testingRecorderCancel = testingRecorderCancel
+        self.testingTranscribeCancel = testingTranscribeCancel
 
         let defaults = UserDefaults.standard
         self.isEnabled = testingEnabled ?? defaults.bool(forKey: Keys.enabled)
@@ -337,6 +341,7 @@ final class DictationController {
         hotkey.stop()
         transcribeTask?.cancel()
         transcribeTask = nil
+        transcribeRequestID = nil
         beginRecordingTask?.cancel()
         beginRecordingTask = nil
         beginRecordingRequestID = nil
@@ -364,6 +369,11 @@ final class DictationController {
             } else {
                 recorder.cancelCapture()
             }
+        } else if phase == .transcribing {
+            testingTranscribeCancel?()
+            transcribeTask?.cancel()
+            transcribeTask = nil
+            transcribeRequestID = nil
         }
         stopTicking()
         recordingStart = nil
@@ -414,17 +424,18 @@ final class DictationController {
     /// server has to swap the whole process instead. Getting this wrong fails
     /// at request time with nothing to distinguish it from a missing model.
     @discardableResult
-    private func ensureModelServing() async -> Bool {
-        guard !modelAlias.isEmpty else { return false }
+    private func ensureModelServing(alias requestedAlias: String? = nil) async -> Bool {
+        let alias = requestedAlias ?? modelAlias
+        guard !alias.isEmpty else { return false }
         // Only models already on disk get through. This is the choke point
         // that kills every silent-download path dictation used to have: the
         // server is never handed a repo to fetch, so the worst it can do is
         // fail fast on a missing model.
-        guard let facts = await catalogFacts(for: modelAlias), facts.cached else {
+        guard let facts = await catalogFacts(for: alias), facts.cached else {
             return false
         }
         return await server.ensureServing(
-            alias: modelAlias,
+            alias: alias,
             hfPath: facts.repo,
             residencyEligible: false
         )
@@ -512,7 +523,7 @@ final class DictationController {
         // that mutates the sidecar or touches the wire.
         guard !Task.isCancelled, isEnabled, modelAlias == alias else { return false }
         if server.servingAlias != alias {
-            guard await ensureModelServing() else { return false }
+            guard await ensureModelServing(alias: alias) else { return false }
             guard !Task.isCancelled, isEnabled, modelAlias == alias else { return false }
         }
         return await warmUpEngine()
@@ -701,16 +712,34 @@ final class DictationController {
         hud.update(.transcribing)
 
         let app = capturingApp
+        let alias = modelAlias
+        let requestID = UUID()
+        transcribeRequestID = requestID
         transcribeTask = Task { [weak self] in
-            await self?.transcribe(audio: audio, duration: duration, appName: app)
+            await self?.transcribe(
+                audio: audio,
+                duration: duration,
+                appName: app,
+                alias: alias,
+                requestID: requestID
+            )
         }
     }
 
-    private func transcribe(audio: Data, duration: TimeInterval, appName: String?) async {
+    private func transcribe(
+        audio: Data,
+        duration: TimeInterval,
+        appName: String?,
+        alias: String,
+        requestID: UUID
+    ) async {
         defer {
-            hud.hide()
-            phase = .idle
-            transcribeTask = nil
+            if transcribeRequestID == requestID {
+                hud.hide()
+                phase = .idle
+                transcribeTask = nil
+                transcribeRequestID = nil
+            }
         }
 
         let started = Date()
@@ -718,14 +747,15 @@ final class DictationController {
         // number when the cost can hide in catalog resolution, a model swap,
         // or inference. The split is surfaced in the Dictation tab.
         let ensureStarted = Date()
-        guard await ensureModelServing() else {
-            let facts = catalogByAlias[modelAlias]
+        guard await ensureModelServing(alias: alias) else {
+            guard transcribeRequestID == requestID, modelAlias == alias else { return }
+            let facts = catalogByAlias[alias]
             if facts == nil {
-                lastError = "\(modelAlias) isn't in the audio model catalog. Pick another model."
+                lastError = "\(alias) isn't in the audio model catalog. Pick another model."
             } else if facts?.cached != true {
-                lastError = "\(modelAlias) isn't downloaded. Open Rapid → Audio to download it."
+                lastError = "\(alias) isn't downloaded. Open Rapid → Audio to download it."
             } else {
-                lastError = "\(modelAlias) couldn't start. There may not be enough memory to swap models."
+                lastError = "\(alias) couldn't start. There may not be enough memory to swap models."
             }
             // The user is mid-flow in another app with only the HUD visible.
             // Leaving "Transcribing…" up while silently failing reads as a
@@ -734,7 +764,9 @@ final class DictationController {
             try? await Task.sleep(nanoseconds: 1_600_000_000)
             return
         }
-        guard !Task.isCancelled else { return }
+        guard !Task.isCancelled,
+              transcribeRequestID == requestID,
+              modelAlias == alias else { return }
         let ensureSeconds = Date().timeIntervalSince(ensureStarted)
 
         do {
@@ -742,13 +774,15 @@ final class DictationController {
             let requestStarted = Date()
             let result = try await client.transcribe(
                 audioData: audio,
-                model: modelAlias,
+                model: alias,
                 context: context.isEmpty ? nil : context,
                 port: server.activePort,
                 bearer: server.activeBearer
             )
             let requestSeconds = Date().timeIntervalSince(requestStarted)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled,
+                  transcribeRequestID == requestID,
+                  modelAlias == alias else { return }
 
             let text = Self.tidy(result.text)
             guard !text.isEmpty else {
@@ -789,7 +823,9 @@ final class DictationController {
                 archiveAudio: archiveAudio
             )
         } catch {
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled,
+                  transcribeRequestID == requestID,
+                  modelAlias == alias else { return }
             lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
         }
     }
@@ -802,11 +838,12 @@ final class DictationController {
     /// unsafe default.
     func retranscribe(_ entry: DictationHistory.Entry) async -> String? {
         guard let audio = history.audioData(for: entry), !modelAlias.isEmpty else { return nil }
-        guard await ensureModelServing() else { return nil }
+        let alias = modelAlias
+        guard await ensureModelServing(alias: alias), modelAlias == alias else { return nil }
         let context = vocabulary.contextPrompt
         guard let result = try? await client.transcribe(
             audioData: audio,
-            model: modelAlias,
+            model: alias,
             context: context.isEmpty ? nil : context,
             port: server.activePort,
             bearer: server.activeBearer

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -12,6 +12,7 @@ import Observation
 final class DictationController {
     enum Phase: Equatable {
         case off
+        case preparingModel
         case idle
         case starting
         case recording
@@ -47,9 +48,6 @@ final class DictationController {
     /// one slow" without a log dive.
     private(set) var lastLatencyDetail: String?
     private(set) var elapsed: TimeInterval = 0
-    /// The model is installed but not yet hot. This is user-visible readiness:
-    /// “on disk” alone is not enough to promise an immediate first dictation.
-    private(set) var isPreparingModel = false
     /// Set when the TCC row says Accessibility is granted but this process
     /// still cannot install an event tap — i.e. the grant landed after launch.
     private(set) var accessibilityNeedsRelaunch = false
@@ -82,12 +80,15 @@ final class DictationController {
             // renders from has to move with it — otherwise picking a model
             // leaves the Enable switch stuck until something else refreshes.
             refreshReadiness()
-            // Replacing, not joining: a prewarm still in flight here is
-            // warming the PREVIOUS model, and joining it would return with
-            // the new selection never warmed.
+            if isEnabled {
+                hotkey.stop()
+                phase = .preparingModel
+            }
             Task {
                 await refreshModelCacheState()
-                await prewarmModel(replacingCurrent: true)
+                if isEnabled {
+                    await enable(replacingCurrentPrewarm: true)
+                }
             }
         }
     }
@@ -115,6 +116,9 @@ final class DictationController {
     /// Keeping those states distinct prevents a transient CLI failure from
     /// masquerading as the user deleting every cached audio model.
     private let audioCatalogLoader: @MainActor (URL) async -> [ModelEntry]?
+    private let testingReadiness: Readiness?
+    private let testingPrewarm: (@MainActor () async -> Bool)?
+    private let testingHotkeyStart: (@MainActor () -> Bool)?
 
     private var tickTimer: Timer?
     private var recordingStart: Date?
@@ -129,7 +133,11 @@ final class DictationController {
     /// The in-flight prewarm, retained so ``disable()`` and a hotkey press
     /// can cancel it and so concurrent triggers join it (single-flight)
     /// instead of stacking probes in the engine's serial STT lane.
-    private var prewarmTask: Task<Void, Never>?
+    private var prewarmTask: Task<Bool, Never>?
+    private var prewarmRequestID: UUID?
+    /// Invalidates stale `enable()` continuations when the model changes, the
+    /// feature is disabled, or another enable attempt supersedes them.
+    private var enableRequestID: UUID?
     /// alias → catalog facts. ``ensureServing`` needs the repo; readiness
     /// needs ``cached``. One `audioEntries` fetch fills both. The repo is
     /// only ever passed to the server for models already on disk — passing
@@ -150,6 +158,9 @@ final class DictationController {
         testingEnabled: Bool? = nil,
         testingModelAlias: String? = nil,
         testingPhase: Phase? = nil,
+        testingReadiness: Readiness? = nil,
+        testingPrewarm: (@MainActor () async -> Bool)? = nil,
+        testingHotkeyStart: (@MainActor () -> Bool)? = nil,
         audioCatalogLoader: @escaping @MainActor (URL) async -> [ModelEntry]? = {
             await ModelCatalog.audioEntriesIfAvailable(binary: $0)
         }
@@ -159,6 +170,9 @@ final class DictationController {
         self.vocabulary = vocabulary ?? DictationVocabulary()
         self.history = history ?? DictationHistory()
         self.audioCatalogLoader = audioCatalogLoader
+        self.testingReadiness = testingReadiness
+        self.testingPrewarm = testingPrewarm
+        self.testingHotkeyStart = testingHotkeyStart
 
         let defaults = UserDefaults.standard
         self.isEnabled = testingEnabled ?? defaults.bool(forKey: Keys.enabled)
@@ -186,7 +200,8 @@ final class DictationController {
     // MARK: - Readiness
 
     var readiness: Readiness {
-        Readiness(
+        if let testingReadiness { return testingReadiness }
+        return Readiness(
             microphone: DictationRecorder.microphoneAuthorization == .authorized,
             accessibility: DictationHotkey.hasAccessibilityPermission,
             modelSelected: !modelAlias.isEmpty,
@@ -233,8 +248,10 @@ final class DictationController {
         await enable()
     }
 
-    func enable() async {
+    func enable(replacingCurrentPrewarm: Bool = false) async {
         guard isEnabled else { return }
+        let requestID = UUID()
+        enableRequestID = requestID
         // The on-disk bit comes from a catalog subprocess; fetch it before
         // judging readiness so a fresh launch doesn't refuse to arm a model
         // that is sitting right there in the cache.
@@ -242,7 +259,7 @@ final class DictationController {
         // The user can turn the switch off while the catalog subprocess is
         // running. Never let that stale enable continuation install a hotkey
         // after ``disable()`` has already torn the session down.
-        guard isEnabled else { return }
+        guard isEnabled, enableRequestID == requestID else { return }
         refreshReadiness()
         guard readinessSnapshot.microphone else {
             lastError = "Dictation needs Microphone access before it can be enabled."
@@ -273,7 +290,23 @@ final class DictationController {
             phase = .off
             return
         }
-        guard hotkey.start() else {
+        hotkey.stop()
+        phase = .preparingModel
+        let preparingAlias = modelAlias
+        guard await prewarmModel(replacingCurrent: replacingCurrentPrewarm),
+              isEnabled,
+              enableRequestID == requestID,
+              modelAlias == preparingAlias,
+              phase == .preparingModel,
+              server.servingAlias == preparingAlias
+        else {
+            if isEnabled, enableRequestID == requestID, modelAlias == preparingAlias {
+                lastError = "\(preparingAlias) couldn't load. There may not be enough memory to start dictation."
+                phase = .off
+            }
+            return
+        }
+        guard testingHotkeyStart?() ?? hotkey.start() else {
             // macOS does not apply an Accessibility grant to an already-running
             // process, so this is the common shape right after the user flips
             // the switch in System Settings: the TCC row says yes, this process
@@ -288,10 +321,7 @@ final class DictationController {
         accessibilityNeedsRelaunch = false
         lastError = nil
         phase = .idle
-        // Warm the whole lane now — catalog cache, sidecar, STT weights — so
-        // the first hotkey press of the session starts from a hot path. Fire
-        // and forget: enabling must not block on a model coming up.
-        Task { [weak self] in await self?.prewarmModel() }
+        enableRequestID = nil
     }
 
     func disable() {
@@ -308,7 +338,8 @@ final class DictationController {
         beginRecordingRequestID = nil
         prewarmTask?.cancel()
         prewarmTask = nil
-        isPreparingModel = false
+        prewarmRequestID = nil
+        enableRequestID = nil
         stopTicking()
         recorder.shutdown()
         hud.hide()
@@ -343,6 +374,9 @@ final class DictationController {
             Task { await enable() }
             return
         }
+        // A foreground activation must never sneak the event tap back in
+        // while `enable()` is still loading the model.
+        guard phase != .preparingModel else { return }
         hotkey.reEnableIfDisabled()
     }
 
@@ -413,7 +447,8 @@ final class DictationController {
     ///   superseded, not joined. The default joins it: for a same-model
     ///   trigger (enable + tab appear firing close together) the running
     ///   flight already covers this call.
-    func prewarmModel(replacingCurrent: Bool = false) async {
+    @discardableResult
+    private func prewarmModel(replacingCurrent: Bool = false) async -> Bool {
         if replacingCurrent {
             prewarmTask?.cancel()
             prewarmTask = nil
@@ -423,46 +458,47 @@ final class DictationController {
         // past: the second joins the task the first created instead of
         // racing it through the engine's serial STT lane.
         if let running = prewarmTask {
-            await running.value
-            return
+            return await running.value
         }
-        var created: Task<Void, Never>!
-        isPreparingModel = true
-        created = Task { [weak self] in
-            await self?.performPrewarm()
+        let requestID = UUID()
+        prewarmRequestID = requestID
+        let created = Task { [weak self] in
+            let succeeded = await self?.performPrewarm() ?? false
             // Only the flight that still OWNS the slot may clear it. A
             // cancelled predecessor finishing late must not null out the
             // task a later enable started, or single-flight breaks.
-            if let self, self.prewarmTask == created {
+            if let self, self.prewarmRequestID == requestID {
                 self.prewarmTask = nil
-                self.isPreparingModel = false
+                self.prewarmRequestID = nil
             }
+            return succeeded
         }
         prewarmTask = created
-        await created.value
+        return await created.value
     }
 
-    private func performPrewarm() async {
-        guard isEnabled, !modelAlias.isEmpty else { return }
+    private func performPrewarm() async -> Bool {
+        guard isEnabled, !modelAlias.isEmpty else { return false }
+        if let testingPrewarm { return await testingPrewarm() }
         let alias = modelAlias
         _ = await catalogFacts(for: alias)
         // Actor reentrancy: every await above and below is a window for
         // disable() or a model change to land. Re-check before each step
         // that mutates the sidecar or touches the wire.
-        guard !Task.isCancelled, isEnabled, modelAlias == alias else { return }
+        guard !Task.isCancelled, isEnabled, modelAlias == alias else { return false }
         if server.servingAlias != alias {
-            guard await ensureModelServing() else { return }
-            guard !Task.isCancelled, isEnabled, modelAlias == alias else { return }
+            guard await ensureModelServing() else { return false }
+            guard !Task.isCancelled, isEnabled, modelAlias == alias else { return false }
         }
-        await warmUpEngine()
+        return await warmUpEngine()
     }
 
     /// Forces the sidecar to load the STT weights by transcribing a beat of
     /// silence. Skipped whenever a real dictation is underway — the engine
     /// serialises transcriptions, so a probe would queue in front of it.
-    private func warmUpEngine() async {
-        guard phase == .idle else { return }
-        guard server.servingAlias == modelAlias else { return }
+    private func warmUpEngine() async -> Bool {
+        guard phase == .idle || phase == .preparingModel else { return false }
+        guard server.servingAlias == modelAlias else { return false }
         do {
             _ = try await client.transcribe(
                 audioData: Self.silentProbeWAV,
@@ -471,13 +507,16 @@ final class DictationController {
                 port: server.activePort,
                 bearer: server.activeBearer
             )
+            return true
         } catch is CancellationError {
             // Expected: a hotkey press or disable() superseded the probe.
+            return false
         } catch {
             // Not user-facing — the cost of a failed probe is only that the
             // first real dictation pays the weight load again — but leave a
             // trace so a recurring failure is diagnosable.
             NSLog("Dictation prewarm probe failed for %@: %@", modelAlias, String(describing: error))
+            return false
         }
     }
 
@@ -513,9 +552,9 @@ final class DictationController {
     /// Called by the view when the pull reaches `.completed`.
     func modelDownloadDidFinish() async {
         await refreshModelCacheState()
-        // The flight that matters is the one seeded with post-download
-        // catalog state; a stale no-op flight must not absorb this call.
-        await prewarmModel(replacingCurrent: true)
+        if isEnabled {
+            await enable(replacingCurrentPrewarm: true)
+        }
     }
 
     // MARK: - Hotkey
@@ -539,7 +578,7 @@ final class DictationController {
                 self.beginRecordingRequestID = nil
             }
         case .starting, .recording: finishRecording()
-        case .transcribing, .off: break
+        case .preparingModel, .transcribing, .off: break
         }
     }
 
@@ -552,36 +591,13 @@ final class DictationController {
             return
         }
         let requestedAlias = modelAlias
-        // If enable-time prewarm is still running, or an LLM/VLM displaced the
-        // audio sidecar since then, pay that cold load before opening the mic.
-        // Cancelling a probe after it reached the sidecar cannot remove it from
-        // the engine's serial STT lane; the real transcription would simply
-        // queue behind it while the HUD misleadingly said “Transcribing…”.
-        if Self.shouldPrepareModelForRecording(
-            prewarmInFlight: prewarmTask != nil,
-            servingAlias: server.servingAlias,
-            requestedAlias: requestedAlias
-        ) {
-            hud.show(.loadingModel)
-            await prewarmModel()
-            guard !Task.isCancelled,
-                  beginRecordingRequestID == requestID,
-                  isEnabled,
-                  phase == .idle,
-                  modelAlias == requestedAlias
-            else {
-                hud.hide()
-                return
-            }
-            guard server.servingAlias == requestedAlias else {
-                lastError = "\(requestedAlias) couldn't start. There may not be enough memory to load it."
-                hud.update(.failed(message: "Couldn't start the model"))
-                Task {
-                    try? await Task.sleep(nanoseconds: 1_600_000_000)
-                    if phase == .idle { hud.hide() }
-                }
-                return
-            }
+        guard server.servingAlias == requestedAlias else {
+            hotkey.stop()
+            phase = .preparingModel
+            beginRecordingTask = nil
+            beginRecordingRequestID = nil
+            Task { await enable(replacingCurrentPrewarm: true) }
+            return
         }
         // Model Management changes the cache out of process from this
         // controller. Re-read disk facts on every hotkey press; trusting the
@@ -618,17 +634,6 @@ final class DictationController {
         phase = .starting
         hud.show(.starting)
         startTicking()
-    }
-
-    /// A same-alias sidecar plus a completed enable-time probe is the only hot
-    /// path. Any in-flight probe or process swap must finish before capture so
-    /// its latency cannot be attributed to transcription after the user talks.
-    nonisolated static func shouldPrepareModelForRecording(
-        prewarmInFlight: Bool,
-        servingAlias: String?,
-        requestedAlias: String
-    ) -> Bool {
-        prewarmInFlight || servingAlias != requestedAlias
     }
 
     /// Fresh cache truth used at the recording boundary. Internal so the

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -47,6 +47,9 @@ final class DictationController {
     /// only when model bring-up took noticeable time. Answers "why was that
     /// one slow" without a log dive.
     private(set) var lastLatencyDetail: String?
+    /// Non-fatal preparation diagnostic. The sidecar is usable, but the
+    /// optional lazy-weight probe failed and the first dictation may be cold.
+    private(set) var lastWarmupWarning: String?
     private(set) var elapsed: TimeInterval = 0
     /// Set when the TCC row says Accessibility is granted but this process
     /// still cannot install an event tap — i.e. the grant landed after launch.
@@ -119,6 +122,7 @@ final class DictationController {
     private let audioCatalogLoader: @MainActor (URL) async -> [ModelEntry]?
     private let testingReadiness: Readiness?
     private let testingPrewarm: (@MainActor () async -> Bool)?
+    private let testingWarmup: (@MainActor () async -> Bool)?
     private let testingHotkeyStart: (@MainActor () -> Bool)?
     private let testingRecorderCancel: (@MainActor () -> Void)?
     private let testingTranscribeCancel: (@MainActor () -> Void)?
@@ -164,6 +168,7 @@ final class DictationController {
         testingPhase: Phase? = nil,
         testingReadiness: Readiness? = nil,
         testingPrewarm: (@MainActor () async -> Bool)? = nil,
+        testingWarmup: (@MainActor () async -> Bool)? = nil,
         testingHotkeyStart: (@MainActor () -> Bool)? = nil,
         testingRecorderCancel: (@MainActor () -> Void)? = nil,
         testingTranscribeCancel: (@MainActor () -> Void)? = nil,
@@ -178,6 +183,7 @@ final class DictationController {
         self.audioCatalogLoader = audioCatalogLoader
         self.testingReadiness = testingReadiness
         self.testingPrewarm = testingPrewarm
+        self.testingWarmup = testingWarmup
         self.testingHotkeyStart = testingHotkeyStart
         self.testingRecorderCancel = testingRecorderCancel
         self.testingTranscribeCancel = testingTranscribeCancel
@@ -485,20 +491,21 @@ final class DictationController {
     ///   flight already covers this call.
     @discardableResult
     private func prewarmModel(replacingCurrent: Bool = false) async -> Bool {
-        if replacingCurrent {
-            prewarmTask?.cancel()
-            prewarmTask = nil
-        }
-        // Single-flight. The check-and-assign below is MainActor-synchronous
-        // (no await between them), so concurrent triggers cannot both slip
-        // past: the second joins the task the first created instead of
-        // racing it through the engine's serial STT lane.
-        if let running = prewarmTask {
+        // Same-alias requests share one flight. A replacement creates a new
+        // flight immediately, but chains it behind the cancelled predecessor:
+        // ServerManager's stop/start sequence is not cancellation-aware, so
+        // waiting for it is what prevents model A from resuming after B and
+        // stealing the shared sidecar back.
+        if !replacingCurrent, let running = prewarmTask {
             return await running.value
         }
+        let predecessor = prewarmTask
+        if replacingCurrent { predecessor?.cancel() }
         let requestID = UUID()
         prewarmRequestID = requestID
         let created = Task { [weak self] in
+            if let predecessor { _ = await predecessor.value }
+            guard !Task.isCancelled else { return false }
             let succeeded = await self?.performPrewarm() ?? false
             // Only the flight that still OWNS the slot may clear it. A
             // cancelled predecessor finishing late must not null out the
@@ -526,7 +533,20 @@ final class DictationController {
             guard await ensureModelServing(alias: alias) else { return false }
             guard !Task.isCancelled, isEnabled, modelAlias == alias else { return false }
         }
-        return await warmUpEngine()
+        let warmed = await warmUpEngine()
+        guard !Task.isCancelled,
+              isEnabled,
+              modelAlias == alias,
+              server.servingAlias == alias else { return false }
+        if warmed {
+            lastWarmupWarning = nil
+        } else {
+            // Serving readiness is the hard boundary. The silence probe only
+            // moves lazy weight cost earlier; a transient HTTP failure must
+            // not make an otherwise healthy local model unusable.
+            lastWarmupWarning = "Model is ready, but its warmup probe failed. The first dictation may be slower."
+        }
+        return true
     }
 
     /// Forces the sidecar to load the STT weights by transcribing a beat of
@@ -535,6 +555,7 @@ final class DictationController {
     private func warmUpEngine() async -> Bool {
         guard phase == .idle || phase == .preparingModel else { return false }
         guard server.servingAlias == modelAlias else { return false }
+        if let testingWarmup { return await testingWarmup() }
         do {
             _ = try await client.transcribe(
                 audioData: Self.silentProbeWAV,

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationHUD.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationHUD.swift
@@ -6,9 +6,6 @@ import SwiftUI
 @MainActor
 final class DictationHUD {
     enum Phase: Equatable {
-        /// The model is installed, but its sidecar and lazy weights are still
-        /// coming into memory. No user audio has been submitted in this phase.
-        case loadingModel
         /// Only seen on a cold microphone. With the recorder kept warm between
         /// dictations this phase is usually skipped entirely.
         case starting
@@ -113,10 +110,6 @@ private struct DictationHUDView: View {
     @ViewBuilder
     private var content: some View {
         switch model.phase {
-        case .loadingModel:
-            Text("Loading model…")
-                .font(.system(size: 13, design: .monospaced))
-                .foregroundStyle(Color.white.opacity(0.9))
         case .starting:
             Text("Starting…")
                 .font(.system(size: 13, design: .monospaced))
@@ -143,7 +136,7 @@ private struct DictationHUDView: View {
 
     private var dotColor: Color {
         switch model.phase {
-        case .loadingModel, .starting: return Color(red: 0.88, green: 0.64, blue: 0.24)
+        case .starting: return Color(red: 0.88, green: 0.64, blue: 0.24)
         case .recording: return Color(red: 0.95, green: 0.25, blue: 0.29)
         case .transcribing: return Color(red: 0.35, green: 0.62, blue: 0.86)
         case .failed: return Color(red: 0.86, green: 0.34, blue: 0.30)

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationHUD.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationHUD.swift
@@ -6,6 +6,9 @@ import SwiftUI
 @MainActor
 final class DictationHUD {
     enum Phase: Equatable {
+        /// The model is installed, but its sidecar and lazy weights are still
+        /// coming into memory. No user audio has been submitted in this phase.
+        case loadingModel
         /// Only seen on a cold microphone. With the recorder kept warm between
         /// dictations this phase is usually skipped entirely.
         case starting
@@ -110,6 +113,10 @@ private struct DictationHUDView: View {
     @ViewBuilder
     private var content: some View {
         switch model.phase {
+        case .loadingModel:
+            Text("Loading model…")
+                .font(.system(size: 13, design: .monospaced))
+                .foregroundStyle(Color.white.opacity(0.9))
         case .starting:
             Text("Starting…")
                 .font(.system(size: 13, design: .monospaced))
@@ -136,7 +143,7 @@ private struct DictationHUDView: View {
 
     private var dotColor: Color {
         switch model.phase {
-        case .starting: return Color(red: 0.88, green: 0.64, blue: 0.24)
+        case .loadingModel, .starting: return Color(red: 0.88, green: 0.64, blue: 0.24)
         case .recording: return Color(red: 0.95, green: 0.25, blue: 0.29)
         case .transcribing: return Color(red: 0.35, green: 0.62, blue: 0.86)
         case .failed: return Color(red: 0.86, green: 0.34, blue: 0.30)

--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -280,7 +280,25 @@ struct RapidApp: App {
             fixtureState: updateBusyFixture ? .busy : nil
         )
         let downloadsInstance = DownloadManager(binaryPath: manager.binaryPath)
-        let dictationController = DictationController(server: manager)
+        // TCC cannot be granted hermetically on an unattended runner. This
+        // two-key fixture exercises the real model/server warmup lifecycle
+        // while replacing only the OS permission and event-tap boundaries.
+        let dictationReadinessFixture = ProcessInfo.processInfo.environment["RAPID_GUI_GOLDEN_MODE"] == "1"
+            && ProcessInfo.processInfo.environment["RAPID_GUI_DICTATION_READINESS_FIXTURE"] == "1"
+        let fixtureReadiness: DictationController.Readiness? = dictationReadinessFixture
+            ? .init(microphone: true, accessibility: true, modelSelected: true, modelOnDisk: true)
+            : nil
+        let fixtureHotkeyStart: (@MainActor () -> Bool)?
+        if dictationReadinessFixture {
+            fixtureHotkeyStart = { @MainActor in true }
+        } else {
+            fixtureHotkeyStart = nil
+        }
+        let dictationController = DictationController(
+            server: manager,
+            testingReadiness: fixtureReadiness,
+            testingHotkeyStart: fixtureHotkeyStart
+        )
         // #253: let ``ServerManager.start(alias:)`` await any in-flight
         // background pull for the same alias before spawning serve.
         manager.attachDownloads(downloadsInstance)

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -198,6 +198,7 @@ struct DictationView: View {
                 .menuStyle(.button)
                 .buttonStyle(.plain)
                 .menuIndicator(.hidden)
+                .disabled(controller.phase != .off && controller.phase != .idle)
                 .accessibilityLabel("Model")
                 .accessibilityValue(controller.modelAlias)
                 .accessibilityIdentifier("Dictation.Model")

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -102,6 +102,7 @@ struct DictationView: View {
             VStack(alignment: .leading, spacing: RapidTheme.Space.xxs) {
                 Text(statusHeadline)
                     .font(.subheadline.weight(.medium))
+                    .accessibilityIdentifier("Dictation.Status")
                 Text(statusDetail)
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -160,6 +160,9 @@ struct DictationView: View {
         if let detail = controller.lastLatencyDetail {
             parts.append(detail)
         }
+        if let warning = controller.lastWarmupWarning {
+            parts.append(warning)
+        }
         return parts.filter { !$0.isEmpty }.joined(separator: " · ")
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -49,9 +49,6 @@ struct DictationView: View {
             if controller.vocabulary.suggestions.isEmpty {
                 await controller.vocabulary.scanForSuggestions()
             }
-            // Swap the model in while the user is still reading this page,
-            // rather than on the first hotkey press when they are mid-sentence.
-            await controller.prewarmModel()
         }
         // Runs when the selected alias's pull changes state; on completion,
         // re-read the catalog so the row flips to "Ready on disk" and the
@@ -130,13 +127,13 @@ struct DictationView: View {
 
     private var statusColor: Color {
         guard controller.isEnabled else { return .secondary }
-        if controller.isPreparingModel { return .orange }
+        if controller.phase == .preparingModel { return .orange }
         return controller.phase == .off ? .orange : RapidTheme.green
     }
 
     private var statusHeadline: String {
         guard controller.isEnabled else { return "Dictation is off" }
-        if controller.isPreparingModel {
+        if controller.phase == .preparingModel {
             return "Loading \(controller.modelAlias) into memory…"
         }
         return controller.phase == .off
@@ -150,7 +147,7 @@ struct DictationView: View {
                 ? "Turn it on to dictate into any app."
                 : blockingReason
         }
-        if controller.isPreparingModel {
+        if controller.phase == .preparingModel {
             return "The local model is warming up. Recording starts when it’s ready."
         }
         var parts = [controller.modelAlias]

--- a/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DictationView.swift
@@ -130,11 +130,15 @@ struct DictationView: View {
 
     private var statusColor: Color {
         guard controller.isEnabled else { return .secondary }
+        if controller.isPreparingModel { return .orange }
         return controller.phase == .off ? .orange : RapidTheme.green
     }
 
     private var statusHeadline: String {
         guard controller.isEnabled else { return "Dictation is off" }
+        if controller.isPreparingModel {
+            return "Loading \(controller.modelAlias) into memory…"
+        }
         return controller.phase == .off
             ? "Not listening — the hotkey isn't armed"
             : "Ready — press \(controller.trigger.label) in any app"
@@ -145,6 +149,9 @@ struct DictationView: View {
             return controller.readinessSnapshot.isReady
                 ? "Turn it on to dictate into any app."
                 : blockingReason
+        }
+        if controller.isPreparingModel {
+            return "The local model is warming up. Recording starts when it’s ready."
         }
         var parts = [controller.modelAlias]
         if let latency = controller.lastLatency {

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -391,6 +391,83 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("failed model warmup leaves dictation visibly unarmed")
+    func failedWarmupDoesNotArmHotkey() async {
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            prewarm: { false },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        await controller.enable()
+
+        #expect(controller.phase == .off)
+        #expect(hotkeyStartCount == 0)
+        #expect(controller.lastError?.contains("couldn't load") == true)
+    }
+
+    @MainActor
+    @Test("disabling during model warmup cannot register a stale hotkey")
+    func disableDuringWarmupDoesNotArmHotkey() async {
+        var continuation: CheckedContinuation<Bool, Never>?
+        var hotkeyStartCount = 0
+        let controller = readinessController(
+            prewarm: {
+                await withCheckedContinuation { continuation = $0 }
+            },
+            hotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            }
+        )
+
+        let enabling = Task { await controller.enable() }
+        while continuation == nil { await Task.yield() }
+        controller.isEnabled = false
+        continuation?.resume(returning: true)
+        await enabling.value
+
+        #expect(controller.phase == .off)
+        #expect(hotkeyStartCount == 0)
+    }
+
+    @MainActor
+    private func readinessController(
+        prewarm: @escaping @MainActor () async -> Bool,
+        hotkeyStart: @escaping @MainActor () -> Bool
+    ) -> DictationController {
+        let entry = ModelEntry(
+            alias: "whisper-small",
+            hfRepo: "mlx-community/whisper-small",
+            sizeOnDisk: "461 MiB",
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription,
+            audioFamily: "whisper"
+        )
+        return DictationController(
+            server: ServerManager(
+                testingState: .ready(alias: "whisper-small"),
+                binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx")
+            ),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingReadiness: .init(
+                microphone: true,
+                accessibility: true,
+                modelSelected: true,
+                modelOnDisk: true
+            ),
+            testingPrewarm: prewarm,
+            testingHotkeyStart: hotkeyStart,
+            audioCatalogLoader: { _ in [entry] }
+        )
+    }
+
+    @MainActor
     @Test("a failed catalog probe preserves the last successful cache snapshot")
     func failedCatalogProbePreservesCacheSnapshot() async {
         let state = CatalogState()

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -415,6 +415,7 @@ struct DictationTests {
         var continuation: CheckedContinuation<Bool, Never>?
         var hotkeyStartCount = 0
         let controller = readinessController(
+            phase: .idle,
             prewarm: {
                 await withCheckedContinuation { continuation = $0 }
             },
@@ -435,7 +436,46 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("changing models cancels an active capture before preparation")
+    func modelChangeCancelsActiveCapture() {
+        var cancellationCount = 0
+        let controller = DictationController(
+            server: ServerManager(testingState: .ready(alias: "whisper-small")),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingPhase: .recording,
+            testingRecorderCancel: { cancellationCount += 1 },
+            audioCatalogLoader: { _ in [] }
+        )
+
+        controller.modelAlias = "qwen3-asr"
+
+        #expect(cancellationCount == 1)
+        #expect(controller.phase == .preparingModel)
+    }
+
+    @MainActor
+    @Test("replaying a retained completed download keeps a ready hotkey armed")
+    func completedDownloadReplayIsIdempotent() async {
+        var prewarmCount = 0
+        let controller = readinessController(
+            phase: .idle,
+            prewarm: {
+                prewarmCount += 1
+                return true
+            },
+            hotkeyStart: { true }
+        )
+
+        await controller.modelDownloadDidFinish()
+
+        #expect(controller.phase == .idle)
+        #expect(prewarmCount == 0)
+    }
+
+    @MainActor
     private func readinessController(
+        phase: DictationController.Phase = .off,
         prewarm: @escaping @MainActor () async -> Bool,
         hotkeyStart: @escaping @MainActor () -> Bool
     ) -> DictationController {
@@ -455,6 +495,7 @@ struct DictationTests {
             ),
             testingEnabled: true,
             testingModelAlias: "whisper-small",
+            testingPhase: phase,
             testingReadiness: .init(
                 microphone: true,
                 accessibility: true,

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -493,6 +493,83 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("a failed optional weight probe still arms a serving model")
+    func failedWeightProbeStillArmsServingModel() async {
+        var hotkeyStartCount = 0
+        let entry = cachedAudioEntry(alias: "whisper-small")
+        let controller = DictationController(
+            server: ServerManager(
+                testingState: .ready(alias: "whisper-small"),
+                binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx")
+            ),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingReadiness: .init(
+                microphone: true,
+                accessibility: true,
+                modelSelected: true,
+                modelOnDisk: true
+            ),
+            testingWarmup: { false },
+            testingHotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            },
+            audioCatalogLoader: { _ in [entry] }
+        )
+
+        await controller.enable()
+
+        #expect(controller.phase == .idle)
+        #expect(hotkeyStartCount == 1)
+        #expect(controller.lastWarmupWarning?.contains("first dictation may be slower") == true)
+    }
+
+    @MainActor
+    @Test("replacement preparation waits for the old server mutation")
+    func replacementPrewarmIsSerialized() async {
+        var starts = 0
+        var firstContinuation: CheckedContinuation<Bool, Never>?
+        var secondContinuation: CheckedContinuation<Bool, Never>?
+        let entries = [cachedAudioEntry(alias: "whisper-small"), cachedAudioEntry(alias: "qwen3-asr")]
+        let controller = DictationController(
+            server: ServerManager(
+                testingState: .ready(alias: "whisper-small"),
+                binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx")
+            ),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingReadiness: .init(
+                microphone: true,
+                accessibility: true,
+                modelSelected: true,
+                modelOnDisk: true
+            ),
+            testingPrewarm: {
+                starts += 1
+                if starts == 1 {
+                    return await withCheckedContinuation { firstContinuation = $0 }
+                }
+                return await withCheckedContinuation { secondContinuation = $0 }
+            },
+            testingHotkeyStart: { true },
+            audioCatalogLoader: { _ in entries }
+        )
+
+        let firstEnable = Task { await controller.enable() }
+        while firstContinuation == nil { await Task.yield() }
+        controller.modelAlias = "qwen3-asr"
+        for _ in 0..<20 { await Task.yield() }
+        #expect(starts == 1)
+
+        firstContinuation?.resume(returning: false)
+        while secondContinuation == nil { await Task.yield() }
+        #expect(starts == 2)
+        secondContinuation?.resume(returning: true)
+        await firstEnable.value
+    }
+
+    @MainActor
     private func readinessController(
         phase: DictationController.Phase = .off,
         prewarm: @escaping @MainActor () async -> Bool,
@@ -524,6 +601,18 @@ struct DictationTests {
             testingPrewarm: prewarm,
             testingHotkeyStart: hotkeyStart,
             audioCatalogLoader: { _ in [entry] }
+        )
+    }
+
+    private func cachedAudioEntry(alias: String) -> ModelEntry {
+        ModelEntry(
+            alias: alias,
+            hfRepo: "mlx-community/\(alias)",
+            sizeOnDisk: "461 MiB",
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription,
+            audioFamily: "whisper"
         )
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -455,6 +455,25 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("changing models invalidates an active transcription before preparation")
+    func modelChangeCancelsActiveTranscription() {
+        var cancellationCount = 0
+        let controller = DictationController(
+            server: ServerManager(testingState: .ready(alias: "whisper-small")),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingPhase: .transcribing,
+            testingTranscribeCancel: { cancellationCount += 1 },
+            audioCatalogLoader: { _ in [] }
+        )
+
+        controller.modelAlias = "qwen3-asr"
+
+        #expect(cancellationCount == 1)
+        #expect(controller.phase == .preparingModel)
+    }
+
+    @MainActor
     @Test("replaying a retained completed download keeps a ready hotkey armed")
     func completedDownloadReplayIsIdempotent() async {
         var prewarmCount = 0

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -320,7 +320,7 @@ struct DictationTests {
         var continuation: CheckedContinuation<[ModelEntry]?, Never>?
         let controller = DictationController(
             server: ServerManager(
-                testingState: .idle,
+                testingState: .ready(alias: "whisper-small"),
                 binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx")
             ),
             testingEnabled: true,
@@ -338,6 +338,56 @@ struct DictationTests {
         await Task.yield()
 
         #expect(controller.phase == .idle)
+    }
+
+    @MainActor
+    @Test("the hotkey is registered only after model warmup finishes")
+    func hotkeyWaitsForModelWarmup() async {
+        var warmupContinuation: CheckedContinuation<Bool, Never>?
+        var hotkeyStartCount = 0
+        let entry = ModelEntry(
+            alias: "whisper-small",
+            hfRepo: "mlx-community/whisper-small",
+            sizeOnDisk: "461 MiB",
+            cached: true,
+            kind: .audio,
+            audioCapability: .transcription,
+            audioFamily: "whisper"
+        )
+        let controller = DictationController(
+            server: ServerManager(
+                testingState: .ready(alias: "whisper-small"),
+                binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx")
+            ),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingReadiness: .init(
+                microphone: true,
+                accessibility: true,
+                modelSelected: true,
+                modelOnDisk: true
+            ),
+            testingPrewarm: {
+                await withCheckedContinuation { warmupContinuation = $0 }
+            },
+            testingHotkeyStart: {
+                hotkeyStartCount += 1
+                return true
+            },
+            audioCatalogLoader: { _ in [entry] }
+        )
+
+        let enabling = Task { await controller.enable() }
+        while warmupContinuation == nil { await Task.yield() }
+
+        #expect(controller.phase == .preparingModel)
+        #expect(hotkeyStartCount == 0)
+
+        warmupContinuation?.resume(returning: true)
+        await enabling.value
+
+        #expect(controller.phase == .idle)
+        #expect(hotkeyStartCount == 1)
     }
 
     @MainActor
@@ -366,24 +416,6 @@ struct DictationTests {
         #expect(await controller.modelIsOnDiskAfterRefresh("whisper-small"))
     }
 
-    @Test("recording waits for an active prewarm or a displaced audio sidecar")
-    func recordingPreparationBoundary() {
-        #expect(DictationController.shouldPrepareModelForRecording(
-            prewarmInFlight: true,
-            servingAlias: "qwen3-asr",
-            requestedAlias: "qwen3-asr"
-        ))
-        #expect(DictationController.shouldPrepareModelForRecording(
-            prewarmInFlight: false,
-            servingAlias: "qwen3-4b",
-            requestedAlias: "qwen3-asr"
-        ))
-        #expect(!DictationController.shouldPrepareModelForRecording(
-            prewarmInFlight: false,
-            servingAlias: "qwen3-asr",
-            requestedAlias: "qwen3-asr"
-        ))
-    }
 
     /// Only right-hand modifiers are offered. Left ⌘ rides along with ⌘C/⌘V/
     /// ⌘Tab dozens of times an hour, so "tapped on its own" cannot be detected

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -366,6 +366,25 @@ struct DictationTests {
         #expect(await controller.modelIsOnDiskAfterRefresh("whisper-small"))
     }
 
+    @Test("recording waits for an active prewarm or a displaced audio sidecar")
+    func recordingPreparationBoundary() {
+        #expect(DictationController.shouldPrepareModelForRecording(
+            prewarmInFlight: true,
+            servingAlias: "qwen3-asr",
+            requestedAlias: "qwen3-asr"
+        ))
+        #expect(DictationController.shouldPrepareModelForRecording(
+            prewarmInFlight: false,
+            servingAlias: "qwen3-4b",
+            requestedAlias: "qwen3-asr"
+        ))
+        #expect(!DictationController.shouldPrepareModelForRecording(
+            prewarmInFlight: false,
+            servingAlias: "qwen3-asr",
+            requestedAlias: "qwen3-asr"
+        ))
+    }
+
     /// Only right-hand modifiers are offered. Left ⌘ rides along with ⌘C/⌘V/
     /// ⌘Tab dozens of times an hour, so "tapped on its own" cannot be detected
     /// reliably enough to arm a microphone with.

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -784,6 +784,9 @@ class Handler(BaseHTTPRequestHandler):
             if length:
                 self.rfile.read(length)
             _event("audio_transcription")
+            delay_ms = int(_setting("FAKE_AUDIO_TRANSCRIPTION_DELAY_MS", "0") or "0")
+            if delay_ms > 0:
+                time.sleep(delay_ms / 1000)
             self._json(200, {
                 "text": "Golden transcription result.",
                 "language": "en",
@@ -1007,6 +1010,8 @@ def _emit_catalog(subcommand, alias):
             # requires a resumptive `pull fake-qwen3-tts`.
             print("(incomplete)           fake/qwen3-tts        633 MB")
         if "fake-whisper-small" in pulled_audio:
+            print("fake-whisper-small     fake/whisper-small    461 MiB")
+        elif _setting("FAKE_CACHED_DICTATION") == "1":
             print("fake-whisper-small     fake/whisper-small    461 MiB")
         return True
     if subcommand == "info":

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4508,8 +4508,8 @@ flow_dictation() {
         see_main "$OUT/dictation-loading.json"
         if jq -e '.data.ui_elements[]?
                   | select(.identifier == "Dictation.Status"
-                           and ((.description // .value // .label // "") | tostring)
-                               | contains("Loading fake-whisper-small into memory"))' \
+                           and (((.description // .value // .label // "") | tostring)
+                                | contains("Loading fake-whisper-small into memory")))' \
                  "$OUT/dictation-loading.json" >/dev/null; then
             loading_seen=1; break
         fi
@@ -4527,8 +4527,8 @@ flow_dictation() {
         see_main "$OUT/dictation-ready.json"
         if jq -e '.data.ui_elements[]?
                   | select(.identifier == "Dictation.Status"
-                           and ((.description // .value // .label // "") | tostring)
-                               | startswith("Ready — press"))' \
+                           and (((.description // .value // .label // "") | tostring)
+                                | startswith("Ready — press")))' \
                  "$OUT/dictation-ready.json" >/dev/null; then
             ready_seen=1; break
         fi

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -4413,14 +4413,20 @@ flow_audio_readiness() {
 # Dictation is its own product journey, not merely the landing state of Audio.
 # Keep this separate from audio-readiness so a regression in its controls is
 # named directly in CI. Microphone and Accessibility grants are intentionally
-# not faked: their TCC state belongs to the host. The stable contract is that
-# every setup control is reachable, raw recordings remain opt-in, local
-# vocabulary edits work, mode round-trips preserve the pane, and opening it
-# alone never downloads or starts a model.
+# not globally faked: their TCC state belongs to the host. This journey opts
+# into a two-key, process-local readiness fixture only around the OS permission
+# and event-tap boundaries, allowing the real server/warmup state machine to be
+# exercised deterministically. The stable contract is that every setup control
+# is reachable, raw recordings remain opt-in, local vocabulary edits work,
+# mode round-trips preserve the pane, opening it alone never starts a model,
+# and enabling visibly transitions from Loading to Ready.
 flow_dictation() {
     log "flow: dictation"
     start_persona dictation \
-        RAPID_GUI_GOLDEN_MODE=1
+        RAPID_GUI_GOLDEN_MODE=1 \
+        RAPID_GUI_DICTATION_READINESS_FIXTURE=1 \
+        FAKE_CACHED_DICTATION=1 \
+        FAKE_AUDIO_TRANSCRIPTION_DELAY_MS=1800
     dismiss_first_run
     see_main "$OUT/chat.json"
     press "$OUT/chat.json" Sidebar.Audio "$OUT/dictation-open.json" \
@@ -4491,7 +4497,47 @@ flow_dictation() {
         die "Opening and configuring Dictation started a model before dictation"
     fi
 
-    log "  setup controls, privacy toggle, vocabulary, and mode round-trip produced effects"
+    # Enabling is a readiness operation, not merely a preference flip. Hold
+    # the fake STT probe open long enough to observe the contract in AX: the
+    # pane says Loading while the model's lazy weights are cold, and only
+    # changes to Ready after the probe returns and the hotkey can be armed.
+    press "$OUT/dictation-restored.json" Dictation.Enable "$OUT/dictation-enable.json" \
+        || die "Dictation Enable is not pressable with complete readiness"
+    local loading_seen=0
+    for ((i=0; i<80; i++)); do
+        see_main "$OUT/dictation-loading.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "Dictation.Status"
+                           and ((.description // .value // .label // "") | tostring)
+                               | contains("Loading fake-whisper-small into memory"))' \
+                 "$OUT/dictation-loading.json" >/dev/null; then
+            loading_seen=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$loading_seen" == 1 ]] \
+        || die "Dictation never exposed model loading before readiness"
+    [[ "$(element_field "$OUT/dictation-loading.json" Dictation.Enable value)" == "1" ]] \
+        || die "Dictation lost the user's Enabled intent while loading"
+
+    wait_fake_event '.event == "audio_transcription"' \
+        "Dictation never sent the lazy-weight warmup probe"
+    local ready_seen=0
+    for ((i=0; i<120; i++)); do
+        see_main "$OUT/dictation-ready.json"
+        if jq -e '.data.ui_elements[]?
+                  | select(.identifier == "Dictation.Status"
+                           and ((.description // .value // .label // "") | tostring)
+                               | startswith("Ready — press"))' \
+                 "$OUT/dictation-ready.json" >/dev/null; then
+            ready_seen=1; break
+        fi
+        sleep 0.1
+    done
+    [[ "$ready_seen" == 1 ]] \
+        || die "Dictation did not become Ready after model warmup"
+
+    log "  setup controls, privacy toggle, vocabulary, mode round-trip, and Loading -> Ready produced effects"
     log "  dictation OK"
     cleanup_persona
 }

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -50,6 +50,7 @@ def test_dictation_journey_proves_loading_before_ready():
     assert "Dictation never exposed model loading before readiness" in flow
     assert "Dictation did not become Ready after model warmup" in flow
     assert '.event == "audio_transcription"' in flow
+    assert 'and (((.description // .value // .label // "") | tostring)' in flow
 
 
 def test_image_generation_journey_asserts_the_product_default_request_size():

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -27,9 +27,7 @@ def test_audio_readiness_actions_start_the_selected_model_and_clear_the_gate():
     assert "Speech loaded automatically after a download-only action" in flow
     assert "Opening Audio started a model before any user action" in flow
     assert "Opening Dictation loaded its model before the user dictated" in flow
-    assert "Transcription loaded automatically after Download" in flow
-    assert "Audio.Transcription.Run" in flow
-    assert "Audio.Transcription.Result" in flow
+    assert "Dictation loaded the model after Download while dictation was off" in flow
 
 
 def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():
@@ -41,6 +39,17 @@ def test_audio_control_journey_is_blocking_gui_ci_and_has_failure_evidence():
         1
     ]
     assert "image-generation audio-readiness" in diagnostic
+
+
+def test_dictation_journey_proves_loading_before_ready():
+    source = HARNESS.read_text()
+    flow = source.split("flow_dictation() {", 1)[1].split("\n}", 1)[0]
+
+    assert "RAPID_GUI_DICTATION_READINESS_FIXTURE=1" in flow
+    assert "FAKE_AUDIO_TRANSCRIPTION_DELAY_MS=1800" in flow
+    assert "Dictation never exposed model loading before readiness" in flow
+    assert "Dictation did not become Ready after model warmup" in flow
+    assert '.event == "audio_transcription"' in flow
 
 
 def test_image_generation_journey_asserts_the_product_default_request_size():


### PR DESCRIPTION
## Summary
- keep the global dictation hotkey unregistered while the selected ASR model is loading
- make readiness explicit in the Audio UI: `Loading <model> into memory…` until both the audio sidecar and lazy STT weights are hot
- register the hotkey only after warmup succeeds; model changes, foreground revalidation, disable, and stale async completions cannot bypass that boundary
- if another workload later displaces the audio sidecar, disarm and return to the same loading → ready lifecycle
- add a hermetic Dictation golden journey that observes `Loading → Ready` across a deliberately delayed STT warmup

## User impact
The first hotkey press no longer appears to start recording and then hang in transcription while Rapid secretly loads a model. The UI tells the user that preparation is in progress, and the shortcut becomes active only when dictation is genuinely ready.

## Validation
- `swift test --package-path apps/rapid-mac --filter "DictationTests|AudioCatalogTests|AudioClientTests"` (46 passed)
- readiness regressions: warmup success arms exactly once; warmup failure and disable-during-warmup never arm
- `python3 -m pytest tests/test_gui_control_behavior_contract.py tests/test_gui_preflight_contract.py tests/test_rapid_mac_ax_identifiers.py -q` (86 passed)
- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `bash -n apps/rapid-mac/scripts/fake-rapid-mlx.sh`
- `git diff --check`
- local `--flow dictation` attempted; runner stopped at preflight because macOS screen was locked, before app launch. CI reruns the same blocking flow on its GUI runner.