### PR TITLE
fix(mac): collapse cached model variants in onboarding [skip-version-bump]

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -339,6 +339,12 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/cached-curated-tradeup
 
+      - name: 'Golden flow: cached-variant-collapse'
+        continue-on-error: true
+        run: ./scripts/gui-golden-flows.sh --flow cached-variant-collapse
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/cached-variant-collapse
+
       - name: 'Golden flow: download-progress'
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow download-progress
@@ -497,7 +503,7 @@ jobs:
           from pathlib import Path
 
           root = Path(os.environ["GOLDEN_ROOT"])
-          expected = 27
+          expected = 28
           results = sorted(root.glob("*/result.json"))
           failures = []
           for path in results:

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -1434,6 +1434,12 @@ struct QuickstartView: View {
     /// the transfer is the job's own status.
     @State private var cancelRequestedAlias: String?
 
+    /// First-run setup should present a decision, not mirror every cached
+    /// quantization of that decision.  Sibling variants stay reachable behind
+    /// one explicit disclosure; Settings → Models and Browse all remain the
+    /// complete inventory surfaces.
+    @State private var showsOtherCachedVariants = false
+
     /// Callback the parent supplies for "Skip for now". The parent
     /// dismisses the Quickstart surface for the current session (without
     /// flipping the persisted flag) so the existing picker becomes visible.
@@ -2231,6 +2237,44 @@ struct QuickstartView: View {
                             ) { coordinator.select(choice) }
                             .accessibilityIdentifier("Quickstart.CachedModel.\(entry.alias)")
                         }
+                        if !list.cachedAlternates.isEmpty {
+                            Button {
+                                showsOtherCachedVariants.toggle()
+                            } label: {
+                                HStack(spacing: 7) {
+                                    Image(systemName: showsOtherCachedVariants
+                                        ? "minus" : "plus")
+                                        .font(.system(size: 10, weight: .semibold))
+                                    Text("Other variants (\(list.cachedAlternates.count))")
+                                        .scaledSystemFont(12, weight: .medium)
+                                }
+                                .foregroundStyle(RapidTheme.textSecondary)
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("Quickstart.CachedVariants.Toggle")
+                            .accessibilityLabel(
+                                showsOtherCachedVariants
+                                    ? "Hide other downloaded model variants"
+                                    : "Show \(list.cachedAlternates.count) other downloaded model variants"
+                            )
+
+                            if showsOtherCachedVariants {
+                                ForEach(list.cachedAlternates) { entry in
+                                    let choice = Self.choice(forCachedModel: entry)
+                                    QuickstartCompactCard(
+                                        choice: choice,
+                                        selected: coordinator.selection.alias == entry.alias,
+                                        sizeText: entry.sizeOnDisk ?? "",
+                                        isCached: true,
+                                        onActivate: { activatePrimary(in: .shortlist) }
+                                    ) { coordinator.select(choice) }
+                                    .accessibilityIdentifier(
+                                        "Quickstart.CachedVariant.\(entry.alias)"
+                                    )
+                                }
+                            }
+                        }
                     }
 
                     ForEach(list.starters) { choice in
@@ -2278,7 +2322,9 @@ struct QuickstartView: View {
                     // user rather than vanishing — otherwise Back lands them on
                     // a list that visibly disagrees with the footer, which
                     // reads as "my choice was ignored".
-                    if let pick = list.yourPick {
+                    if let pick = list.yourPick,
+                       !(showsOtherCachedVariants
+                         && list.cachedAlternates.contains(where: { $0.alias == pick.alias })) {
                         OnboardingGroupLabel(text: "YOUR PICK")
                             .padding(.top, 14)
                         let choice = Self.choice(forCatalogEntry: pick)
@@ -3014,6 +3060,7 @@ struct QuickstartView: View {
     /// The recommended shortlist exactly as it renders, in render order.
     struct Shortlist: Equatable {
         var cached: [ModelEntry] = []
+        var cachedAlternates: [ModelEntry] = []
         var starters: [QuickstartModelChoice] = []
         var lowMemory: [QuickstartModelChoice] = []
         var tradeUps: [QuickstartModelChoice] = []
@@ -3022,12 +3069,22 @@ struct QuickstartView: View {
 
         /// Every alias the user can currently see and click, in render order.
         /// This is the "visible" half of `selection ∩ visible rows`.
-        var visibleAliases: [String] {
-            cached.map(\.alias)
+        func visibleAliases(includeCachedAlternates: Bool) -> [String] {
+            let aliases = cached.map(\.alias)
+                + (includeCachedAlternates ? cachedAlternates.map(\.alias) : [])
                 + starters.map(\.alias)
                 + lowMemory.map(\.alias)
                 + tradeUps.map(\.alias)
                 + (yourPick.map { [$0.alias] } ?? [])
+            return aliases.reduce(into: []) { result, alias in
+                guard !result.contains(alias) else { return }
+                result.append(alias)
+            }
+        }
+
+        /// Collapsed-by-default render used by pure callers and tests.
+        var visibleAliases: [String] {
+            visibleAliases(includeCachedAlternates: false)
         }
     }
 
@@ -3035,12 +3092,14 @@ struct QuickstartView: View {
     /// visible-alias set can be pinned without a SwiftUI host.
     static func shortlist(catalog: [ModelEntry], selection: String) -> Shortlist {
         let choices = QuickstartCoordinator.onboardingChoices
-        let existing = Array(quickstartCachedModels(catalog).prefix(6))
+        let cachedPresentation = quickstartCachedPresentation(catalog, limit: 6)
+        let existing = cachedPresentation.primary
         let existingAliases = Set(existing.map(\.alias))
         var native = existingAliases
         native.formUnion(choices.map(\.alias))
         return Shortlist(
             cached: existing,
+            cachedAlternates: cachedPresentation.alternates,
             starters: choices.filter { $0.isStarter && !existingAliases.contains($0.alias) },
             lowMemory: choices.filter { $0.isLowMemory && !existingAliases.contains($0.alias) },
             tradeUps: choices.filter { $0.tier == .tradeUp && !existingAliases.contains($0.alias) },
@@ -3109,7 +3168,9 @@ struct QuickstartView: View {
         switch context {
         case .shortlist:
             let cachedAliases = Set(Self.quickstartCachedModels(cachedModels).map(\.alias))
-            return shortlist.visibleAliases.map { alias in
+            return shortlist.visibleAliases(
+                includeCachedAlternates: showsOtherCachedVariants
+            ).map { alias in
                 OnboardingModelSelection.Row(
                     alias: alias,
                     isCached: cachedAliases.contains(alias),
@@ -3201,6 +3262,64 @@ struct QuickstartView: View {
     /// correctness must not depend on the UI's six-row presentation bound.
     static func quickstartCachedModels(_ entries: [ModelEntry]) -> [ModelEntry] {
         entries.filter { $0.cached && $0.kind == .chat }
+    }
+
+    /// The quieter cached slice used only by the first-run shortlist.
+    ///
+    /// Models are siblings only when both their known family and parameter
+    /// count match.  That collapses `qwen3-0.6b-{4bit,8bit}` without ever
+    /// collapsing Qwen 3 0.6B and Qwen 3 4B into one decision. Unknown
+    /// families or sizes deliberately stand alone: hiding an unrelated model
+    /// is worse than leaving one extra row visible.
+    struct CachedPresentation: Equatable {
+        var primary: [ModelEntry]
+        var alternates: [ModelEntry]
+    }
+
+    static func quickstartCachedPresentation(
+        _ entries: [ModelEntry],
+        limit: Int
+    ) -> CachedPresentation {
+        let cached = quickstartCachedModels(entries)
+        var orderedKeys: [String] = []
+        var groups: [String: [ModelEntry]] = [:]
+
+        for entry in cached {
+            let key = cachedVariantGroupKey(for: entry)
+            if groups[key] == nil { orderedKeys.append(key) }
+            groups[key, default: []].append(entry)
+        }
+
+        var primary: [ModelEntry] = []
+        var alternates: [ModelEntry] = []
+        for key in orderedKeys.prefix(max(0, limit)) {
+            let siblings = (groups[key] ?? []).sorted(by: cachedVariantPreferred)
+            if let first = siblings.first { primary.append(first) }
+            alternates.append(contentsOf: siblings.dropFirst())
+        }
+        return CachedPresentation(primary: primary, alternates: alternates)
+    }
+
+    private static func cachedVariantGroupKey(for entry: ModelEntry) -> String {
+        let family = ModelInfoCatalog.familyAndContext(for: entry.alias).family
+        guard family != "Unknown",
+              let params = ModelSizing.estimate(alias: entry.alias).paramsBillions
+        else { return "alias:\(entry.alias.lowercased())" }
+        return "family:\(family.lowercased())|params:\(params)"
+    }
+
+    private static func cachedVariantPreferred(_ lhs: ModelEntry, _ rhs: ModelEntry) -> Bool {
+        let lhsBits = ModelSizing.parseBitsPerWeight(lhs.alias)
+        let rhsBits = ModelSizing.parseBitsPerWeight(rhs.alias)
+        let lhsFourBit = lhsBits == 4
+        let rhsFourBit = rhsBits == 4
+        if lhsFourBit != rhsFourBit { return lhsFourBit }
+        if lhs.isExternal != rhs.isExternal { return !lhs.isExternal }
+
+        let lhsGB = ModelSizing.estimate(alias: lhs.alias).weightsGB
+        let rhsGB = ModelSizing.estimate(alias: rhs.alias).weightsGB
+        if lhsGB != rhsGB { return lhsGB < rhsGB }
+        return lhs.alias.localizedStandardCompare(rhs.alias) == .orderedAscending
     }
 
     static func choice(forCachedModel entry: ModelEntry) -> QuickstartModelChoice {

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -3266,11 +3266,12 @@ struct QuickstartView: View {
 
     /// The quieter cached slice used only by the first-run shortlist.
     ///
-    /// Models are siblings only when both their known family and parameter
-    /// count match.  That collapses `qwen3-0.6b-{4bit,8bit}` without ever
-    /// collapsing Qwen 3 0.6B and Qwen 3 4B into one decision. Unknown
-    /// families or sizes deliberately stand alone: hiding an unrelated model
-    /// is worse than leaving one extra row visible.
+    /// Models are siblings only when their alias lineage matches after removing
+    /// a terminal quantization suffix. The known family and parameter count are
+    /// additional guards. This collapses `qwen3-0.6b-{4bit,8bit}` without
+    /// merging same-sized Instruct and Thinking models. Unknown families or
+    /// sizes deliberately stand alone: hiding an unrelated model is worse than
+    /// leaving one extra row visible.
     struct CachedPresentation: Equatable {
         var primary: [ModelEntry]
         var alternates: [ModelEntry]
@@ -3305,7 +3306,12 @@ struct QuickstartView: View {
         guard family != "Unknown",
               let params = ModelSizing.estimate(alias: entry.alias).paramsBillions
         else { return "alias:\(entry.alias.lowercased())" }
-        return "family:\(family.lowercased())|params:\(params)"
+        let lineage = entry.alias.lowercased().replacingOccurrences(
+            of: #"[-_](?:2|3|4|5|6|8)bit$"#,
+            with: "",
+            options: .regularExpression
+        )
+        return "family:\(family.lowercased())|params:\(params)|lineage:\(lineage)"
     }
 
     private static func cachedVariantPreferred(_ lhs: ModelEntry, _ rhs: ModelEntry) -> Bool {

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
@@ -60,6 +60,17 @@ struct QuickstartCachedModelTests {
         #expect(presentation.alternates.isEmpty)
     }
 
+    @Test("same-family same-size semantic variants remain separate decisions")
+    func semanticVariantsDoNotCollapse() {
+        let rows = [
+            entry("qwen3-4b-instruct-2507-4bit"),
+            entry("qwen3-4b-thinking-2507-8bit"),
+        ]
+        let presentation = QuickstartView.quickstartCachedPresentation(rows, limit: 6)
+        #expect(presentation.primary.map(\.alias) == rows.map(\.alias))
+        #expect(presentation.alternates.isEmpty)
+    }
+
     @Test("presentation cap counts decisions, not hidden quant siblings")
     func capCountsDistinctModelDecisions() {
         let rows = [

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
@@ -35,6 +35,43 @@ struct QuickstartCachedModelTests {
         ))
     }
 
+    @Test("first-run cached list collapses quant siblings but not model sizes")
+    func collapsesOnlyTrueVariantSiblings() {
+        let rows = [
+            entry("qwen3-0.6b-8bit"),
+            entry("qwen3-0.6b-4bit"),
+            entry("qwen3-4b-4bit"),
+            entry("llama3-3b-8bit"),
+        ]
+
+        let presentation = QuickstartView.quickstartCachedPresentation(rows, limit: 6)
+
+        #expect(presentation.primary.map(\.alias) == [
+            "qwen3-0.6b-4bit", "qwen3-4b-4bit", "llama3-3b-8bit",
+        ])
+        #expect(presentation.alternates.map(\.alias) == ["qwen3-0.6b-8bit"])
+    }
+
+    @Test("unknown cached families remain independently visible")
+    func unknownFamiliesDoNotCollapse() {
+        let rows = [entry("custom-a-7b-4bit"), entry("custom-b-7b-8bit")]
+        let presentation = QuickstartView.quickstartCachedPresentation(rows, limit: 6)
+        #expect(presentation.primary.map(\.alias) == rows.map(\.alias))
+        #expect(presentation.alternates.isEmpty)
+    }
+
+    @Test("presentation cap counts decisions, not hidden quant siblings")
+    func capCountsDistinctModelDecisions() {
+        let rows = [
+            entry("qwen3-0.6b-8bit"),
+            entry("qwen3-0.6b-4bit"),
+            entry("qwen3-4b-4bit"),
+        ]
+        let presentation = QuickstartView.quickstartCachedPresentation(rows, limit: 2)
+        #expect(presentation.primary.map(\.alias) == ["qwen3-0.6b-4bit", "qwen3-4b-4bit"])
+        #expect(presentation.alternates.map(\.alias) == ["qwen3-0.6b-8bit"])
+    }
+
     @Test("a selected cached alias takes the start-only path")
     func cachedAliasNeedsNoDownload() {
         let cached = entry("qwen3.5-4b-4bit")

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartCachedModelTests.swift
@@ -54,7 +54,7 @@ struct QuickstartCachedModelTests {
 
     @Test("unknown cached families remain independently visible")
     func unknownFamiliesDoNotCollapse() {
-        let rows = [entry("custom-a-7b-4bit"), entry("custom-b-7b-8bit")]
+        let rows = [entry("custom-7b-4bit"), entry("custom-7b-8bit")]
         let presentation = QuickstartView.quickstartCachedPresentation(rows, limit: 6)
         #expect(presentation.primary.map(\.alias) == rows.map(\.alias))
         #expect(presentation.alternates.isEmpty)

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -950,6 +950,10 @@ def _emit_catalog(subcommand, alias):
             for index in range(6):
                 print(f"a-cached-{index}             hermes           none")
             print("qwen3.5-4b-4bit       hermes           qwen3")
+        if _setting("FAKE_CACHED_VARIANTS") == "1":
+            print("qwen3-0.6b-8bit       hermes           qwen3")
+            print("qwen3-0.6b-4bit       hermes           qwen3")
+            print("qwen3-4b-4bit         hermes           qwen3")
         print("fake-alias             hermes           qwen3")
         print("fake-external-alias    hermes           qwen3")
         if _setting("FAKE_SETTINGS_MTP") == "1":
@@ -995,6 +999,10 @@ def _emit_catalog(subcommand, alias):
             for index in range(6):
                 print(f"a-cached-{index}             fake-org/a-cached-{index}        100 MB")
             print("qwen3.5-4b-4bit       mlx-community/Qwen3.5-4B-MLX-4bit  2.9 GB")
+        if _setting("FAKE_CACHED_VARIANTS") == "1":
+            print("qwen3-0.6b-8bit       mlx-community/Qwen3-0.6B-MLX-8bit  720 MB")
+            print("qwen3-0.6b-4bit       mlx-community/Qwen3-0.6B-MLX-4bit  370 MB")
+            print("qwen3-4b-4bit         mlx-community/Qwen3-4B-MLX-4bit    2.4 GB")
         if _setting("FAKE_SETTINGS_MTP") == "1":
             print("qwen3.8-27b-4bit       rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX  15.2 GB")
         # Cached, so the Images tab resolves to it without a download path —

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -36,7 +36,7 @@ usage() {
     cat <<'EOF'
 Usage: gui-golden-flows.sh [--flow NAME] [--keep] [--update-baselines]
 
-Flows: fresh-install, cached-quickstart, cached-curated-tradeup, download-progress, settings-persistence, settings-mtp, chat-restore, message-actions, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
+Flows: fresh-install, cached-quickstart, cached-curated-tradeup, cached-variant-collapse, download-progress, settings-persistence, settings-mtp, chat-restore, message-actions, restored-tools, tool-loop-budget, chat-depth, math-rendering, launch-integrations,
        slow-stream-stop,
        model-crash-recovery, low-memory-choice,
        update-state, update-busy, campaign-banner, window-close-prompt, no-dead-controls, catalog-integrity,
@@ -99,7 +99,7 @@ flow_requires_screen_recording() {
 # unattended without taking on any of that.
 flow_requires_peekaboo() {
     case "$FLOW" in
-        fresh-install|cached-quickstart|cached-curated-tradeup|download-progress|settings-persistence|settings-mtp|chat-restore|message-actions|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|update-busy|campaign-banner|launch-integrations) return 1 ;;
+        fresh-install|cached-quickstart|cached-curated-tradeup|cached-variant-collapse|download-progress|settings-persistence|settings-mtp|chat-restore|message-actions|restored-tools|tool-loop-budget|chat-depth|math-rendering|browse-all-destination|no-dead-controls|catalog-integrity|update-state|update-busy|campaign-banner|launch-integrations) return 1 ;;
         slow-stream-stop|model-crash-recovery|low-memory-choice|chat-document-attachment|image-generation|dictation|audio-readiness|window-close-prompt|resident-load-rejected) return 1 ;;
         *) return 0 ;;
     esac
@@ -1409,6 +1409,31 @@ flow_cached_curated_tradeup() {
     # this exact card becomes selected. Footer wording is presentation copy and
     # is not required for the cached trade-up behavior under test.
     wait_selected Quickstart.Choice.qwen3.5-4b-4bit "$OUT/selected.json"
+    cleanup_persona
+}
+
+flow_cached_variant_collapse() {
+    log "first-run chooser collapses cached quant siblings (#2033 finding 3)"
+    start_persona cached-variant-collapse FAKE_CACHED_VARIANTS=1
+    see_main "$OUT/consent.json"
+    if jq -e '.data.ui_elements[]? | select(.identifier == "TelemetryConsent.DontShare")' \
+        "$OUT/consent.json" >/dev/null; then
+        press "$OUT/consent.json" TelemetryConsent.DontShare "$OUT/consent-dismiss.json"
+    fi
+
+    wait_identifier Quickstart.GetStarted "$OUT/welcome.json"
+    press "$OUT/welcome.json" Quickstart.GetStarted "$OUT/get-started.json"
+    wait_identifier Quickstart.CachedModel.qwen3-0.6b-4bit "$OUT/chooser.json"
+    wait_identifier Quickstart.CachedModel.qwen3-4b-4bit "$OUT/distinct-size.json"
+    wait_identifier Quickstart.CachedVariants.Toggle "$OUT/collapsed.json"
+    if jq -e '.data.ui_elements[]?
+              | select(.identifier == "Quickstart.CachedVariant.qwen3-0.6b-8bit")' \
+        "$OUT/collapsed.json" >/dev/null; then
+        die "cached sibling variant is visible before disclosure"
+    fi
+
+    press "$OUT/collapsed.json" Quickstart.CachedVariants.Toggle "$OUT/expand.json"
+    wait_identifier Quickstart.CachedVariant.qwen3-0.6b-8bit "$OUT/expanded.json"
     cleanup_persona
 }
 
@@ -4553,6 +4578,7 @@ case "$FLOW" in
     fresh-install) flow_fresh_install ;;
     cached-quickstart) flow_cached_quickstart ;;
     cached-curated-tradeup) flow_cached_curated_tradeup ;;
+    cached-variant-collapse) flow_cached_variant_collapse ;;
     download-progress) flow_download_progress ;;
     settings-persistence) flow_settings_persistence ;;
     settings-mtp) flow_settings_mtp ;;
@@ -4582,6 +4608,7 @@ case "$FLOW" in
         flow_fresh_install
         flow_cached_quickstart
         flow_cached_curated_tradeup
+        flow_cached_variant_collapse
         flow_download_progress
         flow_settings_persistence
         flow_settings_mtp

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -94,6 +94,7 @@ def test_peekaboo_requirement_is_default_deny():
         "message-actions",
         "cached-quickstart",
         "cached-curated-tradeup",
+        "cached-variant-collapse",
         "download-progress",
         "settings-persistence",
         "settings-mtp",


### PR DESCRIPTION
Closes #2033

## Summary
- collapse cached quantization siblings into one first-run model decision
- keep different parameter sizes distinct and preserve unknown models
- expose hidden siblings through an accessible Other variants control
- add unit contracts and an isolated GUI golden flow

## Validation
- swift test --filter QuickstartCachedModelTests --filter Step2ModelSelectionBehaviorTests --filter OnboardingDirectionDTests (100 passed)
- python3 -m pytest -q tests/test_gui_control_behavior_contract.py tests/test_gui_preflight_contract.py (17 passed)
- RAPID_BUILD_CONFIG=debug ./scripts/build.sh
- GUI flow attempted; macOS rejected window presentation because the local screen is locked (preflight fail, not an app assertion)