### PR TITLE
feat(aliases): first-class support for Ornith-1.5 MLX checkpoints (9B dense + 35B-A3B MoE)

### DIFF
--- a/tests/test_ornith_aliases.py
+++ b/tests/test_ornith_aliases.py
@@ -95,16 +95,15 @@ def test_detect_ornith_alias_routes_35b_hybrid():
     assert cfg.supports_spec_decode is False
 
 
-def test_detect_ornith_raw_hf_path_falls_back_to_regex():
-    """A user serving the bare HF path (no alias) must still get the right
-    family routing from the ``_MODEL_PATTERNS`` regex — dense 9B non-hybrid,
-    MoE 35B hybrid, matching the alias profiles."""
-    cfg9 = detect_model_config(ORNITH_9B_HF)
+def test_detect_ornith_unregistered_repack_falls_back_to_regex():
+    """Unregistered repacks must route through ``_MODEL_PATTERNS`` rather
+    than resolving one of the official HF paths through the alias registry."""
+    cfg9 = detect_model_config("community/Ornith-1.5-9B-MLX-repack")
     assert cfg9 is not None
     assert cfg9.is_hybrid is False
     assert cfg9.supports_spec_decode is False
 
-    cfg35 = detect_model_config(ORNITH_35B_HF)
+    cfg35 = detect_model_config("community/Ornith-1.5-35B-A3B-MLX-repack")
     assert cfg35 is not None
     assert cfg35.is_hybrid is True
     assert cfg35.is_moe is True
@@ -112,13 +111,20 @@ def test_detect_ornith_raw_hf_path_falls_back_to_regex():
 
 
 def test_detect_ornith_local_snapshot_dir():
-    """A local checkout dir whose name contains the ornith family with an
-    MoE / dense marker still routes via the regex (regex uses ``search`` on
-    the path, per the module contract)."""
+    """The final local-directory segment can identify an Ornith repack."""
     cfg = detect_model_config("/tmp/ornith-1.5-35b-a3b-checkout")
     assert cfg is not None
     assert cfg.is_hybrid is True
     assert cfg.is_moe is True
+
+
+def test_ornith_parent_directory_does_not_hijack_unrelated_checkpoint():
+    """An Ornith-named parent must not stamp its routing onto a child model."""
+    cfg = detect_model_config("/models/ornith-1.5-35b-a3b/Qwen3-4B")
+    assert cfg is not None
+    assert cfg.is_hybrid is False
+    assert cfg.is_moe is False
+    assert cfg.supports_spec_decode is True
 
 
 # ---- cross-check: hf_path markers match the JSON flags -----------------

--- a/tests/test_ornith_aliases.py
+++ b/tests/test_ornith_aliases.py
@@ -133,6 +133,13 @@ def test_ornith_prefix_collision_does_not_match_family_fallback():
     assert detect_model_config("community/ornithopter-35b-a3b") is None
 
 
+def test_ornith_size_marker_substrings_do_not_match_family_fallback():
+    """Size and architecture markers must be complete name tokens."""
+    assert detect_model_config("community/Ornith-1.5-135B") is None
+    assert detect_model_config("community/Ornith-1.5-19B") is None
+    assert detect_model_config("community/Ornith-1.5-condensed") is None
+
+
 # ---- cross-check: hf_path markers match the JSON flags -----------------
 
 

--- a/tests/test_ornith_aliases.py
+++ b/tests/test_ornith_aliases.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused alias-routing contracts for the Ornith-1.5 family.
+
+Ornith-1.5 is an NVIDIA-adjacent open LLM family (MIT) with official MLX
+checkpoints. Both supported sizes (9B dense, 35B-A3B MoE) ship
+``model_type=qwen3_5`` / ``qwen3_5_moe`` — the Qwen3.5 hybrid GatedDeltaNet
+wrapper — with the *standard* 248320-vocab text head (unlike rapid-mlx's own
+``qwen3.5-*`` short-gen 4M-vocab variants). They carry the Qwen3 XML
+tool/thinking chat contract (Qwen2Tokenizer, ``<|im_end|>``), so the aliases
+wire ``tool_call_parser="hermes"`` + ``reasoning_parser="qwen3"``, matching
+the existing qwen3.5 family parser choice.
+
+Dense-vs-MoE split (mirrors ``test_alias_hybrid_classification.py``):
+  - 9B dense -> NOT hybrid, ``is_hybrid_explicit=True`` (the dense
+    GatedDeltaNet cache layout wedges on metal::malloc under the hybrid
+    scheduler path — same r6-A R6-C1 story as Qwen3.5-4B/9B).
+  - 35B-A3B MoE -> hybrid (sparse experts + GatedDeltaNet, the path the
+    prefix-boundary snapshot / throttle scheduler was benched for).
+Both are bf16 unquantized and carry no MTP draft weights, so spec decode is
+off family-wide and no ``mtp_draft_model`` is set.
+"""
+
+from __future__ import annotations
+
+from vllm_mlx.model_aliases import list_profiles, resolve_profile
+from vllm_mlx.model_auto_config import detect_model_config
+
+ORNITH_9B = "ornith-1.5-9b-bf16"
+ORNITH_35B = "ornith-1.5-35b-a3b-bf16"
+ORNITH_9B_HF = "ornith-ai/Ornith-1.5-9B-MLX"
+ORNITH_35B_HF = "ornith-ai/Ornith-1.5-35B-A3B-MLX"
+
+
+# ---- SSOT alias profile -------------------------------------------------
+
+
+def test_ornith_9b_alias_profile():
+    """9B dense: non-hybrid with the explicit pin (dense GatedDeltaNet must
+    stay off the hybrid scheduler), hermes/qwen3 parsers, no spec decode."""
+    p = resolve_profile(ORNITH_9B)
+    assert p is not None
+    assert p.hf_path == ORNITH_9B_HF
+    assert p.tool_call_parser == "hermes"
+    assert p.reasoning_parser == "qwen3"
+    assert p.is_hybrid is False
+    assert p.is_hybrid_explicit is True
+    assert p.is_moe is False
+    assert p.supports_spec_decode is False
+    assert p.modality == "text"
+
+
+def test_ornith_35b_alias_profile():
+    """35B-A3B MoE: hybrid + MoE (the hybrid scheduler path is what the
+    sparse-expert variant needs), same parsers, no spec decode."""
+    p = resolve_profile(ORNITH_35B)
+    assert p is not None
+    assert p.hf_path == ORNITH_35B_HF
+    assert p.tool_call_parser == "hermes"
+    assert p.reasoning_parser == "qwen3"
+    assert p.is_hybrid is True
+    assert p.is_moe is True
+    assert p.supports_spec_decode is False
+    assert p.modality == "text"
+
+
+def test_ornith_aliases_are_registered():
+    """Both aliases must be in the registry (list_aliases lower-bound and
+    orphan checks in ``test_model_profiles_ssot.py`` also cover this, but a
+    non-existent alias resolving to ``None`` here is the sharpest signal)."""
+    profiles = list_profiles()
+    assert ORNITH_9B in profiles
+    assert ORNITH_35B in profiles
+
+
+# ---- detect_model_config routing ---------------------------------------
+
+
+def test_detect_ornith_alias_routes_9b_non_hybrid():
+    """Alias-first lookup: the 9B alias must resolve to the non-hybrid
+    profile (not get stamped hybrid by any heuristic)."""
+    cfg = detect_model_config(ORNITH_9B)
+    assert cfg is not None
+    assert cfg.tool_call_parser == "hermes"
+    assert cfg.is_hybrid is False
+    assert cfg.is_hybrid_explicit is True
+    assert cfg.supports_spec_decode is False
+
+
+def test_detect_ornith_alias_routes_35b_hybrid():
+    cfg = detect_model_config(ORNITH_35B)
+    assert cfg is not None
+    assert cfg.tool_call_parser == "hermes"
+    assert cfg.is_hybrid is True
+    assert cfg.is_moe is True
+    assert cfg.supports_spec_decode is False
+
+
+def test_detect_ornith_raw_hf_path_falls_back_to_regex():
+    """A user serving the bare HF path (no alias) must still get the right
+    family routing from the ``_MODEL_PATTERNS`` regex — dense 9B non-hybrid,
+    MoE 35B hybrid, matching the alias profiles."""
+    cfg9 = detect_model_config(ORNITH_9B_HF)
+    assert cfg9 is not None
+    assert cfg9.is_hybrid is False
+    assert cfg9.supports_spec_decode is False
+
+    cfg35 = detect_model_config(ORNITH_35B_HF)
+    assert cfg35 is not None
+    assert cfg35.is_hybrid is True
+    assert cfg35.is_moe is True
+    assert cfg35.supports_spec_decode is False
+
+
+def test_detect_ornith_local_snapshot_dir():
+    """A local checkout dir whose name contains the ornith family with an
+    MoE / dense marker still routes via the regex (regex uses ``search`` on
+    the path, per the module contract)."""
+    cfg = detect_model_config("/tmp/ornith-1.5-35b-a3b-checkout")
+    assert cfg is not None
+    assert cfg.is_hybrid is True
+    assert cfg.is_moe is True
+
+
+# ---- cross-check: hf_path markers match the JSON flags -----------------
+
+
+def test_ornith_hf_path_markers_match_classification():
+    """Sanity: the alias the JSON marks hybrid/MoE must point at an A3B repo,
+    and the non-hybrid one at a repo without an MoE marker."""
+    profiles = list_profiles()
+    assert "a3b" in profiles[ORNITH_35B].hf_path.lower()
+    assert not any(
+        m in profiles[ORNITH_9B].hf_path.lower() for m in ("a3b", "a10b", "moe")
+    )

--- a/tests/test_ornith_aliases.py
+++ b/tests/test_ornith_aliases.py
@@ -127,6 +127,12 @@ def test_ornith_parent_directory_does_not_hijack_unrelated_checkpoint():
     assert cfg.supports_spec_decode is True
 
 
+def test_ornith_prefix_collision_does_not_match_family_fallback():
+    """Words beginning with ``ornith`` are not Ornith-1.5 checkpoints."""
+    assert detect_model_config("community/ornithology-9b") is None
+    assert detect_model_config("community/ornithopter-35b-a3b") is None
+
+
 # ---- cross-check: hf_path markers match the JSON flags -----------------
 
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1989,5 +1989,22 @@
     "is_hybrid": false,
     "is_moe": false,
     "supports_spec_decode": false
+  },
+  "ornith-1.5-9b-bf16": {
+    "hf_path": "ornith-ai/Ornith-1.5-9B-MLX",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false
+  },
+  "ornith-1.5-35b-a3b-bf16": {
+    "hf_path": "ornith-ai/Ornith-1.5-35B-A3B-MLX",
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "is_moe": true,
+    "supports_spec_decode": false
   }
 }

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -311,6 +311,36 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
             reasoning_parser="qwen3",
         ),
     ),
+    # Ornith-1.5 (NVIDIA-adjacent open LLM family, MIT) — Qwen3.5 hybrid
+    # arch (model_type=qwen3_5 / qwen3_5_moe). The MLX checkpoints are
+    # unquantized bf16; the family splits on MoE marker the same way the
+    # qwen3.5 family does. 35B-A3B is sparse expert + GatedDeltaNet hybrid
+    # (needs the hybrid scheduler); 9B is the dense GatedDeltaNet sibling
+    # that wedges on metal::malloc under the hybrid path, so it is pinned
+    # non-hybrid via ``is_hybrid_explicit``. Both ship the Qwen3 XML
+    # tool/thinking contract (Qwen2Tokenizer with ``<|im_end|>``), so they
+    # use hermes tool + qwen3 reasoning parsers. ``supports_spec_decode``
+    # is False family-wide (GatedDeltaNet rules out self-spec).
+    (
+        re.compile(r"ornith.*(35b|a3b|moe)", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser="qwen3",
+            is_hybrid=True,
+            is_moe=True,
+            supports_spec_decode=False,
+        ),
+    ),
+    (
+        re.compile(r"ornith.*(9b|dense)", re.IGNORECASE),
+        ModelConfig(
+            tool_call_parser="hermes",
+            reasoning_parser="qwen3",
+            is_hybrid=False,
+            is_hybrid_explicit=True,
+            supports_spec_decode=False,
+        ),
+    ),
     # Qwen3-Coder (older, pure-attention) — not Coder-Next
     (
         re.compile(r"qwen3[-_]?coder", re.IGNORECASE),

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -322,7 +322,10 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     # use hermes tool + qwen3 reasoning parsers. ``supports_spec_decode``
     # is False family-wide (GatedDeltaNet rules out self-spec).
     (
-        re.compile(r"(?:^|[/\\])ornith[^/\\]*(35b|a3b|moe)[^/\\]*$", re.IGNORECASE),
+        re.compile(
+            r"(?:^|[/\\])ornith[-_.]1[-_.]5[^/\\]*(35b|a3b|moe)[^/\\]*$",
+            re.IGNORECASE,
+        ),
         ModelConfig(
             tool_call_parser="hermes",
             reasoning_parser="qwen3",
@@ -332,7 +335,10 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
         ),
     ),
     (
-        re.compile(r"(?:^|[/\\])ornith[^/\\]*(9b|dense)[^/\\]*$", re.IGNORECASE),
+        re.compile(
+            r"(?:^|[/\\])ornith[-_.]1[-_.]5[^/\\]*(9b|dense)[^/\\]*$",
+            re.IGNORECASE,
+        ),
         ModelConfig(
             tool_call_parser="hermes",
             reasoning_parser="qwen3",

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -322,7 +322,7 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     # use hermes tool + qwen3 reasoning parsers. ``supports_spec_decode``
     # is False family-wide (GatedDeltaNet rules out self-spec).
     (
-        re.compile(r"ornith.*(35b|a3b|moe)", re.IGNORECASE),
+        re.compile(r"(?:^|[/\\])ornith[^/\\]*(35b|a3b|moe)[^/\\]*$", re.IGNORECASE),
         ModelConfig(
             tool_call_parser="hermes",
             reasoning_parser="qwen3",
@@ -332,7 +332,7 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
         ),
     ),
     (
-        re.compile(r"ornith.*(9b|dense)", re.IGNORECASE),
+        re.compile(r"(?:^|[/\\])ornith[^/\\]*(9b|dense)[^/\\]*$", re.IGNORECASE),
         ModelConfig(
             tool_call_parser="hermes",
             reasoning_parser="qwen3",

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -323,7 +323,8 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     # is False family-wide (GatedDeltaNet rules out self-spec).
     (
         re.compile(
-            r"(?:^|[/\\])ornith[-_.]1[-_.]5[^/\\]*(35b|a3b|moe)[^/\\]*$",
+            r"(?:^|[/\\])ornith[-_.]1[-_.]5[^/\\]*"
+            r"[-_.](35b|a3b|moe)(?=[-_.]|$)[^/\\]*$",
             re.IGNORECASE,
         ),
         ModelConfig(
@@ -336,7 +337,8 @@ _MODEL_PATTERNS: list[tuple[re.Pattern, ModelConfig]] = [
     ),
     (
         re.compile(
-            r"(?:^|[/\\])ornith[-_.]1[-_.]5[^/\\]*(9b|dense)[^/\\]*$",
+            r"(?:^|[/\\])ornith[-_.]1[-_.]5[^/\\]*"
+            r"[-_.](9b|dense)(?=[-_.]|$)[^/\\]*$",
             re.IGNORECASE,
         ),
         ModelConfig(

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -195,6 +195,8 @@
     "notapalindrome/ltx23-mlx-av-q4": 22815502995,
     "MrMofer/ltx-2.5-mlx-q8": 67695751883,
     "openbmb/MiniCPM5-1B-MLX": 617961816,
+    "ornith-ai/Ornith-1.5-35B-A3B-MLX": 69341391877,
+    "ornith-ai/Ornith-1.5-9B-MLX": 17927699601,
     "pipenetwork/GLM-5.2-REAP50-MLX-4bit": 214380689191,
     "pipenetwork/Holo-3.1-35B-A3B-MLX-4bit": 23490832707,
     "pipenetwork/Holo-3.1-35B-A3B-MLX-8bit": 40810031931,


### PR DESCRIPTION
## Summary

Add first-class alias support for the two **Ornith-1.5** official MLX checkpoints (NVIDIA-adjacent open LLM family, MIT license):
- `ornith-1.5-9b-bf16` → `ornith-ai/Ornith-1.5-9B-MLX` (dense)
- `ornith-1.5-35b-a3b-bf16` → `ornith-ai/Ornith-1.5-35B-A3B-MLX` (MoE A3B)

Both ship `model_type=qwen3_5` / `qwen3_5_moe` — the Qwen3.5 hybrid GatedDeltaNet wrapper — with the **standard 248320-vocab text head** (unlike rapid-mlx's own short-gen 4M-vocab `qwen3.5-*` variants) and the Qwen3 XML tool/thinking chat contract, so they wire `hermes` tool + `qwen3` reasoning parsers and need **no vendored arch** (mlx-lm 0.31.3 serves them natively) — unlike the earlier Nemotron-Labs-Diffusion PR.

## Routing decision (mirrors the qwen3.5 family r6-A R6-C1 precedent)

| alias | size | arch | `is_hybrid` | `is_moe` | spec decode |
|---|---|---|---|---|---|
| `ornith-1.5-9b-bf16` | 9B | dense GatedDeltaNet | **false** (+`is_hybrid_explicit` pin) | false | off |
| `ornith-1.5-35b-a3b-bf16` | 35B-A3B | sparse-expert MoE + GatedDeltaNet | **true** | true | off |

The dense 9B is pinned non-hybrid because the dense GatedDeltaNet cache layout wedges on `metal::malloc` under the hybrid scheduler (same story as Qwen3.5-4B/9B). The MoE 35B keeps the hybrid scheduler path it was benched for. Spec decode is off family-wide (GatedDeltaNet rules out self-spec). Both are unquantized bf16 — no pflash/turboquant tier, no MTP draft set (no MTP weights shipped).

## Changes

- `vllm_mlx/aliases.json` — two rich-schema alias profiles (explicit SSOT fields)
- `vllm_mlx/model_auto_config.py` — `_MODEL_PATTERNS` regex rows (MoE row before dense row) so bare HF paths / local snapshots also route correctly
- `vllm_mlx/model_sizes.json` — download-footprint entries for both hf_paths
- `tests/test_ornith_aliases.py` — focused routing contracts (alias profile, `detect_model_config` via alias + raw-HF fallback, local snapshot dir, hf_path-marker cross-check)

## Verification

- Full suite: **18305 passed**; the only two failures are pre-existing/environmental, confirmed on pristine `origin/main`:
  - a `PYTHONPATH` leak causing the test-env venv probe to see all packages (env-only),
  - a live-DeepSeek-api `httpx.ConnectTimeout` in an integration test (network-only).
- `ruff check` + `ruff format` clean on all changed files.
- No new vendored arch, no `pyproject.toml` change, no install-size impact (G12-safe: config/JSON/test only).
